### PR TITLE
fix: add name prop to ButtonBase for link variant compatibility

### DIFF
--- a/apps/root/src/components/Button.tsx
+++ b/apps/root/src/components/Button.tsx
@@ -27,6 +27,7 @@ interface ButtonBase {
   variant?: ButtonVariant;
   size?: ButtonSize;
   children: ReactNode;
+  name?: string;
 }
 
 interface ButtonProps


### PR DESCRIPTION
## Summary

- React 19 types removed the obsolete `name` attribute from `AnchorHTMLAttributes<HTMLAnchorElement>`, causing a type error when passing `name` to `Button` with `as='link'`
- Added `name?: string` to `ButtonBase` so both button and link variants support the prop

## Test plan

- [x] TypeScript typecheck passes (zero errors)
- [x] All 618 unit tests pass

https://claude.ai/code/session_01J8LcM1JHqewPPZPBT8g35V