### PR TITLE
feat(services): add CMS & Tooling section (#114)

### DIFF
--- a/apps/root/src/app/services/page.spec.tsx
+++ b/apps/root/src/app/services/page.spec.tsx
@@ -54,6 +54,15 @@ describe('Services Page', () => {
     expect(screen.getByTestId('faq')).toBeInTheDocument();
   });
 
+  it('renders CMS & Tooling section', () => {
+    render(<Page />);
+    expect(
+      screen.getByText(
+        /your marketing team files an engineering ticket every time they need a landing page changed/i
+      )
+    ).toBeInTheDocument();
+  });
+
   it('renders CTA section', () => {
     render(<Page />);
     expect(

--- a/apps/root/src/app/services/page.tsx
+++ b/apps/root/src/app/services/page.tsx
@@ -12,10 +12,16 @@ import {
   FOCUS_RING_OFFSET,
 } from '@danieljoffe.com/shared-ui/styles/formStyles';
 import { servicesPageStructuredData } from '@/data/structuredData/services';
-import { services, servicesAudience, howItWorks } from '@/data/services';
+import {
+  services,
+  servicesAudience,
+  howItWorks,
+  cmsToolingSection,
+} from '@/data/services';
 import { servicesMetadata } from '@/data/metadata/services';
 import { cardBase } from '@/lib/layoutStyles';
 import { cn } from '@/lib/cn';
+import { ServiceSection } from './ServiceSection';
 import HeroCTA from './HeroCTA';
 import CalendlyEmbed from './CalendlyEmbed';
 import FAQ from './FAQ';
@@ -124,6 +130,13 @@ export default function Services() {
             </div>
           ))}
         </div>
+      </Section>
+
+      {/* ══════════════════════════════════
+          CMS & TOOLING
+          ══════════════════════════════════ */}
+      <Section>
+        <ServiceSection {...cmsToolingSection} />
       </Section>
 
       {/* ══════════════════════════════════

--- a/apps/root/src/data/services.ts
+++ b/apps/root/src/data/services.ts
@@ -188,4 +188,87 @@ export const servicesFAQs = [
   },
 ];
 
+export const cmsToolingSection: ServiceSectionData = {
+  id: 'cms-tooling',
+  painPoint: {
+    headline:
+      'Your marketing team files an engineering ticket every time they need a landing page changed.',
+    subtext: undefined,
+  },
+  description:
+    'I build tooling that gives non-technical teams full autonomy over content and landing pages — without risking broken layouts or needing a developer on call.',
+  questions: [
+    {
+      question:
+        'We already have a CMS. Can you improve it instead of replacing it?',
+      answer:
+        'Absolutely. Most of my work is improving what you already have — better content models, composable page sections, and guardrails that prevent accidental breakage.',
+    },
+    {
+      question: 'What CMS platforms do you work with?',
+      answer:
+        "Contentful, Storyblok, Sanity, headless WordPress, and custom admin panels. I pick what fits your team's workflow and technical constraints.",
+    },
+    {
+      question: 'Will non-technical people actually be able to use it?',
+      answer:
+        "That's the whole point. I design the editing interface for marketers, not developers. I include training, documentation, and guardrails so your team can't accidentally break the layout.",
+    },
+    {
+      question: 'What if we only need landing pages for now?',
+      answer:
+        "That's the best place to start. Landing pages are high-impact and low-risk — perfect for proving out self-serve tooling before expanding to other content types.",
+    },
+    {
+      question: 'How do you prevent accidental layout breaks?',
+      answer:
+        "Composable components with constrained options. Your team picks from pre-built sections and fills in content — they can't accidentally break the grid or mess up spacing.",
+    },
+  ],
+  deliverables: [
+    'CMS architecture and implementation',
+    'Composable page builder components',
+    'Content editing guardrails',
+    'Team training and documentation',
+  ],
+  proof: {
+    title: 'Winc Landing Page Engine',
+    metrics: [
+      {
+        label: 'Landing Pages/Month',
+        before: '12',
+        after: '200+',
+        improvement: '1,600% increase',
+        delta: 'positive',
+      },
+      {
+        label: 'Weekly Velocity',
+        before: '3–4 pages',
+        after: '8–12 pages',
+        improvement: '3× throughput',
+        delta: 'positive',
+      },
+      {
+        label: 'Engineering Time Saved',
+        before: '12+ hrs/week',
+        after: '0',
+        improvement: 'Full autonomy',
+        delta: 'positive',
+      },
+      {
+        label: 'Conversion Rate',
+        before: '1.4%',
+        after: '2.0%',
+        improvement: '+43% lift',
+        delta: 'positive',
+      },
+    ],
+    caseStudySlug: 'cms-tooling-case-study',
+  },
+  timeline: '3–6 weeks',
+  price: '$8,000',
+  ctaLabel: undefined,
+  ctaHref: undefined,
+};
+
 export const serviceSections: ServiceSectionData[] = [];


### PR DESCRIPTION
## Summary
- Adds CMS & Self-Serve Tooling service section with pain point hook, description, 5 Q&A pairs, deliverables, and Winc case study proof with MetricsDashboard metrics
- Renders `ServiceSection` component on the services page between the services grid and "How I Work" sections
- Adds page test verifying the section renders

Closes #114

## Test plan
- [x] `pnpm tsc --noEmit` — zero errors
- [x] `pnpm exec nx test root -- --testPathPatterns="services"` — all tests pass

https://claude.ai/code/session_01VYS6SKU6BmbvD38tvHjmnL