### PR TITLE
content(blog): mobile VR data-driven + Sentry DSN guard posts

### DIFF
--- a/apps/root/src/data/__tests__/contentRegistry.spec.ts
+++ b/apps/root/src/data/__tests__/contentRegistry.spec.ts
@@ -26,7 +26,7 @@ describe('contentRegistry', () => {
 
     it('returns all blog entries in order', () => {
       const blogs = getContentByType('blog');
-      expect(blogs.length).toBe(30);
+      expect(blogs.length).toBe(32);
       expect(blogs[0].type).toBe('blog');
       expect(blogs[0].slug).toBe('unified-content-pipeline');
       expect(blogs[1].slug).toBe('auto-generated-toc-scroll-spy');
@@ -97,7 +97,7 @@ describe('contentRegistry', () => {
       expect(slugs).toContain('accessible-dropdown-keyboard-nav');
       expect(slugs).toContain('toast-pause-on-hover');
       expect(slugs).toContain('keyboard-navigable-data-tables');
-      expect(slugs.length).toBe(30);
+      expect(slugs.length).toBe(32);
     });
   });
 
@@ -145,7 +145,7 @@ describe('contentRegistry', () => {
   describe('getAllContent', () => {
     it('returns all entries (projects + experience)', () => {
       const all = getAllContent();
-      expect(all.length).toBe(45); // 10 projects + 5 experiences + 30 blogs
+      expect(all.length).toBe(47); // 10 projects + 5 experiences + 32 blogs
     });
 
     it('contains entries of all types', () => {

--- a/apps/root/src/data/blog.ts
+++ b/apps/root/src/data/blog.ts
@@ -31,6 +31,8 @@ export const blogSlugs = {
   cyclingThemeToggle: 'cycling-theme-toggle',
   minisearchRankedSearchCmdk: 'minisearch-ranked-search-cmdk',
   funnelSessionIdAnalytics: 'funnel-session-id-analytics',
+  mobileVrDataDrivenPlaywright: 'mobile-vr-data-driven-playwright',
+  sentrySkipWithoutDsn: 'sentry-skip-without-dsn',
 } as const;
 
 export const blogPageSlugs = [...Object.values(blogSlugs)];

--- a/apps/root/src/data/blogThumbnails.ts
+++ b/apps/root/src/data/blogThumbnails.ts
@@ -457,4 +457,34 @@ export const blogRecords: Record<AllowedBlogSlugs, PostThumbnail> = {
       creator: '@unsplash',
     },
   },
+  [blogSlugs.mobileVrDataDrivenPlaywright]: {
+    slug: blogSlugs.mobileVrDataDrivenPlaywright,
+    title: 'Mobile Visual Regression Without Doubling Your Test Count',
+    description:
+      'A typed page config array turns 9 copy-pasted Playwright tests into a loop that runs at two viewports with zero duplication.',
+    link: {
+      href: `${BLOG_LINK.href}/${blogSlugs.mobileVrDataDrivenPlaywright}`,
+    },
+    cover: {
+      alt: 'A grid of device screens showing the same interface at different sizes',
+      src: '/photo-1512758017271-d7b84c2113f1',
+      origin: `${UNSPLASH_URL}/photos/multiple-device-screens-responsive-design-dC6Pb2JdAqs`,
+      creator: '@halgatewood',
+    },
+  },
+  [blogSlugs.sentrySkipWithoutDsn]: {
+    slug: blogSlugs.sentrySkipWithoutDsn,
+    title: 'Sentry Should Be Optional in Your Next.js App',
+    description:
+      'A single boolean guard across three runtimes keeps Sentry from crashing local dev when the DSN is missing.',
+    link: {
+      href: `${BLOG_LINK.href}/${blogSlugs.sentrySkipWithoutDsn}`,
+    },
+    cover: {
+      alt: 'A shield icon protecting a circuit board',
+      src: '/photo-1563986768609-322da13575f2',
+      origin: `${UNSPLASH_URL}/photos/shield-protection-security-circuit-LKN76gpQ3Fo`,
+      creator: '@markusspiske',
+    },
+  },
 };

--- a/apps/root/src/data/content/blog/index.ts
+++ b/apps/root/src/data/content/blog/index.ts
@@ -91,6 +91,12 @@ import MinisearchRankedSearchCmdk, {
 import FunnelSessionIdAnalytics, {
   metadata as funnelSessionIdAnalyticsMeta,
 } from './funnel-session-id-analytics.mdx';
+import MobileVrDataDrivenPlaywright, {
+  metadata as mobileVrDataDrivenPlaywrightMeta,
+} from './mobile-vr-data-driven-playwright.mdx';
+import SentrySkipWithoutDsn, {
+  metadata as sentrySkipWithoutDsnMeta,
+} from './sentry-skip-without-dsn.mdx';
 
 export const blogMdxComponents: Record<AllowedBlogSlugs, ComponentType> = {
   'unified-content-pipeline': UnifiedContentPipeline,
@@ -125,6 +131,8 @@ export const blogMdxComponents: Record<AllowedBlogSlugs, ComponentType> = {
   'cycling-theme-toggle': CyclingThemeToggle,
   'minisearch-ranked-search-cmdk': MinisearchRankedSearchCmdk,
   'funnel-session-id-analytics': FunnelSessionIdAnalytics,
+  'mobile-vr-data-driven-playwright': MobileVrDataDrivenPlaywright,
+  'sentry-skip-without-dsn': SentrySkipWithoutDsn,
 };
 
 export const blogMdxMetadata: Record<AllowedBlogSlugs, PostMetadata> = {
@@ -158,4 +166,6 @@ export const blogMdxMetadata: Record<AllowedBlogSlugs, PostMetadata> = {
   'cycling-theme-toggle': cyclingThemeToggleMeta,
   'minisearch-ranked-search-cmdk': minisearchRankedSearchCmdkMeta,
   'funnel-session-id-analytics': funnelSessionIdAnalyticsMeta,
+  'mobile-vr-data-driven-playwright': mobileVrDataDrivenPlaywrightMeta,
+  'sentry-skip-without-dsn': sentrySkipWithoutDsnMeta,
 };

--- a/apps/root/src/data/content/blog/mobile-vr-data-driven-playwright.mdx
+++ b/apps/root/src/data/content/blog/mobile-vr-data-driven-playwright.mdx
@@ -1,0 +1,138 @@
+export const metadata = {
+  title: 'Mobile Visual Regression Without Doubling Your Test Count',
+  date: '2026-04-10',
+  excerpt:
+    'A typed page config array turns 9 copy-pasted Playwright tests into a loop that runs at two viewports with zero duplication.',
+  author: 'Daniel Joffe',
+  category: 'Testing',
+  tags: ['Playwright', 'Testing', 'CI', 'TypeScript'],
+  slug: 'mobile-vr-data-driven-playwright',
+  type: 'blog',
+  topic: 'Testing',
+};
+
+## Nine Tests, Copied Twice
+
+We had nine visual regression tests in Playwright, one per page. Each test navigated to a URL, waited for load, and called `toHaveScreenshot`. They were nearly identical except for three things: the URL, the snapshot name, and a few per-page quirks (the homepage needs a stable-height poll for GSAP animations; the about page masks the hCaptcha widget).
+
+When we needed mobile screenshots at 390×844 alongside the existing 1280×720 desktops, the obvious approach was to duplicate all nine tests with a different viewport. That would have taken us from 9 tests to 18, with every line of navigation and wait logic copied.
+
+## The Page Config
+
+Instead of duplicating tests, we described what varies in a typed array:
+
+```ts
+const pages = [
+  {
+    name: 'homepage',
+    path: '/',
+    headingSelector: 'h1',
+    maxDiffPixelRatio: 0.05,
+    waitForStableHeight: true,
+    maskHCaptcha: false,
+  },
+  {
+    name: 'about',
+    path: '/about',
+    headingSelector: 'h1',
+    maxDiffPixelRatio: 0.02,
+    waitForStableHeight: false,
+    maskHCaptcha: true,
+  },
+  // ... 7 more entries
+] as const;
+```
+
+Each entry captures the decisions that were previously buried in test bodies. The homepage gets a 5% diff threshold because GSAP animations cause layout height variance. The about page masks hCaptcha because the widget loads dynamically. Every other page uses the same 2% threshold with no masks beyond `[data-gsap]`.
+
+## Two Helpers, Two Loops
+
+The shared logic lives in two functions. `waitForPageReady` handles navigation, heading visibility, and the optional stable-height poll:
+
+```ts
+async function waitForPageReady(page: Page, entry: (typeof pages)[number]) {
+  await page.goto(entry.path, { waitUntil: 'domcontentloaded' });
+  await page.waitForLoadState('load');
+
+  if (entry.name === 'audit-report-not-found') {
+    await page
+      .getByRole('heading', { name: 'Report Not Found' })
+      .waitFor({ state: 'visible' });
+  } else {
+    await page
+      .locator(entry.headingSelector!)
+      .first()
+      .waitFor({ state: 'visible' });
+  }
+
+  if (entry.waitForStableHeight) {
+    await expect
+      .poll(
+        async () => {
+          const h1 = await page.evaluate(() => document.body.scrollHeight);
+          await new Promise(r => setTimeout(r, 250));
+          const h2 = await page.evaluate(() => document.body.scrollHeight);
+          return h1 === h2;
+        },
+        { timeout: 5000 }
+      )
+      .toBeTruthy();
+  }
+}
+```
+
+`getMasks` builds the locator array from the config flags:
+
+```ts
+function getMasks(page: Page, entry: (typeof pages)[number]) {
+  const masks = [page.locator('[data-gsap]')];
+  if (entry.maskHCaptcha) masks.push(page.locator('.min-h-\\[78px\\]'));
+  return masks;
+}
+```
+
+The test blocks are two `test.describe` wrappers that loop over the same array at different viewport sizes. The only difference is the `beforeEach` viewport and the snapshot filename suffix:
+
+```ts
+test.describe('desktop (1280x720)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 720 });
+  });
+
+  for (const entry of pages) {
+    test(`${entry.name} visual regression`, async ({ page }) => {
+      await waitForPageReady(page, entry);
+      await expect(page).toHaveScreenshot(`${entry.name}.png`, {
+        fullPage: true,
+        maxDiffPixelRatio: entry.maxDiffPixelRatio,
+        mask: getMasks(page, entry),
+      });
+    });
+  }
+});
+
+test.describe('mobile (390x844)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+  });
+
+  for (const entry of pages) {
+    test(`${entry.name} mobile visual regression`, async ({ page }) => {
+      await waitForPageReady(page, entry);
+      await expect(page).toHaveScreenshot(`${entry.name}-mobile.png`, {
+        fullPage: true,
+        maxDiffPixelRatio: entry.maxDiffPixelRatio,
+        mask: getMasks(page, entry),
+      });
+    });
+  }
+});
+```
+
+## CI Got It for Free
+
+The existing `update-snapshots` workflow dispatch runs `playwright test src/visual-regression.spec.ts --update-snapshots --project=chromium`. Because both viewport blocks live in the same spec file, the workflow regenerates desktop and mobile baselines in one pass. No workflow changes needed.
+
+## The Takeaway
+
+When tests differ only in data, not in logic, the test itself should be a loop over that data. A nine-element config array gave us 18 visual regression tests across two viewports at 180 lines, down from what would have been 300+ lines of copy-paste. Adding a third viewport, say tablet at 768×1024, is three lines: one `test.describe`, one `setViewportSize`, one filename suffix.

--- a/apps/root/src/data/content/blog/sentry-skip-without-dsn.mdx
+++ b/apps/root/src/data/content/blog/sentry-skip-without-dsn.mdx
@@ -1,0 +1,56 @@
+export const metadata = {
+  title: 'Sentry Should Be Optional in Your Next.js App',
+  date: '2026-04-10',
+  excerpt:
+    'A single boolean guard across three runtimes keeps Sentry from crashing local dev when the DSN is missing.',
+  author: 'Daniel Joffe',
+  category: 'Observability',
+  tags: ['Sentry', 'Next.js', 'TypeScript', 'DX'],
+  slug: 'sentry-skip-without-dsn',
+  type: 'blog',
+  topic: 'Observability',
+};
+
+## The Problem
+
+Sentry's Next.js SDK initializes in three places: `instrumentation-client.ts` (browser), `sentry.server.config.ts` (Node), and `sentry.edge.config.ts` (edge runtime). Each calls `Sentry.init()` at module scope. When the DSN environment variable is missing, the SDK throws, polluting the console with errors on every request.
+
+That is fine in production where the DSN is always set. In local development, on a fresh clone, or in CI jobs that do not need error monitoring, it makes the terminal unreadable.
+
+## One Boolean, Three Files
+
+The fix is a single exported constant in the shared config:
+
+```ts
+// lib/sentry.config.ts
+export const sentryEnabled = !!publicEnv.NEXT_PUBLIC_SENTRY_CONFIG_ID;
+```
+
+Each initialization file wraps its `Sentry.init()` call in the guard:
+
+```ts
+// sentry.server.config.ts
+import { sentryEnabled, sharedSentryConfig } from '@/lib/sentry.config';
+
+if (sentryEnabled) {
+  Sentry.init({ ...sharedSentryConfig });
+}
+```
+
+The edge config is identical. The client config follows the same pattern but has additional work inside the guard: deferred integration loading via `requestIdleCallback` to avoid blocking LCP.
+
+## The Router Transition Export
+
+Next.js 16 expects `instrumentation-client.ts` to export `onRouterTransitionStart` for Sentry's router instrumentation. When Sentry is disabled, the export should be `undefined` so Next.js skips it:
+
+```ts
+export const onRouterTransitionStart = sentryEnabled
+  ? Sentry.captureRouterTransitionStart
+  : undefined;
+```
+
+This avoids a runtime error from calling `Sentry.captureRouterTransitionStart` when the SDK was never initialized.
+
+## The Takeaway
+
+SDKs that initialize at module scope should always be guarded by the presence of their configuration. One boolean in a shared config file is cheaper than debugging why local dev is spewing errors, and it keeps the "works on a fresh clone" contract honest.

--- a/apps/root/src/data/contentOrder.ts
+++ b/apps/root/src/data/contentOrder.ts
@@ -93,4 +93,6 @@ export const blogHistory: AllowedBlogSlugs[] = [
   blogSlugs.cyclingThemeToggle, // 2026-04-08
   blogSlugs.minisearchRankedSearchCmdk, // 2026-04-10
   blogSlugs.funnelSessionIdAnalytics, // 2026-04-10
+  blogSlugs.mobileVrDataDrivenPlaywright, // 2026-04-10
+  blogSlugs.sentrySkipWithoutDsn, // 2026-04-10
 ];

--- a/apps/root/src/data/structuredData/blog.ts
+++ b/apps/root/src/data/structuredData/blog.ts
@@ -296,6 +296,25 @@ export const blogStructuredData: Record<AllowedBlogSlugs, BlogStructuredData> =
         blogMdxMetadata[blogSlugs.funnelSessionIdAnalytics]?.date ?? '',
       author,
     },
+    [blogSlugs.mobileVrDataDrivenPlaywright]: {
+      '@context': 'https://schema.org',
+      '@type': 'Article',
+      headline: blogRecords[blogSlugs.mobileVrDataDrivenPlaywright].title,
+      description:
+        blogRecords[blogSlugs.mobileVrDataDrivenPlaywright].description,
+      datePublished:
+        blogMdxMetadata[blogSlugs.mobileVrDataDrivenPlaywright]?.date ?? '',
+      author,
+    },
+    [blogSlugs.sentrySkipWithoutDsn]: {
+      '@context': 'https://schema.org',
+      '@type': 'Article',
+      headline: blogRecords[blogSlugs.sentrySkipWithoutDsn].title,
+      description: blogRecords[blogSlugs.sentrySkipWithoutDsn].description,
+      datePublished:
+        blogMdxMetadata[blogSlugs.sentrySkipWithoutDsn]?.date ?? '',
+      author,
+    },
   };
 
 export const blogRootStructuredData: CollectionPageStructuredData = {


### PR DESCRIPTION
## Summary
- Adds blog post on data-driven Playwright visual regression testing (from #330): typed page config array replaces 9 copy-pasted tests with a loop at two viewports
- Adds short-note blog post on Sentry DSN guard pattern (from #332): single boolean across three runtimes skips init when DSN is missing
- Full post checklist: slugs, thumbnails, index imports, contentOrder, structuredData, test count updates

## Test plan
- [x] `pnpm tsc --noEmit` passes
- [x] `pnpm nx test root` — 680/680 tests pass
- [ ] Verify posts render at `/blog/mobile-vr-data-driven-playwright` and `/blog/sentry-skip-without-dsn`

🤖 Generated with [Claude Code](https://claude.com/claude-code)