### PR TITLE
refactor: complete content registry migration and cleanup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,6 +85,7 @@ app/                    # Next.js App Router pages
 ├── home/               # Homepage components (Hero, Achievements, etc.)
 ├── about/              # About page
 ├── audit/              # Audit tool page
+├── blog/               # Blog pages with dynamic [slug] routes
 ├── experience/         # Experience pages with dynamic [slug] routes
 ├── projects/           # Projects pages with dynamic [slug] routes
 ├── services/           # Services page
@@ -92,8 +93,10 @@ app/                    # Next.js App Router pages
 components/             # App-specific React components
 ├── kit/                # Shared UI primitives (Spinner, ErrorAlert, PostPagination, etc.)
 data/                   # Content data and metadata
-├── content/            # MDX content files (projects/, experience/)
-├── contentOrder.ts     # Chronological ordering and prev/next pagination
+├── content/            # MDX content files (projects/, experience/, blog/)
+├── contentRegistry.ts  # Unified content registry (single data access layer)
+├── contentTypeConfig.ts # Per-type config (basePath, label, contentDir)
+├── contentOrder.ts     # Chronological ordering arrays per content type
 ├── metadata/           # Page metadata (SEO, OpenGraph)
 ├── structuredData/     # JSON-LD structured data
 ├── *Thumbnails.ts      # Thumbnail/cover records for content pages
@@ -209,19 +212,39 @@ Page-level SEO metadata is derived automatically from the MDX `metadata` export 
 - **Projects** (`data/content/projects/`): `date` is the git creation date of the file. Query with `git log --diff-filter=A --follow --format="%ai" -- <file> | tail -1`.
 - **Experience** (`data/content/experience/`): `date` is the employment start date (e.g. `2021-11-01` for "November 2021").
 
-### Content Ordering & Pagination
+### Content Registry
 
-Chronological ordering and prev/next pagination are managed in `data/contentOrder.ts`:
+All content access goes through `data/contentRegistry.ts` — the single source of truth for querying content:
+
+```ts
+import { getContentByType, getContentBySlug, getContentSlugs, getContentPagination, getAllContent } from '@/data/contentRegistry';
+
+getContentByType('project')      // All project entries in display order
+getContentBySlug('blog', slug)   // Single entry by type + slug
+getContentSlugs('experience')    // All slugs (for generateStaticParams)
+getContentPagination('blog', s)  // { prev, next } pagination links
+getAllContent()                   // Every entry across all types
+```
+
+Each entry contains: `slug`, `type`, `thumbnail`, `component`, `metadata`, `structuredData`, `readingTime`.
+
+**Detail pages** use `getPostDetailProps(type, slug)` from `lib/getPostDetailProps.ts` + `PostDetailLayout` — a ~35-line pattern shared by all content types.
+
+**Listing pages** use `getContentByType(type)` and map entries to `PostCard` props.
+
+### Content Ordering
+
+Chronological ordering arrays live in `data/contentOrder.ts`:
 
 - **`projectHistory`**: Ordered by git creation date; entries sharing the same date are sub-sorted by the chronology of the work they describe. New projects must be inserted in the correct position.
 - **`experienceHistory`**: Ordered by employment start date (earliest first). New entries must be inserted chronologically.
-- **`getProjectPagination(slug)`** / **`getExperiencePagination(slug)`**: Return `{ prev, next }` links for a given slug.
+- **`blogHistory`**: Ordered by publish date (earliest first).
 
-When adding a new post:
+### Adding a New Post
 
 1. Create the `.mdx` file with an `export const metadata` block (see format above).
-2. Add the slug constant to `data/project.ts` or `data/experience.ts`.
-3. Add the thumbnail record to `projectThumbnails.ts` or `experienceThumbnails.ts`.
+2. Add the slug constant to `data/project.ts`, `data/experience.ts`, or `data/blog.ts`.
+3. Add the thumbnail record to `projectThumbnails.ts`, `experienceThumbnails.ts`, or `blogThumbnails.ts`.
 4. Import the MDX component **and metadata** in the corresponding `data/content/*/index.ts`.
 5. Insert the slug into the correct position in `contentOrder.ts`.
 6. Add structured data in `data/structuredData/`. (Page metadata is auto-generated from the MDX `metadata` export.)

