### PR TITLE
fix(docker): skip lifecycle scripts in prod install

### DIFF
--- a/apps/audit-scan-service/Dockerfile
+++ b/apps/audit-scan-service/Dockerfile
@@ -59,7 +59,7 @@ COPY --from=builder /app/apps/audit-scan-service/dist .
 
 # Bring in the package definitions and lockfile
 COPY package.json pnpm-lock.yaml ./
-RUN pnpm install --prod --frozen-lockfile
+RUN pnpm install --prod --frozen-lockfile --ignore-scripts
 
 # Run as non-root user with a writable home dir for Chromium temp/crash files
 RUN groupadd -r scanner && useradd -r -g scanner -m scanner \


### PR DESCRIPTION
## Summary
- Add `--ignore-scripts` to the runtime stage `pnpm install --prod` in the audit-scan-service Dockerfile
- The `prepare` script runs `husky`, which is a devDependency and unavailable during prod-only installs, causing the Railway build to fail

## Test plan
- [x] Railway build for PR #301 should succeed after this merges into `develop`

🤖 Generated with [Claude Code](https://claude.com/claude-code)