### PR TITLE
Syntax highlighting for MDX code blocks

### DIFF
--- a/apps/root/mdx-components.tsx
+++ b/apps/root/mdx-components.tsx
@@ -61,12 +61,22 @@ export function useMDXComponents(components: MDXComponents): MDXComponents {
         {...props}
       />
     ),
-    code: props => (
-      <code
-        className='px-1.5 py-0.5 rounded bg-surface-tertiary text-text-primary text-xs font-mono'
-        {...props}
-      />
-    ),
+    // Inline code only — rehype-pretty-code handles code blocks via
+    // [data-rehype-pretty-code-figure] styles in theme.css
+    code: ({ children, ...props }) => {
+      // rehype-pretty-code adds data-theme; skip custom styling for those
+      if ('data-theme' in props) return <code {...props}>{children}</code>;
+      return (
+        <code
+          className='px-1.5 py-0.5 rounded bg-surface-tertiary text-text-primary text-xs font-mono'
+          {...props}
+        >
+          {children}
+        </code>
+      );
+    },
+    // rehype-pretty-code wraps code blocks in <figure data-rehype-pretty-code-figure>
+    // so bare <pre> only appears for non-highlighted blocks
     pre: props => (
       <pre
         className='p-4 bg-surface-secondary rounded-lg border border-border overflow-x-auto text-sm leading-relaxed mb-4 [&>code]:p-0 [&>code]:bg-transparent [&>code]:text-sm [&>code]:rounded-none'

--- a/apps/root/next-env.d.ts
+++ b/apps/root/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import './.next/dev/types/routes.d.ts';
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/root/next.config.mjs
+++ b/apps/root/next.config.mjs
@@ -1,9 +1,12 @@
 //@ts-check
 
-const { composePlugins, withNx } = require('@nx/next');
-const { withBotId } = require('botid/next/config');
-const createMDX = require('@next/mdx');
-const bundleAnalyzer = require('@next/bundle-analyzer');
+import { composePlugins, withNx } from '@nx/next';
+import { withBotId } from 'botid/next/config';
+import createMDX from '@next/mdx';
+import bundleAnalyzer from '@next/bundle-analyzer';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
 
 const isDev = process.env.NODE_ENV === 'development';
 const isTest = process.env.NODE_ENV === 'test';
@@ -16,7 +19,22 @@ const withBundleAnalyzer = bundleAnalyzer({
   enabled: isAnalyze,
 });
 
-const withMDX = createMDX({});
+/** @type {import('rehype-pretty-code').Options} */
+const prettyCodeOptions = {
+  theme: {
+    dark: 'github-dark-dimmed',
+    light: 'github-light',
+  },
+  keepBackground: false,
+};
+
+// Pass rehype-pretty-code as a string so @next/mdx resolves it at load time.
+// This keeps loader options JSON-serializable for both webpack and Turbopack.
+const withMDX = createMDX({
+  options: {
+    rehypePlugins: [['rehype-pretty-code', prettyCodeOptions]],
+  },
+});
 
 /**
  * @type {import('@nx/next/plugins/with-nx').WithNxOptions}
@@ -285,7 +303,7 @@ const plugins = [
 ];
 
 // Injected content via Sentry wizard below
-const { withSentryConfig } = require('@sentry/nextjs');
+const { withSentryConfig } = await import('@sentry/nextjs');
 
 const nextConfigWithPlugins = composePlugins(...plugins)(nextConfig);
 
@@ -327,4 +345,4 @@ const finalConfig =
         },
       });
 
-module.exports = withBotId(finalConfig);
+export default withBotId(finalConfig);

--- a/apps/root/public/sw.js
+++ b/apps/root/public/sw.js
@@ -76,7 +76,11 @@ function getCacheStrategy(request) {
     url.pathname.startsWith('/_next/image') ||
     url.pathname.match(/\.(jpg|jpeg|png|gif|webp|avif|svg|ico)$/i)
   ) {
-    return { cache: IMAGE_CACHE, strategy: 'cache-first', limit: IMAGE_CACHE_LIMIT };
+    return {
+      cache: IMAGE_CACHE,
+      strategy: 'cache-first',
+      limit: IMAGE_CACHE_LIMIT,
+    };
   }
 
   // Static assets (JS, CSS) - skip SW caching
@@ -96,11 +100,19 @@ function getCacheStrategy(request) {
     request.mode === 'navigate' ||
     request.headers.get('accept')?.includes('text/html')
   ) {
-    return { cache: DYNAMIC_CACHE, strategy: 'stale-while-revalidate', limit: DYNAMIC_CACHE_LIMIT };
+    return {
+      cache: DYNAMIC_CACHE,
+      strategy: 'stale-while-revalidate',
+      limit: DYNAMIC_CACHE_LIMIT,
+    };
   }
 
   // Default - network first
-  return { cache: DYNAMIC_CACHE, strategy: 'network-first', limit: DYNAMIC_CACHE_LIMIT };
+  return {
+    cache: DYNAMIC_CACHE,
+    strategy: 'network-first',
+    limit: DYNAMIC_CACHE_LIMIT,
+  };
 }
 
 // Fetch event - apply caching strategies
@@ -119,17 +131,19 @@ self.addEventListener('fetch', event => {
         caches.match(event.request).then(cached => {
           if (cached) return cached;
 
-          return fetch(event.request).then(response => {
-            if (!response || response.status !== 200) return response;
+          return fetch(event.request)
+            .then(response => {
+              if (!response || response.status !== 200) return response;
 
-            const responseClone = response.clone();
-            caches.open(cache).then(c => {
-              c.put(event.request, responseClone);
-              if (limit) limitCacheSize(cache, limit);
-            });
+              const responseClone = response.clone();
+              caches.open(cache).then(c => {
+                c.put(event.request, responseClone);
+                if (limit) limitCacheSize(cache, limit);
+              });
 
-            return response;
-          }).catch(() => caches.match(event.request));
+              return response;
+            })
+            .catch(() => caches.match(event.request));
         })
       );
       break;

--- a/apps/root/src/data/content/projects/contact-form-case-study.mdx
+++ b/apps/root/src/data/content/projects/contact-form-case-study.mdx
@@ -54,7 +54,7 @@ A contact form on a public portfolio site is an open invitation for abuse. Bots 
 
 The form uses `react-hook-form` with a `yupResolver` for instant feedback. The same Yup schema validates on both client and server — one source of truth.
 
-```typescript
+```typescript title="schema.ts" {21-23}
 // schema.ts — shared between client and server
 export const formSchema = yup
   .object()
@@ -90,7 +90,7 @@ The anti-spam URL check in the message field catches a surprising amount of auto
 
 Every form input includes proper ARIA attributes for accessibility:
 
-```tsx
+```tsx title="ContactForm.tsx" /aria-invalid/ /aria-describedby/ /data-sentry-mask/
 <input
   id='name'
   aria-invalid={!!errors?.name}
@@ -107,7 +107,7 @@ The `data-sentry-mask` attribute ensures PII never reaches error tracking.
 
 A hidden `address` field that real users never see. Bots filling out every field trigger an immediate 403:
 
-```tsx
+```tsx title="ContactForm.tsx" {4}
 {
   /* Client: invisible to humans, irresistible to bots */
 }
