### PR TITLE
fix(shared-ui): Toast aria-live region, roles, and close button label (#207)

### DIFF
--- a/libs/shared/ui/src/lib/Toast.spec.tsx
+++ b/libs/shared/ui/src/lib/Toast.spec.tsx
@@ -8,6 +8,12 @@ function ToastTrigger() {
       <button onClick={() => toast({ variant: 'success', title: 'Saved!' })}>
         Success
       </button>
+      <button onClick={() => toast({ variant: 'info', title: 'Heads up' })}>
+        Info
+      </button>
+      <button onClick={() => toast({ variant: 'warning', title: 'Watch out' })}>
+        Warning
+      </button>
       <button
         onClick={() =>
           toast({
@@ -87,11 +93,9 @@ describe('Toast', () => {
     fireEvent.click(screen.getByText('Success'));
     expect(screen.getByText('Saved!')).toBeInTheDocument();
 
-    const closeButtons = screen.getAllByRole('button').filter(btn => {
-      const svg = btn.querySelector('svg');
-      return svg && btn.closest('.animate-slide-up');
-    });
-    fireEvent.click(closeButtons[0]);
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Dismiss notification' })
+    );
 
     expect(screen.queryByText('Saved!')).not.toBeInTheDocument();
   });
@@ -116,5 +120,133 @@ describe('Toast', () => {
       </ToastProvider>
     );
     expect(screen.getByText('App Content')).toBeInTheDocument();
+  });
+
+  // --- Accessibility: aria-live region ---
+
+  it('toast container has aria-live="polite"', () => {
+    const { container } = render(
+      <ToastProvider>
+        <div>App</div>
+      </ToastProvider>
+    );
+    const region = container.querySelector('[aria-live="polite"]');
+    expect(region).toBeInTheDocument();
+  });
+
+  it('toast container has aria-atomic="true"', () => {
+    const { container } = render(
+      <ToastProvider>
+        <div>App</div>
+      </ToastProvider>
+    );
+    const region = container.querySelector('[aria-live="polite"]');
+    expect(region).toHaveAttribute('aria-atomic', 'true');
+  });
+
+  // --- Accessibility: role per variant ---
+
+  it('info toast has role="status"', () => {
+    render(
+      <ToastProvider>
+        <ToastTrigger />
+      </ToastProvider>
+    );
+    fireEvent.click(screen.getByText('Info'));
+    expect(screen.getByRole('status')).toBeInTheDocument();
+  });
+
+  it('success toast has role="status"', () => {
+    render(
+      <ToastProvider>
+        <ToastTrigger />
+      </ToastProvider>
+    );
+    fireEvent.click(screen.getByText('Success'));
+    expect(screen.getByRole('status')).toBeInTheDocument();
+  });
+
+  it('error toast has role="alert"', () => {
+    render(
+      <ToastProvider>
+        <ToastTrigger />
+      </ToastProvider>
+    );
+    fireEvent.click(screen.getByText('Error'));
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+  });
+
+  it('warning toast has role="alert"', () => {
+    render(
+      <ToastProvider>
+        <ToastTrigger />
+      </ToastProvider>
+    );
+    fireEvent.click(screen.getByText('Warning'));
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+  });
+
+  // --- Accessibility: aria-atomic on individual toast ---
+
+  it('individual toast has aria-atomic="true"', () => {
+    render(
+      <ToastProvider>
+        <ToastTrigger />
+      </ToastProvider>
+    );
+    fireEvent.click(screen.getByText('Info'));
+    expect(screen.getByRole('status')).toHaveAttribute('aria-atomic', 'true');
+  });
+
+  // --- Accessibility: close button label ---
+
+  it('close button has aria-label="Dismiss notification"', () => {
+    render(
+      <ToastProvider>
+        <ToastTrigger />
+      </ToastProvider>
+    );
+    fireEvent.click(screen.getByText('Info'));
+    expect(
+      screen.getByRole('button', { name: 'Dismiss notification' })
+    ).toBeInTheDocument();
+  });
+
+  // --- Pause on hover ---
+
+  it('pauses auto-dismiss on mouse hover and resumes on leave', () => {
+    render(
+      <ToastProvider>
+        <ToastTrigger />
+      </ToastProvider>
+    );
+    fireEvent.click(screen.getByText('Info'));
+    const toast = screen.getByRole('status');
+
+    // Advance partway through the timeout
+    act(() => {
+      jest.advanceTimersByTime(2000);
+    });
+
+    // Hover to pause
+    fireEvent.mouseEnter(toast);
+
+    // Advance well past the original timeout
+    act(() => {
+      jest.advanceTimersByTime(5000);
+    });
+
+    // Toast should still be visible because hover paused the timer
+    expect(screen.getByText('Heads up')).toBeInTheDocument();
+
+    // Mouse leave to resume
+    fireEvent.mouseLeave(toast);
+
+    // Advance the remaining time (~2000ms)
+    act(() => {
+      jest.advanceTimersByTime(2000);
+    });
+
+    expect(screen.queryByText('Heads up')).not.toBeInTheDocument();
   });
 });

--- a/libs/shared/ui/src/lib/Toast.tsx
+++ b/libs/shared/ui/src/lib/Toast.tsx
@@ -5,6 +5,8 @@ import {
   createContext,
   useCallback,
   useContext,
+  useEffect,
+  useRef,
   useState,
   type ReactNode,
 } from 'react';
@@ -45,54 +47,104 @@ const iconColors: Record<ToastVariant, string> = {
   error: 'text-error',
 };
 
+const AUTO_DISMISS_MS = 4000;
+
+function ToastCard({
+  toast: t,
+  onDismiss,
+}: {
+  toast: ToastItem;
+  onDismiss: (id: string) => void;
+}) {
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const remainingRef = useRef(AUTO_DISMISS_MS);
+  const startRef = useRef(Date.now());
+
+  const isUrgent = t.variant === 'error' || t.variant === 'warning';
+  const Icon = icons[t.variant];
+
+  const startTimer = useCallback(() => {
+    startRef.current = Date.now();
+    timerRef.current = setTimeout(() => {
+      onDismiss(t.id);
+    }, remainingRef.current);
+  }, [onDismiss, t.id]);
+
+  const pauseTimer = useCallback(() => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+      remainingRef.current -= Date.now() - startRef.current;
+    }
+  }, []);
+
+  useEffect(() => {
+    startTimer();
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, [startTimer]);
+
+  return (
+    // eslint-disable-next-line jsx-a11y/no-static-element-interactions -- hover/focus pause timer, not user interaction
+    <div
+      role={isUrgent ? 'alert' : 'status'}
+      aria-atomic='true'
+      onMouseEnter={pauseTimer}
+      onMouseLeave={startTimer}
+      onFocus={pauseTimer}
+      onBlur={startTimer}
+      className={cn(
+        'flex items-start gap-3 p-4 bg-surface-elevated border border-border',
+        'rounded-lg shadow-lg animate-slide-up'
+      )}
+    >
+      <Icon className={cn('h-5 w-5 shrink-0', iconColors[t.variant])} />
+      <div className='flex-1 min-w-0'>
+        <Heading variant='cardTitle' as='p'>
+          {t.title}
+        </Heading>
+        {t.description && (
+          <Text variant='meta' className='mt-0.5'>
+            {t.description}
+          </Text>
+        )}
+      </div>
+      <button
+        onClick={() => onDismiss(t.id)}
+        aria-label='Dismiss notification'
+        className='p-0.5 text-text-tertiary hover:text-text-primary transition-colors cursor-pointer'
+      >
+        <X className='h-4 w-4' />
+      </button>
+    </div>
+  );
+}
+
 export function ToastProvider({ children }: { children: ReactNode }) {
   const [toasts, setToasts] = useState<ToastItem[]>([]);
 
   const addToast = useCallback((params: Omit<ToastItem, 'id'>) => {
     const id = Math.random().toString(36).slice(2);
     setToasts(prev => [...prev, { ...params, id }]);
-    setTimeout(() => {
-      setToasts(prev => prev.filter(t => t.id !== id));
-    }, 4000);
   }, []);
 
-  const dismiss = (id: string) =>
-    setToasts(prev => prev.filter(t => t.id !== id));
+  const dismiss = useCallback(
+    (id: string) => setToasts(prev => prev.filter(t => t.id !== id)),
+    []
+  );
 
   return (
     <ToastContext.Provider value={{ toast: addToast }}>
       {children}
-      <div className='fixed bottom-4 right-4 z-[100] flex flex-col gap-2 max-w-sm'>
-        {toasts.map(t => {
-          const Icon = icons[t.variant];
-          return (
-            <div
-              key={t.id}
-              className={cn(
-                'flex items-start gap-3 p-4 bg-surface-elevated border border-border',
-                'rounded-lg shadow-lg animate-slide-up'
-              )}
-            >
-              <Icon className={cn('h-5 w-5 shrink-0', iconColors[t.variant])} />
-              <div className='flex-1 min-w-0'>
-                <Heading variant='cardTitle' as='p'>
-                  {t.title}
-                </Heading>
-                {t.description && (
-                  <Text variant='meta' className='mt-0.5'>
-                    {t.description}
-                  </Text>
-                )}
-              </div>
-              <button
-                onClick={() => dismiss(t.id)}
-                className='p-0.5 text-text-tertiary hover:text-text-primary transition-colors cursor-pointer'
-              >
-                <X className='h-4 w-4' />
-              </button>
-            </div>
-          );
-        })}
+      <div
+        aria-live='polite'
+        aria-atomic='true'
+        className='fixed bottom-4 right-4 z-[100] flex flex-col gap-2 max-w-sm'
+      >
+        {toasts.map(t => (
+          <ToastCard key={t.id} toast={t} onDismiss={dismiss} />
+        ))}
       </div>
     </ToastContext.Provider>
   );


### PR DESCRIPTION
## Summary
- Add `aria-live="polite"` and `aria-atomic="true"` on toast container
- Add `role="alert"` for error/warning toasts, `role="status"` for info/success
- Add `aria-label="Dismiss notification"` on close button
- Extract `ToastCard` component with pause-on-hover auto-dismiss timer
- 9 new tests for ARIA attributes and pause-on-hover behavior

## Test plan
- [x] Toast tests pass (16 tests)
- [x] Full suite passes (648 tests)
- [x] Typecheck passes

Closes #207

🤖 Generated with [Claude Code](https://claude.com/claude-code)