### PR TITLE
content: add 3 blog posts from recent develop work

### DIFF
--- a/.claude/hooks/run-spec-tests.sh
+++ b/.claude/hooks/run-spec-tests.sh
@@ -12,11 +12,17 @@ echo "$FILE_PATH" | grep -qE '\.spec\.tsx?$' || exit 0
 
 # Use the spec filename (e.g. "page.spec.tsx") as the pattern for an exact match
 SPEC_FILE=$(basename "$FILE_PATH")
-OUTPUT=$(timeout 60 npx nx test root -- --testPathPatterns="$SPEC_FILE" --no-coverage 2>&1)
-RC=$?
+# macOS doesn't have `timeout`; use perl one-liner as portable fallback
+if command -v timeout >/dev/null 2>&1; then
+  OUTPUT=$(timeout 60 npx nx test root -- --testPathPatterns="$SPEC_FILE" --no-coverage 2>&1)
+  RC=$?
+else
+  OUTPUT=$(perl -e 'alarm 60; exec @ARGV' npx nx test root -- --testPathPatterns="$SPEC_FILE" --no-coverage 2>&1)
+  RC=$?
+fi
 
-# timeout exits 124 when the command is killed
-if [ $RC -eq 124 ]; then
+# timeout exits 124, perl alarm sends SIGALRM (RC=142) when the command is killed
+if [ $RC -eq 124 ] || [ $RC -eq 142 ]; then
   echo "TIMEOUT: tests exceeded 60s limit" >&2
   exit 2
 fi