@@ -123,7 +123,7 @@ A hidden `address` field that real users never see. Bots filling out every field
 </div>;
 ```
 
-```typescript
+```typescript title="validateFormData.ts" /address/ {3}
 // Server: checked before any other validation
 if (data?.address && data.address.length > 0) {
   throw {
@@ -139,7 +139,7 @@ The honeypot check runs outside the `try/catch` block intentionally — a filled
 
 hCaptcha is loaded dynamically and only when the form scrolls into view, keeping it off the critical path:
 
-```tsx
+```tsx title="ContactForm.tsx" {1-3} /rootMargin/
 const HCaptcha = dynamic(() => import('@hcaptcha/react-hcaptcha'), {
   ssr: false,
   loading: () => <LoadingDots />,
@@ -167,7 +167,7 @@ The `rootMargin: '200px'` starts loading the captcha before the user actually sc
 
 IP-based throttling with an in-memory store. Five requests per IP within a 15-minute window:
 
-```typescript
+```typescript title="rateLimit.ts" {13-20}
 const globalStore = globalThis as typeof globalThis & {
   __apiRateLimitStore?: Map<string, RateLimitEntry>;
   __apiRateLimitLastCleanup?: number;
@@ -197,7 +197,7 @@ Expired entries are purged every 5 minutes to prevent unbounded memory growth. T
 
 Every text field runs through DOMPurify before schema validation:
 
-```typescript
+```typescript title="validateFormData.ts" /DOMPurify.sanitize/ /stripUnknown: true/
 const sanitized: RawFormData = {
   name: DOMPurify.sanitize(data.name),
   email: DOMPurify.sanitize(data.email),
@@ -215,7 +215,7 @@ await schema.validate(sanitized, { stripUnknown: true });
 
 The API route verifies the request originated from the contact page via the referer header:
 
-```typescript
+```typescript title="requestFromSource.ts" /referer/
 export const requestFromSource = async (req: NextRequest, source: string) => {
   const referer = req.headers.get('referer');
   if (!referer) throw errorResponse;
@@ -229,7 +229,7 @@ export const requestFromSource = async (req: NextRequest, source: string) => {
 
 Each security layer is a composable middleware. The route handler reads like a checklist:
 
-```typescript
+```typescript title="route.ts" {5-8}
 export async function POST(request: NextRequest) {
   const data = await request.json();
 

--- a/apps/root/src/styles/theme.css
+++ b/apps/root/src/styles/theme.css
@@ -242,7 +242,8 @@
     margin-bottom: 0;
   }
 
-  code {
+  /* Inline code only — code blocks are styled by rehype-pretty-code below */
+  code:not([data-theme]) {
     font-family: var(--font-mono);
     font-size: 0.875rem;
     line-height: 1.5;
@@ -290,6 +291,83 @@
 }
 ::-webkit-scrollbar-thumb:hover {
   background: var(--color-text-tertiary);
+}
+
+/* ─── rehype-pretty-code ─── */
+
+/* Code block figure wrapper */
+[data-rehype-pretty-code-figure] pre {
+  @apply p-4 rounded-lg border border-border overflow-x-auto text-sm leading-relaxed mb-4;
+}
+
+[data-rehype-pretty-code-figure] code {
+  @apply font-mono text-sm;
+  font-family: var(--font-mono);
+  background: transparent;
+  padding: 0;
+  border-radius: 0;
+  counter-reset: line;
+}
+
+[data-rehype-pretty-code-figure] [data-line] {
+  @apply px-4 border-l-2 border-transparent;
+}
+
+/* Highlighted lines */
+[data-rehype-pretty-code-figure] [data-highlighted-line] {
+  @apply bg-brand-50/50 border-l-2 border-brand-400;
+}
+
+.dark [data-rehype-pretty-code-figure] [data-highlighted-line] {
+  @apply bg-brand-900/30 border-brand-500;
+}
+
+/* Highlighted words/chars */
+[data-highlighted-chars] {
+  @apply bg-brand-100 rounded px-1 py-0.5;
+}
+
+.dark [data-highlighted-chars] {
+  @apply bg-brand-800/50;
+}
+
+/* Dual-theme colors — Shiki CSS vars live on individual <span> elements.
+   Use &:is(.dark *) pattern matching @custom-variant dark to survive cssnano. */
+[data-rehype-pretty-code-figure] span:not(:is(.dark *)) {
+  color: var(--shiki-light);
+}
+
+[data-rehype-pretty-code-figure] span:is(.dark *) {
+  color: var(--shiki-dark);
+}
+
+/* Code block title (```ts title="filename.ts") */
+[data-rehype-pretty-code-title] {
+  @apply text-xs font-mono text-text-tertiary bg-surface-tertiary border border-b-0 border-border rounded-t-lg px-4 py-2;
+}
+
+[data-rehype-pretty-code-title] + pre {
+  @apply rounded-t-none;
+}
+
+/* Line numbers (opt-in via ```ts showLineNumbers) */
+code[data-line-numbers] > [data-line]::before {
+  counter-increment: line;
+  content: counter(line);
+  @apply inline-block w-4 mr-6 text-right text-text-tertiary;
+}
+
+code[data-line-numbers-max-digits='2'] > [data-line]::before {
+  @apply w-8;
+}
+
+code[data-line-numbers-max-digits='3'] > [data-line]::before {
+  @apply w-12;
+}
+
+/* Inline code within prose (rehype-pretty-code wraps inline code too) */
+[data-rehype-pretty-code-figure] > code[data-theme] {
+  @apply text-xs rounded px-1.5 py-0.5;
 }
 
 /* Reduced motion */

