### PR TITLE
fix(ci): install Playwright browsers unconditionally

### DIFF
--- a/.github/actions/ci/action.yml
+++ b/.github/actions/ci/action.yml
@@ -25,7 +25,6 @@ runs:
       run: yarn install --frozen-lockfile
 
     - name: Install Playwright
-      if: ${{ inputs.run-e2e == 'true' }}
       shell: bash
       run: yarn playwright install --with-deps
 


### PR DESCRIPTION
## Summary
- Removes the `run-e2e` condition from the Playwright install step in CI
- shared-ui tests use Vitest browser mode (`@vitest/browser-playwright`) which requires Playwright browsers to be installed regardless of whether E2E tests run

## Test plan
- [ ] Verify shared-ui tests pass in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)