### PR TITLE
content(blog): MDX single-source-of-truth refactor post

### DIFF
--- a/apps/root/src/data/__tests__/contentRegistry.spec.ts
+++ b/apps/root/src/data/__tests__/contentRegistry.spec.ts
@@ -26,7 +26,7 @@ describe('contentRegistry', () => {
 
     it('returns all blog entries in order', () => {
       const blogs = getContentByType('blog');
-      expect(blogs.length).toBe(32);
+      expect(blogs.length).toBe(33);
       expect(blogs[0].type).toBe('blog');
       expect(blogs[0].slug).toBe('unified-content-pipeline');
       expect(blogs[1].slug).toBe('auto-generated-toc-scroll-spy');
@@ -97,7 +97,7 @@ describe('contentRegistry', () => {
       expect(slugs).toContain('accessible-dropdown-keyboard-nav');
       expect(slugs).toContain('toast-pause-on-hover');
       expect(slugs).toContain('keyboard-navigable-data-tables');
-      expect(slugs.length).toBe(32);
+      expect(slugs.length).toBe(33);
     });
   });
 
@@ -145,7 +145,7 @@ describe('contentRegistry', () => {
   describe('getAllContent', () => {
     it('returns all entries (projects + experience)', () => {
       const all = getAllContent();
-      expect(all.length).toBe(47); // 10 projects + 5 experiences + 32 blogs
+      expect(all.length).toBe(48); // 10 projects + 5 experiences + 33 blogs
     });
 
     it('contains entries of all types', () => {

--- a/apps/root/src/data/blog.ts
+++ b/apps/root/src/data/blog.ts
@@ -33,6 +33,7 @@ export const blogSlugs = {
   funnelSessionIdAnalytics: 'funnel-session-id-analytics',
   mobileVrDataDrivenPlaywright: 'mobile-vr-data-driven-playwright',
   sentrySkipWithoutDsn: 'sentry-skip-without-dsn',
+  mdxSingleSourceOfTruth: 'mdx-single-source-of-truth',
 } as const;
 
 export const blogPageSlugs = [...Object.values(blogSlugs)];

--- a/apps/root/src/data/content/blog/index.ts
+++ b/apps/root/src/data/content/blog/index.ts
@@ -97,6 +97,9 @@ import MobileVrDataDrivenPlaywright, {
 import SentrySkipWithoutDsn, {
   metadata as sentrySkipWithoutDsnMeta,
 } from './sentry-skip-without-dsn.mdx';
+import MdxSingleSourceOfTruth, {
+  metadata as mdxSingleSourceOfTruthMeta,
+} from './mdx-single-source-of-truth.mdx';
 
 export const blogMdxComponents: Record<AllowedBlogSlugs, ComponentType> = {
   'unified-content-pipeline': UnifiedContentPipeline,
@@ -133,6 +136,7 @@ export const blogMdxComponents: Record<AllowedBlogSlugs, ComponentType> = {
   'funnel-session-id-analytics': FunnelSessionIdAnalytics,
   'mobile-vr-data-driven-playwright': MobileVrDataDrivenPlaywright,
   'sentry-skip-without-dsn': SentrySkipWithoutDsn,
+  'mdx-single-source-of-truth': MdxSingleSourceOfTruth,
 };
 
 export const blogMdxMetadata: Record<AllowedBlogSlugs, PostMetadata> = {
@@ -168,4 +172,5 @@ export const blogMdxMetadata: Record<AllowedBlogSlugs, PostMetadata> = {
   'funnel-session-id-analytics': funnelSessionIdAnalyticsMeta,
   'mobile-vr-data-driven-playwright': mobileVrDataDrivenPlaywrightMeta,
   'sentry-skip-without-dsn': sentrySkipWithoutDsnMeta,
+  'mdx-single-source-of-truth': mdxSingleSourceOfTruthMeta,
 };

--- a/apps/root/src/data/content/blog/mdx-single-source-of-truth.mdx
+++ b/apps/root/src/data/content/blog/mdx-single-source-of-truth.mdx
@@ -1,0 +1,127 @@
+export const metadata = {
+  title: 'Killing Split-Brain Content with One Metadata Export',
+  date: '2026-04-11',
+  excerpt:
+    'How moving cover images, titles, and excerpts into MDX metadata eliminated 680 lines of duplicate records and the silent drift between them.',
+  author: 'Daniel Joffe',
+  category: 'Architecture',
+  tags: ['Next.js', 'MDX', 'TypeScript', 'Jest'],
+  slug: 'mdx-single-source-of-truth',
+  type: 'blog',
+  cover: {
+    alt: 'A single bright thread connecting scattered fabric swatches on a table',
+    src: '/photo-1620641788421-7a1c342ea42e',
+    origin:
+      'https://unsplash.com/photos/yellow-and-black-abstract-painting-nGrfKmtwv24',
+    creator: '@milad_fakurian',
+  },
+};
+
+## The Problem
+
+This portfolio has 47 MDX content files across three types: blog posts, project case studies, and experience entries. Each file already exported a `metadata` object with a title, excerpt, date, tags, and slug. But that metadata was not the source of truth for what appeared on the site.
+
+Listing-page cards pulled titles and descriptions from separate `*Thumbnails.ts` files: `blogThumbnails.ts` (430 lines), `projectThumbnails.ts` (161 lines), and `experienceThumbnails.ts` (96 lines). Structured data for blog and project pages lived in hand-authored records inside `structuredData/blog.ts` (300 lines) and `structuredData/project.ts` (104 lines). OG image generators read from the thumbnail records too.
+
+That is five files duplicating what MDX already knew. And duplication drifts. After 47 entries, several listing cards showed different titles or descriptions than the actual post. The thumbnails said one thing; the MDX said another. Nobody noticed because the data never ran through a single codepath.
+
+## The Fix: Extend MDX Metadata, Delete Everything Else
+
+The approach was straightforward: make the MDX `export const metadata` block carry every field the site needs, then derive everything else from it at registry-build time.
+
+I extended `PostMetadata` with the fields that previously only lived in thumbnail records:
+
+```typescript
+export interface PostMetadata {
+  title: string;
+  date: string;
+  excerpt: string;
+  author: string;
+  category: string;
+  tags: string[];
+  slug: string;
+  type: ContentType | (string & {});
+  cover: UnsplashImageMeta; // new
+  company?: string;
+  role?: string;
+  duration?: string;
+  industry?: string;
+  featured?: boolean; // new
+  logo?: string; // new (experience)
+  invert?: boolean; // new (experience)
+  domain?: string; // new (experience)
+}
+```
+
+Then I wrote `buildThumbnail()`, a 27-line function that derives the `PostThumbnail` shape from metadata at registry-build time:
+
+```typescript
+export function buildThumbnail(
+  metadata: PostMetadata,
+  readingTime: number
+): PostThumbnail {
+  const basePath = contentTypeConfigs[metadata.type as ContentType].basePath;
+  const thumbnail: PostThumbnail = {
+    slug: metadata.slug,
+    title: metadata.title,
+    description: metadata.excerpt,
+    cover: metadata.cover,
+    link: { href: `${basePath}/${metadata.slug}` },
+    readingTime,
+  };
+  if (metadata.role !== undefined) thumbnail.role = metadata.role;
+  if (metadata.duration !== undefined) thumbnail.duration = metadata.duration;
+  if (metadata.featured !== undefined) thumbnail.featured = metadata.featured;
+  return thumbnail;
+}
+```
+
+The content registry calls `buildThumbnail()` for every entry during module initialization. Listing cards, OG images, and pagination all read from the same derived shape. There is no second copy of the data.
+
+## Collapsing Structured Data
+
+The structured data files were the most dramatic reduction. Blog structured data went from 300 lines of hand-authored per-slug records to a programmatic generator:
+
+```typescript
+export const blogStructuredData = Object.fromEntries(
+  blogPageSlugs.map(slug => {
+    const meta = blogMdxMetadata[slug];
+    return [
+      slug,
+      {
+        '@context': 'https://schema.org',
+        '@type': 'Article',
+        headline: meta.title,
+        description: meta.excerpt,
+        datePublished: meta.date,
+        author,
+      },
+    ];
+  })
+) as Record<AllowedBlogSlugs, BlogStructuredData>;
+```
+
+Project structured data collapsed from 104 lines to the same pattern. Adding a new blog post or project no longer requires a structured data entry: the generator picks it up automatically from the MDX metadata.
+
+## Testing MDX Imports in Jest
+
+One complication: the content registry imports `.mdx` files to read their metadata, but Jest does not understand MDX out of the box. Turbopack handles it in dev; webpack handles it in production builds. Tests had neither.
+
+I wrote a minimal Jest transformer (`__mocks__/mdxTransform.js`) that parses the `export const metadata` block from MDX source and returns it as a JavaScript module. The transformer does not render MDX content; it extracts the metadata export so registry tests can verify that every slug resolves to a valid entry with the right fields.
+
+## The Voice Pass
+
+With MDX as the single source of truth, I ran a brand-voice audit across all 47 entries. The portfolio had accumulated first-person plural ("we built," "our library") from early drafts when the voice was undefined. I converted every instance to first-person singular, shifted project and experience excerpts to past-tense outcomes, and enforced character budgets: titles under 60 characters, excerpts under 160.
+
+The rewrite touched 32 blog entries, 10 project case studies, and 5 experience entries. It included 5 title rewrites, 19 excerpt rewrites, and over 120 body-level substitutions. Because the metadata block is now the only place titles and excerpts live, every surface picked up the new copy automatically: listing cards, OG images, structured data, and pagination links. No second file to forget.
+
+## The Numbers
+
+- **Deleted**: `blogThumbnails.ts`, `projectThumbnails.ts`, `experienceThumbnails.ts` (687 lines)
+- **Collapsed**: `structuredData/blog.ts` from 300 to 46 lines; `structuredData/project.ts` from 104 to 45 lines
+- **Added**: `buildThumbnail.ts` (27 lines), `mdxTransform.js` (61 lines)
+- **Net**: roughly 600 fewer lines of hand-maintained content data, and zero drift between what MDX says and what the site shows
+
+## The Lesson
+
+Every duplicated record is a drift vector. If listing cards read from file A and the post reads from file B, the only question is when they diverge, not whether. Making the content file the sole authority is not just a cleanup; it changes the failure mode. With one source, incorrect metadata is visible everywhere immediately. With two, it hides in the gap between them.

--- a/apps/root/src/data/contentOrder.ts
+++ b/apps/root/src/data/contentOrder.ts
@@ -95,4 +95,5 @@ export const blogHistory: AllowedBlogSlugs[] = [
   blogSlugs.funnelSessionIdAnalytics, // 2026-04-10
   blogSlugs.mobileVrDataDrivenPlaywright, // 2026-04-10
   blogSlugs.sentrySkipWithoutDsn, // 2026-04-10
+  blogSlugs.mdxSingleSourceOfTruth, // 2026-04-11
 ];


### PR DESCRIPTION
## Summary

- Adds a new blog post covering the architectural decision from #334 (eliminating split-brain between MDX metadata and separate `*Thumbnails.ts` / structured data files) with the brand-voice rewrite (#335) woven in as what single-source enabled
- Post walks through: the drift problem, extending `PostMetadata`, the `buildThumbnail()` helper, collapsing structured data generators, the Jest MDX transformer, and the 47-file voice pass
- Wires up slug, index imports, content ordering, and updates test counts (32→33 blogs, 47→48 total)

## Test plan

- [x] `pnpm tsc --noEmit` passes with zero errors
- [x] `pnpm nx test root` — all 680 tests pass
- [ ] CI pipeline passes on this PR
- [ ] Verify `/blog/mdx-single-source-of-truth` renders correctly on Vercel preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)