--- a/package.json
+++ b/package.json
@@ -67,8 +67,10 @@
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "react-hook-form": "7.71.2",
+    "rehype-pretty-code": "^0.14.3",
     "resend": "6.9.3",
     "schema-dts": "^1.1.5",
+    "shiki": "^4.0.2",
     "tailwind-merge": "3.5.0",
     "yup": "^1.7.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5572,6 +5572,70 @@
     "@sentry/bundler-plugin-core" "5.1.1"
     uuid "^9.0.0"
 
+"@shikijs/core@4.0.2":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@shikijs/core/-/core-4.0.2.tgz#386a00acc6965ced582e9066bfb237de7ee99174"
+  integrity sha512-hxT0YF4ExEqB8G/qFdtJvpmHXBYJ2lWW7qTHDarVkIudPFE6iCIrqdgWxGn5s+ppkGXI0aEGlibI0PAyzP3zlw==
+  dependencies:
+    "@shikijs/primitive" "4.0.2"
+    "@shikijs/types" "4.0.2"
+    "@shikijs/vscode-textmate" "^10.0.2"
+    "@types/hast" "^3.0.4"
+    hast-util-to-html "^9.0.5"
+
+"@shikijs/engine-javascript@4.0.2":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@shikijs/engine-javascript/-/engine-javascript-4.0.2.tgz#d49b766c23fb6e71c19b9a797ff5357c8a61db5e"
+  integrity sha512-7PW0Nm49DcoUIQEXlJhNNBHyoGMjalRETTCcjMqEaMoJRLljy1Bi/EGV3/qLBgLKQejdspiiYuHGQW6dX94Nag==
+  dependencies:
+    "@shikijs/types" "4.0.2"
+    "@shikijs/vscode-textmate" "^10.0.2"
+    oniguruma-to-es "^4.3.4"
+
+"@shikijs/engine-oniguruma@4.0.2":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@shikijs/engine-oniguruma/-/engine-oniguruma-4.0.2.tgz#41ed06adcc4a4e6f49e05643dfe0d772dbb19c2b"
+  integrity sha512-UpCB9Y2sUKlS9z8juFSKz7ZtysmeXCgnRF0dlhXBkmQnek7lAToPte8DkxmEYGNTMii72zU/lyXiCB6StuZeJg==
+  dependencies:
+    "@shikijs/types" "4.0.2"
+    "@shikijs/vscode-textmate" "^10.0.2"
+
+"@shikijs/langs@4.0.2":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@shikijs/langs/-/langs-4.0.2.tgz#1ac31a223d74729cf230441f9bb7d7975384101f"
+  integrity sha512-KaXby5dvoeuZzN0rYQiPMjFoUrz4hgwIE+D6Du9owcHcl6/g16/yT5BQxSW5cGt2MZBz6Hl0YuRqf12omRfUUg==
+  dependencies:
+    "@shikijs/types" "4.0.2"
+
+"@shikijs/primitive@4.0.2":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@shikijs/primitive/-/primitive-4.0.2.tgz#4efa1efab1b828c20563c2097d2effa5ac79bf04"
+  integrity sha512-M6UMPrSa3fN5ayeJwFVl9qWofl273wtK1VG8ySDZ1mQBfhCpdd8nEx7nPZ/tk7k+TYcpqBZzj/AnwxT9lO+HJw==
+  dependencies:
+    "@shikijs/types" "4.0.2"
+    "@shikijs/vscode-textmate" "^10.0.2"
+    "@types/hast" "^3.0.4"
+
+"@shikijs/themes@4.0.2":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@shikijs/themes/-/themes-4.0.2.tgz#24c5c059e89a8e7630fb40a240bc6b5a336bb080"
+  integrity sha512-mjCafwt8lJJaVSsQvNVrJumbnnj1RI8jbUKrPKgE6E3OvQKxnuRoBaYC51H4IGHePsGN/QtALglWBU7DoKDFnA==
+  dependencies:
+    "@shikijs/types" "4.0.2"
+
+"@shikijs/types@4.0.2":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@shikijs/types/-/types-4.0.2.tgz#75180a19acf124b37f48b53a9e6373de2e2e4f28"
+  integrity sha512-qzbeRooUTPnLE+sHD/Z8DStmaDgnbbc/pMrU203950aRqjX/6AFHeDYT+j00y2lPdz0ywJKx7o/7qnqTivtlXg==
+  dependencies:
+    "@shikijs/vscode-textmate" "^10.0.2"
+    "@types/hast" "^3.0.4"
+
+"@shikijs/vscode-textmate@^10.0.2":
+  version "10.0.2"
+  resolved "https://registry.yarnpkg.com/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz#a90ab31d0cc1dfb54c66a69e515bf624fa7b2224"
+  integrity sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==
+
 "@sinclair/typebox@^0.27.8":
   version "0.27.8"
   resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.27.8.tgz#6667fac16c436b5434a387a34dedb013198f6e6e"