--- a/apps/root/src/data/__tests__/contentRegistry.spec.ts
+++ b/apps/root/src/data/__tests__/contentRegistry.spec.ts
@@ -26,7 +26,7 @@ describe('contentRegistry', () => {
 
     it('returns all blog entries in order', () => {
       const blogs = getContentByType('blog');
-      expect(blogs.length).toBe(13);
+      expect(blogs.length).toBe(16);
       expect(blogs[0].type).toBe('blog');
       expect(blogs[0].slug).toBe('unified-content-pipeline');
       expect(blogs[1].slug).toBe('auto-generated-toc-scroll-spy');
@@ -97,7 +97,7 @@ describe('contentRegistry', () => {
       expect(slugs).toContain('accessible-dropdown-keyboard-nav');
       expect(slugs).toContain('toast-pause-on-hover');
       expect(slugs).toContain('keyboard-navigable-data-tables');
-      expect(slugs.length).toBe(13);
+      expect(slugs.length).toBe(16);
     });
   });
 
@@ -145,7 +145,7 @@ describe('contentRegistry', () => {
   describe('getAllContent', () => {
     it('returns all entries (projects + experience)', () => {
       const all = getAllContent();
-      expect(all.length).toBe(28); // 10 projects + 5 experiences + 13 blogs
+      expect(all.length).toBe(31); // 10 projects + 5 experiences + 16 blogs
     });
 
     it('contains entries of all types', () => {

--- a/apps/root/src/data/blog.ts
+++ b/apps/root/src/data/blog.ts
@@ -12,6 +12,10 @@ export const blogSlugs = {
   accessibleDropdownKeyboardNav: 'accessible-dropdown-keyboard-nav',
   toastPauseOnHover: 'toast-pause-on-hover',
   keyboardNavigableDataTables: 'keyboard-navigable-data-tables',
+  importTypeCircularDependency: 'import-type-circular-dependency',
+  mobileBottomNavZIndex: 'mobile-bottom-nav-z-index',
+  gracefulDegradationThirdPartyEmbeds:
+    'graceful-degradation-third-party-embeds',
 } as const;
 
 export const blogPageSlugs = [...Object.values(blogSlugs)];

--- a/apps/root/src/data/blogThumbnails.ts
+++ b/apps/root/src/data/blogThumbnails.ts
@@ -226,4 +226,56 @@ export const blogRecords: Record<AllowedBlogSlugs, PostThumbnail> = {
       blurHash: 'L26*n%~q00xu-;j[ofWB00of%Mxu',
     },
   },
+  [blogSlugs.importTypeCircularDependency]: {
+    slug: blogSlugs.importTypeCircularDependency,
+    title:
+      "When import type Isn't Optional: Fixing a Circular Dependency Crash",
+    description:
+      'A production crash caused by a subtle difference between import and import type in a Turbopack-bundled Next.js app.',
+    link: {
+      label: 'import type Circular Dependency',
+      href: `${BLOG_LINK.href}/${blogSlugs.importTypeCircularDependency}`,
+    },
+    cover: {
+      alt: 'Tangled cables forming a circular loop',
+      src: '/photo-1558618666-fcd25c85f82e',
+      origin: `${UNSPLASH_URL}/photos/close-up-photo-of-cables-plugged-into-the-server-bUWBWMH0kE0`,
+      creator: '@thomasjsn',
+      blurHash: 'L24o;G9F00D%~q%MRjRj00of-;WB',
+    },
+  },
+  [blogSlugs.mobileBottomNavZIndex]: {
+    slug: blogSlugs.mobileBottomNavZIndex,
+    title: 'Designing a Mobile Bottom Nav That Plays Nice with FABs and Sheets',
+    description:
+      'The z-index choreography behind adding a fixed bottom bar without breaking scroll-to-top, table-of-contents, and bottom sheet overlays.',
+    link: {
+      label: 'Mobile Bottom Nav z-index',
+      href: `${BLOG_LINK.href}/${blogSlugs.mobileBottomNavZIndex}`,
+    },
+    cover: {
+      alt: 'A layered architectural structure showing different levels',
+      src: '/photo-1486406146926-c627a92ad1ab',
+      origin: `${UNSPLASH_URL}/photos/low-angle-photography-of-gray-building-at-daytime-yEauzeZU6xo`,
+      creator: '@aronvisuals',
+      blurHash: 'L37UxT-:00NG~qt7-:NG00xu9FRj',
+    },
+  },
+  [blogSlugs.gracefulDegradationThirdPartyEmbeds]: {
+    slug: blogSlugs.gracefulDegradationThirdPartyEmbeds,
+    title: 'Graceful Degradation for Third-Party Embeds',
+    description:
+      'Adding a timeout-based fallback when a Calendly iframe gets blocked by ad blockers or network issues.',
+    link: {
+      label: 'Third-Party Embed Fallbacks',
+      href: `${BLOG_LINK.href}/${blogSlugs.gracefulDegradationThirdPartyEmbeds}`,
+    },
+    cover: {
+      alt: 'A safety net stretched beneath a high structure',
+      src: '/photo-1504639725590-34d0984388bd',
+      origin: `${UNSPLASH_URL}/photos/macbook-pro-on-brown-wooden-table-8qEB0fTe9Vw`,
+      creator: '@kevinku',
+      blurHash: 'LGF~o]_N~q%M%MRjIUj[-;WBD%WB',
+    },
+  },
 };

--- a/apps/root/src/data/content/blog/graceful-degradation-third-party-embeds.mdx
+++ b/apps/root/src/data/content/blog/graceful-degradation-third-party-embeds.mdx
@@ -1,0 +1,127 @@
+export const metadata = {
+  title: 'Graceful Degradation for Third-Party Embeds',
+  date: '2026-04-06',
+  excerpt:
+    'Adding a timeout-based fallback when a Calendly iframe gets blocked by ad blockers or network issues.',
+  author: 'Daniel Joffe',
+  category: 'Frontend Engineering',
+  tags: ['React', 'UX', 'Performance', 'Resilience'],
+  slug: 'graceful-degradation-third-party-embeds',
+  type: 'blog',
+  topic: 'Resilience',
+};
+
+## The Problem
+
+The services page embeds a Calendly scheduling widget in an iframe.
+When it works, users book a call without leaving the site. When it
+doesn't — ad blocker, corporate firewall, flaky CDN — users see a
+spinner that never stops.
+
+There's no error event. Iframes don't fire `onerror` when a third-party
+domain is blocked. The `onload` event simply never fires. The only signal
+is silence.
+
+## The Pattern
+
+The fix is a timeout. If the iframe hasn't loaded after a reasonable
+window, show a fallback that lets users complete the action through a
+different path:
+
+```tsx
+const LOAD_TIMEOUT_MS = 8000;
+
+const [isLoaded, setIsLoaded] = useState(false);
+const [timedOut, setTimedOut] = useState(false);
+
+// Start the timeout when the iframe begins loading
+useEffect(() => {
+  if (!shouldLoad || isLoaded) return;
+
+  const timer = setTimeout(() => setTimedOut(true), LOAD_TIMEOUT_MS);
+  return () => clearTimeout(timer);
+}, [shouldLoad, isLoaded]);
+```
+
+The timeout only runs while `shouldLoad` is true (the container is in
+the viewport) and `isLoaded` is false. If the iframe loads before the
+timer fires, the cleanup function clears it. If the iframe loads after
+the timer fires (slow network, not a block), `onLoad` resets `timedOut`
+to false and shows the embed.
+
+## The Fallback
+
+When the timeout triggers, replace the spinner with a direct link:
+
+```tsx
+if (timedOut && !isLoaded) {
+  return (
+    <div className='flex flex-col items-center justify-center gap-4 ...'>
+      <Calendar className='h-10 w-10 text-text-tertiary' />
+      <p className='text-text-secondary text-sm max-w-md'>
+        The scheduling widget couldn&apos;t load. Book directly on Calendly
+        instead.
+      </p>
+      <Button
+        name='calendly-fallback'
+        as='link'
+        href={CALENDLY_URL}
+        target='_blank'
+        onClick={() =>
+          analytics.ctaClick('services_calendly_fallback', CALENDLY_URL)
+        }
+      >
+        Open Calendly
+      </Button>
+    </div>
+  );
+}
+```
+
+The fallback does three things right:
+
+1. **Explains what happened** — "couldn't load" is honest without being
+   technical
+2. **Provides an alternative** — the direct Calendly link always works
+3. **Tracks the event** — analytics tells you how often users hit the
+   fallback, which informs whether 8 seconds is the right timeout
+
+## Lazy Loading the Embed
+
+The iframe itself is lazy-loaded with an IntersectionObserver. No point
+fetching Calendly's JavaScript until the user scrolls near the booking
+section:
+
+```tsx
+useEffect(() => {
+  const observer = new IntersectionObserver(
+    ([entry]) => {
+      if (entry.isIntersecting) {
+        setShouldLoad(true);
+        observer.disconnect();
+      }
+    },
+    { rootMargin: '200px' }
+  );
+  observer.observe(el);
+  return () => observer.disconnect();
+}, []);
+```
+
+`rootMargin: '200px'` starts loading 200px before the container enters the
+viewport. Combined with the iframe's `loading="lazy"` attribute, the
+embed begins fetching right around when the user would naturally scroll
+to it.
+
+## When to Use This Pattern
+
+Any time you embed a third-party widget that could be blocked:
+
+- **Calendly, Cal.com** — scheduling
+- **Typeform, Tally** — forms
+- **YouTube, Vimeo** — video
+- **Intercom, Drift** — chat widgets
+
+The pattern is always the same: set a timeout, show a fallback with a
+direct link, track how often it fires. If the fallback rate is high,
+consider making the direct link the primary UI instead of the embed.

--- a/apps/root/src/data/content/blog/import-type-circular-dependency.mdx
+++ b/apps/root/src/data/content/blog/import-type-circular-dependency.mdx
@@ -1,0 +1,98 @@
+export const metadata = {
+  title: "When import type Isn't Optional: Fixing a Circular Dependency Crash",
+  date: '2026-04-06',
+  excerpt:
+    'A production crash caused by a subtle difference between import and import type in a Turbopack-bundled Next.js app.',
+  author: 'Daniel Joffe',
+  category: 'Debugging',
+  tags: ['TypeScript', 'Next.js', 'Turbopack', 'Debugging'],
+  slug: 'import-type-circular-dependency',
+  type: 'blog',
+  topic: 'TypeScript',
+};
+
+## The Crash
+
+Every page except the homepage threw "Something went wrong!" — the root
+error boundary. No build errors, no type errors, no lint warnings. The app
+compiled cleanly and the homepage rendered fine. Navigate anywhere else and
+the entire React tree unmounted.
+
+The error: `Cannot read properties of undefined (reading 'href')`.
+
+## Tracing the Cycle
+
+The undefined value was `BLOG_LINK` — a constant exported from
+`utils/constants.ts`. It's used everywhere, and it's clearly defined. So
+why was it `undefined`?
+
+The answer was a five-module circular dependency:
+
+```
+constants.ts ──imports NavLink──→ types/base.ts ──imports blogPageSlugs──→ data/blog.ts
+      ↑                                                                         │
+      └──────────── blogThumbnails.ts ←── searchIndex.ts ←── CommandPalette ←────┘
+```
+
+`constants.ts` imported `NavLink` from `types/base.ts` as a **value
+import**:
+
+```tsx
+import { NavLink } from '@/types/base';
+```
+
+`NavLink` is a TypeScript interface — it doesn't exist at runtime. But
+Turbopack doesn't know that at module evaluation time. A value import tells
+the bundler "this module needs to be evaluated before mine." So Turbopack
+evaluates `types/base.ts`, which imports `blogPageSlugs` from `data/blog.ts`,
+which imports `blogThumbnails.ts`, which imports `BLOG_LINK` from
+`constants.ts` — the module that hasn't finished initializing yet.
+
+Result: `BLOG_LINK` is `undefined` when `blogThumbnails.ts` reads it.
+
+The homepage survived because its render path didn't touch `CommandPalette`
+early enough to trigger the cycle. Every other page hit it immediately.
+
+## The One-Line Fix
+
+```diff
+- import { NavLink } from '@/types/base';
++ import type { NavLink } from '@/types/base';
+```
+
+`import type` is guaranteed to be erased by TypeScript before the bundler
+sees it. No module evaluation, no dependency edge, no cycle. We applied
+the same fix to the two other files that imported types from `types/base.ts`
+using value imports:
+
+```diff
+// BreadCrumbs.tsx
+- import { BreadCrumbsProps } from '@/types/base';
++ import type { BreadCrumbsProps } from '@/types/base';
+
+// getPostDetailProps.ts
+- import { NavLink } from '@/types/base';
++ import type { NavLink } from '@/types/base';
+```
+
+Three lines changed. Every page renders.
+
+## Why This Wasn't Caught Earlier
+
+Webpack resolved the cycle differently — it happened to evaluate modules
+in an order that worked. Turbopack (used in Next.js dev mode) evaluates
+more eagerly, exposing cycles that webpack silently tolerated. The ESLint
+`import/no-cycle` rule we added later would have caught this, but it
+wasn't enabled at the time.
+
+## The Rule
+
+**Always use `import type` for type-only imports.** It's not a style
+preference — it's a correctness guarantee. Value imports create module
+evaluation dependencies. Type imports don't. In a codebase with enough
+modules, that distinction is the difference between "it works" and
+"every page crashes."
+
+TypeScript's `verbatimModuleSyntax` flag enforces this automatically. If
+you're not using it yet, the next circular dependency crash might convince
+you.

--- a/apps/root/src/data/content/blog/index.ts
+++ b/apps/root/src/data/content/blog/index.ts
@@ -40,6 +40,15 @@ import ToastPauseOnHover, {
 import KeyboardNavigableDataTables, {
   metadata as keyboardNavigableTablesMeta,
 } from './keyboard-navigable-data-tables.mdx';
+import ImportTypeCircularDependency, {
+  metadata as importTypeCircularDependencyMeta,
+} from './import-type-circular-dependency.mdx';
+import MobileBottomNavZIndex, {
+  metadata as mobileBottomNavZIndexMeta,
+} from './mobile-bottom-nav-z-index.mdx';
+import GracefulDegradationThirdPartyEmbeds, {
+  metadata as gracefulDegradationMeta,
+} from './graceful-degradation-third-party-embeds.mdx';
 
 export const blogMdxComponents: Record<AllowedBlogSlugs, ComponentType> = {
   'unified-content-pipeline': UnifiedContentPipeline,
@@ -55,6 +64,10 @@ export const blogMdxComponents: Record<AllowedBlogSlugs, ComponentType> = {
   'accessible-dropdown-keyboard-nav': AccessibleDropdownKeyboardNav,
   'toast-pause-on-hover': ToastPauseOnHover,
   'keyboard-navigable-data-tables': KeyboardNavigableDataTables,
+  'import-type-circular-dependency': ImportTypeCircularDependency,
+  'mobile-bottom-nav-z-index': MobileBottomNavZIndex,
+  'graceful-degradation-third-party-embeds':
+    GracefulDegradationThirdPartyEmbeds,
 };
 
 export const blogMdxMetadata: Record<AllowedBlogSlugs, PostMetadata> = {
@@ -71,4 +84,7 @@ export const blogMdxMetadata: Record<AllowedBlogSlugs, PostMetadata> = {
   'accessible-dropdown-keyboard-nav': accessibleDropdownMeta,
   'toast-pause-on-hover': toastPauseOnHoverMeta,
   'keyboard-navigable-data-tables': keyboardNavigableTablesMeta,
+  'import-type-circular-dependency': importTypeCircularDependencyMeta,
+  'mobile-bottom-nav-z-index': mobileBottomNavZIndexMeta,
+  'graceful-degradation-third-party-embeds': gracefulDegradationMeta,
 };

--- a/apps/root/src/data/content/blog/mobile-bottom-nav-z-index.mdx
+++ b/apps/root/src/data/content/blog/mobile-bottom-nav-z-index.mdx
@@ -1,0 +1,108 @@
+export const metadata = {
+  title: 'Designing a Mobile Bottom Nav That Plays Nice with FABs and Sheets',
+  date: '2026-04-06',
+  excerpt:
+    'The z-index choreography behind adding a fixed bottom bar without breaking scroll-to-top, table-of-contents, and bottom sheet overlays.',
+  author: 'Daniel Joffe',
+  category: 'Frontend Engineering',
+  tags: ['CSS', 'Mobile', 'Accessibility', 'React'],
+  slug: 'mobile-bottom-nav-z-index',
+  type: 'blog',
+  topic: 'CSS Architecture',
+};
+
+## The Layering Problem
+
+Adding a fixed bottom navigation bar to a mobile app sounds simple. But
+this site already had two fixed-position elements at the bottom of the
+screen: a scroll-to-top FAB on the right and a table-of-contents FAB on
+the left. Both sat at `bottom: 1.5rem` and `z-index: 50`.
+
+Drop a `h-14` fixed bottom bar at `z-index: 50` and both buttons
+disappear behind it. Tap where the scroll-to-top button should be and
+you're hitting the nav bar instead.
+
+## The Z-Index Stack
+
+The fix required defining a deliberate stacking order — not just "make it
+higher." We settled on three layers:
+
+| Layer      | z-index | Elements                          |
+| ---------- | ------- | --------------------------------- |
+| FABs       | 40      | ScrollToTop, ToC trigger          |
+| Navigation | 50      | Bottom bar, backdrop              |
+| Sheets     | 51      | ToC bottom sheet, More menu sheet |
+
+FABs sit below the nav bar. They're secondary actions — you can always
+scroll to find the content, but you always need the nav. Sheets that
+slide up from the bottom need to cover the nav bar, so they get `z-51`.
+
+```tsx
+// ScrollToTop — z-40, raised above nav on mobile
+'fixed bottom-20 md:bottom-6 right-6 z-40 ...';
+
+// Bottom nav bar — z-50
+'fixed bottom-0 left-0 right-0 z-50 bg-surface/95 ...';
+
+// ToC bottom sheet — z-51, covers nav when open
+'fixed bottom-0 left-0 right-0 z-51 bg-surface ...';
+```
+
+## The Responsive Escape Hatch
+
+The bottom nav only exists on mobile (`md:hidden`). Desktop has a
+traditional sticky top bar. So FABs need different positioning per
+breakpoint:
+
+```tsx
+className = 'fixed bottom-20 md:bottom-6 right-6 z-40 ...';
+```
+
+`bottom-20` (5rem) clears the `h-14` (3.5rem) nav bar plus breathing
+room on mobile. `md:bottom-6` restores the original position on desktop
+where there's no bottom bar. One utility class, no JavaScript.
+
+## Reusing the Sheet Pattern
+
+The site already had a bottom sheet for the table of contents — a
+`translate-y` transition that slides up from off-screen:
+
+```tsx
+<div
+  className={cn(
+    'fixed bottom-0 left-0 right-0 z-51 ...',
+    isOpen ? 'translate-y-0' : 'translate-y-full pointer-events-none'
+  )}
+>
+```
+
+The "More" menu in the new bottom nav uses the exact same pattern:
+`translate-y-0` when open, `translate-y-full pointer-events-none` when
+closed. Same focus trap hook, same Escape key handler, same body scroll
+lock. Consistency in animation patterns means users build a mental model
+once and apply it everywhere.
+
+## Accessibility Considerations
+
+A fixed bottom bar introduces several a11y requirements:
+
+- **`aria-current="page"`** on the active nav link, not just a color change
+- **`aria-expanded`** on the More button to communicate sheet state
+- **`aria-modal="true"`** on the sheet dialog
+- **Focus trap** inside the sheet when open (via `useFocusTrap` hook)
+- **Escape key** closes the sheet and returns focus to the More button
+- **Body scroll lock** prevents background scrolling while the sheet is open
+
+The More button's label also changes dynamically:
+
+```tsx
+aria-label={sheetOpen ? 'Close more menu' : 'Open more menu'}
+```
+
+## The Takeaway
+
+Fixed-position elements are easy to add individually. The complexity is in
+how they interact. Defining a z-index stack as a deliberate system — not
+ad-hoc increments — prevents the "just make it higher" escalation that
+eventually leads to `z-index: 9999`. Three layers with clear ownership
+is all this site needs.

--- a/apps/root/src/data/contentOrder.ts
+++ b/apps/root/src/data/contentOrder.ts
@@ -76,4 +76,7 @@ export const blogHistory: AllowedBlogSlugs[] = [
   blogSlugs.accessibleDropdownKeyboardNav, // 2026-04-06
   blogSlugs.toastPauseOnHover, // 2026-04-06
   blogSlugs.keyboardNavigableDataTables, // 2026-04-06
+  blogSlugs.importTypeCircularDependency, // 2026-04-06
+  blogSlugs.mobileBottomNavZIndex, // 2026-04-06
+  blogSlugs.gracefulDegradationThirdPartyEmbeds, // 2026-04-06
 ];

--- a/apps/root/src/data/structuredData/blog.ts
+++ b/apps/root/src/data/structuredData/blog.ts
@@ -131,6 +131,37 @@ export const blogStructuredData: Record<AllowedBlogSlugs, BlogStructuredData> =
         blogMdxMetadata[blogSlugs.keyboardNavigableDataTables]?.date ?? '',
       author,
     },
+    [blogSlugs.importTypeCircularDependency]: {
+      '@context': 'https://schema.org',
+      '@type': 'Article',
+      headline: blogRecords[blogSlugs.importTypeCircularDependency].title,
+      description:
+        blogRecords[blogSlugs.importTypeCircularDependency].description,
+      datePublished:
+        blogMdxMetadata[blogSlugs.importTypeCircularDependency]?.date ?? '',
+      author,
+    },
+    [blogSlugs.mobileBottomNavZIndex]: {
+      '@context': 'https://schema.org',
+      '@type': 'Article',
+      headline: blogRecords[blogSlugs.mobileBottomNavZIndex].title,
+      description: blogRecords[blogSlugs.mobileBottomNavZIndex].description,
+      datePublished:
+        blogMdxMetadata[blogSlugs.mobileBottomNavZIndex]?.date ?? '',
+      author,
+    },
+    [blogSlugs.gracefulDegradationThirdPartyEmbeds]: {
+      '@context': 'https://schema.org',
+      '@type': 'Article',
+      headline:
+        blogRecords[blogSlugs.gracefulDegradationThirdPartyEmbeds].title,
+      description:
+        blogRecords[blogSlugs.gracefulDegradationThirdPartyEmbeds].description,
+      datePublished:
+        blogMdxMetadata[blogSlugs.gracefulDegradationThirdPartyEmbeds]?.date ??
+        '',
+      author,
+    },
   };
 
 export const blogRootStructuredData: CollectionPageStructuredData = {

--- a/apps/root/src/lib/__tests__/searchIndex.spec.ts
+++ b/apps/root/src/lib/__tests__/searchIndex.spec.ts
@@ -25,7 +25,7 @@ describe('buildSearchIndex', () => {
 
   it('includes blog entries', () => {
     const blogs = index.filter(e => e.type === 'blog');
-    expect(blogs.length).toBe(13);
+    expect(blogs.length).toBe(16);
     expect(blogs[0].url).toMatch(/^\/blog\//);
   });
 
@@ -56,7 +56,7 @@ describe('buildSearchIndex', () => {
   });
 
   it('total count matches sum of all types', () => {
-    // 10 projects + 5 experiences + 13 blogs + 4 services + 4 pages = 36
-    expect(index.length).toBe(36);
+    // 10 projects + 5 experiences + 16 blogs + 4 services + 4 pages = 39
+    expect(index.length).toBe(39);
   });
 });


### PR DESCRIPTION
## Summary
- **"When import type Isn't Optional"** — debugging a circular dependency crash caused by value-importing a TypeScript interface in Turbopack (from #248)
- **"Designing a Mobile Bottom Nav That Plays Nice with FABs and Sheets"** — z-index stack design for layering a bottom bar with FABs and bottom sheets (from #253)
- **"Graceful Degradation for Third-Party Embeds"** — timeout-based fallback pattern for blocked iframes (from #250)
- Fix `run-spec-tests.sh` hook for macOS compatibility (no `timeout` command)

## Test plan
- [x] `yarn tsc --noEmit` — zero errors
- [x] `yarn nx test root` — 66 suites, 650 tests pass
- [x] Content registry, search index, and structured data updated
- [ ] Visual review of blog listing and detail pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)