### PR TITLE
fix: UI/UX audit phase 1 — accessibility fixes

### DIFF
--- a/apps/root-e2e/src/navigation.spec.ts
+++ b/apps/root-e2e/src/navigation.spec.ts
@@ -20,14 +20,14 @@ test.describe('desktop navigation', () => {
     }
   });
 
-  test('nav links have correct aria-labels', async ({ page }) => {
+  test('nav links are accessible with visible text', async ({ page }) => {
     await page.goto('/', { waitUntil: 'domcontentloaded' });
     await page.waitForLoadState('domcontentloaded');
 
     for (const link of NAV_LINKS) {
       const navLink = page
         .locator('nav[aria-label="Main navigation"]')
-        .locator(`a[aria-label="Navigate to ${link.label} page"]`);
+        .locator(`a[role="menuitem"]`, { hasText: link.label });
       await expect(navLink).toBeAttached();
     }
   });

--- a/apps/root/src/components/Nav/Links.spec.tsx
+++ b/apps/root/src/components/Nav/Links.spec.tsx
@@ -49,16 +49,16 @@ describe('NavLinks', () => {
   test('renders all navigation links', () => {
     render(<NavLinks pathname='/' />);
     expect(
-      screen.getByRole('menuitem', { name: /navigate to home page/i })
+      screen.getByRole('menuitem', { name: /^home$/i })
     ).toBeInTheDocument();
     expect(
-      screen.getByRole('menuitem', { name: /navigate to about page/i })
+      screen.getByRole('menuitem', { name: /^about$/i })
     ).toBeInTheDocument();
     expect(
-      screen.getByRole('menuitem', { name: /navigate to experience page/i })
+      screen.getByRole('menuitem', { name: /^experience$/i })
     ).toBeInTheDocument();
     expect(
-      screen.getByRole('menuitem', { name: /navigate to projects page/i })
+      screen.getByRole('menuitem', { name: /^projects$/i })
     ).toBeInTheDocument();
   });
 
@@ -76,7 +76,7 @@ describe('NavLinks', () => {
   test('highlights current page link with aria-current', () => {
     render(<NavLinks pathname='/' />);
     const homeLink = screen.getByRole('menuitem', {
-      name: /navigate to home page/i,
+      name: /^home$/i,
     });
     expect(homeLink).toHaveAttribute('aria-current', 'page');
   });
@@ -84,7 +84,7 @@ describe('NavLinks', () => {
   test('does not set aria-current on non-current pages', () => {
     render(<NavLinks pathname='/' />);
     const aboutLink = screen.getByRole('menuitem', {
-      name: /navigate to about page/i,
+      name: /^about$/i,
     });
     expect(aboutLink).not.toHaveAttribute('aria-current');
   });
@@ -92,7 +92,7 @@ describe('NavLinks', () => {
   test('correctly identifies About page as current', () => {
     render(<NavLinks pathname='/about' />);
     const aboutLink = screen.getByRole('menuitem', {
-      name: /navigate to about page/i,
+      name: /^about$/i,
     });
     expect(aboutLink).toHaveAttribute('aria-current', 'page');
   });
@@ -100,7 +100,7 @@ describe('NavLinks', () => {
   test('correctly identifies Projects page as current', () => {
     render(<NavLinks pathname='/projects' />);
     const projectsLink = screen.getByRole('menuitem', {
-      name: /navigate to projects page/i,
+      name: /^projects$/i,
     });
     expect(projectsLink).toHaveAttribute('aria-current', 'page');
   });
@@ -112,7 +112,7 @@ describe('NavLinks', () => {
 
     render(<NavLinks pathname='/' handleClick={handleClick} />);
     const aboutLink = screen.getByRole('menuitem', {
-      name: /navigate to about page/i,
+      name: /^about$/i,
     });
 
     await user.click(aboutLink);
@@ -123,17 +123,19 @@ describe('NavLinks', () => {
 
   test('renders links with correct href values', () => {
     render(<NavLinks pathname='/' />);
+    expect(screen.getByRole('menuitem', { name: /^home$/i })).toHaveAttribute(
+      'href',
+      HOME_LINK.href
+    );
+    expect(screen.getByRole('menuitem', { name: /^about$/i })).toHaveAttribute(
+      'href',
+      ABOUT_LINK.href
+    );
     expect(
-      screen.getByRole('menuitem', { name: /navigate to home page/i })
-    ).toHaveAttribute('href', HOME_LINK.href);
-    expect(
-      screen.getByRole('menuitem', { name: /navigate to about page/i })
-    ).toHaveAttribute('href', ABOUT_LINK.href);
-    expect(
-      screen.getByRole('menuitem', { name: /navigate to experience page/i })
+      screen.getByRole('menuitem', { name: /^experience$/i })
     ).toHaveAttribute('href', EXPERIENCE_LINK.href);
     expect(
-      screen.getByRole('menuitem', { name: /navigate to projects page/i })
+      screen.getByRole('menuitem', { name: /^projects$/i })
     ).toHaveAttribute('href', PROJECTS_LINK.href);
   });
 

--- a/apps/root/src/components/Nav/Links.tsx
+++ b/apps/root/src/components/Nav/Links.tsx
@@ -43,7 +43,6 @@ export default function NavLinks({
               }
               role='menuitem'
               aria-current={pathname === link.href ? 'page' : undefined}
-              aria-label={`Navigate to ${link.label} page`}
               className={cn(
                 'px-3 py-1.5 rounded-lg text-sm font-medium transition-colors',
                 pathname === link.href
@@ -62,7 +61,6 @@ export default function NavLinks({
           handleLinkClick(e, AUDIT_LINK.label, AUDIT_LINK.href)
         }
         aria-current={pathname === AUDIT_LINK.href ? 'page' : undefined}
-        aria-label={`Navigate to ${AUDIT_LINK.label} page`}
         className='inline-flex items-center px-3 py-1.5 rounded-lg bg-brand-600 text-white text-sm font-medium hover:bg-brand-700 transition-colors md:ml-2'
       >
         {AUDIT_LINK.label}

--- a/apps/root/src/data/content/blog/documenting-design-tokens.mdx
+++ b/apps/root/src/data/content/blog/documenting-design-tokens.mdx
@@ -5,7 +5,12 @@ export const metadata = {
     'Why a comprehensive theme token reference is part of the design system — not an afterthought — and how we documented 100+ tokens for a Tailwind CSS 4 component library.',
   author: 'Daniel Joffe',
   category: 'Design Systems',
-  tags: ['Design Systems', 'Documentation', 'Tailwind CSS', 'Developer Experience'],
+  tags: [
+    'Design Systems',
+    'Documentation',
+    'Tailwind CSS',
+    'Developer Experience',
+  ],
   slug: 'documenting-design-tokens',
   type: 'blog',
   topic: 'Developer Experience',
@@ -73,12 +78,12 @@ remember oklch values — they pick the semantic token that matches their intent
 
 Rather than listing font sizes, we documented the **variant components**:
 
-| Use case | Component | Output |
-|----------|-----------|--------|
-| Page hero | `<Heading variant="hero">` | 36px → 48px responsive, bold |
-| Card title | `<Heading variant="cardTitle">` | 14px, semibold |
-| Body text | `<Text variant="body">` | 14px, secondary color |
-| Metadata | `<Text variant="meta">` | 12px, tertiary color |
+| Use case   | Component                       | Output                       |
+| ---------- | ------------------------------- | ---------------------------- |
+| Page hero  | `<Heading variant="hero">`      | 36px → 48px responsive, bold |
+| Card title | `<Heading variant="cardTitle">` | 14px, semibold               |
+| Body text  | `<Text variant="body">`         | 14px, secondary color        |
+| Metadata   | `<Text variant="meta">`         | 12px, tertiary color         |
 
 This bridges the gap between "I need small gray text" and "use
 `<Text variant='meta'>`."
@@ -89,15 +94,16 @@ Each component gets a consistent entry:
 
 ```markdown
 ### Alert
+
 Status messages with contextual styling.
 
 **Variants:** `info` | `success` | `warning` | `error`
 **Props:** `title?`, `dismissible?`, `onDismiss?`
 
 Usage:
-  <Alert variant="warning" title="Heads up">
-    Check your input values.
-  </Alert>
+<Alert variant="warning" title="Heads up">
+Check your input values.
+</Alert>
 ```
 
 Key decisions are called out explicitly: "Alert title uses `text-sm

--- a/apps/root/src/data/content/blog/removing-focus-trap-react.mdx
+++ b/apps/root/src/data/content/blog/removing-focus-trap-react.mdx
@@ -51,7 +51,9 @@ export function Modal({ isOpen, onClose, title, children }: ModalProps) {
     } else {
       document.body.style.overflow = '';
     }
-    return () => { document.body.style.overflow = ''; };
+    return () => {
+      document.body.style.overflow = '';
+    };
   }, [isOpen]);
 
   const handleClose = useCallback(() => {

--- a/apps/root/src/data/content/blog/rule-of-three-design-systems.mdx
+++ b/apps/root/src/data/content/blog/rule-of-three-design-systems.mdx
@@ -34,23 +34,23 @@ The findings split cleanly into two categories:
 
 ### Patterns that repeated 3+ times (extract)
 
-| Pattern | Occurrences | Action |
-|---------|:-----------:|--------|
-| Page hero title | 7 pages | `<Heading variant="hero">` |
-| Card title | 5+ components | `<Heading variant="cardTitle">` |
-| Card description | 5+ components | `<Text variant="cardDescription">` |
-| Section label | 5 sections | `<Text variant="label">` |
-| Metadata/timestamp | 4+ components | `<Text variant="meta">` |
-| Body paragraph | 6+ pages | `<Text variant="body">` |
+| Pattern            |  Occurrences  | Action                             |
+| ------------------ | :-----------: | ---------------------------------- |
+| Page hero title    |    7 pages    | `<Heading variant="hero">`         |
+| Card title         | 5+ components | `<Heading variant="cardTitle">`    |
+| Card description   | 5+ components | `<Text variant="cardDescription">` |
+| Section label      |  5 sections   | `<Text variant="label">`           |
+| Metadata/timestamp | 4+ components | `<Text variant="meta">`            |
+| Body paragraph     |   6+ pages    | `<Text variant="body">`            |
 
 ### Patterns that appeared 1–2 times (leave inline)
 
-| Pattern | Occurrences | Decision |
-|---------|:-----------:|----------|
-| About page name/title styling | 1 | Leave inline |
-| FAQ question text | 1 component | Leave inline |
-| Experience role badge text | 1 component | Leave inline |
-| Breadcrumb current page | 1 component | Leave inline |
+| Pattern                       | Occurrences | Decision     |
+| ----------------------------- | :---------: | ------------ |
+| About page name/title styling |      1      | Leave inline |
+| FAQ question text             | 1 component | Leave inline |
+| Experience role badge text    | 1 component | Leave inline |
+| Breadcrumb current page       | 1 component | Leave inline |
 
 The one-off patterns are specific to their context. Extracting "FAQ question
 text" into a variant would create a variant used by exactly one file — overhead
@@ -76,12 +76,12 @@ There are cases where extracting before three occurrences makes sense:
 
 The rule works for any design system decision:
 
-| Abstraction | Extract when... |
-|-------------|-----------------|
-| **UI component** | 3+ files use the same element + class combo |
-| **Style constant** | 3+ components share the same className string |
-| **Custom hook** | 3+ components duplicate the same stateful logic |
-| **Utility function** | 3+ call sites with the same transformation |
+| Abstraction          | Extract when...                                 |
+| -------------------- | ----------------------------------------------- |
+| **UI component**     | 3+ files use the same element + class combo     |
+| **Style constant**   | 3+ components share the same className string   |
+| **Custom hook**      | 3+ components duplicate the same stateful logic |
+| **Utility function** | 3+ call sites with the same transformation      |
 
 The key insight: **three is the minimum where a pattern proves it's stable**.
 Two occurrences might converge by coincidence. Three occurrences prove there's

--- a/apps/root/src/data/content/blog/typography-system-nextjs.mdx
+++ b/apps/root/src/data/content/blog/typography-system-nextjs.mdx
@@ -16,11 +16,11 @@ export const metadata = {
 Every mature codebase accumulates typographic debt. Ours had three competing
 systems that didn't agree on what an `<h2>` should look like:
 
-| Layer | h1 | h2 | h3 |
-|-------|----|----|-----|
-| **theme.css** | 2.25rem / 600 | 1.75rem / 600 | 1.375rem / 600 |
-| **mdx-components.tsx** | `text-2xl bold` | `text-lg semibold` | `text-sm semibold` |
-| **Page components** | `text-4xl sm:text-5xl bold` | varies | varies |
+| Layer                  | h1                          | h2                 | h3                 |
+| ---------------------- | --------------------------- | ------------------ | ------------------ |
+| **theme.css**          | 2.25rem / 600               | 1.75rem / 600      | 1.375rem / 600     |
+| **mdx-components.tsx** | `text-2xl bold`             | `text-lg semibold` | `text-sm semibold` |
+| **Page components**    | `text-4xl sm:text-5xl bold` | varies             | varies             |
 
 The same "card title" pattern (`text-sm font-semibold text-text-primary`)
 appeared in 5+ files. Hero headings were copy-pasted across 6 pages with
@@ -50,10 +50,12 @@ The key architecture decision was **what belongs where**. The shared-ui library
 page layout or MDX rendering had to stay in the app.
 
 **Shared-ui variants** (framework-agnostic):
+
 - `Heading`: `section`, `cardTitle`, `component`
 - `Text`: `body`, `bodyLg`, `cardDescription`, `label`, `meta`, `caption`, `helper`, `error`
 
 **App-level extensions** (Next.js-specific):
+
 - `Heading`: `hero`, `detail`, `subtitle`, `mdxH1`–`mdxH4`
 - `Text`: `subtitle`
 

--- a/apps/root/src/data/structuredData/blog.ts
+++ b/apps/root/src/data/structuredData/blog.ts
@@ -89,8 +89,7 @@ export const blogStructuredData: Record<AllowedBlogSlugs, BlogStructuredData> =
       '@context': 'https://schema.org',
       '@type': 'Article',
       headline: blogRecords[blogSlugs.ruleOfThreeDesignSystems].title,
-      description:
-        blogRecords[blogSlugs.ruleOfThreeDesignSystems].description,
+      description: blogRecords[blogSlugs.ruleOfThreeDesignSystems].description,
       datePublished:
         blogMdxMetadata[blogSlugs.ruleOfThreeDesignSystems]?.date ?? '',
       author,

--- a/apps/root/src/styles/theme.css
+++ b/apps/root/src/styles/theme.css
@@ -54,7 +54,7 @@
   /* Semantic Colors - Text */
   --color-text-primary: #111827;
   --color-text-secondary: #6b7280;
-  --color-text-tertiary: #737373;
+  --color-text-tertiary: #6b6b6b;
   --color-text-inverse: #ffffff;
   --color-text-brand: oklch(0.5 0.19 250);
 


### PR DESCRIPTION
## Summary
- **label-content-name-mismatch (WCAG 2.5.3)**: Removed verbose `aria-label` attributes from nav links (`"Navigate to Home page"` → let visible text `"Home"` serve as the accessible name). The expanded labels caused a mismatch between what sighted users read and what assistive technology announced.
- **color-contrast (WCAG 1.4.3)**: Darkened `text-text-tertiary` from `#737373` to `#6b6b6b` in light mode. The original value had ~4.32:1 contrast ratio against `surface-tertiary` (`#f3f4f6`), failing AA for small text. New value achieves ~5.20:1 on white and ~4.77:1 on `surface-tertiary`.
- Updated unit tests (Links.spec.tsx) and E2E tests (navigation.spec.ts) to match new accessible names
- Applied Prettier formatting to blog MDX files (whitespace-only changes)

### Audit findings (from Lighthouse accessibility audits)

| Page | Score | Issues |
|------|-------|--------|
| Homepage | 100 | — |
| About | 100 | — |
| Services | 100 | — |
| Projects | 100 | — |
| Experience | 100 | — |
| Blog | 100 | — |
| Blog detail | 96→100 | color-contrast (fixed), label-content-name-mismatch (fixed) |
| ui-components-v2 | 97 | frame-title (pre-existing; resolved by PR #199 InteractiveDemo) |

### Pre-existing issue (not addressed here)
- `frame-title` on ui-components-v2: Raw `<iframe>` embeds lack `title` attributes. This will be resolved when PR #199 (InteractiveDemo component) is merged, as `InteractiveDemo` includes proper `title` props on all iframes.

## Test plan
- [x] Production build succeeds
- [x] TypeScript typecheck passes (zero errors)
- [x] All 619 unit tests pass
- [x] Lint passes (0 errors, 1 pre-existing warning)
- [x] Prettier formatting applied
- [ ] E2E navigation tests pass with updated selectors
- [ ] Visual check: tertiary text still visually distinguishable from secondary text

Closes #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)