### PR TITLE
fix: rate limiting, email sending in tests, skip link, and mobile nav

### DIFF
--- a/apps/root-e2e/playwright.config.ts
+++ b/apps/root-e2e/playwright.config.ts
@@ -69,6 +69,8 @@ export default defineConfig({
       MOCK_FONTS: 'true',
       // Use hCaptcha test sitekey (always passes verification)
       NEXT_PUBLIC_HCAPTCHA_SITE_ID: '10000000-ffff-ffff-ffff-000000000001',
+      // Disable Resend so E2E tests never send real emails
+      RESEND_API_KEY: '',
       ...(isCI && {
         // Disable Sentry to speed up startup
         SENTRY_DSN: '',

--- a/apps/root-e2e/src/api-email.spec.ts
+++ b/apps/root-e2e/src/api-email.spec.ts
@@ -162,18 +162,26 @@ test.describe('api email - rate limiting', () => {
       'x-forwarded-for': uniqueIP,
     };
 
+    // Use a payload that fails validation so sendEmail is never reached.
+    // rateLimit runs first in the route, so the counter still increments
+    // even though the request ultimately fails at validateFormData.
+    const rateLimitPayload = {
+      ...validPayload,
+      message: 'short',
+    };
+
     // Send 5 requests (should all pass rate limit check)
     for (let i = 0; i < 5; i++) {
       await request.post(API_URL, {
         headers,
-        data: validPayload,
+        data: rateLimitPayload,
       });
     }
 
     // 6th request should be rate limited
     const response = await request.post(API_URL, {
       headers,
-      data: validPayload,
+      data: rateLimitPayload,
     });
 
     const body = await response.json();

--- a/apps/root/src/app/api/email/contact/API_DOCUMENTATION.md
+++ b/apps/root/src/app/api/email/contact/API_DOCUMENTATION.md
@@ -60,7 +60,7 @@ Referer: https://danieljoffe.com/about (required)
 #### Validation Rules
 
 - **Name**: Must contain only letters, spaces, hyphens, and apostrophes
-- **Email**: Must be a valid email format and pass deliverability check
+- **Email**: Must be a valid email format
 - **Message**: Cannot contain URLs (anti-spam protection)
 - **CAPTCHA**: Must be a valid hCaptcha token
 - **Honeypot**: Hidden `address` field must be empty (anti-bot protection)
@@ -97,7 +97,7 @@ Referer: https://danieljoffe.com/about (required)
 | Error Path                | Status | Description                           |
 | ------------------------- | ------ | ------------------------------------- |
 | `name`                    | 400    | Name validation failed                |
-| `email`                   | 400    | Email format or deliverability issue  |
+| `email`                   | 400    | Email format validation failed        |
 | `message`                 | 400    | Message validation failed             |
 | `hcaptcha`                | 400    | CAPTCHA verification failed           |
 | `root.forbidden`          | 403    | Rate limit exceeded or invalid source |
@@ -115,9 +115,8 @@ Referer: https://danieljoffe.com/about (required)
 1. **Source Validation**: Must be called from `/about` page
 2. **Rate Limiting**: IP-based request throttling
 3. **Input Sanitization**: All inputs sanitized with DOMPurify
-4. **Email Validation**: Real-time deliverability checking via ValidKit
-5. **Anti-Spam**: URL detection and honeypot field
-6. **CAPTCHA**: hCaptcha verification required
+4. **Anti-Spam**: URL detection and honeypot field
+5. **CAPTCHA**: hCaptcha verification required
 
 #### Example Usage
 
@@ -167,14 +166,6 @@ The API requires the following environment variables:
 ### Required for Production
 
 ```bash
-# Email validation service
-VALIDKIT_API_KEY=your_validkit_api_key
-VALIDKIT_API_URL=https://api.validkit.io/v1/validate
-
-# Email delivery service
-WEB3FORMS_ACCESS_KEY=your_web3forms_access_key
-WEB3FORMS_API_URL=https://api.web3forms.com/submit
-
 # Application environment
 NODE_ENV=production
 

--- a/apps/root/src/app/api/email/contact/helpers.test.ts
+++ b/apps/root/src/app/api/email/contact/helpers.test.ts
@@ -7,14 +7,6 @@ import { formSchema } from './schema';
 const mockSend = jest.fn();
 
 // Mock dependencies before importing the module under test
-jest.mock('@/lib/env', () => ({
-  serverEnv: {
-    VALIDKIT_API_KEY: 'test-validkit-key',
-    VALIDKIT_API_URL: 'https://api.validkit.test/validate',
-    NODE_ENV: 'test',
-  },
-}));
-
 jest.mock('@/lib/email/resend', () => ({
   createResendClient: jest.fn(() => ({ emails: { send: mockSend } })),
   EMAIL_FROM: 'Test <test@test.com>',
@@ -36,7 +28,6 @@ jest.mock('@/lib/public.env', () => ({
 
 import {
   validateFormData,
-  validateEmail,
   sendEmail,
   requestFromSource,
   rateLimit,
@@ -93,54 +84,6 @@ describe('validateFormData', () => {
     await expect(validateFormData(badData, formSchema)).rejects.toMatchObject({
       statusCode: 400,
     });
-  });
-});
-
-describe('validateEmail', () => {
-  const originalFetch = global.fetch;
-
-  afterEach(() => {
-    global.fetch = originalFetch;
-  });
-
-  it('returns null for valid email', async () => {
-    global.fetch = jest.fn().mockResolvedValue({
-      json: () => Promise.resolve({ valid: true }),
-    });
-
-    const result = await validateEmail('test@example.com');
-    expect(result).toBeNull();
-  });
-
-  it('throws when ValidKit returns an error', async () => {
-    global.fetch = jest.fn().mockResolvedValue({
-      json: () =>
-        Promise.resolve({
-          error: {
-            message: 'Invalid email',
-            code: 'INVALID_EMAIL',
-            statusCode: 400,
-          },
-        }),
-    });
-
-    await expect(validateEmail('bad@email.com')).rejects.toMatchObject({
-      statusCode: 400,
-      error: { path: 'email', message: 'Invalid email' },
-    });
-  });
-
-  it('throws 500 when API key is missing', async () => {
-    // Temporarily override the mock
-    const envModule = require('@/lib/env');
-    const original = envModule.serverEnv.VALIDKIT_API_KEY;
-    envModule.serverEnv.VALIDKIT_API_KEY = '';
-
-    await expect(validateEmail('test@example.com')).rejects.toMatchObject({
-      statusCode: 500,
-    });
-
-    envModule.serverEnv.VALIDKIT_API_KEY = original;
   });
 });
 

--- a/apps/root/src/app/api/email/contact/helpers.ts
+++ b/apps/root/src/app/api/email/contact/helpers.ts
@@ -1,14 +1,8 @@
-import {
-  ErrorResponse,
-  FormFieldSchema,
-  RawFormData,
-  ValidKitErrorResponse,
-} from './schema';
+import { ErrorResponse, FormFieldSchema, RawFormData } from './schema';
 import { createResendClient, EMAIL_FROM, EMAIL_TO } from '@/lib/email/resend';
 import ContactNotification from '@/components/emails/ContactNotification';
 import * as yup from 'yup';
 import { ValidationError } from 'yup';
-import { serverEnv } from '@/lib/env';
 import { NextRequest } from 'next/server';
 import DOMPurify from 'isomorphic-dompurify';
 import { FORM_LIMITS } from '@/utils/constants';
@@ -77,69 +71,6 @@ export const validateFormData = async <T extends yup.AnyObject>(
         message: error.message,
       },
       statusCode: 400,
-    } as ErrorResponse;
-  }
-};
-
-/**
- * Validates email address using ValidKit API service
- *
- * Performs real-time email validation to check:
- * - Email format validity
- * - Domain existence
- * - Mailbox deliverability
- * - Disposable email detection
- *
- * @param email - Email address to validate
- * @returns Promise that resolves to null on success
- * @throws {ErrorResponse} When email is invalid or service is unavailable
- *
- * @example
- * ```typescript
- * await validateEmail("user@example.com");
- * // Throws error if email is invalid or undeliverable
- * ```
- */
-export const validateEmail = async (
-  email: string
-): Promise<ErrorResponse | null> => {
-  // Skip external email validation in development to avoid hitting API rate limits
-  if (serverEnv.NODE_ENV === 'development') return null;
-
-  if (!serverEnv.VALIDKIT_API_KEY) {
-    throw {
-      error: {
-        path: 'root.configurationError',
-        message: `Sorry, we're experiencing technical difficulties. Please try again later.`,
-      },
-      statusCode: 500,
-    } as ErrorResponse;
-  }
-
-  try {
-    const res = await fetch(serverEnv.VALIDKIT_API_URL ?? '', {
-      method: 'POST',
-      body: JSON.stringify({ email }),
-      headers: {
-        'Content-Type': 'application/json',
-        'X-API-Key': serverEnv.VALIDKIT_API_KEY ?? '',
-      },
-    });
-    const response = await res.json();
-    const { error } = response as ValidKitErrorResponse;
-
-    if (error) {
-      throw response;
-    }
-    return null;
-  } catch (e: unknown) {
-    const error = e as ValidKitErrorResponse;
-    throw {
-      error: {
-        path: 'email',
-        message: error.error.message,
-      },
-      statusCode: error.error.statusCode,
     } as ErrorResponse;
   }
 };
@@ -280,9 +211,6 @@ export const requestFromSource = async (
 export const rateLimit = async (
   req: NextRequest
 ): Promise<ErrorResponse | null> => {
-  // Skip rate limiting in development to avoid blocking during testing
-  if (serverEnv.NODE_ENV === 'development') return null;
-
   const ip =
     req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
     req.headers.get('x-real-ip');

--- a/apps/root/src/app/api/email/contact/route.test.ts
+++ b/apps/root/src/app/api/email/contact/route.test.ts
@@ -6,14 +6,12 @@ import { NextRequest } from 'next/server';
 const mockRateLimit = jest.fn();
 const mockRequestFromSource = jest.fn();
 const mockValidateFormData = jest.fn();
-const mockValidateEmail = jest.fn();
 const mockSendEmail = jest.fn();
 
 jest.mock('./helpers', () => ({
   rateLimit: (...args: unknown[]) => mockRateLimit(...args),
   requestFromSource: (...args: unknown[]) => mockRequestFromSource(...args),
   validateFormData: (...args: unknown[]) => mockValidateFormData(...args),
-  validateEmail: (...args: unknown[]) => mockValidateEmail(...args),
   sendEmail: (...args: unknown[]) => mockSendEmail(...args),
 }));
 
@@ -52,7 +50,6 @@ describe('POST /api/email/contact', () => {
     mockRateLimit.mockResolvedValue(null);
     mockRequestFromSource.mockResolvedValue(null);
     mockValidateFormData.mockResolvedValue(null);
-    mockValidateEmail.mockResolvedValue(null);
     mockSendEmail.mockResolvedValue(null);
   });
 
@@ -78,7 +75,6 @@ describe('POST /api/email/contact', () => {
       '/about'
     );
     expect(mockValidateFormData).toHaveBeenCalledWith(validBody, {});
-    expect(mockValidateEmail).toHaveBeenCalledWith(validBody.email);
     expect(mockSendEmail).toHaveBeenCalledWith(validBody);
   });
 

--- a/apps/root/src/app/api/email/contact/route.ts
+++ b/apps/root/src/app/api/email/contact/route.ts
@@ -3,7 +3,6 @@ import { ErrorResponse, formSchema, SuccessResponse } from './schema';
 import {
   requestFromSource,
   sendEmail,
-  validateEmail,
   validateFormData,
   rateLimit,
 } from './helpers';
@@ -30,7 +29,6 @@ export async function POST(
     await rateLimit(request);
     await requestFromSource(request, ABOUT_LINK.href);
     await validateFormData(data, formSchema);
-    await validateEmail(data.email);
     await sendEmail(data);
 
     const successResponse: SuccessResponse = {

--- a/apps/root/src/app/api/email/contact/schema.ts
+++ b/apps/root/src/app/api/email/contact/schema.ts
@@ -49,19 +49,6 @@ export type ErrorResponse = {
   retryAfter?: number;
 };
 
-/**
- * ValidKit email validation service error response format
- *
- * Used when email validation fails via the ValidKit API.
- */
-export type ValidKitErrorResponse = {
-  error: {
-    message: string;
-    code: string;
-    statusCode: 400;
-  };
-};
-
 /** Success response from the contact form API */
 export type SuccessResponse = {
   statusCode: 200;

--- a/apps/root/src/components/MainContent.tsx
+++ b/apps/root/src/components/MainContent.tsx
@@ -3,5 +3,9 @@ export default function MainContent({
 }: {
   children: React.ReactNode;
 }) {
-  return <main id='main-content'>{children}</main>;
+  return (
+    <main id='main-content' tabIndex={-1}>
+      {children}
+    </main>
+  );
 }

--- a/apps/root/src/components/Nav/Links.spec.tsx
+++ b/apps/root/src/components/Nav/Links.spec.tsx
@@ -10,6 +10,13 @@ import {
   PROJECTS_LINK,
 } from '@/utils/constants';
 
+const mockPush = jest.fn();
+
+// Mock next/navigation
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush, prefetch: jest.fn() }),
+}));
+
 // Mock next/link
 jest.mock('next/link', () => {
   const React = require('react');
@@ -98,10 +105,10 @@ describe('NavLinks', () => {
     expect(projectsLink).toHaveAttribute('aria-current', 'page');
   });
 
-  test('calls handleClick after link click with delay', async () => {
-    jest.useFakeTimers();
-    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+  test('calls handleClick and router.push immediately on link click in mobile context', async () => {
+    const user = userEvent.setup();
     const handleClick = jest.fn();
+    mockPush.mockReset();
 
     render(<NavLinks pathname='/' handleClick={handleClick} />);
     const aboutLink = screen.getByRole('menuitem', {
@@ -110,13 +117,8 @@ describe('NavLinks', () => {
 
     await user.click(aboutLink);
 
-    expect(handleClick).not.toHaveBeenCalled();
-
-    jest.advanceTimersByTime(150);
-
     expect(handleClick).toHaveBeenCalledTimes(1);
-
-    jest.useRealTimers();
+    expect(mockPush).toHaveBeenCalledWith('/about');
   });
 
   test('renders links with correct href values', () => {

--- a/apps/root/src/components/Nav/Links.tsx
+++ b/apps/root/src/components/Nav/Links.tsx
@@ -3,6 +3,7 @@
 import Button from '@/components/Button';
 import { analytics } from '@/lib/analytics';
 import { NAV_LINKS } from '@/utils/constants';
+import { useRouter } from 'next/navigation';
 
 export default function NavLinks({
   pathname,
@@ -11,11 +12,23 @@ export default function NavLinks({
   pathname?: string;
   handleClick?: () => void;
 }) {
-  const handleLinkClick = (label: string) => {
+  const router = useRouter();
+
+  const handleLinkClick = (
+    e: React.MouseEvent,
+    label: string,
+    href: string
+  ) => {
     analytics.navClick(label);
-    setTimeout(() => {
-      handleClick?.();
-    }, 150);
+    if (handleClick) {
+      // Mobile modal context: navigate programmatically because the
+      // HeadlessUI Dialog renders in a portal outside the TransitionRouter's
+      // DOM subtree, preventing next-transition-router from intercepting
+      // the Link click. router.push() triggers the transition via auto mode.
+      e.preventDefault();
+      handleClick();
+      router.push(href);
+    }
   };
 
   return (
@@ -31,7 +44,9 @@ export default function NavLinks({
               size='sm'
               as='link'
               href={link.href}
-              onClick={() => handleLinkClick(link.label)}
+              onClick={(e: React.MouseEvent) =>
+                handleLinkClick(e, link.label, link.href)
+              }
               highlighted={pathname === link.href}
               role='menuitem'
               aria-current={pathname === link.href ? 'page' : undefined}

--- a/apps/root/src/lib/env.ts
+++ b/apps/root/src/lib/env.ts
@@ -1,9 +1,5 @@
-const VALIDKIT_API_KEY = process.env.VALIDKIT_API_KEY;
-const VALIDKIT_API_URL = process.env.VALIDKIT_API_URL;
 const NODE_ENV = process.env.NODE_ENV ?? 'development';
 
 export const serverEnv = {
-  VALIDKIT_API_KEY,
-  VALIDKIT_API_URL,
   NODE_ENV,
 };


### PR DESCRIPTION
## Summary
- **Rate limiting**: Removed `NODE_ENV === 'development'` skip so rate limiting works against the dev server (fixes E2E 429 test)
- **Email in tests**: Set `RESEND_API_KEY=''` in Playwright webServer env and use invalid payload in rate limit test to prevent real emails from being sent during E2E runs
- **Skip link a11y**: Added `tabindex="-1"` to `MainContent` so the skip link target is focusable (WCAG best practice)
- **Mobile nav**: Fixed navigation from mobile menu — HeadlessUI Dialog renders in a portal outside the TransitionRouter's DOM, so nav links now use `router.push()` programmatically instead of relying on `next-transition-router` Link
- **Cleanup**: Removed ValidKit email validation and related env/types/tests

## Test plan
- [x] All 799 unit tests pass (89 suites)
- [ ] E2E: rate limit test returns 429 on 6th request
- [ ] E2E: skip link focuses `#main-content`
- [ ] E2E: mobile menu About link navigates to `/about`
- [ ] No real emails sent during E2E runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)