@@ -6474,7 +6538,7 @@
     "@types/express-serve-static-core" "^5.0.0"
     "@types/serve-static" "^2"
 
-"@types/hast@^3.0.0":
+"@types/hast@^3.0.0", "@types/hast@^3.0.4":
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/@types/hast/-/hast-3.0.4.tgz#1d6b39993b82cea6ad783945b0508c25903e15aa"
   integrity sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==
@@ -11502,6 +11566,39 @@ hasown@^2.0.2:
   dependencies:
     function-bind "^1.1.2"
 
+hast-util-from-html@^2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/hast-util-from-html/-/hast-util-from-html-2.0.3.tgz#485c74785358beb80c4ba6346299311ac4c49c82"
+  integrity sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    devlop "^1.1.0"
+    hast-util-from-parse5 "^8.0.0"
+    parse5 "^7.0.0"
+    vfile "^6.0.0"
+    vfile-message "^4.0.0"
+
+hast-util-from-parse5@^8.0.0:
+  version "8.0.3"
+  resolved "https://registry.yarnpkg.com/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz#830a35022fff28c3fea3697a98c2f4cc6b835a2e"
+  integrity sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    "@types/unist" "^3.0.0"
+    devlop "^1.0.0"
+    hastscript "^9.0.0"
+    property-information "^7.0.0"
+    vfile "^6.0.0"
+    vfile-location "^5.0.0"
+    web-namespaces "^2.0.0"
+
+hast-util-parse-selector@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz#352879fa86e25616036037dd8931fb5f34cb4a27"
+  integrity sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==
+  dependencies:
+    "@types/hast" "^3.0.0"
+
 hast-util-to-estree@^3.0.0:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/hast-util-to-estree/-/hast-util-to-estree-3.1.3.tgz#e654c1c9374645135695cc0ab9f70b8fcaf733d7"
