### PR TITLE
fix: resolve circular dependency crashing all pages except home

### DIFF
--- a/apps/root/src/components/BreadCrumbs.spec.tsx
+++ b/apps/root/src/components/BreadCrumbs.spec.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import { NavLink } from '@/types/base';
+import type { NavLink } from '@/types/base';
 import BreadCrumbs from './BreadCrumbs';
 
 // Mock next/navigation

--- a/apps/root/src/components/BreadCrumbs.tsx
+++ b/apps/root/src/components/BreadCrumbs.tsx
@@ -2,7 +2,7 @@
 import { ChevronRight } from 'lucide-react';
 import { usePathname } from 'next/navigation';
 import Button from '@/components/Button';
-import { BreadCrumbsProps } from '@/types/base';
+import type { BreadCrumbsProps } from '@/types/base';
 
 export default function BreadCrumbs({ items }: BreadCrumbsProps) {
   const pathname = usePathname();

--- a/apps/root/src/lib/getPostDetailProps.ts
+++ b/apps/root/src/lib/getPostDetailProps.ts
@@ -1,4 +1,4 @@
-import { NavLink } from '@/types/base';
+import type { NavLink } from '@/types/base';
 import { ContentType } from '@/types/postTypes';
 import { contentTypeConfigs } from '@/data/contentTypeConfig';
 import {

--- a/apps/root/src/utils/constants.ts
+++ b/apps/root/src/utils/constants.ts
@@ -99,7 +99,7 @@ export const A11Y = {
 // ============================================================================
 // NAVIGATION CONSTANTS
 // ============================================================================
-import { NavLink } from '@/types/base';
+import type { NavLink } from '@/types/base';
 
 export const HOME_LINK: NavLink = { href: '/', label: 'Home' };
 export const ABOUT_LINK: NavLink = { href: '/about', label: 'About' };


### PR DESCRIPTION
## Summary
- **P0 bug**: Every page except `/` crashes with "Something went wrong!" due to a circular module dependency
- `constants.ts` imported `NavLink` from `types/base.ts` using a value import, causing Turbopack to evaluate `types/base.ts` and its data module imports (`data/blog.ts`) during constants initialization
- When `blogThumbnails.ts` later imported `BLOG_LINK` from `constants.ts`, the module hadn't finished initializing → `BLOG_LINK` is `undefined` → `Cannot read properties of undefined (reading 'href')` → crashes `CommandPalette` → `searchIndex` → root layout error boundary
- Fix: switch all type-only imports from `types/base.ts` to `import type` statement syntax, which is guaranteed to be erased and never triggers module evaluation

## Dependency cycle
```
constants.ts ──imports NavLink──→ types/base.ts ──imports blogPageSlugs──→ data/blog.ts
      ↑                                                                         │
      └──────────── blogThumbnails.ts ←── searchIndex.ts ←── CommandPalette ←────┘
```

## Test plan
- [x] `yarn tsc --noEmit` — zero errors
- [x] `npx nx test root` — 66 suites, 650 tests pass
- [ ] CI pipeline passes
- [ ] All pages render without crashes (visual audit to follow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)