### PR TITLE
fix(shared-ui): Dropdown ARIA attributes and keyboard navigation (#206)

### DIFF
--- a/libs/shared/ui/src/lib/Dropdown.spec.tsx
+++ b/libs/shared/ui/src/lib/Dropdown.spec.tsx
@@ -1,6 +1,20 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import { Dropdown } from './Dropdown';
 
+// Mock requestAnimationFrame to run callbacks synchronously in tests
+beforeEach(() => {
+  jest
+    .spyOn(window, 'requestAnimationFrame')
+    .mockImplementation((cb: FrameRequestCallback) => {
+      cb(0);
+      return 0;
+    });
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
 const items = [
   { label: 'Edit', onClick: jest.fn() },
   { label: 'Delete', onClick: jest.fn(), danger: true },
@@ -100,5 +114,229 @@ describe('Dropdown', () => {
     fireEvent.click(screen.getByText('Menu'));
     const dropdown = screen.getByText('Edit').closest('.right-0');
     expect(dropdown).toBeInTheDocument();
+  });
+
+  describe('ARIA attributes', () => {
+    it('has aria-haspopup on trigger', () => {
+      render(<Dropdown trigger={<span>Menu</span>} items={items} />);
+      const trigger = screen.getByRole('button', { name: 'Menu' });
+      expect(trigger).toHaveAttribute('aria-haspopup', 'true');
+    });
+
+    it('has aria-expanded=false when closed', () => {
+      render(<Dropdown trigger={<span>Menu</span>} items={items} />);
+      const trigger = screen.getByRole('button', { name: 'Menu' });
+      expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    it('has aria-expanded=true when open', () => {
+      render(<Dropdown trigger={<span>Menu</span>} items={items} />);
+      const trigger = screen.getByRole('button', { name: 'Menu' });
+      fireEvent.click(trigger);
+      expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    });
+
+    it('links trigger to menu via aria-controls', () => {
+      render(<Dropdown trigger={<span>Menu</span>} items={items} />);
+      const trigger = screen.getByRole('button', { name: 'Menu' });
+      expect(trigger).not.toHaveAttribute('aria-controls');
+      fireEvent.click(trigger);
+      const menuId = trigger.getAttribute('aria-controls');
+      expect(menuId).toBeTruthy();
+      expect(screen.getByRole('menu')).toHaveAttribute('id', menuId);
+    });
+
+    it('has role="menu" on the dropdown container', () => {
+      render(<Dropdown trigger={<span>Menu</span>} items={items} />);
+      fireEvent.click(screen.getByRole('button', { name: 'Menu' }));
+      expect(screen.getByRole('menu')).toBeInTheDocument();
+    });
+
+    it('has role="menuitem" on each item', () => {
+      render(<Dropdown trigger={<span>Menu</span>} items={items} />);
+      fireEvent.click(screen.getByRole('button', { name: 'Menu' }));
+      const menuItems = screen.getAllByRole('menuitem');
+      expect(menuItems).toHaveLength(2);
+    });
+
+    it('has role="separator" on divider items', () => {
+      render(
+        <Dropdown
+          trigger={<span>Menu</span>}
+          items={[
+            { label: 'Edit', onClick: jest.fn() },
+            { label: '', divider: true },
+            { label: 'Delete', onClick: jest.fn() },
+          ]}
+        />
+      );
+      fireEvent.click(screen.getByRole('button', { name: 'Menu' }));
+      expect(screen.getByRole('separator')).toBeInTheDocument();
+    });
+
+    it('has aria-labelledby linking menu to trigger', () => {
+      render(<Dropdown trigger={<span>Menu</span>} items={items} />);
+      const trigger = screen.getByRole('button', { name: 'Menu' });
+      fireEvent.click(trigger);
+      const menu = screen.getByRole('menu');
+      expect(menu).toHaveAttribute('aria-labelledby', trigger.id);
+    });
+  });
+
+  describe('Keyboard navigation', () => {
+    it('opens menu on ArrowDown and focuses first item', () => {
+      render(<Dropdown trigger={<span>Menu</span>} items={items} />);
+      const trigger = screen.getByRole('button', { name: 'Menu' });
+      fireEvent.keyDown(trigger, { key: 'ArrowDown' });
+      expect(screen.getByRole('menu')).toBeInTheDocument();
+      expect(screen.getAllByRole('menuitem')[0]).toHaveFocus();
+    });
+
+    it('opens menu on ArrowUp', () => {
+      render(<Dropdown trigger={<span>Menu</span>} items={items} />);
+      const trigger = screen.getByRole('button', { name: 'Menu' });
+      fireEvent.keyDown(trigger, { key: 'ArrowUp' });
+      expect(screen.getByRole('menu')).toBeInTheDocument();
+    });
+
+    it('navigates down with ArrowDown', () => {
+      render(<Dropdown trigger={<span>Menu</span>} items={items} />);
+      fireEvent.click(screen.getByRole('button', { name: 'Menu' }));
+      const menuItems = screen.getAllByRole('menuitem');
+      expect(menuItems[0]).toHaveFocus();
+      fireEvent.keyDown(screen.getByRole('menu'), { key: 'ArrowDown' });
+      expect(menuItems[1]).toHaveFocus();
+    });
+
+    it('wraps around when navigating past last item', () => {
+      render(<Dropdown trigger={<span>Menu</span>} items={items} />);
+      fireEvent.click(screen.getByRole('button', { name: 'Menu' }));
+      const menuItems = screen.getAllByRole('menuitem');
+      fireEvent.keyDown(screen.getByRole('menu'), { key: 'ArrowDown' });
+      expect(menuItems[1]).toHaveFocus();
+      fireEvent.keyDown(screen.getByRole('menu'), { key: 'ArrowDown' });
+      expect(menuItems[0]).toHaveFocus();
+    });
+
+    it('navigates up with ArrowUp', () => {
+      render(<Dropdown trigger={<span>Menu</span>} items={items} />);
+      fireEvent.click(screen.getByRole('button', { name: 'Menu' }));
+      const menuItems = screen.getAllByRole('menuitem');
+      fireEvent.keyDown(screen.getByRole('menu'), { key: 'ArrowDown' });
+      expect(menuItems[1]).toHaveFocus();
+      fireEvent.keyDown(screen.getByRole('menu'), { key: 'ArrowUp' });
+      expect(menuItems[0]).toHaveFocus();
+    });
+
+    it('wraps around when navigating before first item', () => {
+      render(<Dropdown trigger={<span>Menu</span>} items={items} />);
+      fireEvent.click(screen.getByRole('button', { name: 'Menu' }));
+      const menuItems = screen.getAllByRole('menuitem');
+      fireEvent.keyDown(screen.getByRole('menu'), { key: 'ArrowUp' });
+      expect(menuItems[1]).toHaveFocus();
+    });
+
+    it('closes menu on Escape and returns focus to trigger', () => {
+      render(<Dropdown trigger={<span>Menu</span>} items={items} />);
+      const trigger = screen.getByRole('button', { name: 'Menu' });
+      fireEvent.click(trigger);
+      expect(screen.getByRole('menu')).toBeInTheDocument();
+      fireEvent.keyDown(screen.getByRole('menu'), { key: 'Escape' });
+      expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+      expect(trigger).toHaveFocus();
+    });
+
+    it('selects item with Enter', () => {
+      const onClick = jest.fn();
+      render(
+        <Dropdown
+          trigger={<span>Menu</span>}
+          items={[{ label: 'Action', onClick }]}
+        />
+      );
+      fireEvent.click(screen.getByRole('button', { name: 'Menu' }));
+      fireEvent.keyDown(screen.getByRole('menu'), { key: 'Enter' });
+      expect(onClick).toHaveBeenCalledTimes(1);
+      expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+    });
+
+    it('selects item with Space', () => {
+      const onClick = jest.fn();
+      render(
+        <Dropdown
+          trigger={<span>Menu</span>}
+          items={[{ label: 'Action', onClick }]}
+        />
+      );
+      fireEvent.click(screen.getByRole('button', { name: 'Menu' }));
+      fireEvent.keyDown(screen.getByRole('menu'), { key: ' ' });
+      expect(onClick).toHaveBeenCalledTimes(1);
+      expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+    });
+
+    it('jumps to first item with Home', () => {
+      render(<Dropdown trigger={<span>Menu</span>} items={items} />);
+      fireEvent.click(screen.getByRole('button', { name: 'Menu' }));
+      const menuItems = screen.getAllByRole('menuitem');
+      fireEvent.keyDown(screen.getByRole('menu'), { key: 'ArrowDown' });
+      expect(menuItems[1]).toHaveFocus();
+      fireEvent.keyDown(screen.getByRole('menu'), { key: 'Home' });
+      expect(menuItems[0]).toHaveFocus();
+    });
+
+    it('jumps to last item with End', () => {
+      render(<Dropdown trigger={<span>Menu</span>} items={items} />);
+      fireEvent.click(screen.getByRole('button', { name: 'Menu' }));
+      const menuItems = screen.getAllByRole('menuitem');
+      expect(menuItems[0]).toHaveFocus();
+      fireEvent.keyDown(screen.getByRole('menu'), { key: 'End' });
+      expect(menuItems[1]).toHaveFocus();
+    });
+
+    it('skips disabled items during navigation', () => {
+      render(
+        <Dropdown
+          trigger={<span>Menu</span>}
+          items={[
+            { label: 'First', onClick: jest.fn() },
+            { label: 'Disabled', disabled: true },
+            { label: 'Last', onClick: jest.fn() },
+          ]}
+        />
+      );
+      fireEvent.click(screen.getByRole('button', { name: 'Menu' }));
+      const menuItems = screen.getAllByRole('menuitem');
+      expect(menuItems[0]).toHaveFocus();
+      fireEvent.keyDown(screen.getByRole('menu'), { key: 'ArrowDown' });
+      expect(menuItems[2]).toHaveFocus();
+    });
+
+    it('skips divider items during navigation', () => {
+      render(
+        <Dropdown
+          trigger={<span>Menu</span>}
+          items={[
+            { label: 'First', onClick: jest.fn() },
+            { label: '', divider: true },
+            { label: 'Last', onClick: jest.fn() },
+          ]}
+        />
+      );
+      fireEvent.click(screen.getByRole('button', { name: 'Menu' }));
+      const menuItems = screen.getAllByRole('menuitem');
+      expect(menuItems[0]).toHaveFocus();
+      fireEvent.keyDown(screen.getByRole('menu'), { key: 'ArrowDown' });
+      expect(menuItems[1]).toHaveFocus();
+    });
+
+    it('closes menu on Tab', () => {
+      render(<Dropdown trigger={<span>Menu</span>} items={items} />);
+      const trigger = screen.getByRole('button', { name: 'Menu' });
+      fireEvent.click(trigger);
+      expect(screen.getByRole('menu')).toBeInTheDocument();
+      fireEvent.keyDown(screen.getByRole('menu'), { key: 'Tab' });
+      expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+      expect(trigger).toHaveFocus();
+    });
   });
 });

--- a/libs/shared/ui/src/lib/Dropdown.tsx
+++ b/libs/shared/ui/src/lib/Dropdown.tsx
@@ -1,6 +1,14 @@
 'use client';
 
-import { useEffect, useRef, useState, type ReactNode } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
 import { cn } from './utils/cn';
 
 export interface DropdownItem {
@@ -26,29 +34,155 @@ export function Dropdown({
   className,
 }: DropdownProps) {
   const [open, setOpen] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(-1);
   const ref = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const itemRefs = useRef<(HTMLButtonElement | null)[]>([]);
+  const uid = useId();
+  const menuId = `dropdown-menu-${uid}`;
+  const triggerId = `dropdown-trigger-${uid}`;
+
+  const actionableItems = useMemo(
+    () =>
+      items.reduce<number[]>((acc, item, i) => {
+        if (!item.divider && !item.disabled) acc.push(i);
+        return acc;
+      }, []),
+    [items]
+  );
+
+  const focusItem = useCallback((index: number) => {
+    setActiveIndex(index);
+    itemRefs.current[index]?.focus();
+  }, []);
+
+  const openMenu = useCallback(() => {
+    setOpen(true);
+  }, []);
+
+  const closeMenu = useCallback(() => {
+    setOpen(false);
+    setActiveIndex(-1);
+    triggerRef.current?.focus();
+  }, []);
+
+  // Focus first actionable item when menu opens
+  const prevOpenRef = useRef(false);
+  useEffect(() => {
+    const firstActionable = actionableItems[0];
+    if (open && !prevOpenRef.current && firstActionable != null) {
+      requestAnimationFrame(() => {
+        focusItem(firstActionable);
+      });
+    }
+    prevOpenRef.current = open;
+  }, [open, actionableItems, focusItem]);
 
   useEffect(() => {
     const handler = (e: MouseEvent) => {
       if (ref.current && !ref.current.contains(e.target as Node)) {
         setOpen(false);
+        setActiveIndex(-1);
       }
     };
     document.addEventListener('mousedown', handler);
     return () => document.removeEventListener('mousedown', handler);
   }, []);
 
+  const handleTriggerKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+      e.preventDefault();
+      if (!open) {
+        openMenu();
+      }
+    } else if (e.key === 'Escape' && open) {
+      e.preventDefault();
+      closeMenu();
+    }
+  };
+
+  const handleMenuKeyDown = (e: React.KeyboardEvent) => {
+    const currentActionableIndex = actionableItems.indexOf(activeIndex);
+
+    switch (e.key) {
+      case 'ArrowDown': {
+        e.preventDefault();
+        const nextIdx =
+          currentActionableIndex < actionableItems.length - 1
+            ? actionableItems[currentActionableIndex + 1]
+            : actionableItems[0];
+        if (nextIdx != null) focusItem(nextIdx);
+        break;
+      }
+      case 'ArrowUp': {
+        e.preventDefault();
+        const prevIdx =
+          currentActionableIndex > 0
+            ? actionableItems[currentActionableIndex - 1]
+            : actionableItems[actionableItems.length - 1];
+        if (prevIdx != null) focusItem(prevIdx);
+        break;
+      }
+      case 'Home': {
+        e.preventDefault();
+        const first = actionableItems[0];
+        if (first != null) focusItem(first);
+        break;
+      }
+      case 'End': {
+        e.preventDefault();
+        const last = actionableItems[actionableItems.length - 1];
+        if (last != null) focusItem(last);
+        break;
+      }
+      case 'Escape': {
+        e.preventDefault();
+        closeMenu();
+        break;
+      }
+      case 'Enter':
+      case ' ': {
+        e.preventDefault();
+        if (activeIndex >= 0) {
+          const item = items[activeIndex];
+          if (item && !item.divider && !item.disabled) {
+            item.onClick?.();
+            setOpen(false);
+            setActiveIndex(-1);
+            triggerRef.current?.focus();
+          }
+        }
+        break;
+      }
+      case 'Tab': {
+        closeMenu();
+        break;
+      }
+    }
+  };
+
   return (
     <div ref={ref} className={cn('relative inline-flex', className)}>
       <button
+        ref={triggerRef}
+        id={triggerId}
         type='button'
-        onClick={() => setOpen(!open)}
+        aria-haspopup='true'
+        aria-expanded={open}
+        aria-controls={open ? menuId : undefined}
+        onClick={() => (open ? closeMenu() : openMenu())}
+        onKeyDown={handleTriggerKeyDown}
         className='inline-flex items-center'
       >
         {trigger}
       </button>
       {open && (
         <div
+          id={menuId}
+          role='menu'
+          aria-labelledby={triggerId}
+          tabIndex={-1}
+          onKeyDown={handleMenuKeyDown}
           className={cn(
             'absolute z-50 mt-1 top-full min-w-[180px]',
             'bg-surface-elevated border border-border rounded-lg shadow-lg',
@@ -58,14 +192,25 @@ export function Dropdown({
         >
           {items.map((item, i) =>
             item.divider ? (
-              <div key={i} className='my-1 border-t border-border' />
+              <div
+                key={i}
+                role='separator'
+                className='my-1 border-t border-border'
+              />
             ) : (
               <button
                 key={i}
+                ref={el => {
+                  itemRefs.current[i] = el;
+                }}
+                role='menuitem'
+                tabIndex={i === activeIndex ? 0 : -1}
                 disabled={item.disabled}
                 onClick={() => {
                   item.onClick?.();
                   setOpen(false);
+                  setActiveIndex(-1);
+                  triggerRef.current?.focus();
                 }}
                 className={cn(
                   'w-full flex items-center gap-2 px-3 py-1.5 text-sm text-left',


### PR DESCRIPTION
## Summary
- Add `aria-haspopup`, `aria-expanded`, `aria-controls` on trigger button
- Add `role="menu"` with `aria-labelledby` on dropdown list
- Add `role="menuitem"` on items, `role="separator"` on dividers
- Implement roving `tabIndex` focus management
- Keyboard navigation: Arrow Up/Down (wrapping), Enter/Space to activate, Escape to close, Home/End, Tab to close
- Skip disabled and divider items during navigation
- Tests expanded from 10 → 32

## Test plan
- [x] Dropdown tests pass (32 tests)
- [x] Full suite passes (648 tests)
- [x] Typecheck passes

Closes #206

🤖 Generated with [Claude Code](https://claude.com/claude-code)