### PR TITLE
fix(nx): remove ci.yml from cache globals, ignore storybook-static

### DIFF
--- a/.nxignore
+++ b/.nxignore
@@ -1,3 +1,4 @@
 .next
 node_modules
 .env*
+storybook-static

--- a/nx.json
+++ b/nx.json
@@ -18,7 +18,6 @@
       "!{projectRoot}/tsconfig.storybook.json"
     ],
     "sharedGlobals": [
-      "{workspaceRoot}/.github/workflows/ci.yml",
       "{workspaceRoot}/eslint.config.mjs",
       "{workspaceRoot}/tsconfig.base.json"
     ]


### PR DESCRIPTION
## Summary
- Removed `.github/workflows/ci.yml` from `namedInputs.sharedGlobals` — CI workflow edits were unnecessarily invalidating the Nx cache for all projects
- Added `storybook-static` to `.nxignore` — local Storybook builds contain a `project.json` metadata file that Nx could detect as a phantom project

Findings from `/nx-audit` skill run.

## Test plan
- [x] `npx nx show projects` — still lists all 5 projects correctly
- [ ] Verify CI cache hits improve after merging (CI workflow edits no longer bust cache)

🤖 Generated with [Claude Code](https://claude.com/claude-code)