### PR TITLE
fix(ci): use Vercel prebuilt output for Storybook deploy

### DIFF
--- a/.github/actions/vercel-deploy-storybook/action.yml
+++ b/.github/actions/vercel-deploy-storybook/action.yml
@@ -42,6 +42,21 @@ runs:
       shell: bash
       run: npm i -g vercel@50.15.1
 
+    - name: Prepare Vercel prebuilt output
+      shell: bash
+      run: |
+        ENV_FLAG=""
+        if [ "${{ inputs.production }}" = "true" ]; then
+          ENV_FLAG="--environment=production"
+        fi
+        vercel pull --yes $ENV_FLAG --token=${{ inputs.vercel-token }} --cwd=libs/shared/ui
+        mkdir -p libs/shared/ui/.vercel/output/static
+        cp -r libs/shared/ui/storybook-static/* libs/shared/ui/.vercel/output/static/
+        echo '{"version":3}' > libs/shared/ui/.vercel/output/config.json
+      env:
+        VERCEL_ORG_ID: ${{ inputs.vercel-org-id }}
+        VERCEL_PROJECT_ID: ${{ inputs.vercel-project-id }}
+
     - name: Deploy
       id: deploy
       shell: bash
@@ -50,7 +65,7 @@ runs:
         if [ "${{ inputs.production }}" = "true" ]; then
           PROD_FLAG="--prod"
         fi
-        url=$(vercel deploy ./libs/shared/ui/storybook-static $PROD_FLAG --token=${{ inputs.vercel-token }})
+        url=$(vercel deploy --prebuilt $PROD_FLAG --token=${{ inputs.vercel-token }} --cwd=libs/shared/ui)
         echo "url=$url" >> "$GITHUB_OUTPUT"
       env:
         VERCEL_ORG_ID: ${{ inputs.vercel-org-id }}


### PR DESCRIPTION
## Summary
- Uses Vercel Build Output API (v3) to deploy pre-built Storybook as static files
- `vercel pull` with `--cwd=` syntax (single arg, no shell splitting)
- Copies `storybook-static/` into `.vercel/output/static/` with `config.json`
- `vercel deploy --prebuilt` skips the remote build that was failing without full workspace context

## Test plan
- [ ] Verify Storybook deploy action completes successfully in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)