@@ -11524,6 +11621,23 @@ hast-util-to-estree@^3.0.0:
     unist-util-position "^5.0.0"
     zwitch "^2.0.0"
 
+hast-util-to-html@^9.0.5:
+  version "9.0.5"
+  resolved "https://registry.yarnpkg.com/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz#ccc673a55bb8e85775b08ac28380f72d47167005"
+  integrity sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    "@types/unist" "^3.0.0"
+    ccount "^2.0.0"
+    comma-separated-tokens "^2.0.0"
+    hast-util-whitespace "^3.0.0"
+    html-void-elements "^3.0.0"
+    mdast-util-to-hast "^13.0.0"
+    property-information "^7.0.0"
+    space-separated-tokens "^2.0.0"
+    stringify-entities "^4.0.0"
+    zwitch "^2.0.4"
+
 hast-util-to-jsx-runtime@^2.0.0:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz#ff31897aae59f62232e21594eac7ef6b63333e98"
@@ -11545,12 +11659,30 @@ hast-util-to-jsx-runtime@^2.0.0:
     unist-util-position "^5.0.0"
     vfile-message "^4.0.0"
 
+hast-util-to-string@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/hast-util-to-string/-/hast-util-to-string-3.0.1.tgz#a4f15e682849326dd211c97129c94b0c3e76527c"
+  integrity sha512-XelQVTDWvqcl3axRfI0xSeoVKzyIFPwsAGSLIsKdJKQMXDYJS4WYrBNF/8J7RdhIcFI2BOHgAifggsvsxp/3+A==
+  dependencies:
+    "@types/hast" "^3.0.0"
+
 hast-util-whitespace@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz#7778ed9d3c92dd9e8c5c8f648a49c21fc51cb621"
   integrity sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==
   dependencies:
     "@types/hast" "^3.0.0"
