### PR TITLE
fix: pass remark-gfm as string for Turbopack-serializable MDX options

### DIFF
--- a/apps/root/next.config.mjs
+++ b/apps/root/next.config.mjs
@@ -3,7 +3,8 @@
 import { composePlugins, withNx } from '@nx/next';
 import { withBotId } from 'botid/next/config';
 import createMDX from '@next/mdx';
-import remarkGfm from 'remark-gfm';
+// remark-gfm is referenced by string below to keep MDX loader options
+// JSON-serializable for Turbopack (same approach as rehype-pretty-code).
 import bundleAnalyzer from '@next/bundle-analyzer';
 import { createRequire } from 'node:module';
 
@@ -33,7 +34,7 @@ const prettyCodeOptions = {
 // This keeps loader options JSON-serializable for both webpack and Turbopack.
 const withMDX = createMDX({
   options: {
-    remarkPlugins: [remarkGfm],
+    remarkPlugins: ['remark-gfm'],
     rehypePlugins: [['rehype-pretty-code', prettyCodeOptions]],
   },
 });


### PR DESCRIPTION
## Summary
- `remarkGfm` was imported as a function and passed directly to `@next/mdx`, breaking Turbopack's requirement for JSON-serializable loader options
- Use the same string-reference pattern already applied to `rehype-pretty-code`
- Dev server now starts successfully with Turbopack

## Root cause
Next.js 16 Turbopack requires all MDX loader options to be plain JSON-serializable values. The `rehype-pretty-code` plugin was already passed as a string (`'rehype-pretty-code'`), but `remark-gfm` was still imported as a function reference.

## Test plan
- [x] `npx nx dev root` starts without error
- [x] `curl localhost:3000` returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)