### PR TITLE
fix(config): restrict Supabase remotePatterns, remove optimizeCss

### DIFF
--- a/apps/root/next.config.mjs
+++ b/apps/root/next.config.mjs
@@ -51,8 +51,6 @@ const nextConfig = {
   experimental: {
     // Disable fetch caching across HMR refreshes so dev always shows fresh data
     serverComponentsHmrCache: false,
-    // Enable critical CSS inlining with critters
-    optimizeCss: true,
     optimizePackageImports: [
       '@gsap/react',
       'gsap',
@@ -114,7 +112,7 @@ const nextConfig = {
       },
       {
         protocol: 'https',
-        hostname: '*.supabase.co',
+        hostname: 'grwmzluuqyczatkxorfa.supabase.co',
       },
     ],
     formats: ['image/webp', 'image/avif'],


### PR DESCRIPTION
## Summary
- Narrowed `images.remotePatterns` from `*.supabase.co` (any project) to `grwmzluuqyczatkxorfa.supabase.co` (our project only) — prevents image optimizer proxy abuse
- Removed `experimental.optimizeCss` (Critters) which can conflict with Tailwind CSS v4 and cause FOUC

Findings from `/nextjs-audit` skill run.

## Test plan
- [x] `yarn tsc --noEmit` — zero errors
- [x] `yarn nx test root` — 650/650 passed
- [ ] Verify images from Supabase storage still load on preview deploy
- [ ] Check no FOUC regression after removing optimizeCss (should improve if anything)

🤖 Generated with [Claude Code](https://claude.com/claude-code)