+
+hastscript@^9.0.0:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/hastscript/-/hastscript-9.0.1.tgz#dbc84bef6051d40084342c229c451cd9dc567dff"
+  integrity sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    comma-separated-tokens "^2.0.0"
+    hast-util-parse-selector "^4.0.0"
+    property-information "^7.0.0"
+    space-separated-tokens "^2.0.0"
 
 he@^1.2.0:
   version "1.2.0"
@@ -11615,6 +11747,11 @@ html-to-text@^9.0.5:
     dom-serializer "^2.0.0"
     htmlparser2 "^8.0.2"
     selderee "^0.11.0"
+
+html-void-elements@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/html-void-elements/-/html-void-elements-3.0.0.tgz#fc9dbd84af9e747249034d4d62602def6517f1d7"
+  integrity sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==
 
 htmlparser2@^8.0.2:
   version "8.0.2"
@@ -15123,6 +15260,20 @@ onetime@^7.0.0:
   dependencies:
     mimic-function "^5.0.0"
 
+oniguruma-parser@^0.12.1:
+  version "0.12.1"
+  resolved "https://registry.yarnpkg.com/oniguruma-parser/-/oniguruma-parser-0.12.1.tgz#82ba2208d7a2b69ee344b7efe0ae930c627dcc4a"
+  integrity sha512-8Unqkvk1RYc6yq2WBYRj4hdnsAxVze8i7iPfQr8e4uSP3tRv0rpZcbGUDvxfQQcdwHt/e9PrMvGCsa8OqG9X3w==
+
+oniguruma-to-es@^4.3.4:
+  version "4.3.5"
+  resolved "https://registry.yarnpkg.com/oniguruma-to-es/-/oniguruma-to-es-4.3.5.tgz#f2571bb8c8ea52c0bec5595c48cb2d5ebb2b809c"
+  integrity sha512-Zjygswjpsewa0NLTsiizVuMQZbp0MDyM6lIt66OxsF21npUDlzpHi1Mgb/qhQdkb+dWFTzJmFbEWdvZgRho8eQ==
+  dependencies:
+    oniguruma-parser "^0.12.1"
+    regex "^6.1.0"
+    regex-recursion "^6.0.2"
+
 open@^10.0.3, open@^10.2.0:
   version "10.2.0"
   resolved "https://registry.yarnpkg.com/open/-/open-10.2.0.tgz#b9d855be007620e80b6fb05fac98141fe62db73c"
