### PR TITLE
fix(sentry): skip initialization when DSN is not configured

### DIFF
--- a/apps/root/src/instrumentation-client.ts
+++ b/apps/root/src/instrumentation-client.ts
@@ -4,86 +4,91 @@
 
 import * as Sentry from '@sentry/nextjs';
 import { initBotId } from 'botid/client/core';
+import { sentryEnabled } from '@/lib/sentry.config';
 import { publicEnv } from '@/lib/public.env';
 import { isProduction } from '@/utils/helpers';
 
-Sentry.init({
-  dsn: publicEnv.NEXT_PUBLIC_SENTRY_CONFIG_ID as string,
+if (sentryEnabled) {
+  Sentry.init({
+    dsn: publicEnv.NEXT_PUBLIC_SENTRY_CONFIG_ID as string,
 
-  // Environment identification
-  environment: publicEnv.NEXT_PUBLIC_NODE_ENV,
+    // Environment identification
+    environment: publicEnv.NEXT_PUBLIC_NODE_ENV,
 
-  // Sample 100% of errors, but only 10% of performance traces in production
-  // to balance visibility with quota usage
-  tracesSampleRate: isProduction() ? 0.1 : 1.0,
+    // Sample 100% of errors, but only 10% of performance traces in production
+    // to balance visibility with quota usage
+    tracesSampleRate: isProduction() ? 0.1 : 1.0,
 
-  // Sample rate for error events (1.0 = 100% of errors)
-  sampleRate: 1.0,
+    // Sample rate for error events (1.0 = 100% of errors)
+    sampleRate: 1.0,
 
-  // Enable logs to be sent to Sentry
-  enableLogs: true,
+    // Enable logs to be sent to Sentry
+    enableLogs: true,
 
-  // All heavy integrations are deferred below to avoid blocking LCP paint
-  integrations: [],
+    // All heavy integrations are deferred below to avoid blocking LCP paint
+    integrations: [],
 
-  // Session Replay sampling
-  replaysSessionSampleRate: isProduction() ? 0.1 : 0,
-  replaysOnErrorSampleRate: 1.0, // Always capture replay when error occurs
+    // Session Replay sampling
+    replaysSessionSampleRate: isProduction() ? 0.1 : 0,
+    replaysOnErrorSampleRate: 1.0, // Always capture replay when error occurs
 
-  // Filter out noisy errors that aren't actionable
-  ignoreErrors: [
-    // Browser extensions
-    /extensions\//i,
-    /^chrome-extension:\/\//,
-    /^moz-extension:\/\//,
-    // Network errors that are often transient
-    'Network request failed',
-    'Failed to fetch',
-    'Load failed',
-    // ResizeObserver loop errors (browser quirk, not actionable)
-    'ResizeObserver loop limit exceeded',
-    'ResizeObserver loop completed with undelivered notifications',
-  ],
+    // Filter out noisy errors that aren't actionable
+    ignoreErrors: [
+      // Browser extensions
+      /extensions\//i,
+      /^chrome-extension:\/\//,
+      /^moz-extension:\/\//,
+      // Network errors that are often transient
+      'Network request failed',
+      'Failed to fetch',
+      'Load failed',
+      // ResizeObserver loop errors (browser quirk, not actionable)
+      'ResizeObserver loop limit exceeded',
+      'ResizeObserver loop completed with undelivered notifications',
+    ],
 
-  // Add custom context to all events
-  beforeSend(event) {
-    // Add page URL context
-    if (typeof window !== 'undefined') {
-      event.tags = {
-        ...event.tags,
-        'page.url': window.location.pathname,
-        'page.referrer': document.referrer || 'direct',
-      };
+    // Add custom context to all events
+    beforeSend(event) {
+      // Add page URL context
+      if (typeof window !== 'undefined') {
+        event.tags = {
+          ...event.tags,
+          'page.url': window.location.pathname,
+          'page.referrer': document.referrer || 'direct',
+        };
+      }
+      return event;
+    },
+
+    // Setting this option to true will print useful information to the console while you're setting up Sentry.
+    debug: false,
+  });
+
+  // Defer heavy Sentry integrations to avoid blocking LCP and TTI.
+  // browserTracingIntegration and replayIntegration are added after the page
+  // becomes interactive, keeping the initial JS evaluation cost low.
+  if (typeof window !== 'undefined') {
+    const loadDeferredIntegrations = () => {
+      Sentry.addIntegration(Sentry.browserTracingIntegration());
+      Sentry.addIntegration(
+        Sentry.replayIntegration({
+          maskAllText: false,
+          blockAllMedia: false,
+        })
+      );
+    };
+
+    if ('requestIdleCallback' in window) {
+      window.requestIdleCallback(loadDeferredIntegrations);
+    } else {
+      setTimeout(loadDeferredIntegrations, 0);
     }
-    return event;
-  },
-
-  // Setting this option to true will print useful information to the console while you're setting up Sentry.
-  debug: false,
-});
-
-// Defer heavy Sentry integrations to avoid blocking LCP and TTI.
-// browserTracingIntegration and replayIntegration are added after the page
-// becomes interactive, keeping the initial JS evaluation cost low.
-if (typeof window !== 'undefined') {
-  const loadDeferredIntegrations = () => {
-    Sentry.addIntegration(Sentry.browserTracingIntegration());
-    Sentry.addIntegration(
-      Sentry.replayIntegration({
-        maskAllText: false,
-        blockAllMedia: false,
-      })
-    );
-  };
-
-  if ('requestIdleCallback' in window) {
-    window.requestIdleCallback(loadDeferredIntegrations);
-  } else {
-    setTimeout(loadDeferredIntegrations, 0);
   }
 }
 
-export const onRouterTransitionStart = Sentry.captureRouterTransitionStart;
+export const onRouterTransitionStart = sentryEnabled
+  ? Sentry.captureRouterTransitionStart
+  : undefined;
 
 initBotId({
   protect: [

--- a/apps/root/src/lib/sentry.config.ts
+++ b/apps/root/src/lib/sentry.config.ts
@@ -6,6 +6,8 @@ import type * as Sentry from '@sentry/nextjs';
 import { publicEnv } from '@/lib/public.env';
 import { isProduction } from '@/utils/helpers';
 
+export const sentryEnabled = !!publicEnv.NEXT_PUBLIC_SENTRY_CONFIG_ID;
+
 export const sharedSentryConfig: Parameters<typeof Sentry.init>[0] = {
   dsn: publicEnv.NEXT_PUBLIC_SENTRY_CONFIG_ID as string,
 

--- a/apps/root/src/sentry.edge.config.ts
+++ b/apps/root/src/sentry.edge.config.ts
@@ -4,17 +4,19 @@
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
 import * as Sentry from '@sentry/nextjs';
-import { sharedSentryConfig } from '@/lib/sentry.config';
+import { sentryEnabled, sharedSentryConfig } from '@/lib/sentry.config';
 
-Sentry.init({
-  ...sharedSentryConfig,
+if (sentryEnabled) {
+  Sentry.init({
+    ...sharedSentryConfig,
 
-  // Add edge runtime context to all events
-  beforeSend(event) {
-    event.tags = {
-      ...event.tags,
-      runtime: 'edge',
-    };
-    return event;
-  },
-});
+    // Add edge runtime context to all events
+    beforeSend(event) {
+      event.tags = {
+        ...event.tags,
+        runtime: 'edge',
+      };
+      return event;
+    },
+  });
+}

--- a/apps/root/src/sentry.server.config.ts
+++ b/apps/root/src/sentry.server.config.ts
@@ -3,17 +3,19 @@
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
 import * as Sentry from '@sentry/nextjs';
-import { sharedSentryConfig } from '@/lib/sentry.config';
+import { sentryEnabled, sharedSentryConfig } from '@/lib/sentry.config';
 
-Sentry.init({
-  ...sharedSentryConfig,
+if (sentryEnabled) {
+  Sentry.init({
+    ...sharedSentryConfig,
 
-  // Add server-side context to all events
-  beforeSend(event) {
-    event.tags = {
-      ...event.tags,
-      runtime: 'nodejs',
-    };
-    return event;
-  },
-});
+    // Add server-side context to all events
+    beforeSend(event) {
+      event.tags = {
+        ...event.tags,
+        runtime: 'nodejs',
+      };
+      return event;
+    },
+  });
+}


### PR DESCRIPTION
## Summary
- Adds `sentryEnabled` flag in `sentry.config.ts` based on `NEXT_PUBLIC_SENTRY_CONFIG_ID` presence
- Wraps `Sentry.init()` in `if (sentryEnabled)` across all three runtimes (client, server, edge)
- Client: deferred integrations and `onRouterTransitionStart` export also gated
- Eliminates Sentry console noise and SDK overhead in local dev and CI

## Test plan
- [x] `pnpm tsc --noEmit` passes
- [x] 69 suites, 680 tests pass
- [ ] Dev server starts without Sentry errors when DSN is unset
- [ ] Production build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)