### PR TITLE
fix: resolve e2e test failures by mocking Google Fonts in test environments

### DIFF
--- a/apps/root-e2e/playwright.config.ts
+++ b/apps/root-e2e/playwright.config.ts
@@ -52,13 +52,14 @@ export default defineConfig({
     cwd: workspaceRoot,
     timeout: isCI ? 120000 : 60000, // 2 minutes in CI, 1 minute locally
     env: {
-      // Disable Sentry in CI to speed up startup
+      // Use test environment to enable font mocking (important!)
+      NODE_ENV: 'test',
+      // Disable Sentry to speed up startup
       ...(isCI && {
         SENTRY_DSN: '',
         SENTRY_AUTH_TOKEN: '',
-        NODE_ENV: 'test',
       }),
-      // Disable analytics and other non-essential services in CI
+      // Disable analytics and other non-essential services
       ...(isCI && {
         NEXT_TELEMETRY_DISABLED: '1',
         ANALYZE: 'false',

--- a/apps/root/next.config.js
+++ b/apps/root/next.config.js
@@ -160,6 +160,18 @@ const nextConfig = {
    */
   webpack: (config, options) => {
     const { dev, isServer } = options;
+
+    // In test/CI environments, replace fonts.ts with fonts.mock.ts to avoid network requests
+    if (isTest || isCI) {
+      config.plugins = config.plugins || [];
+      config.plugins.push(
+        new (require('webpack').NormalModuleReplacementPlugin)(
+          /src\/app\/fonts\.ts$/,
+          require.resolve('./src/app/fonts.mock.ts')
+        )
+      );
+    }
+
     // Optimize bundle size and code splitting
     if (!dev && !isServer) {
       config.optimization = config.optimization || {};

--- a/apps/root/src/app/fonts.mock.ts
+++ b/apps/root/src/app/fonts.mock.ts
@@ -1,0 +1,18 @@
+// Mock fonts for test/CI environments where network access is restricted
+export const josefinSans = {
+  className: '',
+  style: { fontFamily: 'system-ui, sans-serif' },
+  variable: '--font-josefin-sans',
+};
+
+export const irn = {
+  className: '',
+  style: { fontFamily: 'system-ui, serif' },
+  variable: '--font-irn',
+};
+
+export const firaMono = {
+  className: '',
+  style: { fontFamily: 'system-ui, monospace' },
+  variable: '--font-fira-code',
+};


### PR DESCRIPTION
The e2e tests were failing because Next.js couldn't fetch Google Fonts during the build process in restricted network environments (CI/test).

Changes:
- Created fonts.mock.ts with system font fallbacks for test/CI environments
- Updated next.config.js to use webpack NormalModuleReplacementPlugin to replace real fonts with mocks when NODE_ENV=test or CI=true
- Updated playwright.config.ts to set NODE_ENV=test, enabling font mocking during test builds

This allows the build to succeed without network access to fonts.googleapis.com while maintaining the real Google Fonts in production.