@@ -15344,6 +15495,11 @@ parse-node-version@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/parse-node-version/-/parse-node-version-1.0.1.tgz#e2b5dbede00e7fa9bc363607f53327e8b073189b"
   integrity sha512-3YHlOa/JgH6Mnpr05jP9eDG254US9ek25LyIxZlDItp2iJtwyaXQb57lBYLdT3MowkUFYEV2XXNAYIPlESvJlA==
+
+parse-numeric-range@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/parse-numeric-range/-/parse-numeric-range-1.3.0.tgz#7c63b61190d61e4d53a1197f0c83c47bb670ffa3"
+  integrity sha512-twN+njEipszzlMJd4ONUYgSfZPDxgHhT9Ahed5uTigpQn90FggW4SA/AIPq/6a149fTbE9qBEcSwE3FAEp6wQQ==
 
 parse-passwd@^1.0.0:
   version "1.0.0"
@@ -16382,6 +16538,25 @@ regenerate@^1.4.2:
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.2.tgz#b9346d8827e8f5a32f7ba29637d398b69014848a"
   integrity sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==
 
+regex-recursion@^6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/regex-recursion/-/regex-recursion-6.0.2.tgz#a0b1977a74c87f073377b938dbedfab2ea582b33"
+  integrity sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==
+  dependencies:
+    regex-utilities "^2.3.0"
+
+regex-utilities@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/regex-utilities/-/regex-utilities-2.3.0.tgz#87163512a15dce2908cf079c8960d5158ff43280"
+  integrity sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==
+
+regex@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/regex/-/regex-6.1.0.tgz#d7ce98f8ee32da7497c13f6601fca2bc4a6a7803"
+  integrity sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==
+  dependencies:
+    regex-utilities "^2.3.0"
+
 regexp.prototype.flags@^1.5.3, regexp.prototype.flags@^1.5.4:
   version "1.5.4"
   resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz#1ad6c62d44a259007e55b3970e00f746efbcaa19"
@@ -16417,6 +16592,27 @@ regjsparser@^0.12.0:
   integrity sha512-cnE+y8bz4NhMjISKbgeVJtqNbtf5QpjZP+Bslo+UqkIt9QPnX9q095eiRRASJG1/tz6dlNr6Z5NsBiWYokp6EQ==
   dependencies:
     jsesc "~3.0.2"
+
+rehype-parse@^9.0.0:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/rehype-parse/-/rehype-parse-9.0.1.tgz#9993bda129acc64c417a9d3654a7be38b2a94c20"
+  integrity sha512-ksCzCD0Fgfh7trPDxr2rSylbwq9iYDkSn8TCDmEJ49ljEUBxDVCzCHv7QNzZOfODanX4+bWQ4WZqLCRWYLfhag==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    hast-util-from-html "^2.0.0"
+    unified "^11.0.0"
+
+rehype-pretty-code@^0.14.3:
+  version "0.14.3"
+  resolved "https://registry.yarnpkg.com/rehype-pretty-code/-/rehype-pretty-code-0.14.3.tgz#0da342ec5d90247beba0b48f9ba85d24512d932b"
+  integrity sha512-Cz692FeYusTjT5cfFWLc4r7JhgC3/JlJptgUh4iffBxWxUnWW1oqbWFi7jGCeq00DYUm8yzoTnvpocaYa5x82g==
+  dependencies:
+    "@types/hast" "^3.0.4"
+    hast-util-to-string "^3.0.0"
+    parse-numeric-range "^1.3.0"
+    rehype-parse "^9.0.0"
+    unified "^11.0.5"
+    unist-util-visit "^5.0.0"
 
 rehype-recma@^1.0.0:
   version "1.0.0"
