### PR TITLE
fix(root): use window.gtag directly instead of sendGAEvent

### DIFF
--- a/apps/root/src/lib/__tests__/analytics.spec.ts
+++ b/apps/root/src/lib/__tests__/analytics.spec.ts
@@ -1,14 +1,15 @@
-import { sendGAEvent } from '@next/third-parties/google';
 import { analytics } from '../analytics';
 
-jest.mock('@next/third-parties/google', () => ({
-  sendGAEvent: jest.fn(),
-}));
-
-const mockSendGAEvent = sendGAEvent as jest.Mock;
+const mockGtag = jest.fn();
+const win = window as unknown as Record<string, unknown>;
 
 beforeEach(() => {
-  mockSendGAEvent.mockClear();
+  win.gtag = mockGtag;
+  mockGtag.mockClear();
+});
+
+afterEach(() => {
+  delete win.gtag;
 });
 
 describe('analytics', () => {
@@ -29,18 +30,18 @@ describe('analytics', () => {
   });
 
   describe('navigation events', () => {
-    it('navClick calls sendGAEvent with nav_click event', () => {
+    it('navClick calls gtag with nav_click event', () => {
       analytics.navClick('Home');
-      expect(mockSendGAEvent).toHaveBeenCalledWith('event', 'nav_click', {
+      expect(mockGtag).toHaveBeenCalledWith('event', 'nav_click', {
         link_label: 'Home',
       });
     });
   });
 
   describe('CTA events', () => {
-    it('ctaClick calls sendGAEvent with cta_click event', () => {
+    it('ctaClick calls gtag with cta_click event', () => {
       analytics.ctaClick('signup', '/signup');
-      expect(mockSendGAEvent).toHaveBeenCalledWith('event', 'cta_click', {
+      expect(mockGtag).toHaveBeenCalledWith('event', 'cta_click', {
         cta_name: 'signup',
         destination: '/signup',
       });
@@ -48,23 +49,23 @@ describe('analytics', () => {
   });
 
   describe('form events', () => {
-    it('formStart calls sendGAEvent with form_start event', () => {
+    it('formStart calls gtag with form_start event', () => {
       analytics.formStart('contact');
-      expect(mockSendGAEvent).toHaveBeenCalledWith('event', 'form_start', {
+      expect(mockGtag).toHaveBeenCalledWith('event', 'form_start', {
         form_name: 'contact',
       });
     });
 
-    it('formSubmit calls sendGAEvent with form_submit event', () => {
+    it('formSubmit calls gtag with form_submit event', () => {
       analytics.formSubmit('contact');
-      expect(mockSendGAEvent).toHaveBeenCalledWith('event', 'form_submit', {
+      expect(mockGtag).toHaveBeenCalledWith('event', 'form_submit', {
         form_name: 'contact',
       });
     });
 
-    it('formError calls sendGAEvent with form_error event', () => {
+    it('formError calls gtag with form_error event', () => {
       analytics.formError('contact', 'validation failed');
-      expect(mockSendGAEvent).toHaveBeenCalledWith('event', 'form_error', {
+      expect(mockGtag).toHaveBeenCalledWith('event', 'form_error', {
         form_name: 'contact',
         error_message: 'validation failed',
       });
@@ -72,36 +73,32 @@ describe('analytics', () => {
   });
 
   describe('engagement events', () => {
-    it('mobileMenuToggle calls sendGAEvent with mobile_menu_toggle event', () => {
+    it('mobileMenuToggle calls gtag with mobile_menu_toggle event', () => {
       analytics.mobileMenuToggle('open');
-      expect(mockSendGAEvent).toHaveBeenCalledWith(
-        'event',
-        'mobile_menu_toggle',
-        { action: 'open' }
-      );
+      expect(mockGtag).toHaveBeenCalledWith('event', 'mobile_menu_toggle', {
+        action: 'open',
+      });
     });
 
-    it('projectClick calls sendGAEvent with project_click event', () => {
+    it('projectClick calls gtag with project_click event', () => {
       analytics.projectClick('my-project');
-      expect(mockSendGAEvent).toHaveBeenCalledWith('event', 'project_click', {
+      expect(mockGtag).toHaveBeenCalledWith('event', 'project_click', {
         project: 'my-project',
       });
     });
 
-    it('experienceClick calls sendGAEvent with experience_click event', () => {
+    it('experienceClick calls gtag with experience_click event', () => {
       analytics.experienceClick('my-experience');
-      expect(mockSendGAEvent).toHaveBeenCalledWith(
-        'event',
-        'experience_click',
-        { experience: 'my-experience' }
-      );
+      expect(mockGtag).toHaveBeenCalledWith('event', 'experience_click', {
+        experience: 'my-experience',
+      });
     });
   });
 
   describe('theme events', () => {
-    it('themeToggle calls sendGAEvent with theme_toggle event', () => {
+    it('themeToggle calls gtag with theme_toggle event', () => {
       analytics.themeToggle('dark');
-      expect(mockSendGAEvent).toHaveBeenCalledWith('event', 'theme_toggle', {
+      expect(mockGtag).toHaveBeenCalledWith('event', 'theme_toggle', {
         theme: 'dark',
       });
     });
@@ -109,7 +106,6 @@ describe('analytics', () => {
 
   describe('SSR safety', () => {
     it('methods do not throw when called', () => {
-      // In a browser environment (jsdom), all methods should execute without error
       expect(() => analytics.navClick('Home')).not.toThrow();
       expect(() => analytics.ctaClick('cta', '/dest')).not.toThrow();
       expect(() => analytics.formStart('form')).not.toThrow();
@@ -121,8 +117,8 @@ describe('analytics', () => {
       expect(() => analytics.themeToggle('light')).not.toThrow();
     });
 
-    it('all methods call sendGAEvent when window is defined (browser)', () => {
-      mockSendGAEvent.mockClear();
+    it('all methods call gtag when window is defined (browser)', () => {
+      mockGtag.mockClear();
 
       analytics.navClick('Home');
       analytics.ctaClick('cta', '/dest');
@@ -134,8 +130,7 @@ describe('analytics', () => {
       analytics.experienceClick('slug');
       analytics.themeToggle('light');
 
-      // Each method should have called sendGAEvent once (9 total)
-      expect(mockSendGAEvent).toHaveBeenCalledTimes(9);
+      expect(mockGtag).toHaveBeenCalledTimes(9);
     });
   });
 });

--- a/apps/root/src/lib/analytics.spec.ts
+++ b/apps/root/src/lib/analytics.spec.ts
@@ -1,30 +1,28 @@
 import { analytics } from './analytics';
 
-jest.mock('@next/third-parties/google', () => ({
-  sendGAEvent: jest.fn(),
-}));
+const mockGtag = jest.fn();
+const win = window as unknown as Record<string, unknown>;
 
-import { sendGAEvent } from '@next/third-parties/google';
+beforeEach(() => {
+  win.gtag = mockGtag;
+  mockGtag.mockClear();
+});
 
-const mockedSendGAEvent = sendGAEvent as jest.MockedFunction<
-  typeof sendGAEvent
->;
+afterEach(() => {
+  delete win.gtag;
+});
 
 describe('analytics', () => {
-  beforeEach(() => {
-    mockedSendGAEvent.mockClear();
-  });
-
   it('tracks nav click events', () => {
     analytics.navClick('About');
-    expect(mockedSendGAEvent).toHaveBeenCalledWith('event', 'nav_click', {
+    expect(mockGtag).toHaveBeenCalledWith('event', 'nav_click', {
       link_label: 'About',
     });
   });
 
   it('tracks CTA click events', () => {
     analytics.ctaClick('hire_me', '/about');
-    expect(mockedSendGAEvent).toHaveBeenCalledWith('event', 'cta_click', {
+    expect(mockGtag).toHaveBeenCalledWith('event', 'cta_click', {
       cta_name: 'hire_me',
       destination: '/about',
     });
@@ -32,21 +30,21 @@ describe('analytics', () => {
 
   it('tracks form start events', () => {
     analytics.formStart('contact');
-    expect(mockedSendGAEvent).toHaveBeenCalledWith('event', 'form_start', {
+    expect(mockGtag).toHaveBeenCalledWith('event', 'form_start', {
       form_name: 'contact',
     });
   });
 
   it('tracks form submit events', () => {
     analytics.formSubmit('contact');
-    expect(mockedSendGAEvent).toHaveBeenCalledWith('event', 'form_submit', {
+    expect(mockGtag).toHaveBeenCalledWith('event', 'form_submit', {
       form_name: 'contact',
     });
   });
 
   it('tracks form error events', () => {
     analytics.formError('contact', 'Validation failed');
-    expect(mockedSendGAEvent).toHaveBeenCalledWith('event', 'form_error', {
+    expect(mockGtag).toHaveBeenCalledWith('event', 'form_error', {
       form_name: 'contact',
       error_message: 'Validation failed',
     });
@@ -54,32 +52,28 @@ describe('analytics', () => {
 
   it('tracks mobile menu toggle events', () => {
     analytics.mobileMenuToggle('open');
-    expect(mockedSendGAEvent).toHaveBeenCalledWith(
-      'event',
-      'mobile_menu_toggle',
-      { action: 'open' }
-    );
+    expect(mockGtag).toHaveBeenCalledWith('event', 'mobile_menu_toggle', {
+      action: 'open',
+    });
   });
 
   it('tracks project click events', () => {
     analytics.projectClick('my-project');
-    expect(mockedSendGAEvent).toHaveBeenCalledWith('event', 'project_click', {
+    expect(mockGtag).toHaveBeenCalledWith('event', 'project_click', {
       project: 'my-project',
     });
   });
 
   it('tracks experience click events', () => {
     analytics.experienceClick('company-x');
-    expect(mockedSendGAEvent).toHaveBeenCalledWith(
-      'event',
-      'experience_click',
-      { experience: 'company-x' }
-    );
+    expect(mockGtag).toHaveBeenCalledWith('event', 'experience_click', {
+      experience: 'company-x',
+    });
   });
 
   it('tracks theme toggle events', () => {
     analytics.themeToggle('dark');
-    expect(mockedSendGAEvent).toHaveBeenCalledWith('event', 'theme_toggle', {
+    expect(mockGtag).toHaveBeenCalledWith('event', 'theme_toggle', {
       theme: 'dark',
     });
   });
@@ -87,43 +81,37 @@ describe('analytics', () => {
   // Audit events
   it('tracks audit scan started events', () => {
     analytics.auditScanStarted('https://example.com');
-    expect(mockedSendGAEvent).toHaveBeenCalledWith(
-      'event',
-      'audit_scan_started',
-      { url: 'https://example.com' }
-    );
+    expect(mockGtag).toHaveBeenCalledWith('event', 'audit_scan_started', {
+      url: 'https://example.com',
+    });
   });
 
   it('tracks audit scan completed events', () => {
     analytics.auditScanCompleted('scan-123', 'B');
-    expect(mockedSendGAEvent).toHaveBeenCalledWith(
-      'event',
-      'audit_scan_completed',
-      { scan_id: 'scan-123', grade: 'B' }
-    );
+    expect(mockGtag).toHaveBeenCalledWith('event', 'audit_scan_completed', {
+      scan_id: 'scan-123',
+      grade: 'B',
+    });
   });
 
   it('tracks audit scan failed events', () => {
     analytics.auditScanFailed('https://example.com', 'Timeout');
-    expect(mockedSendGAEvent).toHaveBeenCalledWith(
-      'event',
-      'audit_scan_failed',
-      { url: 'https://example.com', error_message: 'Timeout' }
-    );
+    expect(mockGtag).toHaveBeenCalledWith('event', 'audit_scan_failed', {
+      url: 'https://example.com',
+      error_message: 'Timeout',
+    });
   });
 
   it('tracks audit email captured events', () => {
     analytics.auditEmailCaptured('scan-456');
-    expect(mockedSendGAEvent).toHaveBeenCalledWith(
-      'event',
-      'audit_email_captured',
-      { scan_id: 'scan-456' }
-    );
+    expect(mockGtag).toHaveBeenCalledWith('event', 'audit_email_captured', {
+      scan_id: 'scan-456',
+    });
   });
 
   it('tracks audit calendly clicked events', () => {
     analytics.auditCalendlyClicked();
-    expect(mockedSendGAEvent).toHaveBeenCalledWith(
+    expect(mockGtag).toHaveBeenCalledWith(
       'event',
       'audit_calendly_clicked',
       {}
@@ -132,10 +120,8 @@ describe('analytics', () => {
 
   it('tracks audit report shared events', () => {
     analytics.auditReportShared('scan-789');
-    expect(mockedSendGAEvent).toHaveBeenCalledWith(
-      'event',
-      'audit_report_shared',
-      { scan_id: 'scan-789' }
-    );
+    expect(mockGtag).toHaveBeenCalledWith('event', 'audit_report_shared', {
+      scan_id: 'scan-789',
+    });
   });
 });

--- a/apps/root/src/lib/analytics.ts
+++ b/apps/root/src/lib/analytics.ts
@@ -1,12 +1,10 @@
-import { sendGAEvent } from '@next/third-parties/google';
-
 type EventParams = Record<string, string | number | boolean>;
 
 function trackEvent(eventName: string, params?: EventParams) {
   // Skip during SSR
   if (typeof window === 'undefined') return;
 
-  sendGAEvent('event', eventName, params ?? {});
+  window.gtag?.('event', eventName, params ?? {});
 }
 
 export const analytics = {

--- a/libs/shared/ui/eslint.config.mjs
+++ b/libs/shared/ui/eslint.config.mjs
@@ -37,10 +37,7 @@ export default [
       'jsx-a11y/no-interactive-element-to-noninteractive-role': 'error',
       'jsx-a11y/no-noninteractive-element-interactions': 'error',
       'jsx-a11y/no-noninteractive-element-to-interactive-role': 'error',
-      'jsx-a11y/no-noninteractive-tabindex': [
-        'error',
-        { roles: ['tabpanel'] },
-      ],
+      'jsx-a11y/no-noninteractive-tabindex': ['error', { roles: ['tabpanel'] }],
       'jsx-a11y/no-redundant-roles': 'error',
       'jsx-a11y/no-static-element-interactions': 'error',
       'jsx-a11y/role-has-required-aria-props': 'error',


### PR DESCRIPTION
## Summary
- Removes `sendGAEvent` from `@next/third-parties/google` in analytics, calling `window.gtag` directly for simpler, more reliable event tracking
- Updates both test files to mock `gtag` on `window` instead of mocking the `@next/third-parties/google` module
- Minor formatting fix in shared-ui eslint config

## Test plan
- [ ] `npx nx test root` passes (analytics tests updated)
- [ ] Verify GA events still fire in dev/preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)