### PR TITLE
fix(scan-service): prevent Chromium fork errors on Railway

### DIFF
--- a/apps/audit-scan-service/src/scanner.ts
+++ b/apps/audit-scan-service/src/scanner.ts
@@ -31,6 +31,10 @@ export async function runScan(
       '--disable-extensions',
       '--disable-background-networking',
       '--disable-crash-reporter',
+      '--disable-breakpad',
+      '--disable-software-rasterizer',
+      '--single-process',
+      '--no-zygote',
     ],
   });
 


### PR DESCRIPTION
## Summary
- Add `--single-process`, `--no-zygote`, `--disable-breakpad`, and `--disable-software-rasterizer` Chromium flags to prevent `Cannot fork` / `posix_spawn` crashpad handler errors in Railway's constrained container environment

## Test plan
- [ ] Redeploy scan service on Railway
- [ ] Run a scan and verify Chromium launches successfully
- [ ] Confirm scan results are returned correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)