### PR TITLE
fix: stop service worker from intercepting Next.js static assets

### DIFF
--- a/apps/root/public/sw.js
+++ b/apps/root/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_VERSION = 'v2';
+const CACHE_VERSION = 'v3';
 const STATIC_CACHE = `danieljoffe-static-${CACHE_VERSION}`;
 const DYNAMIC_CACHE = `danieljoffe-dynamic-${CACHE_VERSION}`;
 const IMAGE_CACHE = `danieljoffe-images-${CACHE_VERSION}`;
@@ -79,9 +79,11 @@ function getCacheStrategy(request) {
     return { cache: IMAGE_CACHE, strategy: 'cache-first', limit: IMAGE_CACHE_LIMIT };
   }
 
-  // Static assets (JS, CSS) - cache first
+  // Static assets (JS, CSS) - skip SW caching
+  // Next.js uses content-hashed filenames with proper cache headers,
+  // so browser HTTP cache handles these optimally already.
   if (url.pathname.startsWith('/_next/static/')) {
-    return { cache: STATIC_CACHE, strategy: 'cache-first' };
+    return { strategy: 'network-only' };
   }
 
   // API requests - network only
@@ -127,7 +129,7 @@ self.addEventListener('fetch', event => {
             });
 
             return response;
-          });
+          }).catch(() => caches.match(event.request));
         })
       );
       break;


### PR DESCRIPTION
## Summary
- Service worker was using `cache-first` for `_next/static/` requests with no error handling, causing all asset loads to crash on new deployments (chunk hashes change between builds)
- Changed `_next/static/` strategy to `network-only` since Next.js already handles caching via content-hashed filenames and proper cache headers
- Added `.catch()` fallback to `cache-first` handler for robustness
- Bumped cache version to `v3` to purge stale caches on activation

## Test plan
- [ ] Verify `dev.danieljoffe.com` loads without console errors after Vercel deploy
- [ ] Hard refresh to confirm new SW activates and clears old caches
- [ ] Confirm fonts and images still cache correctly (only `_next/static/` changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)