### PR TITLE
feat(services): add Performance Audits section (#112)

### DIFF
--- a/apps/root/src/app/services/page.spec.tsx
+++ b/apps/root/src/app/services/page.spec.tsx
@@ -15,6 +15,41 @@ jest.mock('./FAQ', () => ({
   },
 }));
 
+jest.mock('@/components/Button', () => ({
+  __esModule: true,
+  default: function Button({
+    children,
+    href,
+    name,
+  }: {
+    children: React.ReactNode;
+    href?: string;
+    name?: string;
+  }) {
+    return (
+      <a href={href} data-testid={`button-${name}`}>
+        {children}
+      </a>
+    );
+  },
+}));
+
+jest.mock('@/components/kit/MetricsDashboard', () => ({
+  MetricsDashboard: function MetricsDashboard({
+    metrics,
+  }: {
+    metrics: Array<{ label: string }>;
+  }) {
+    return (
+      <div data-testid='metrics-dashboard'>
+        {metrics.map(m => (
+          <span key={m.label}>{m.label}</span>
+        ))}
+      </div>
+    );
+  },
+}));
+
 describe('Services Page', () => {
   it('renders inside PageLayout wrapper', () => {
     render(<Page />);
@@ -59,6 +94,15 @@ describe('Services Page', () => {
     expect(
       screen.getByRole('heading', {
         name: /let's figure out how i can help/i,
+      })
+    ).toBeInTheDocument();
+  });
+
+  it('renders Performance Audits section', () => {
+    render(<Page />);
+    expect(
+      screen.getByRole('heading', {
+        name: /your site takes 8 seconds to load/i,
       })
     ).toBeInTheDocument();
   });

--- a/apps/root/src/app/services/page.tsx
+++ b/apps/root/src/app/services/page.tsx
@@ -12,10 +12,16 @@ import {
   FOCUS_RING_OFFSET,
 } from '@danieljoffe.com/shared-ui/styles/formStyles';
 import { servicesPageStructuredData } from '@/data/structuredData/services';
-import { services, servicesAudience, howItWorks } from '@/data/services';
+import {
+  services,
+  servicesAudience,
+  howItWorks,
+  performanceAuditsSection,
+} from '@/data/services';
 import { servicesMetadata } from '@/data/metadata/services';
 import { cardBase } from '@/lib/layoutStyles';
 import { cn } from '@/lib/cn';
+import { ServiceSection } from './ServiceSection';
 import HeroCTA from './HeroCTA';
 import CalendlyEmbed from './CalendlyEmbed';
 import FAQ from './FAQ';
@@ -124,6 +130,13 @@ export default function Services() {
             </div>
           ))}
         </div>
+      </Section>
+
+      {/* ══════════════════════════════════
+          PERFORMANCE AUDITS
+          ══════════════════════════════════ */}
+      <Section>
+        <ServiceSection {...performanceAuditsSection} />
       </Section>
 
       {/* ══════════════════════════════════

--- a/apps/root/src/data/services.ts
+++ b/apps/root/src/data/services.ts
@@ -9,6 +9,7 @@ import {
   Target,
 } from 'lucide-react';
 import type { Metric } from '@/components/kit/MetricsDashboard';
+import { projectSlugs } from '@/data/project';
 
 interface Service {
   Icon: LucideIcon;
@@ -187,5 +188,87 @@ export const servicesFAQs = [
       'I offer monthly retainer packages for teams that need continued engineering support after the initial build.',
   },
 ];
+
+export const performanceAuditsSection: ServiceSectionData = {
+  id: 'performance-audits',
+  painPoint: {
+    headline:
+      "Your site takes 8 seconds to load. You're losing 53% of mobile visitors before they see your content.",
+    subtext: undefined,
+  },
+  description:
+    "I measure exactly what's slowing your site down, fix the biggest bottlenecks, and prove the improvement with before/after metrics.",
+  questions: [
+    {
+      question: 'How is this different from running PageSpeed Insights?',
+      answer:
+        'PageSpeed gives you a score. I give you a fixed site. I diagnose root causes — render-blocking resources, unoptimized images, bloated bundles — implement the fixes, and measure the real-world impact.',
+    },
+    {
+      question: 'Do Core Web Vitals really affect search rankings?',
+      answer:
+        'Yes. Google uses Core Web Vitals as a ranking signal. Poor performance means lower visibility, fewer clicks, and lost revenue.',
+    },
+    {
+      question: 'What platforms do you work with?',
+      answer:
+        "React, Next.js, Vue, WordPress, Shopify — performance principles apply universally. The tooling changes, but the methodology doesn't.",
+    },
+    {
+      question: 'How do you measure improvement?',
+      answer:
+        "Before/after Lighthouse audits, Core Web Vitals field data, and real user metrics. You get a clear report showing exactly what changed and by how much.",
+    },
+    {
+      question: 'What kind of ROI can I expect?',
+      answer:
+        "Faster sites convert better. A 1-second improvement in load time can increase conversions by 7%. I've seen bounce rates drop 39% and page views increase significantly after optimization work.",
+    },
+  ],
+  deliverables: [
+    'Lighthouse & Core Web Vitals audit report',
+    'Prioritized fix recommendations with effort estimates',
+    'Implementation of top-priority improvements',
+    'Before/after performance metrics report',
+  ],
+  proof: {
+    title: 'FightCamp Performance Overhaul',
+    metrics: [
+      {
+        label: 'Lighthouse Score',
+        before: '32–43',
+        after: '~80',
+        improvement: '+40 points',
+        delta: 'positive',
+      },
+      {
+        label: 'Bundle Size',
+        before: '650–800KB',
+        after: '250–300KB',
+        improvement: '~62% reduction',
+        delta: 'positive',
+      },
+      {
+        label: 'Mobile Bounce Rate',
+        before: 'High',
+        after: '−39%',
+        improvement: '39% drop',
+        delta: 'positive',
+      },
+      {
+        label: 'First Contentful Paint',
+        before: '8–12s',
+        after: '1.8–2.5s',
+        improvement: '~80% faster',
+        delta: 'positive',
+      },
+    ],
+    caseStudySlug: projectSlugs.csPerformance,
+  },
+  timeline: '2–4 weeks',
+  price: '$5,000',
+  ctaLabel: undefined,
+  ctaHref: undefined,
+};
 
 export const serviceSections: ServiceSectionData[] = [];


### PR DESCRIPTION
## Summary
- Adds Performance Audits service section with pain point hook, description, 5 Q&A pairs, deliverables, and FightCamp case study proof with MetricsDashboard metrics
- Renders `ServiceSection` component on the services page between the services grid and "How I Work" sections
- Adds page test verifying the section renders

Closes #112

## Test plan
- [x] `pnpm tsc --noEmit` — zero errors
- [x] `pnpm exec nx test root -- --testPathPatterns="services"` — all tests pass

https://claude.ai/code/session_01VYS6SKU6BmbvD38tvHjmnL