### PR TITLE
feat(services): add MVP Builds section (#115)

### DIFF
--- a/apps/root/src/app/services/page.spec.tsx
+++ b/apps/root/src/app/services/page.spec.tsx
@@ -54,6 +54,15 @@ describe('Services Page', () => {
     expect(screen.getByTestId('faq')).toBeInTheDocument();
   });
 
+  it('renders MVP Builds service section', () => {
+    render(<Page />);
+    expect(
+      screen.getByRole('heading', {
+        name: /you have a product idea, a market opportunity, and a window that's closing/i,
+      })
+    ).toBeInTheDocument();
+  });
+
   it('renders CTA section', () => {
     render(<Page />);
     expect(

--- a/apps/root/src/app/services/page.tsx
+++ b/apps/root/src/app/services/page.tsx
@@ -12,10 +12,16 @@ import {
   FOCUS_RING_OFFSET,
 } from '@danieljoffe.com/shared-ui/styles/formStyles';
 import { servicesPageStructuredData } from '@/data/structuredData/services';
-import { services, servicesAudience, howItWorks } from '@/data/services';
+import {
+  services,
+  servicesAudience,
+  howItWorks,
+  mvpBuildsSection,
+} from '@/data/services';
 import { servicesMetadata } from '@/data/metadata/services';
 import { cardBase } from '@/lib/layoutStyles';
 import { cn } from '@/lib/cn';
+import { ServiceSection } from './ServiceSection';
 import HeroCTA from './HeroCTA';
 import CalendlyEmbed from './CalendlyEmbed';
 import FAQ from './FAQ';
@@ -124,6 +130,13 @@ export default function Services() {
             </div>
           ))}
         </div>
+      </Section>
+
+      {/* ══════════════════════════════════
+          MVP BUILDS
+          ══════════════════════════════════ */}
+      <Section>
+        <ServiceSection {...mvpBuildsSection} />
       </Section>
 
       {/* ══════════════════════════════════

--- a/apps/root/src/data/services.ts
+++ b/apps/root/src/data/services.ts
@@ -188,4 +188,83 @@ export const servicesFAQs = [
   },
 ];
 
+export const mvpBuildsSection: ServiceSectionData = {
+  id: 'mvp-builds',
+  painPoint: {
+    headline:
+      "You have a product idea, a market opportunity, and a window that's closing. You need a working product, not a roadmap.",
+    subtext:
+      "Or: your last developer left. There's a half-built codebase, no documentation, and a deadline.",
+  },
+  description:
+    'I build production-ready MVPs from scratch or rescue stalled projects — frontend, backend integration, authentication, and deployment. You get a working product and clean handoff documentation.',
+  questions: [
+    {
+      question: 'Can you work with my existing API or backend?',
+      answer:
+        'Yes. I integrate with any REST or GraphQL API. If you need backend work too, I handle Node.js, Express, and serverless architectures.',
+    },
+    {
+      question:
+        'What if I have a half-built codebase from another developer?',
+      answer:
+        "I start with an honest codebase audit. I'll tell you what's salvageable, what needs rewriting, and give you a realistic timeline before we commit to anything.",
+    },
+    {
+      question:
+        "I don't have a designer. Can you still build something good?",
+      answer:
+        'Yes. I use proven UI patterns, component libraries, and clean layouts to build interfaces that look professional without needing custom design. If you bring designs later, the code adapts.',
+    },
+    {
+      question: 'Who owns the code when we\'re done?',
+      answer:
+        'You do. 100%. You get the full codebase, deployment access, documentation, and a walkthrough. No lock-in, no dependencies on me.',
+    },
+    {
+      question: 'What happens after launch?',
+      answer:
+        'I offer monthly retainers for ongoing support, or I hand off completely with documentation your team can maintain. Your call.',
+    },
+  ],
+  deliverables: [
+    'Complete full-stack MVP application',
+    'Responsive, accessible user interface',
+    'Authentication and state management',
+    'CI/CD pipeline and hosting setup',
+    'Knowledge transfer documentation',
+  ],
+  proof: {
+    title: 'Logistics Dashboard MVP',
+    metrics: [
+      {
+        label: 'Delivery Timeline',
+        before: 'No product',
+        after: '3 months',
+        improvement: 'On-time delivery',
+        delta: 'positive',
+      },
+      {
+        label: 'Authentication',
+        before: 'None',
+        after: 'AWS Cognito',
+        improvement: 'Enterprise-grade',
+        delta: 'positive',
+      },
+      {
+        label: 'User Roles',
+        before: '0',
+        after: '3',
+        improvement: 'Role-based access',
+        delta: 'neutral',
+      },
+    ],
+    caseStudySlug: 'logistics-dashboard-study-case',
+  },
+  timeline: '4–12 weeks',
+  price: '$12,000',
+  ctaLabel: undefined,
+  ctaHref: undefined,
+};
+
 export const serviceSections: ServiceSectionData[] = [];


### PR DESCRIPTION
## Summary
- Adds MVP & Product Builds service section with pain point hook (greenfield + rescue subtext), description, 5 Q&A pairs, deliverables, and Logistics Dashboard case study proof with MetricsDashboard metrics
- Renders `ServiceSection` component on the services page between the services grid and "How I Work" sections
- Adds page test verifying the section renders

Closes #115

## Test plan
- [x] `pnpm tsc --noEmit` — zero errors
- [x] `pnpm exec nx test root -- --testPathPatterns="services"` — all tests pass

https://claude.ai/code/session_01VYS6SKU6BmbvD38tvHjmnL