### PR TITLE
feat: add keyboard shortcut hints to UI

### DIFF
--- a/apps/root/src/app/home/AppContext.tsx
+++ b/apps/root/src/app/home/AppContext.tsx
@@ -9,6 +9,7 @@ import ModalProvider from '@/state/Modal/ModalProvider';
 import Nav from '@/components/Nav';
 import ErrorBoundary from '@/components/ErrorBoundary';
 import { ScrollToTop } from '@/components/kit';
+import KeyboardShortcuts from '@/components/KeyboardShortcuts';
 
 const Modal = dynamic(() => import('@/components/Modal'), { ssr: false });
 const ScrollToElement = dynamic(() => import('./ScrollToElement'), {
@@ -39,6 +40,7 @@ export default function AppContext({ children }: WithChildren) {
       <ErrorBoundary>{children}</ErrorBoundary>
       <Modal />
       <ScrollToTop />
+      <KeyboardShortcuts />
       <Suspense fallback={null}>
         <ScrollToElement />
       </Suspense>

--- a/apps/root/src/components/KeyboardShortcuts.tsx
+++ b/apps/root/src/components/KeyboardShortcuts.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import { useCallback } from 'react';
+import { useRouter } from 'next/navigation';
+import { useKeyboardShortcut } from '@/hooks/useKeyboardShortcut';
+import { HOME_LINK } from '@/utils/constants';
+
+export default function KeyboardShortcuts() {
+  const router = useRouter();
+
+  const goHome = useCallback(() => {
+    router.push(HOME_LINK.href);
+  }, [router]);
+
+  useKeyboardShortcut('h', goHome);
+
+  return null;
+}

--- a/apps/root/src/components/Nav/DarkModeToggle.tsx
+++ b/apps/root/src/components/Nav/DarkModeToggle.tsx
@@ -1,14 +1,23 @@
 'use client';
 
+import { useCallback } from 'react';
 import { Moon, Sun, Monitor } from 'lucide-react';
 import { cn } from '@/lib/cn';
 import { useTheme } from '@/state/Theme/ThemeProvider';
 import { analytics } from '@/lib/analytics';
+import { useKeyboardShortcut } from '@/hooks/useKeyboardShortcut';
+import { Kbd } from '@/components/kit';
 
 const options = [
   { value: 'light' as const, icon: Sun, label: 'Light' },
   { value: 'dark' as const, icon: Moon, label: 'Dark' },
   { value: 'system' as const, icon: Monitor, label: 'System' },
+];
+
+const cycleOrder: ('light' | 'dark' | 'system')[] = [
+  'light',
+  'dark',
+  'system',
 ];
 
 export default function DarkModeToggle() {
@@ -19,11 +28,20 @@ export default function DarkModeToggle() {
     setTheme(value);
   };
 
+  const cycleTheme = useCallback(() => {
+    const currentIndex = cycleOrder.indexOf(theme);
+    const next = cycleOrder[(currentIndex + 1) % cycleOrder.length];
+    analytics.themeToggle(next);
+    setTheme(next);
+  }, [theme, setTheme]);
+
+  useKeyboardShortcut('d', cycleTheme);
+
   return (
     <div
       className='inline-flex items-center gap-0.5 p-0.5 bg-surface-tertiary rounded-lg'
       role='radiogroup'
-      aria-label='Theme'
+      aria-label='Theme (press D to cycle)'
     >
       {options.map(({ value, icon: Icon, label }) => (
         <button
@@ -43,6 +61,9 @@ export default function DarkModeToggle() {
           <Icon className='h-4 w-4' aria-hidden='true' />
         </button>
       ))}
+      <span className='pl-0.5 pr-1'>
+        <Kbd>D</Kbd>
+      </span>
     </div>
   );
 }

--- a/apps/root/src/components/Nav/__tests__/DarkModeToggle.spec.tsx
+++ b/apps/root/src/components/Nav/__tests__/DarkModeToggle.spec.tsx
@@ -41,7 +41,7 @@ describe('DarkModeToggle', () => {
   test('renders radiogroup with Theme label', () => {
     render(<DarkModeToggle />);
     expect(
-      screen.getByRole('radiogroup', { name: 'Theme' })
+      screen.getByRole('radiogroup', { name: /theme/i })
     ).toBeInTheDocument();
   });
 

--- a/apps/root/src/components/kit/Kbd.tsx
+++ b/apps/root/src/components/kit/Kbd.tsx
@@ -1,0 +1,7 @@
+export function Kbd({ children }: { children: string }) {
+  return (
+    <kbd className='hidden sm:inline-flex items-center justify-center min-w-[1.25rem] h-5 px-1 text-[10px] font-mono font-medium text-text-tertiary bg-surface-tertiary border border-border rounded'>
+      {children}
+    </kbd>
+  );
+}

--- a/apps/root/src/components/kit/ScrollToTop.spec.tsx
+++ b/apps/root/src/components/kit/ScrollToTop.spec.tsx
@@ -22,19 +22,19 @@ describe('ScrollToTop', () => {
   test('renders a button with accessible label', () => {
     render(<ScrollToTop />);
     expect(
-      screen.getByRole('button', { name: 'Scroll to top' })
+      screen.getByRole('button', { name: /scroll to top/i })
     ).toBeInTheDocument();
   });
 
   test('is hidden by default (below threshold)', () => {
     render(<ScrollToTop />);
-    const button = screen.getByRole('button', { name: 'Scroll to top' });
+    const button = screen.getByRole('button', { name: /scroll to top/i });
     expect(button).toHaveClass('opacity-0', 'pointer-events-none');
   });
 
   test('becomes visible after scrolling past threshold', () => {
     render(<ScrollToTop />);
-    const button = screen.getByRole('button', { name: 'Scroll to top' });
+    const button = screen.getByRole('button', { name: /scroll to top/i });
 
     act(() => {
       Object.defineProperty(window, 'scrollY', { value: 400, writable: true });
@@ -47,7 +47,7 @@ describe('ScrollToTop', () => {
 
   test('hides again when scrolling back above threshold', () => {
     render(<ScrollToTop />);
-    const button = screen.getByRole('button', { name: 'Scroll to top' });
+    const button = screen.getByRole('button', { name: /scroll to top/i });
 
     act(() => {
       Object.defineProperty(window, 'scrollY', { value: 400, writable: true });
@@ -64,7 +64,7 @@ describe('ScrollToTop', () => {
 
   test('calls window.scrollTo with smooth behavior on click', () => {
     render(<ScrollToTop />);
-    const button = screen.getByRole('button', { name: 'Scroll to top' });
+    const button = screen.getByRole('button', { name: /scroll to top/i });
 
     act(() => {
       Object.defineProperty(window, 'scrollY', { value: 400, writable: true });

--- a/apps/root/src/components/kit/ScrollToTop.tsx
+++ b/apps/root/src/components/kit/ScrollToTop.tsx
@@ -1,8 +1,10 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { ArrowUp } from 'lucide-react';
 import { cn } from '@/lib/cn';
+import { useKeyboardShortcut } from '@/hooks/useKeyboardShortcut';
+import { Kbd } from './Kbd';
 
 const SCROLL_THRESHOLD = 300;
 
@@ -18,25 +20,29 @@ export function ScrollToTop() {
     return () => window.removeEventListener('scroll', handleScroll);
   }, []);
 
-  const scrollToTop = () => {
+  const scrollToTop = useCallback(() => {
     window.scrollTo({ top: 0, behavior: 'smooth' });
-  };
+  }, []);
+
+  useKeyboardShortcut('t', scrollToTop);
 
   return (
     <button
       onClick={scrollToTop}
-      aria-label='Scroll to top'
+      aria-label='Scroll to top (T)'
       className={cn(
         'fixed bottom-6 right-6 z-50 p-2.5 rounded-full',
         'bg-surface-elevated border border-brand-500/20 shadow-lg',
         'text-text-primary hover:border-brand-500/40 hover:bg-brand-500/5',
         'transition-all duration-200 cursor-pointer',
+        'flex items-center gap-1.5',
         visible
           ? 'opacity-100 translate-y-0'
           : 'opacity-0 translate-y-2 pointer-events-none'
       )}
     >
       <ArrowUp className='h-4 w-4' />
+      <Kbd>T</Kbd>
     </button>
   );
 }

--- a/apps/root/src/components/kit/index.ts
+++ b/apps/root/src/components/kit/index.ts
@@ -13,3 +13,4 @@ export { Pagination } from './Pagination';
 export { PostPagination } from './PostPagination';
 export { FormFieldError } from './FormFieldError';
 export { ScrollToTop } from './ScrollToTop';
+export { Kbd } from './Kbd';

--- a/apps/root/src/hooks/useKeyboardShortcut.ts
+++ b/apps/root/src/hooks/useKeyboardShortcut.ts
@@ -1,0 +1,33 @@
+import { useEffect } from 'react';
+
+/**
+ * Registers a global keyboard shortcut that fires only when no input/textarea
+ * is focused and no modifier keys are held.
+ */
+export function useKeyboardShortcut(key: string, callback: () => void) {
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      // Ignore when typing in inputs, textareas, or contenteditable
+      const target = e.target as HTMLElement;
+      if (
+        target.tagName === 'INPUT' ||
+        target.tagName === 'TEXTAREA' ||
+        target.tagName === 'SELECT' ||
+        target.isContentEditable
+      ) {
+        return;
+      }
+
+      // Ignore with modifier keys
+      if (e.metaKey || e.ctrlKey || e.altKey) return;
+
+      if (e.key.toLowerCase() === key.toLowerCase()) {
+        e.preventDefault();
+        callback();
+      }
+    };
+
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [key, callback]);
+}


### PR DESCRIPTION
## Summary
Adds keyboard shortcut hints to the UI to improve discoverability of keyboard-accessible features.

### Shortcuts added
| Key | Action | Hint location |
|-----|--------|---------------|
| `T` | Scroll to top | `<kbd>` badge on ScrollToTop button |
| `D` | Cycle theme (light → dark → system) | `<kbd>` badge next to DarkModeToggle |
| `H` | Navigate home | Global (no visible hint — too subtle to warrant one) |

### New components/hooks
- **`Kbd`** (`components/kit/Kbd.tsx`) — styled `<kbd>` badge, hidden on mobile (`hidden sm:inline-flex`)
- **`useKeyboardShortcut`** (`hooks/useKeyboardShortcut.ts`) — registers a global keydown listener that ignores inputs, textareas, contenteditable, and modifier keys
- **`KeyboardShortcuts`** (`components/KeyboardShortcuts.tsx`) — centralized global shortcuts (currently just `H` for home), rendered in AppContext

## Changes
| File | Change |
|------|--------|
| `components/kit/Kbd.tsx` | **New** — `<kbd>` badge component |
| `components/kit/index.ts` | Added `Kbd` export |
| `hooks/useKeyboardShortcut.ts` | **New** — global keyboard shortcut hook |
| `components/kit/ScrollToTop.tsx` | Added `T` shortcut via hook + `<Kbd>T</Kbd>` badge |
| `components/Nav/DarkModeToggle.tsx` | Added `D` shortcut to cycle themes + `<Kbd>D</Kbd>` badge |
| `components/KeyboardShortcuts.tsx` | **New** — global `H` shortcut for home navigation |
| `app/home/AppContext.tsx` | Renders `KeyboardShortcuts` component |
| `components/kit/ScrollToTop.spec.tsx` | Updated aria-label matcher |
| `components/Nav/__tests__/DarkModeToggle.spec.tsx` | Updated radiogroup label matcher |

## Test plan
- [ ] Press `T` on any page after scrolling — scrolls to top
- [ ] Press `D` on any page — cycles through light/dark/system theme
- [ ] Press `H` on any page — navigates to homepage
- [ ] Shortcuts do NOT fire when typing in an input, textarea, or select
- [ ] Shortcuts do NOT fire with Cmd/Ctrl/Alt held
- [ ] `<kbd>` badges visible on desktop next to ScrollToTop and DarkModeToggle
- [ ] `<kbd>` badges hidden on mobile
- [ ] Screen readers can access the shortcut info via updated aria-labels
- [ ] `tsc --noEmit` — zero errors (verified)
- [ ] `nx test root` — 594 tests pass (verified)

Closes #95

https://claude.ai/code/session_01B64VCBfCkRo9gRGysyTVQY