### PR TITLE
chore: remove unused MCP servers

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,9 +1,5 @@
 {
   "mcpServers": {
-    "tailwindcss-server": {
-      "command": "npx",
-      "args": ["-y", "tailwindcss-mcp-server"]
-    },
     "playwright": {
       "command": "npx",
       "args": ["@playwright/mcp@latest"]
@@ -19,13 +15,6 @@
     "context7": {
       "command": "npx",
       "args": ["-y", "@upstash/context7-mcp"]
-    },
-    "sentry": {
-      "command": "npx",
-      "args": ["-y", "@sentry/mcp-server"],
-      "env": {
-        "SENTRY_AUTH_TOKEN": "${SENTRY_AUTH_TOKEN}"
-      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- Remove `tailwindcss-server` — incompatible with Tailwind CSS 4's `@theme` directive, never used
- Remove `sentry` — never loaded (missing `SENTRY_AUTH_TOKEN`), zero tools registered

## Test plan
- [ ] Verify remaining MCP servers (playwright, next-devtools, lighthouse, context7) still load

🤖 Generated with [Claude Code](https://claude.com/claude-code)