### PR TITLE
fix: add Node.js setup to deploy jobs

### DIFF
--- a/.github/actions/ci/action.yml
+++ b/.github/actions/ci/action.yml
@@ -11,7 +11,7 @@ runs:
   steps:
     - uses: actions/setup-node@v4
       with:
-        node-version: 22
+        node-version-file: .nvmrc
         cache: yarn
 
     - name: Install dependencies

--- a/.github/workflows/ci-preview.yml
+++ b/.github/workflows/ci-preview.yml
@@ -50,6 +50,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: yarn
+
       - name: Install Vercel CLI
         run: npm i -g vercel@50.15.1
 

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -41,6 +41,11 @@ jobs:
         with:
           ref: main
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: yarn
+
       - name: Install Vercel CLI
         run: npm i -g vercel@50.15.1
 


### PR DESCRIPTION
## Summary
- Preview and production deploy jobs were missing `setup-node`, falling back to runner default (Node 20) which breaks `lighthouse@13` (requires `>=22.19`)
- Added `setup-node` with `node-version-file: .nvmrc` to both deploy jobs
- Switched shared CI action from hardcoded `node-version: 22` to `node-version-file: .nvmrc` so all workflows use a single source of truth

## Files changed
- `.github/actions/ci/action.yml` — use `.nvmrc` instead of hardcoded `22`
- `.github/workflows/ci-preview.yml` — add `setup-node` to preview job
- `.github/workflows/deploy-production.yml` — add `setup-node` to deploy job

## Test plan
- [ ] Merge into develop, then re-run PR #36 (`develop` → `main`) — CI + preview deploy should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)