### PR TITLE
Content index pages: rewrite heroes and metadata (Experience, Projects, Blog)

### DIFF
--- a/apps/root/src/app/blog/page.tsx
+++ b/apps/root/src/app/blog/page.tsx
@@ -25,10 +25,11 @@ export default function Blog() {
     <PageLayout>
       <Section>
         <div className='text-center space-y-4'>
-          <Heading variant='hero'>Blog</Heading>
+          <Heading variant='hero'>Notes from shipping code</Heading>
           <Text variant='subtitle' className='max-w-xl mx-auto'>
-            Technical deep-dives, opinions on frontend trends, tutorials, and
-            lessons learned.
+            Deep-dives on the problems I&apos;ve debugged, the patterns
+            I&apos;ve extracted, and the decisions I&apos;d make differently
+            next time.
           </Text>
         </div>
       </Section>

--- a/apps/root/src/app/experience/page.tsx
+++ b/apps/root/src/app/experience/page.tsx
@@ -30,11 +30,10 @@ export default function ExperiencePage() {
           ══════════════════════════════════ */}
       <Section>
         <div className='text-center space-y-4'>
-          <Heading variant='hero'>Experience</Heading>
+          <Heading variant='hero'>Where I&apos;ve worked, what I built</Heading>
           <Text variant='subtitle' className='max-w-xl mx-auto'>
-            My professional journey as a full-stack engineer: key roles,
-            impactful projects, and the technical expertise behind performant,
-            user-focused web applications.
+            Five companies, ten years. Each engagement left the team faster and
+            more autonomous than I found them.
           </Text>
         </div>
       </Section>

--- a/apps/root/src/app/projects/page.tsx
+++ b/apps/root/src/app/projects/page.tsx
@@ -30,11 +30,10 @@ export default function Projects() {
           ══════════════════════════════════ */}
       <Section>
         <div className='text-center space-y-4'>
-          <Heading variant='hero'>Projects</Heading>
+          <Heading variant='hero'>Case studies from the field</Heading>
           <Text variant='subtitle' className='max-w-xl mx-auto'>
-            Case studies and projects spanning full-stack development, backend
-            architecture, and frontend systems. Each project includes the
-            challenge, my approach, and measurable outcomes.
+            The problems I&apos;ve solved and how I solved them. Every study has
+            the challenge, the approach, and the measurable outcome.
           </Text>
         </div>
       </Section>

--- a/apps/root/src/data/metadata/blog.ts
+++ b/apps/root/src/data/metadata/blog.ts
@@ -3,7 +3,7 @@ import { Metadata } from 'next';
 export const blogRootMetadata: Metadata = {
   title: 'Blog | Daniel Joffe - Full-Stack Engineer',
   description:
-    'Technical deep-dives, opinions on frontend trends, tutorials, and lessons learned from a full-stack engineer.',
+    "Notes from shipping code. Deep-dives on the problems I've debugged, the patterns I've extracted, and the decisions I'd make differently next time.",
   keywords: [
     'Daniel Joffe',
     'Blog',
@@ -22,7 +22,7 @@ export const blogRootMetadata: Metadata = {
   openGraph: {
     title: 'Daniel Joffe - Blog',
     description:
-      'Technical deep-dives, opinions on frontend trends, tutorials, and lessons learned.',
+      "Notes from shipping code. Deep-dives on the problems I've debugged, the patterns I've extracted, and the decisions I'd make differently next time.",
     url: 'https://danieljoffe.com/blog',
     type: 'website',
     siteName: 'Daniel Joffe',
@@ -30,7 +30,7 @@ export const blogRootMetadata: Metadata = {
   twitter: {
     title: 'Daniel Joffe - Blog',
     description:
-      'Technical deep-dives, opinions on frontend trends, tutorials, and lessons learned.',
+      'Notes from shipping code. Debugging, patterns, and lessons learned.',
     card: 'summary_large_image',
   },
 };

--- a/apps/root/src/data/metadata/experience.ts
+++ b/apps/root/src/data/metadata/experience.ts
@@ -4,7 +4,7 @@ import { DOMAIN_URL, FULL_NAME, EXPERIENCE_LINK } from '@/utils/constants';
 export const experienceRootMetadata: Metadata = {
   title: `Experience | ${FULL_NAME} - Full-Stack Engineer`,
   description:
-    'My professional journey as a full-stack engineer: key roles, impactful projects, and the technical expertise behind performant, user-focused web applications.',
+    'Five companies, ten years. Every engagement left the team faster and more autonomous than I found them.',
   keywords: [
     FULL_NAME,
     'Portfolio',
@@ -26,7 +26,7 @@ export const experienceRootMetadata: Metadata = {
   openGraph: {
     title: `${FULL_NAME} - Professional Experience & Work History`,
     description:
-      'My professional journey as a full-stack engineer: key roles, impactful projects, and the technical expertise behind performant, user-focused web applications.',
+      'Five companies, ten years. Every engagement left the team faster and more autonomous than I found them.',
     url: `${DOMAIN_URL}${EXPERIENCE_LINK.href}`,
     type: 'website',
     siteName: FULL_NAME,
@@ -34,7 +34,7 @@ export const experienceRootMetadata: Metadata = {
   twitter: {
     title: `${FULL_NAME} - Professional Experience & Work History`,
     description:
-      'My professional journey as a full-stack engineer: key roles, impactful projects, and technical expertise.',
+      'Five companies, ten years. Every engagement left the team faster and more autonomous.',
     card: 'summary_large_image',
   },
 };

--- a/apps/root/src/data/metadata/project.ts
+++ b/apps/root/src/data/metadata/project.ts
@@ -3,7 +3,7 @@ import { Metadata } from 'next';
 export const projectRootMetadata: Metadata = {
   title: 'Projects | Daniel Joffe - Full-Stack Engineer',
   description:
-    'Case studies spanning full-stack development, backend architecture, and frontend systems. Each project includes the challenge, approach, and measurable outcomes.',
+    'Case studies from the field. Every study has the challenge, the approach, and the measurable outcome.',
   keywords: [
     'Daniel Joffe',
     'Portfolio',
@@ -25,14 +25,14 @@ export const projectRootMetadata: Metadata = {
   },
   openGraph: {
     title: `Daniel Joffe - Portfolio & Projects`,
-    description: `A curated portfolio of case studies detailing goals, approach, and measurable outcomes.`,
+    description: `The problems I've solved and how I solved them. Every case study has the challenge, the approach, and the measurable outcome.`,
     url: `https://danieljoffe.com/projects`,
     type: 'website',
     siteName: 'Daniel Joffe',
   },
   twitter: {
     title: `Daniel Joffe - Portfolio & Projects`,
-    description: `Case studies highlighting goals, approach, and results across platforms and industries.`,
+    description: `Case studies from the field. Challenge, approach, outcome.`,
     card: 'summary_large_image',
     creator: '@danieljoffe',
   },

--- a/apps/root/src/data/structuredData/blog.ts
+++ b/apps/root/src/data/structuredData/blog.ts
@@ -294,7 +294,7 @@ export const blogRootStructuredData: CollectionPageStructuredData = {
   '@type': 'CollectionPage',
   name: `Blog | ${FULL_NAME} - Full-Stack Engineer`,
   description:
-    'Technical deep-dives, opinions on frontend trends, tutorials, and lessons learned from a full-stack engineer.',
+    "Notes from shipping code. Deep-dives on the problems I've debugged, the patterns I've extracted, and the decisions I'd make differently next time.",
   url: `${DOMAIN_URL}${BLOG_LINK.href}`,
   author,
   mainEntity: {

--- a/apps/root/src/data/structuredData/experience.ts
+++ b/apps/root/src/data/structuredData/experience.ts
@@ -108,7 +108,7 @@ export const experienceRootStructuredData: CollectionPageStructuredData = {
   '@type': 'CollectionPage',
   name: `Experience | ${FULL_NAME} - Full-Stack Engineer`,
   description:
-    'An overview of my professional journey as a full-stack engineer—covering key roles, impactful projects, and the technical expertise I bring to building performant, user-focused web applications.',
+    'Five companies, ten years. Every engagement left the team faster and more autonomous than I found them.',
   url: `${DOMAIN_URL}${EXPERIENCE_LINK.href}`,
   author: member,
   mainEntity: {

--- a/apps/root/src/data/structuredData/project.ts
+++ b/apps/root/src/data/structuredData/project.ts
@@ -88,7 +88,7 @@ export const projectsRootStructuredData: CollectionPageStructuredData = {
   '@type': 'CollectionPage',
   name: 'Projects | Daniel Joffe - Full-Stack Engineer',
   description:
-    'Case studies and projects spanning full-stack development, backend architecture, and frontend systems. Each project includes the challenge, my approach, and measurable outcomes.',
+    "The problems I've solved and how I solved them. Every case study has the challenge, the approach, and the measurable outcome.",
   url: `${DOMAIN_URL}${PROJECTS_LINK.href}`,
   author,
   mainEntity: {


### PR DESCRIPTION
Stacks on top of #323. Implements #325.

Rewrites the heroes, metadata, and structured data descriptions on the three content index pages (Experience, Projects, Blog) so they match the confident, visitor-focused voice established across Home, About, and Services in #323.

Closes #325

## Changes by page

### Experience — `/experience`

- **Hero headline:** `Experience` → `Where I've worked, what I built`
- **Hero subtitle:** `My professional journey as a full-stack engineer: key roles, impactful projects, and the technical expertise behind performant, user-focused web applications.` → `Five companies, ten years. Each engagement left the team faster and more autonomous than I found them.`
- **OG + Twitter descriptions:** updated to match
- **CollectionPage structured data description:** updated to match, and an em dash in the previous copy (`full-stack engineer—covering key roles`) was cleaned up as part of the em dash reduction pass from #317–#322

Picks up the "left the team faster and more autonomous" thread already established in the About intro rewrite from sub-issue #318.

### Projects — `/projects`

- **Hero headline:** `Projects` → `Case studies from the field`
- **Hero subtitle:** `Case studies and projects spanning full-stack development, backend architecture, and frontend systems. Each project includes the challenge, my approach, and measurable outcomes.` → `The problems I've solved and how I solved them. Every study has the challenge, the approach, and the measurable outcome.`
- **OG + Twitter descriptions:** updated to match
- **CollectionPage structured data description:** updated to match

Trims the "spanning full-stack development, backend architecture, and frontend systems" tag-cloud framing while preserving the "challenge, approach, outcome" promise that's actually useful to visitors.

### Blog — `/blog`

- **Hero headline:** `Blog` → `Notes from shipping code`
- **Hero subtitle:** `Technical deep-dives, opinions on frontend trends, tutorials, and lessons learned.` → `Deep-dives on the problems I've debugged, the patterns I've extracted, and the decisions I'd make differently next time.`
- **OG + Twitter descriptions:** updated to match
- **CollectionPage structured data description:** updated to match

Signals practitioner voice over opinion-blog framing, and replaces the generic "technical deep-dives, opinions, tutorials, lessons learned" grab-bag with the actual genres of posts Daniel writes.

## Deliberate non-changes

- **No filter/search/pagination** — the blog page still renders all 31 posts inline. That's tracked in follow-up issue #326 with a detailed implementation plan.
- **No thumbnail copy changes** — individual titles and excerpts in `*Thumbnails.ts` and MDX frontmatter are untouched. That's tracked in follow-up issue #327.
- **No "Open Source" callout rewrite on Projects** — tracked in follow-up issue #328.
- **`metadata/experience.ts` keywords still contain "key roles"** — these describe past employment, not job-seeking, and were intentionally preserved per the decision in sub-issue #322.
- **Em dash in `structuredData/services.ts`** (`"performance issues—bloated bundles"`) is pre-existing and out of scope for this issue. The #325 acceptance criteria explicitly scoped em dash cleanup to the six files actually modified here.

## Test plan

- [x] `pnpm tsc --noEmit` — zero errors
- [x] `pnpm nx test root` — **680/680 tests passing** across 69 suites (search index regenerated via `scripts/generate-search-index.ts` first since `data/generated/searchIndex.json` is gitignored)
- [x] Em dash audit: `grep -rn "—" apps/root/src/data/metadata apps/root/src/data/structuredData apps/root/src/app/{experience,projects,blog}/page.tsx` returns zero matches in files touched by this PR
- [x] Job-seeking language audit: no new "roles", "Seeking", or "Available for" language introduced
- [ ] **Visual regression snapshots** need regeneration after this merges: `experience-chromium-linux.png` and `projects-chromium-linux.png` will differ due to new hero copy. Blog has no E2E visual regression test so no snapshot work there. Regenerate via `workflow_dispatch` on `ci.yml` with `update-snapshots: true`.
- [ ] Manual visual review after preview deploy: confirm hero copy reads well at mobile and desktop widths, no layout shifts, OG previews match expectations
- [ ] Build not verified locally due to Node version mismatch (repo requires Node 24.x, sandbox has Node 22.22). CI will build on Node 24.

## Follow-up issues spun out from #325's original out-of-scope list

- #326 — Add pagination, tag filtering, and optional search to the content index pages
- #327 — Systematic audit and rewrite of titles and excerpts across all 46 thumbnail/MDX entries
- #328 — Rewrite the Open Source callout copy and button labels on the Projects page

All three have detailed implementation plans and are linked as sub-issues of the parent tracking issue #315.

## Base branch note

This PR targets `claude/review-portfolio-plan-xHHdV` (the branch of PR #323) rather than `develop`. Once #323 merges into `develop`, this PR's base should automatically retarget to `develop`, or it can be rebased.

https://claude.ai/code/session_017gG3pYGFauihk9qa7Jjwxv