--- a/apps/root/src/app/blog/[slug]/page.tsx
+++ b/apps/root/src/app/blog/[slug]/page.tsx
@@ -1,24 +1,23 @@
 import { redirect } from 'next/navigation';
-import { AllowedBlogSlugs, SlugPageProps } from '@/types/base';
+import { SlugPageProps } from '@/types/base';
 import { BLOG_LINK } from '@/utils/constants';
-import { blogMdxMetadata } from '@/data/content/blog';
-import { blogPageSlugs } from '@/data/blog';
+import { getContentBySlug, getContentSlugs } from '@/data/contentRegistry';
 import { buildPostMetadata } from '@/lib/buildPostMetadata';
 import { getPostDetailProps } from '@/lib/getPostDetailProps';
 import PostDetailLayout from '@/components/PostDetailLayout';
 
 export async function generateMetadata({ params }: SlugPageProps) {
   const { slug } = await params;
-  const meta = blogMdxMetadata[slug as AllowedBlogSlugs];
+  const entry = getContentBySlug('blog', slug);
 
-  if (!meta) {
+  if (!entry) {
     return {
       title: 'Blog Post Not Found',
       description: 'The requested blog post could not be found.',
     };
   }
 
-  return buildPostMetadata(meta);
+  return buildPostMetadata(entry.metadata);
 }
 
 export default async function SlugBlogPage({ params }: SlugPageProps) {
@@ -31,7 +30,7 @@ export default async function SlugBlogPage({ params }: SlugPageProps) {
 }
 
 export function generateStaticParams() {
-  return blogPageSlugs.map(slug => ({ slug }));
+  return getContentSlugs('blog').map(slug => ({ slug }));
 }
 
 export const dynamicParams = false;

--- a/apps/root/src/app/blog/page.tsx
+++ b/apps/root/src/app/blog/page.tsx
@@ -1,10 +1,8 @@
 import { Metadata } from 'next';
 import { PenLine } from 'lucide-react';
-import { blogRecords } from '@/data/blogThumbnails';
-import { blogReadingTimes } from '@/data/readingTimes';
+import { getContentByType } from '@/data/contentRegistry';
 import { blogRootMetadata } from '@/data/metadata/blog';
 import { blogRootStructuredData } from '@/data/structuredData/blog';
-import { AllowedBlogSlugs } from '@/types/base';
 import {
   Section,
   SectionLabel,
@@ -13,11 +11,11 @@ import {
   StructuredData,
 } from '@/components/kit';
 
-const blogList = Object.values(blogRecords)
+const blogList = getContentByType('blog')
   .reverse()
-  .map(post => ({
-    ...post,
-    readingTime: blogReadingTimes[post.slug as AllowedBlogSlugs],
+  .map(entry => ({
+    ...entry.thumbnail,
+    readingTime: entry.readingTime,
   }));
 
 export const metadata: Metadata = blogRootMetadata;

--- a/apps/root/src/app/experience/[slug]/page.tsx
+++ b/apps/root/src/app/experience/[slug]/page.tsx
@@ -1,24 +1,23 @@
 import { redirect } from 'next/navigation';
-import { AllowedExperienceSlugs, SlugPageProps } from '@/types/base';
+import { SlugPageProps } from '@/types/base';
 import { EXPERIENCE_LINK } from '@/utils/constants';
-import { experienceMdxMetadata } from '@/data/content/experience';
-import { experiencePageSlugs } from '@/data/experience';
+import { getContentBySlug, getContentSlugs } from '@/data/contentRegistry';
 import { buildPostMetadata } from '@/lib/buildPostMetadata';
 import { getPostDetailProps } from '@/lib/getPostDetailProps';
 import PostDetailLayout from '@/components/PostDetailLayout';
 
 export async function generateMetadata({ params }: SlugPageProps) {
   const { slug } = await params;
-  const meta = experienceMdxMetadata[slug as AllowedExperienceSlugs];
+  const entry = getContentBySlug('experience', slug);
 
-  if (!meta) {
+  if (!entry) {
     return {
       title: 'Work Experience Not Found',
       description: 'The requested work experience could not be found.',
     };
   }
 
-  return buildPostMetadata(meta);
+  return buildPostMetadata(entry.metadata);
 }
 
 export default async function SlugExperiencePage({ params }: SlugPageProps) {
@@ -31,7 +30,7 @@ export default async function SlugExperiencePage({ params }: SlugPageProps) {
 }
 
 export function generateStaticParams() {
-  return experiencePageSlugs.map(slug => ({ slug }));
+  return getContentSlugs('experience').map(slug => ({ slug }));
 }
 
 export const dynamicParams = false;

--- a/apps/root/src/app/feed.xml/route.ts
+++ b/apps/root/src/app/feed.xml/route.ts
@@ -1,12 +1,6 @@
 import { DOMAIN_URL, FULL_NAME } from '@/utils/constants';
-import { projectMdxMetadata } from '@/data/content/projects';
-import { experienceMdxMetadata } from '@/data/content/experience';
-import { blogMdxMetadata } from '@/data/content/blog';
-import {
-  projectHistory,
-  experienceHistory,
-  blogHistory,
-} from '@/data/contentOrder';
+import { getAllContent } from '@/data/contentRegistry';
+import { contentTypeConfigs } from '@/data/contentTypeConfig';
 
 function escapeXml(str: string): string {
   return str
@@ -27,56 +21,22 @@ interface FeedItem {
 }
 
 function buildFeedItems(): FeedItem[] {
-  const items: FeedItem[] = [];
-
-  // Projects — use contentOrder for chronological ordering
-  for (const slug of projectHistory) {
-    const meta = projectMdxMetadata[slug];
-    if (!meta) continue;
-    items.push({
-      title: meta.title,
-      link: `${DOMAIN_URL}/projects/${slug}`,
-      description: meta.excerpt,
-      pubDate: new Date(meta.date).toUTCString(),
-      author: meta.author,
-      category: meta.category,
-    });
-  }
-
-  // Experience
-  for (const slug of experienceHistory) {
-    const meta = experienceMdxMetadata[slug];
-    if (!meta) continue;
-    items.push({
-      title: meta.title,
-      link: `${DOMAIN_URL}/experience/${slug}`,
-      description: meta.excerpt,
-      pubDate: new Date(meta.date).toUTCString(),
-      author: meta.author,
-      category: meta.category,
-    });
-  }
-
-  // Blog
-  for (const slug of blogHistory) {
-    const meta = blogMdxMetadata[slug];
-    if (!meta) continue;
-    items.push({
-      title: meta.title,
-      link: `${DOMAIN_URL}/blog/${slug}`,
-      description: meta.excerpt,
-      pubDate: new Date(meta.date).toUTCString(),
-      author: meta.author,
-      category: meta.category,
-    });
-  }
-
-  // Sort newest first
-  items.sort(
-    (a, b) => new Date(b.pubDate).getTime() - new Date(a.pubDate).getTime()
-  );
-
-  return items;
+  return getAllContent()
+    .map(entry => {
+      const config = contentTypeConfigs[entry.type];
+      const meta = entry.metadata;
+      return {
+        title: meta.title,
+        link: `${DOMAIN_URL}${config.basePath}/${entry.slug}`,
+        description: meta.excerpt,
+        pubDate: new Date(meta.date).toUTCString(),
+        author: meta.author,
+        category: meta.category,
+      };
+    })
+    .sort(
+      (a, b) => new Date(b.pubDate).getTime() - new Date(a.pubDate).getTime()
+    );
 }
 
 function buildRssXml(items: FeedItem[]): string {

--- a/apps/root/src/app/page.tsx
+++ b/apps/root/src/app/page.tsx
@@ -11,7 +11,7 @@ import {
 import { homeMetadata } from '@/data/metadata/home';
 import { offerings } from '@/data/offerings';
 import { experienceFull } from '@/data/experience';
-import { projectsRecords } from '@/data/projectThumbnails';
+import { getContentByType } from '@/data/contentRegistry';
 import {
   FULL_NAME,
   JOB_TITLE,
@@ -37,7 +37,9 @@ import HeroActions from './home/HeroActions';
 export const metadata: Metadata = homeMetadata;
 
 const companies = Object.values(experienceFull);
-const featuredProjects = Object.values(projectsRecords).filter(p => p.featured);
+const featuredProjects = getContentByType('project')
+  .filter(e => e.thumbnail.featured)
+  .map(e => e.thumbnail);
 
 export default function Index() {
   return (

--- a/apps/root/src/app/projects/[slug]/page.tsx
+++ b/apps/root/src/app/projects/[slug]/page.tsx
@@ -1,24 +1,23 @@
 import { redirect } from 'next/navigation';
-import { AllowedProjectSlugs, SlugPageProps } from '@/types/base';
+import { SlugPageProps } from '@/types/base';
 import { PROJECTS_LINK } from '@/utils/constants';
-import { projectMdxMetadata } from '@/data/content/projects';
-import { projectPageSlugs } from '@/data/project';
+import { getContentBySlug, getContentSlugs } from '@/data/contentRegistry';
 import { buildPostMetadata } from '@/lib/buildPostMetadata';
 import { getPostDetailProps } from '@/lib/getPostDetailProps';
 import PostDetailLayout from '@/components/PostDetailLayout';
 
 export async function generateMetadata({ params }: SlugPageProps) {
   const { slug } = await params;
-  const meta = projectMdxMetadata[slug as AllowedProjectSlugs];
+  const entry = getContentBySlug('project', slug);
 
-  if (!meta) {
+  if (!entry) {
     return {
       title: 'Project Not Found',
       description: 'The requested project page could not be found.',
     };
   }
 
-  return buildPostMetadata(meta);
+  return buildPostMetadata(entry.metadata);
 }
 
 export default async function SlugProjectPage({ params }: SlugPageProps) {
@@ -31,7 +30,7 @@ export default async function SlugProjectPage({ params }: SlugPageProps) {
 }
 
 export function generateStaticParams() {
-  return projectPageSlugs.map(slug => ({ slug }));
+  return getContentSlugs('project').map(slug => ({ slug }));
 }
 
 export const dynamicParams = false;

--- a/apps/root/src/data/contentOrder.ts
+++ b/apps/root/src/data/contentOrder.ts
@@ -1,16 +1,7 @@
-import {
-  AllowedProjectSlugs,
-  AllowedExperienceSlugs,
-  AllowedBlogSlugs,
-  NavLink,
-} from '@/types/base';
+import { AllowedProjectSlugs, AllowedExperienceSlugs, AllowedBlogSlugs } from '@/types/base';
 import { projectSlugs } from '@/data/project';
 import { experienceSlugs } from '@/data/experience';
 import { blogSlugs } from '@/data/blog';
-import { PROJECTS_LINK, EXPERIENCE_LINK, BLOG_LINK } from '@/utils/constants';
-import { projectsRecords } from '@/data/projectThumbnails';
-import { experienceRecords } from '@/data/experienceThumbnails';
-import { blogRecords } from '@/data/blogThumbnails';
 
 export interface PaginationLink {
   slug: string;
@@ -63,62 +54,9 @@ export const experienceHistory: AllowedExperienceSlugs[] = [
   experienceSlugs.SD, // Jan 2023
 ];
 
-function buildPaginationData(
-  slug: string,
-  orderedSlugs: readonly string[],
-  records: Record<string, { title: string }>,
-  basePath: NavLink
-): PostPaginationData {
-  const index = orderedSlugs.indexOf(slug);
-
-  const len = orderedSlugs.length;
-  const prevIndex = (index - 1 + len) % len;
-  const nextIndex = (index + 1) % len;
-
-  const prev = {
-    slug: orderedSlugs[prevIndex],
-    title: records[orderedSlugs[prevIndex]].title,
-    href: `${basePath.href}/${orderedSlugs[prevIndex]}`,
-  };
-
-  const next = {
-    slug: orderedSlugs[nextIndex],
-    title: records[orderedSlugs[nextIndex]].title,
-    href: `${basePath.href}/${orderedSlugs[nextIndex]}`,
-  };
-
-  return { prev, next };
-}
-
-export function getProjectPagination(
-  slug: AllowedProjectSlugs
-): PostPaginationData {
-  return buildPaginationData(
-    slug,
-    projectHistory,
-    projectsRecords,
-    PROJECTS_LINK
-  );
-}
-
-export function getExperiencePagination(
-  slug: AllowedExperienceSlugs
-): PostPaginationData {
-  return buildPaginationData(
-    slug,
-    experienceHistory,
-    experienceRecords,
-    EXPERIENCE_LINK
-  );
-}
-
 /**
  * Blog history in chronological order (by publish date).
  */
 export const blogHistory: AllowedBlogSlugs[] = [
   blogSlugs.unifiedContentPipeline, // 2026-04-03
 ];
-
-export function getBlogPagination(slug: AllowedBlogSlugs): PostPaginationData {
-  return buildPaginationData(slug, blogHistory, blogRecords, BLOG_LINK);
-}

--- a/apps/root/src/data/contentRegistry.ts
+++ b/apps/root/src/data/contentRegistry.ts
@@ -163,17 +163,3 @@ export function getContentReadingTime(type: ContentType, slug: string): number {
 export function getAllContent(): ContentEntry[] {
   return entries;
 }
-
-/**
- * Registers additional content entries (used by blog and future types).
- * Entries are appended and indexed.
- */
-export function registerContent(newEntries: ContentEntry[]): void {
-  for (const entry of newEntries) {
-    entries.push(entry);
-    byTypeAndSlug.set(`${entry.type}:${entry.slug}`, entry);
-    const list = byType.get(entry.type) ?? [];
-    list.push(entry);
-    byType.set(entry.type, list);
-  }
-}


### PR DESCRIPTION
## Summary

- Migrate **all** remaining consumer code to use the content registry — no page-level code bypasses the registry anymore
- Remove dead per-type pagination functions and unused `registerContent` export
- Update CLAUDE.md with registry patterns, blog route, and new content architecture docs

Final phase of #78 — Closes #152

## Changes

| File | Change |
|------|--------|
| `app/page.tsx` | `projectsRecords` → `getContentByType('project')` |
| `app/blog/page.tsx` | `blogRecords` + `blogReadingTimes` → `getContentByType('blog')` |
| `app/feed.xml/route.ts` | 3 separate per-type loops → single `getAllContent()` call |
| `app/projects/[slug]/page.tsx` | `generateMetadata` + `generateStaticParams` → registry |
| `app/experience/[slug]/page.tsx` | `generateMetadata` + `generateStaticParams` → registry |
| `app/blog/[slug]/page.tsx` | `generateMetadata` + `generateStaticParams` → registry |
| `data/contentOrder.ts` | Removed `getProjectPagination`, `getExperiencePagination`, `getBlogPagination`, `buildPaginationData` |
| `data/contentRegistry.ts` | Removed unused `registerContent` export |
| `CLAUDE.md` | Documented registry API, blog route, content ordering, adding new posts |

Net **-96 lines** across 9 files.

## Test plan

- [x] `tsc --noEmit` — zero errors
- [x] `nx test root` — 618/618 tests pass
- [ ] Verify homepage featured projects render correctly
- [ ] Verify `/blog` listing renders correctly
- [ ] Verify `/feed.xml` includes all content types
- [ ] Verify all detail pages render with correct metadata

https://claude.ai/code/session_01B64VCBfCkRo9gRGysyTVQY