### PR TITLE
fix(ci): replace dorny/paths-filter with shell-based docs-only check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,31 +31,38 @@ jobs:
   changes:
     runs-on: ubuntu-latest
     outputs:
-      docs-only: ${{ steps.filter.outputs.docs-only }}
+      docs-only: ${{ steps.check.outputs.docs-only }}
     steps:
       - uses: actions/checkout@v5
-      - uses: dorny/paths-filter@v3
+      - name: Check for docs-only changes
+        id: check
         env:
-          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-        id: filter
-        with:
-          predicate-quantifier: 'every'
-          filters: |
-            docs-only:
-              - '**.md'
-              - '.claude/**'
-              - '.mcp.json'
-              - '.vscode/**'
-              - '.github/ISSUE_TEMPLATE/**'
-              - '.github/prompts/**'
-              - '.github/skills/**'
-              - '.github/agents/**'
-              - '.husky/**'
-              - '.prettierrc'
-              - '.nvmrc'
-              - '.sentryclirc'
-              - '.editorconfig'
-              - 'LICENSE'
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            CHANGED=$(gh pr view ${{ github.event.pull_request.number }} --json files --jq '.files[].path')
+          else
+            # Push to develop — always run CI
+            echo "docs-only=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          DOCS_ONLY=true
+          while IFS= read -r file; do
+            [ -z "$file" ] && continue
+            case "$file" in
+              *.md) ;;
+              .claude/*) ;;
+              .mcp.json) ;;
+              .vscode/*) ;;
+              .github/ISSUE_TEMPLATE/*|.github/prompts/*|.github/skills/*|.github/agents/*) ;;
+              .husky/*) ;;
+              .prettierrc|.nvmrc|.sentryclirc|.editorconfig|LICENSE) ;;
+              *) DOCS_ONLY=false; break ;;
+            esac
+          done <<< "$CHANGED"
+
+          echo "docs-only=$DOCS_ONLY" >> "$GITHUB_OUTPUT"
 
   ci:
     needs: changes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,7 +155,7 @@ The workspace uses Nx plugins for automatic target inference:
 
 - `ci.yml`: Runs on push to `develop` and PRs (except to `main`). Runs lint, typecheck, test, build, e2e (PR only), Chromatic, Lighthouse.
 - `ci-preview.yml`: Runs on PRs to `main` (release validation). Requires source branch is `develop`.
-- `ci.yml` uses a `changes` job ([dorny/paths-filter](https://github.com/dorny/paths-filter)) to detect docs-only PRs. When only non-code files change (`**.md`, `.claude/**`, `.mcp.json`, `.vscode/**`, `.github/ISSUE_TEMPLATE/**`, `.github/prompts/**`, `.github/skills/**`, `.github/agents/**`, `.husky/**`, `.prettierrc`, `.nvmrc`, `.sentryclirc`, `.editorconfig`, `LICENSE`), the `ci` job is skipped but the `ci-status` gate job still runs and passes.
+- `ci.yml` uses a `changes` job with a shell-based file check to detect docs-only PRs. When only non-code files change (`*.md`, `.claude/*`, `.mcp.json`, `.vscode/*`, `.github/ISSUE_TEMPLATE/*`, `.github/prompts/*`, `.github/skills/*`, `.github/agents/*`, `.husky/*`, `.prettierrc`, `.nvmrc`, `.sentryclirc`, `.editorconfig`, `LICENSE`), the `ci` job is skipped but the `ci-status` gate job still runs and passes. Push events to `develop` always run CI.
 - Branch protection rulesets require `ci-status` (not `ci`) so docs-only PRs can merge without running the full suite.
 - Snapshot regeneration: `workflow_dispatch` with `update-snapshots: true` on `ci.yml`.
 


### PR DESCRIPTION
## Summary

- `dorny/paths-filter@v3` does not support `predicate-quantifier` (silently ignored) and its glob matching failed to match `.claude/**` files — docs-only PRs always ran full CI
- Replace with a shell `case` statement that checks PR files via `gh` CLI — no glob library ambiguity
- Push events to `develop` always run CI (skip logic only applies to PRs)
- Update CLAUDE.md to reflect the new approach

## Test plan

- [ ] Push a PR with only `.claude/` file changes — CI should be skipped
- [ ] Push a PR with code changes — CI should run normally
- [ ] Push to `develop` — CI should always run

🤖 Generated with [Claude Code](https://claude.com/claude-code)