### PR TITLE
feat: enhance JSON-LD Service schema with pricing

### DIFF
--- a/apps/root/src/data/structuredData/services.ts
+++ b/apps/root/src/data/structuredData/services.ts
@@ -6,21 +6,29 @@ const services = [
     name: 'Performance Audits & Optimization',
     description:
       'Diagnose and fix performance issues—bloated bundles, unoptimized assets, layout shifts. Includes Lighthouse audit, implementation, and metrics report.',
+    price: '5000.00',
+    timeline: '2-4 weeks',
   },
   {
     name: 'Component Libraries & Design Systems',
     description:
       'Build shared component systems that scale. Includes component audit, documented Storybook library, and contribution guidelines.',
+    price: '10000.00',
+    timeline: '4-8 weeks',
   },
   {
     name: 'CMS & Self-Serve Tooling',
     description:
       'Build tooling that gives non-technical teams full autonomy. CMS architecture, composable page builders, and team training.',
+    price: '8000.00',
+    timeline: '3-6 weeks',
   },
   {
     name: 'MVP & Product Frontend Builds',
     description:
       'Architect and build complete frontend applications with Next.js, React, TypeScript. Includes auth, state management, and deployment.',
+    price: '12000.00',
+    timeline: '4-12 weeks',
   },
 ];
 
@@ -39,13 +47,26 @@ export const servicesStructuredData = {
     '@type': 'OfferCatalog',
     name: 'Frontend Development Services',
     itemListElement: services.map((service, index) => ({
-      '@type': 'Offer',
-      itemOffered: {
-        '@type': 'Service',
-        name: service.name,
-        description: service.description,
-      },
+      '@type': 'OfferCatalog',
+      name: service.name,
       position: index + 1,
+      itemListElement: [
+        {
+          '@type': 'Offer',
+          itemOffered: {
+            '@type': 'Service',
+            name: service.name,
+            description: service.description,
+            provider: personStructuredData,
+          },
+          priceSpecification: {
+            '@type': 'UnitPriceSpecification',
+            price: service.price,
+            priceCurrency: 'USD',
+            unitText: 'project',
+          },
+        },
+      ],
     })),
   },
   url: `${DOMAIN_URL}${SERVICES_LINK.href}`,


### PR DESCRIPTION
## Summary

- Enhance existing JSON-LD Service schema with per-service pricing (`priceSpecification` with USD currency)
- Add `provider` references to individual service entries for richer search engine understanding
- Restructure `OfferCatalog` items to use nested `OfferCatalog` → `Offer` → `Service` pattern per Schema.org best practices

Closes #92

## Changes

| File | Change |
|------|--------|
| `data/structuredData/services.ts` | Add pricing, currency, and provider to each service offer |

## Test plan

- [x] No TypeScript errors (`tsc --noEmit`)
- [x] All 17 services tests pass
- [ ] Validate with [Google Rich Results Test](https://search.google.com/test/rich-results)

https://claude.ai/code/session_01B64VCBfCkRo9gRGysyTVQY