### PR TITLE
fix(shared-ui): Table scope, caption, and keyboard support (#208)

### DIFF
--- a/libs/shared/ui/src/lib/Table.spec.tsx
+++ b/libs/shared/ui/src/lib/Table.spec.tsx
@@ -1,7 +1,7 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import { Table } from './Table';
 
-type Row = { name: string; age: number; role: string };
+type Row = { id: number; name: string; age: number; role: string };
 
 const columns = [
   { key: 'name', header: 'Name' },
@@ -10,8 +10,8 @@ const columns = [
 ];
 
 const data: Row[] = [
-  { name: 'Alice', age: 30, role: 'Engineer' },
-  { name: 'Bob', age: 25, role: 'Designer' },
+  { id: 1, name: 'Alice', age: 30, role: 'Engineer' },
+  { id: 2, name: 'Bob', age: 25, role: 'Designer' },
 ];
 
 describe('Table', () => {
@@ -84,5 +84,164 @@ describe('Table', () => {
       <Table columns={columns} data={data} className='custom-class' />
     );
     expect(container.firstChild).toHaveClass('custom-class');
+  });
+
+  // --- scope="col" on th elements ---
+
+  it('renders scope="col" on all header th elements', () => {
+    render(<Table columns={columns} data={data} />);
+    const headers = screen.getAllByRole('columnheader');
+    headers.forEach(th => {
+      expect(th).toHaveAttribute('scope', 'col');
+    });
+  });
+
+  // --- caption prop ---
+
+  it('renders a caption element when caption prop is provided', () => {
+    render(<Table columns={columns} data={data} caption='User list' />);
+    const caption = screen.getByText('User list');
+    expect(caption.tagName).toBe('CAPTION');
+  });
+
+  it('does not render a caption element when caption prop is omitted', () => {
+    const { container } = render(<Table columns={columns} data={data} />);
+    expect(container.querySelector('caption')).toBeNull();
+  });
+
+  // --- aria-label on table ---
+
+  it('renders aria-label on the table when ariaLabel is provided and no caption', () => {
+    render(<Table columns={columns} data={data} ariaLabel='User data' />);
+    const table = screen.getByRole('table');
+    expect(table).toHaveAttribute('aria-label', 'User data');
+  });
+
+  it('does not render aria-label when caption is provided', () => {
+    render(
+      <Table
+        columns={columns}
+        data={data}
+        caption='User list'
+        ariaLabel='User data'
+      />
+    );
+    const table = screen.getByRole('table');
+    expect(table).not.toHaveAttribute('aria-label');
+  });
+
+  // --- keyboard accessibility for clickable rows ---
+
+  it('adds tabIndex={0} and role="button" on rows when onRowClick is provided', () => {
+    render(<Table columns={columns} data={data} onRowClick={jest.fn()} />);
+    const rows = screen.getAllByRole('button');
+    expect(rows).toHaveLength(2);
+    rows.forEach(row => {
+      expect(row.tagName).toBe('TR');
+      expect(row).toHaveAttribute('tabindex', '0');
+    });
+  });
+
+  it('does not add tabIndex or role on rows when onRowClick is not provided', () => {
+    render(<Table columns={columns} data={data} />);
+    const rows = screen.getAllByRole('row');
+    // body rows should not have tabindex or role="button"
+    const bodyRows = rows.slice(1);
+    bodyRows.forEach(row => {
+      expect(row).not.toHaveAttribute('tabindex');
+      expect(row).not.toHaveAttribute('role', 'button');
+    });
+  });
+
+  it('triggers onRowClick on Enter keypress', () => {
+    const onRowClick = jest.fn();
+    render(<Table columns={columns} data={data} onRowClick={onRowClick} />);
+    const rows = screen.getAllByRole('button');
+    fireEvent.keyDown(rows[0], { key: 'Enter' });
+    expect(onRowClick).toHaveBeenCalledWith(data[0]);
+  });
+
+  it('triggers onRowClick on Space keypress', () => {
+    const onRowClick = jest.fn();
+    render(<Table columns={columns} data={data} onRowClick={onRowClick} />);
+    const rows = screen.getAllByRole('button');
+    fireEvent.keyDown(rows[0], { key: ' ' });
+    expect(onRowClick).toHaveBeenCalledWith(data[0]);
+  });
+
+  it('does not trigger onRowClick on other key presses', () => {
+    const onRowClick = jest.fn();
+    render(<Table columns={columns} data={data} onRowClick={onRowClick} />);
+    const rows = screen.getAllByRole('button');
+    fireEvent.keyDown(rows[0], { key: 'Tab' });
+    expect(onRowClick).not.toHaveBeenCalled();
+  });
+
+  it('prevents default on Enter/Space to avoid page scroll', () => {
+    const onRowClick = jest.fn();
+    render(<Table columns={columns} data={data} onRowClick={onRowClick} />);
+    const rows = screen.getAllByRole('button');
+    const event = new KeyboardEvent('keydown', {
+      key: ' ',
+      bubbles: true,
+    });
+    const preventDefaultSpy = jest.spyOn(event, 'preventDefault');
+    rows[0].dispatchEvent(event);
+    expect(preventDefaultSpy).toHaveBeenCalled();
+  });
+
+  // --- aria-label on clickable rows ---
+
+  it('renders aria-label on clickable rows when getRowAriaLabel is provided', () => {
+    render(
+      <Table
+        columns={columns}
+        data={data}
+        onRowClick={jest.fn()}
+        getRowAriaLabel={row => `View ${row.name}`}
+      />
+    );
+    const rows = screen.getAllByRole('button');
+    expect(rows[0]).toHaveAttribute('aria-label', 'View Alice');
+    expect(rows[1]).toHaveAttribute('aria-label', 'View Bob');
+  });
+
+  it('does not render aria-label on rows when getRowAriaLabel is not provided', () => {
+    render(<Table columns={columns} data={data} onRowClick={jest.fn()} />);
+    const rows = screen.getAllByRole('button');
+    rows.forEach(row => {
+      expect(row).not.toHaveAttribute('aria-label');
+    });
+  });
+
+  // --- rowKey prop ---
+
+  it('uses rowKey for unique keys when provided', () => {
+    const { container } = render(
+      <Table columns={columns} data={data} rowKey={row => row.id as number} />
+    );
+    // Verify rows render correctly (key usage is internal to React,
+    // but we can verify no warnings and correct rendering)
+    const rows = container.querySelectorAll('tbody tr');
+    expect(rows).toHaveLength(2);
+  });
+
+  // --- focus-visible styles on clickable rows ---
+
+  it('applies focus-visible outline class on clickable rows', () => {
+    render(<Table columns={columns} data={data} onRowClick={jest.fn()} />);
+    const rows = screen.getAllByRole('button');
+    rows.forEach(row => {
+      expect(row.className).toContain('focus-visible:outline-2');
+    });
+  });
+
+  it('does not apply focus-visible outline class on non-clickable rows', () => {
+    render(<Table columns={columns} data={data} />);
+    const rows = screen.getAllByRole('row');
+    const bodyRows = rows.slice(1);
+    bodyRows.forEach(row => {
+      expect(row.className).not.toContain('focus-visible:outline-2');
+    });
   });
 });

--- a/libs/shared/ui/src/lib/Table.tsx
+++ b/libs/shared/ui/src/lib/Table.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type { ReactNode } from 'react';
+import type { KeyboardEvent, ReactNode } from 'react';
 import { Text } from './Text';
 import { cn } from './utils/cn';
 
@@ -18,6 +18,14 @@ export interface TableProps<T> {
   onRowClick?: (row: T) => void;
   striped?: boolean;
   className?: string;
+  /** Visible caption rendered inside the table for accessibility */
+  caption?: string;
+  /** aria-label for the table (used when caption is not provided) */
+  ariaLabel?: string;
+  /** Function to derive a unique key from each row (avoids index keys) */
+  rowKey?: (row: T) => string | number;
+  /** Function to derive an accessible label for clickable rows */
+  getRowAriaLabel?: (row: T) => string;
 }
 
 export function Table<T extends Record<string, unknown>>({
@@ -26,11 +34,22 @@ export function Table<T extends Record<string, unknown>>({
   onRowClick,
   striped = false,
   className,
+  caption,
+  ariaLabel,
+  rowKey,
+  getRowAriaLabel,
 }: TableProps<T>) {
   const alignClass = {
     left: 'text-left',
     center: 'text-center',
     right: 'text-right',
+  };
+
+  const handleRowKeyDown = (e: KeyboardEvent<HTMLTableRowElement>, row: T) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      onRowClick?.(row);
+    }
   };
 
   return (
@@ -40,12 +59,21 @@ export function Table<T extends Record<string, unknown>>({
         className
       )}
     >
-      <table className='w-full text-sm'>
+      <table
+        className='w-full text-sm'
+        aria-label={!caption ? ariaLabel : undefined}
+      >
+        {caption && (
+          <caption className='px-4 py-3 text-left text-sm font-medium text-text-secondary'>
+            {caption}
+          </caption>
+        )}
         <thead>
           <tr className='border-b border-border bg-surface-secondary'>
             {columns.map(col => (
               <th
                 key={col.key}
+                scope='col'
                 className={cn(
                   'px-4 py-3 font-medium text-text-secondary',
                   alignClass[col.align || 'left']
@@ -58,29 +86,43 @@ export function Table<T extends Record<string, unknown>>({
           </tr>
         </thead>
         <tbody>
-          {data.map((row, i) => (
-            <tr
-              key={i}
-              onClick={() => onRowClick?.(row)}
-              className={cn(
-                'border-b border-border last:border-b-0 transition-colors',
-                onRowClick && 'cursor-pointer hover:bg-surface-secondary',
-                striped && i % 2 === 1 && 'bg-surface-secondary'
-              )}
-            >
-              {columns.map(col => (
-                <td
-                  key={col.key}
-                  className={cn(
-                    'px-4 py-3 text-text-primary',
-                    alignClass[col.align || 'left']
-                  )}
-                >
-                  {col.render ? col.render(row) : (row[col.key] as ReactNode)}
-                </td>
-              ))}
-            </tr>
-          ))}
+          {data.map((row, i) => {
+            const key = rowKey ? rowKey(row) : i;
+            return (
+              <tr
+                key={key}
+                onClick={onRowClick ? () => onRowClick(row) : undefined}
+                onKeyDown={
+                  onRowClick ? e => handleRowKeyDown(e, row) : undefined
+                }
+                tabIndex={onRowClick ? 0 : undefined}
+                role={onRowClick ? 'button' : undefined}
+                aria-label={
+                  onRowClick && getRowAriaLabel
+                    ? getRowAriaLabel(row)
+                    : undefined
+                }
+                className={cn(
+                  'border-b border-border last:border-b-0 transition-colors',
+                  onRowClick &&
+                    'cursor-pointer hover:bg-surface-secondary focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-accent',
+                  striped && i % 2 === 1 && 'bg-surface-secondary'
+                )}
+              >
+                {columns.map(col => (
+                  <td
+                    key={col.key}
+                    className={cn(
+                      'px-4 py-3 text-text-primary',
+                      alignClass[col.align || 'left']
+                    )}
+                  >
+                    {col.render ? col.render(row) : (row[col.key] as ReactNode)}
+                  </td>
+                ))}
+              </tr>
+            );
+          })}
           {data.length === 0 && (
             <tr>
               <td colSpan={columns.length} className='px-4 py-12 text-center'>


### PR DESCRIPTION
## Summary
- Add `scope="col"` on all `<th>` elements in header
- New `caption` and `ariaLabel` props for table accessibility
- Clickable rows get `tabIndex={0}`, `role="button"`, Enter/Space keyboard handlers
- Add `focus-visible` outline styles on clickable rows
- New `rowKey` and `getRowAriaLabel` props for stable keys and accessible labels
- Tests expanded from 10 → 26

## Test plan
- [x] Table tests pass (26 tests)
- [x] Full suite passes (648 tests)
- [x] Typecheck passes

Closes #208

🤖 Generated with [Claude Code](https://claude.com/claude-code)