### PR TITLE
feat: loop post pagination and allow Storybook iframes

### DIFF
--- a/apps/root/src/components/kit/PostPagination.tsx
+++ b/apps/root/src/components/kit/PostPagination.tsx
@@ -8,43 +8,33 @@ interface PostPaginationProps {
 export function PostPagination({ pagination }: PostPaginationProps) {
   const { prev, next } = pagination;
 
-  if (!prev && !next) return null;
-
   return (
     <nav
       aria-label='Post navigation'
       className='flex flex-col sm:flex-row justify-between items-stretch sm:items-center gap-4 mt-10 pt-8 border-t border-border'
     >
-      {prev ? (
-        <Button
-          as='link'
-          href={prev.href}
-          variant='outline'
-          size='sm'
-          aria-label={`Previous: ${prev.title}`}
-          className='flex flex-col items-start gap-0.5 min-w-0 max-w-[48%]'
-        >
-          <span className='text-xs text-text-tertiary'>Previous</span>
-          <span className='truncate w-full text-left'>{prev.title}</span>
-        </Button>
-      ) : (
-        <span />
-      )}
-      {next ? (
-        <Button
-          as='link'
-          href={next.href}
-          variant='outline'
-          size='sm'
-          aria-label={`Next: ${next.title}`}
-          className='flex flex-col items-end gap-0.5 min-w-0 max-w-[48%] sm:ml-auto'
-        >
-          <span className='text-xs text-text-tertiary'>Next</span>
-          <span className='truncate w-full text-right'>{next.title}</span>
-        </Button>
-      ) : (
-        <span />
-      )}
+      <Button
+        as='link'
+        href={prev.href}
+        variant='outline'
+        size='sm'
+        aria-label={`Previous: ${prev.title}`}
+        className='flex flex-col items-start gap-0.5 min-w-0 max-w-[48%]'
+      >
+        <span className='text-xs text-text-tertiary'>Previous</span>
+        <span className='truncate w-full text-left'>{prev.title}</span>
+      </Button>
+      <Button
+        as='link'
+        href={next.href}
+        variant='outline'
+        size='sm'
+        aria-label={`Next: ${next.title}`}
+        className='flex flex-col items-end gap-0.5 min-w-0 max-w-[48%] sm:ml-auto'
+      >
+        <span className='text-xs text-text-tertiary'>Next</span>
+        <span className='truncate w-full text-right'>{next.title}</span>
+      </Button>
     </nav>
   );
 }

--- a/apps/root/src/data/contentOrder.ts
+++ b/apps/root/src/data/contentOrder.ts
@@ -16,8 +16,8 @@ export interface PaginationLink {
 }
 
 export interface PostPaginationData {
-  prev: PaginationLink | undefined;
-  next: PaginationLink | undefined;
+  prev: PaginationLink;
+  next: PaginationLink;
 }
 
 /**
@@ -66,23 +66,21 @@ function buildPaginationData(
 ): PostPaginationData {
   const index = orderedSlugs.indexOf(slug);
 
-  const prev =
-    index > 0
-      ? {
-          slug: orderedSlugs[index - 1],
-          title: records[orderedSlugs[index - 1]].title,
-          href: `${basePath.href}/${orderedSlugs[index - 1]}`,
-        }
-      : undefined;
+  const len = orderedSlugs.length;
+  const prevIndex = (index - 1 + len) % len;
+  const nextIndex = (index + 1) % len;
 
-  const next =
-    index < orderedSlugs.length - 1
-      ? {
-          slug: orderedSlugs[index + 1],
-          title: records[orderedSlugs[index + 1]].title,
-          href: `${basePath.href}/${orderedSlugs[index + 1]}`,
-        }
-      : undefined;
+  const prev = {
+    slug: orderedSlugs[prevIndex],
+    title: records[orderedSlugs[prevIndex]].title,
+    href: `${basePath.href}/${orderedSlugs[prevIndex]}`,
+  };
+
+  const next = {
+    slug: orderedSlugs[nextIndex],
+    title: records[orderedSlugs[nextIndex]].title,
+    href: `${basePath.href}/${orderedSlugs[nextIndex]}`,
+  };
 
   return { prev, next };
 }

--- a/apps/root/src/proxy.ts
+++ b/apps/root/src/proxy.ts
@@ -3,6 +3,7 @@ import {
   allowedImageOrigins,
   HCAPTCHA_URL,
   HCAPTCHA_ASSETS_URL,
+  STORYBOOK_URL,
 } from '@/utils/constants';
 import { NextRequest, NextResponse } from 'next/server';
 import { isProduction } from '@/utils/helpers';
@@ -19,7 +20,7 @@ export function proxy(request: NextRequest) {
     object-src 'none';
     base-uri 'self';
     form-action 'self';
-    frame-src ${HCAPTCHA_URL} ${HCAPTCHA_ASSETS_URL};
+    frame-src ${HCAPTCHA_URL} ${HCAPTCHA_ASSETS_URL} ${STORYBOOK_URL};
     frame-ancestors 'none';${
       request.nextUrl.protocol === 'https:'
         ? `\n    upgrade-insecure-requests;`


### PR DESCRIPTION
## Summary
- Post pagination now loops around: last item's "Next" links to the first, first item's "Previous" links to the last (modulo arithmetic)
- Simplified `PostPagination` component by removing conditional rendering (prev/next are always defined)
- Added Storybook URL (`https://ui.danieljoffe.com`) to CSP `frame-src` directive to fix blocked iframes on preview

## Test plan
- [ ] Navigate to the first project/experience post and verify "Previous" links to the last post
- [ ] Navigate to the last project/experience post and verify "Next" links to the first post
- [ ] Verify Storybook iframes load on the preview URL without CSP errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)