@@ -17264,6 +17460,20 @@ shell-quote@^1.8.3:
   version "1.8.3"
   resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.8.3.tgz#55e40ef33cf5c689902353a3d8cd1a6725f08b4b"
   integrity sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==
+
+shiki@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/shiki/-/shiki-4.0.2.tgz#d81495df11e1cb8a05907310a6d051e054435586"
+  integrity sha512-eAVKTMedR5ckPo4xne/PjYQYrU3qx78gtJZ+sHlXEg5IHhhoQhMfZVzetTYuaJS0L2Ef3AcCRzCHV8T0WI6nIQ==
+  dependencies:
+    "@shikijs/core" "4.0.2"
+    "@shikijs/engine-javascript" "4.0.2"
+    "@shikijs/engine-oniguruma" "4.0.2"
+    "@shikijs/langs" "4.0.2"
+    "@shikijs/themes" "4.0.2"
+    "@shikijs/types" "4.0.2"
+    "@shikijs/vscode-textmate" "^10.0.2"
+    "@types/hast" "^3.0.4"
 
 shimmer@^1.2.1:
   version "1.2.1"
@@ -18638,7 +18848,7 @@ unicode-property-aliases-ecmascript@^2.0.0:
   resolved "https://registry.yarnpkg.com/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.1.0.tgz#43d41e3be698bd493ef911077c9b131f827e8ccd"
   integrity sha512-6t3foTQI9qne+OZoVQB/8x8rk2k1eVy1gRXhV3oFQ5T6R1dqQ1xtin3XqSlx3+ATBkliTaR/hHyJBm+LVPNM8w==
 
-unified@^11.0.0:
+unified@^11.0.0, unified@^11.0.5:
   version "11.0.5"
   resolved "https://registry.yarnpkg.com/unified/-/unified-11.0.5.tgz#f66677610a5c0a9ee90cab2b8d4d66037026d9e1"
   integrity sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==
@@ -18841,6 +19051,14 @@ vary@^1, vary@^1.1.2, vary@~1.1.2:
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==
 
+vfile-location@^5.0.0:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/vfile-location/-/vfile-location-5.0.3.tgz#cb9eacd20f2b6426d19451e0eafa3d0a846225c3"
+  integrity sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==
+  dependencies:
+    "@types/unist" "^3.0.0"
+    vfile "^6.0.0"
+
 vfile-message@^4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/vfile-message/-/vfile-message-4.0.3.tgz#87b44dddd7b70f0641c2e3ed0864ba73e2ea8df4"
@@ -18973,6 +19191,11 @@ wcwidth@^1.0.0, wcwidth@^1.0.1:
   integrity sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==
   dependencies:
     defaults "^1.0.3"
+
+web-namespaces@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/web-namespaces/-/web-namespaces-2.0.1.tgz#1010ff7c650eccb2592cebeeaf9a1b253fd40692"
+  integrity sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==
 
 web-streams-polyfill@^3.0.3:
   version "3.3.3"
@@ -19560,7 +19783,7 @@ zod@^3.24.1:
   resolved "https://registry.yarnpkg.com/zod/-/zod-4.3.6.tgz#89c56e0aa7d2b05107d894412227087885ab112a"
   integrity sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==
 
-zwitch@^2.0.0:
+zwitch@^2.0.0, zwitch@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/zwitch/-/zwitch-2.0.4.tgz#c827d4b0acb76fc3e685a4c6ec2902d51070e9d7"
   integrity sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==


### PR DESCRIPTION
## Summary
- Add `rehype-pretty-code` + Shiki for build-time syntax highlighting in MDX content
- Dual-theme support (github-light / github-dark-dimmed) switches with site dark mode
- Convert `next.config.js` → `next.config.mjs` for native ESM imports
- Turbopack-compatible via string plugin references
- Line/word highlighting and file titles on contact form case study

## Test plan
- [x] Production build passes (`nx build root`)
- [x] Dev server starts without errors (`nx dev root`)
- [x] Unit tests pass (577/577)
- [x] Typecheck passes
- [x] Visual regression baselines unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)