### PR TITLE
content(blog): editorial pass on 3 oldest posts (batch 1 of #337)

### DIFF
--- a/apps/root/src/data/content/blog/auto-generated-toc-scroll-spy.mdx
+++ b/apps/root/src/data/content/blog/auto-generated-toc-scroll-spy.mdx
@@ -220,3 +220,12 @@ FAB was hidden on mobile, exactly when it was needed most.
 - **Self-maintaining**: authors write MDX with headings, TOC generates itself
 - Works across all content types (projects, experience, blog) automatically
   through the shared `PostBody` component
+
+## The Lesson
+
+The best UI affordances are the ones the browser already gives you.
+IntersectionObserver, `prefers-reduced-motion`, native `scrollIntoView`,
+and auto-generated heading IDs from the MDX plugin meant I wrote 149 lines
+of glue code and got an accessible, zero-cost TOC with scroll spy. Before
+adding a throttled scroll listener or a custom animation timing function,
+check whether the platform already solved it. Usually it did.

--- a/apps/root/src/data/content/blog/shared-ui-design-system.mdx
+++ b/apps/root/src/data/content/blog/shared-ui-design-system.mdx
@@ -57,7 +57,7 @@ Before writing any code, I established three rules:
 
 The first target was the Heading/Text split. The kit wrappers maintained a
 `sharedVariants` set to decide whether to delegate to shared-ui or render
-locally — a runtime check for a compile-time concern.
+locally: a runtime check for a compile-time concern.
 
 The fix was simple: move every variant into shared-ui.
 
@@ -112,7 +112,7 @@ No kit layer. No delegation. No variant sets to keep in sync.
 
 The second insight came from looking at the 15 pages that all repeated
 `className='py-16 lg:py-24 space-y-24'` on their PageLayout. If every
-consumer passes the same props, those aren't options — they're the default.
+consumer passes the same props, those aren't options. They're the default.
 
 ### PageLayout
 

--- a/apps/root/src/data/content/blog/unified-content-pipeline.mdx
+++ b/apps/root/src/data/content/blog/unified-content-pipeline.mdx
@@ -19,11 +19,11 @@ export const metadata = {
 
 ## The Problem
 
-Every content type on this portfolio — projects and experience — had its own
+Every content type on this portfolio (projects and experience) had its own
 slug file, thumbnail file, MDX import index, content ordering array, reading
 time map, and structured data file. Adding a single project meant touching six
 files with overlapping data. Adding a _third_ content type (blog) would triple
-the duplication.
+the duplication and make every future content addition cost 18+ file touches.
 
 ## The Solution: A Content Registry
 
@@ -65,3 +65,11 @@ simple config lookup, making the system extensible without code changes.
 - Zero runtime changes to existing pages
 - 18 new registry tests covering all query paths
 - Type-safe throughout: `ContentType` union prevents typos
+
+## The Lesson
+
+The cost of adding a new content type is a signal. If it takes six files, the
+architecture is paying taxes on every addition, and every addition compounds
+the next one's cost. A single registry with a typed config flips the math:
+adding a content type is three files, and the existing query API already works
+on day one. Design for the access pattern, not for the first type that shipped.


### PR DESCRIPTION
Part of #337 (multi-PR editorial series). First batch: the 3 oldest blog posts by `date`.

## Summary

Applies the long-form self-check from the new style guide to the 3 oldest blog posts. Scope is body prose only — metadata, slugs, dates, and code blocks are untouched. Structure-level edits (adding a takeaway section, folding consequence clauses) are in scope; thesis changes are not.

## Posts in this batch

| Slug | Date | Before | After |
|---|---|---|---|
| `unified-content-pipeline` | 2026-04-03 | 256w, 2 em dashes, no takeaway | 340w, 0 em dashes, takeaway added |
| `auto-generated-toc-scroll-spy` | 2026-04-04 | 827w, 0 em dashes, no takeaway | 893w, 0 em dashes, takeaway added |
| `shared-ui-design-system` | 2026-04-04 | 1052w, 2 em dashes, strong takeaways already | 1055w, 0 em dashes, takeaways unchanged |

## Changes per post

### `unified-content-pipeline.mdx`

- **Em dashes → parens.** `"on this portfolio — projects and experience —"` → `"(projects and experience)"`. The aside is short enough that parens read cleaner.
- **Strengthened a consequence clause.** `"Adding a third content type (blog) would triple the duplication"` → `"...would triple the duplication and make every future content addition cost 18+ file touches."` Quantifies the pain.
- **Added `## The Lesson`.** Names the principle: "The cost of adding a new content type is a signal. If it takes six files, the architecture is paying taxes on every addition, and every addition compounds the next one's cost. A single registry with a typed config flips the math: adding a content type is three files, and the existing query API already works on day one. Design for the access pattern, not for the first type that shipped."

### `auto-generated-toc-scroll-spy.mdx`

- **No em dash work needed** (already had zero).
- **Added `## The Lesson`.** Ties the whole post to a platform-primitives principle: "The best UI affordances are the ones the browser already gives you. IntersectionObserver, `prefers-reduced-motion`, native `scrollIntoView`, and auto-generated heading IDs from the MDX plugin meant I wrote 149 lines of glue code and got an accessible, zero-cost TOC with scroll spy. Before adding a throttled scroll listener or a custom animation timing function, check whether the platform already solved it. Usually it did."

### `shared-ui-design-system.mdx`

- **Em dash → colon.** `"render locally — a runtime check for a compile-time concern"` → `"render locally: a runtime check for a compile-time concern"`.
- **Em dash → period.** `"those aren't options — they're the default"` → `"those aren't options. They're the default."` Punchier as two sentences.
- **Takeaways section unchanged.** Already had 4 punchy principle bullets: "Wrappers that only add variants are a code smell", "Defaults should encode the dominant pattern", "The Rule of Three applies to deletion too", "Enforce at the tool level". No edits needed.

## Long-form self-check results

Ran against each post (from `.claude/docs/content-style-guide.md` → "Self-check: long-form"):

| Check | Post 1 | Post 2 | Post 3 |
|---|---|---|---|
| Em dashes only for true parentheticals | ✓ (0) | ✓ (0) | ✓ (0) |
| Every "X happened" has a because/which meant | ✓ | ✓ | ✓ |
| Takeaway is a concrete, punchy principle | ✓ (added) | ✓ (added) | ✓ (already strong) |
| No section re-explains a code block | ✓ | ✓ | ✓ |
| Full artifacts included | ✓ | ✓ (hooks shown in full) | ✓ (architecture-focused, not script-focused) |
| No mechanical-pass residue (awkward `we→I` sub) | ✓ | ✓ | ✓ |

## Test plan

- [x] `rg '—'` against the 3 files (excluding fenced code blocks): **0 matches**
- [x] `pnpm exec tsc --noEmit`: zero new errors (52 pre-existing, 52 post)
- [x] `pnpm exec nx test root`: **680/680 tests passing**
- [x] Search index regenerated (body prose feeds the searchable `body` field in `searchIndex.json`)
- [x] Pre-commit hooks (lint + full nx typecheck) passed
- [ ] Manual dev render of each of the 3 posts in browser — reads smoothly end-to-end, no whiplash at section transitions, no broken code fences, closing sections land.

## Not in this batch

**29 blog posts remain** for the #337 editorial pass. Batches 2+ will spin out as separate PRs — targeting 2–4 posts per batch per the issue's suggestion. Recommended next batch: the next 3 oldest blog posts (April 5, 2026 dates), which have broader drift and more potential em dashes to clean.

**Project case studies and experience entries** are explicitly out of #337's scope — different content shape, different concerns.

## Diff stats

3 files changed, +21 / −4. All additions are the two new `## The Lesson` sections plus the quantified consequence clause.

https://claude.ai/code/session_016wL5KsCR7uGKvYUVSAFHuA