### PR TITLE
Raise coverage threshold to 65% with 17 new test files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,7 +168,7 @@ The workspace uses Nx plugins for automatic target inference:
 - Jest config: `apps/root/jest.config.ts`
 - Setup file: `apps/root/src/test-setup.ts`
 - GSAP plugins are mocked in `apps/root/__mocks__/`
-- Coverage threshold: 50% minimum (branches, functions, lines, statements)
+- Coverage threshold: 65% minimum (branches, functions, lines, statements)
 
 ### E2E Tests
 

--- a/apps/root/jest.config.ts
+++ b/apps/root/jest.config.ts
@@ -33,10 +33,10 @@ const config = {
   ],
   coverageThreshold: {
     global: {
-      branches: 50,
-      functions: 50,
-      lines: 50,
-      statements: 50,
+      branches: 65,
+      functions: 65,
+      lines: 65,
+      statements: 65,
     },
   },
   // Ensure Jest exits cleanly in Nx/Next test envs

--- a/apps/root/src/app/__tests__/global-error.spec.tsx
+++ b/apps/root/src/app/__tests__/global-error.spec.tsx
@@ -1,0 +1,69 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import * as Sentry from '@sentry/nextjs';
+import GlobalError from '../global-error';
+
+jest.mock('@sentry/nextjs', () => ({
+  withScope: jest.fn(callback => {
+    const mockScope = {
+      setLevel: jest.fn(),
+      setTag: jest.fn(),
+      setExtra: jest.fn(),
+    };
+    callback(mockScope);
+  }),
+  captureException: jest.fn(),
+}));
+
+describe('GlobalError', () => {
+  const mockReset = jest.fn();
+  const mockError = new Error('Test error');
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders error message and try again button', () => {
+    render(<GlobalError error={mockError} reset={mockReset} />);
+
+    expect(screen.getByText('Something went wrong!')).toBeInTheDocument();
+    expect(
+      screen.getByText(/an unexpected error occurred/i)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /try again/i })
+    ).toBeInTheDocument();
+  });
+
+  it('calls reset when try again is clicked', () => {
+    render(<GlobalError error={mockError} reset={mockReset} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /try again/i }));
+    expect(mockReset).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports error to Sentry on mount', () => {
+    render(<GlobalError error={mockError} reset={mockReset} />);
+
+    expect(Sentry.withScope).toHaveBeenCalled();
+    expect(Sentry.captureException).toHaveBeenCalledWith(mockError);
+  });
+
+  it('includes digest in Sentry scope when present', () => {
+    const errorWithDigest = Object.assign(new Error('Digest error'), {
+      digest: 'abc123',
+    });
+
+    render(<GlobalError error={errorWithDigest} reset={mockReset} />);
+
+    expect(Sentry.withScope).toHaveBeenCalled();
+    const scopeCallback = (Sentry.withScope as jest.Mock).mock.calls[0][0];
+    const mockScope = {
+      setLevel: jest.fn(),
+      setTag: jest.fn(),
+      setExtra: jest.fn(),
+    };
+    scopeCallback(mockScope);
+
+    expect(mockScope.setExtra).toHaveBeenCalledWith('digest', 'abc123');
+  });
+});

--- a/apps/root/src/app/__tests__/not-found.spec.tsx
+++ b/apps/root/src/app/__tests__/not-found.spec.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from '@testing-library/react';
+import NotFound from '../not-found';
+
+jest.mock('@/utils/constants', () => ({
+  HOME_LINK: { href: '/' },
+}));
+
+jest.mock('@/data/metadata/notFound', () => ({
+  notFoundMetadata: { title: '404' },
+}));
+
+describe('NotFound', () => {
+  it('renders the 404 heading', () => {
+    render(<NotFound />);
+    expect(screen.getByText('404')).toBeInTheDocument();
+    expect(screen.getByText('Page Not Found')).toBeInTheDocument();
+  });
+
+  it('renders a link back to home', () => {
+    render(<NotFound />);
+    const link = screen.getByRole('link', { name: /return to home page/i });
+    expect(link).toHaveAttribute('href', '/');
+  });
+
+  it('renders descriptive text', () => {
+    render(<NotFound />);
+    expect(screen.getByText(/this page doesn't exist/i)).toBeInTheDocument();
+  });
+});

--- a/apps/root/src/app/__tests__/robots.spec.ts
+++ b/apps/root/src/app/__tests__/robots.spec.ts
@@ -1,0 +1,35 @@
+import robots from '../robots';
+
+jest.mock('@/utils/constants', () => ({
+  DOMAIN_URL: 'https://danieljoffe.com',
+}));
+
+describe('robots', () => {
+  it('returns a valid robots.txt configuration', () => {
+    const result = robots();
+
+    expect(result.rules).toBeDefined();
+    expect(result.sitemap).toBe('https://danieljoffe.com/sitemap.xml');
+  });
+
+  it('allows all user agents to crawl /', () => {
+    const result = robots();
+
+    expect(result.rules).toEqual(
+      expect.objectContaining({
+        userAgent: '*',
+        allow: '/',
+      })
+    );
+  });
+
+  it('disallows /thank-you/ and /api/', () => {
+    const result = robots();
+
+    expect(result.rules).toEqual(
+      expect.objectContaining({
+        disallow: ['/thank-you/', '/api/'],
+      })
+    );
+  });
+});

--- a/apps/root/src/app/__tests__/sitemap.spec.ts
+++ b/apps/root/src/app/__tests__/sitemap.spec.ts
@@ -1,0 +1,90 @@
+import sitemap from '../sitemap';
+
+jest.mock('@/utils/constants', () => ({
+  DOMAIN_URL: 'https://danieljoffe.com',
+  ABOUT_LINK: { href: '/about' },
+  AUDIT_LINK: { href: '/audit' },
+  BLOG_LINK: { href: '/blog' },
+  EXPERIENCE_LINK: { href: '/experience' },
+  PROJECTS_LINK: { href: '/projects' },
+  SERVICES_LINK: { href: '/services' },
+}));
+
+jest.mock('@/data/experience', () => ({
+  experiencePageSlugs: ['job-one', 'job-two'],
+}));
+
+jest.mock('@/data/project', () => ({
+  projectPageSlugs: ['project-alpha'],
+}));
+
+jest.mock('@/data/blog', () => ({
+  blogPageSlugs: ['post-one', 'post-two', 'post-three'],
+}));
+
+describe('sitemap', () => {
+  it('returns an array of sitemap entries', () => {
+    const result = sitemap();
+    expect(Array.isArray(result)).toBe(true);
+    expect(result.length).toBeGreaterThan(0);
+  });
+
+  it('includes all static routes', () => {
+    const result = sitemap();
+    const urls = result.map(entry => entry.url);
+
+    expect(urls).toContain('https://danieljoffe.com');
+    expect(urls).toContain('https://danieljoffe.com/about');
+    expect(urls).toContain('https://danieljoffe.com/services');
+    expect(urls).toContain('https://danieljoffe.com/projects');
+    expect(urls).toContain('https://danieljoffe.com/experience');
+    expect(urls).toContain('https://danieljoffe.com/blog');
+    expect(urls).toContain('https://danieljoffe.com/audit');
+  });
+
+  it('includes dynamic experience routes', () => {
+    const result = sitemap();
+    const urls = result.map(entry => entry.url);
+
+    expect(urls).toContain('https://danieljoffe.com/experience/job-one');
+    expect(urls).toContain('https://danieljoffe.com/experience/job-two');
+  });
+
+  it('includes dynamic project routes', () => {
+    const result = sitemap();
+    const urls = result.map(entry => entry.url);
+
+    expect(urls).toContain('https://danieljoffe.com/projects/project-alpha');
+  });
+
+  it('includes dynamic blog routes', () => {
+    const result = sitemap();
+    const urls = result.map(entry => entry.url);
+
+    expect(urls).toContain('https://danieljoffe.com/blog/post-one');
+    expect(urls).toContain('https://danieljoffe.com/blog/post-two');
+    expect(urls).toContain('https://danieljoffe.com/blog/post-three');
+  });
+
+  it('assigns correct priorities', () => {
+    const result = sitemap();
+    const home = result.find(e => e.url === 'https://danieljoffe.com');
+    const project = result.find(
+      e => e.url === 'https://danieljoffe.com/projects/project-alpha'
+    );
+    const experience = result.find(
+      e => e.url === 'https://danieljoffe.com/experience/job-one'
+    );
+
+    expect(home!.priority).toBe(1);
+    expect(project!.priority).toBe(0.7);
+    expect(experience!.priority).toBe(0.6);
+  });
+
+  it('sets lastModified on all entries', () => {
+    const result = sitemap();
+    result.forEach(entry => {
+      expect(entry.lastModified).toBeInstanceOf(Date);
+    });
+  });
+});

--- a/apps/root/src/app/blog/__tests__/slug-page.spec.tsx
+++ b/apps/root/src/app/blog/__tests__/slug-page.spec.tsx
@@ -1,0 +1,103 @@
+import { redirect } from 'next/navigation';
+import { render, screen } from '@testing-library/react';
+import { getContentBySlug, getContentSlugs } from '@/data/contentRegistry';
+import { getPostDetailProps } from '@/lib/getPostDetailProps';
+import SlugBlogPage, {
+  generateMetadata,
+  generateStaticParams,
+} from '../[slug]/page';
+
+jest.mock('next/navigation', () => ({
+  redirect: jest.fn(),
+}));
+
+jest.mock('@/data/contentRegistry');
+jest.mock('@/lib/getPostDetailProps');
+jest.mock('@/lib/buildPostMetadata', () => ({
+  buildPostMetadata: jest.fn((meta: Record<string, unknown>) => ({
+    title: meta.title,
+  })),
+}));
+
+jest.mock('@/components/PostDetailLayout', () => {
+  return function MockPostDetailLayout() {
+    return <div data-testid='post-detail'>Post Detail</div>;
+  };
+});
+
+const mockGetContentBySlug = getContentBySlug as jest.MockedFunction<
+  typeof getContentBySlug
+>;
+const mockGetContentSlugs = getContentSlugs as jest.MockedFunction<
+  typeof getContentSlugs
+>;
+const mockGetPostDetailProps = getPostDetailProps as jest.MockedFunction<
+  typeof getPostDetailProps
+>;
+
+describe('Blog [slug] page', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('generateMetadata', () => {
+    it('returns post metadata when entry exists', async () => {
+      mockGetContentBySlug.mockReturnValue({
+        metadata: { title: 'Test Post' },
+      } as never);
+
+      const result = await generateMetadata({
+        params: Promise.resolve({ slug: 'test-post' }),
+      });
+
+      expect(result).toEqual({ title: 'Test Post' });
+    });
+
+    it('returns fallback metadata when entry is missing', async () => {
+      mockGetContentBySlug.mockReturnValue(undefined);
+
+      const result = await generateMetadata({
+        params: Promise.resolve({ slug: 'nonexistent' }),
+      });
+
+      expect(result.title).toContain('Not Found');
+    });
+  });
+
+  describe('SlugBlogPage', () => {
+    it('renders PostDetailLayout when props exist', async () => {
+      mockGetPostDetailProps.mockReturnValue({
+        entry: {} as never,
+        pagination: {} as never,
+        breadcrumbs: [],
+      });
+
+      const Page = await SlugBlogPage({
+        params: Promise.resolve({ slug: 'test-post' }),
+      });
+      render(Page as React.ReactElement);
+
+      expect(screen.getByTestId('post-detail')).toBeInTheDocument();
+    });
+
+    it('redirects when post is not found', async () => {
+      mockGetPostDetailProps.mockReturnValue(null);
+
+      await SlugBlogPage({
+        params: Promise.resolve({ slug: 'nonexistent' }),
+      });
+
+      expect(redirect).toHaveBeenCalled();
+    });
+  });
+
+  describe('generateStaticParams', () => {
+    it('returns slug params for all blog posts', () => {
+      mockGetContentSlugs.mockReturnValue(['post-1', 'post-2']);
+
+      const result = generateStaticParams();
+
+      expect(result).toEqual([{ slug: 'post-1' }, { slug: 'post-2' }]);
+    });
+  });
+});

--- a/apps/root/src/app/experience/__tests__/slug-page.spec.tsx
+++ b/apps/root/src/app/experience/__tests__/slug-page.spec.tsx
@@ -1,0 +1,103 @@
+import { redirect } from 'next/navigation';
+import { render, screen } from '@testing-library/react';
+import { getContentBySlug, getContentSlugs } from '@/data/contentRegistry';
+import { getPostDetailProps } from '@/lib/getPostDetailProps';
+import SlugExperiencePage, {
+  generateMetadata,
+  generateStaticParams,
+} from '../[slug]/page';
+
+jest.mock('next/navigation', () => ({
+  redirect: jest.fn(),
+}));
+
+jest.mock('@/data/contentRegistry');
+jest.mock('@/lib/getPostDetailProps');
+jest.mock('@/lib/buildPostMetadata', () => ({
+  buildPostMetadata: jest.fn((meta: Record<string, unknown>) => ({
+    title: meta.title,
+  })),
+}));
+
+jest.mock('@/components/PostDetailLayout', () => {
+  return function MockPostDetailLayout() {
+    return <div data-testid='post-detail'>Post Detail</div>;
+  };
+});
+
+const mockGetContentBySlug = getContentBySlug as jest.MockedFunction<
+  typeof getContentBySlug
+>;
+const mockGetContentSlugs = getContentSlugs as jest.MockedFunction<
+  typeof getContentSlugs
+>;
+const mockGetPostDetailProps = getPostDetailProps as jest.MockedFunction<
+  typeof getPostDetailProps
+>;
+
+describe('Experience [slug] page', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('generateMetadata', () => {
+    it('returns post metadata when entry exists', async () => {
+      mockGetContentBySlug.mockReturnValue({
+        metadata: { title: 'My Job' },
+      } as never);
+
+      const result = await generateMetadata({
+        params: Promise.resolve({ slug: 'my-job' }),
+      });
+
+      expect(result).toEqual({ title: 'My Job' });
+    });
+
+    it('returns fallback metadata when entry is missing', async () => {
+      mockGetContentBySlug.mockReturnValue(undefined);
+
+      const result = await generateMetadata({
+        params: Promise.resolve({ slug: 'nonexistent' }),
+      });
+
+      expect(result.title).toContain('Not Found');
+    });
+  });
+
+  describe('SlugExperiencePage', () => {
+    it('renders PostDetailLayout when props exist', async () => {
+      mockGetPostDetailProps.mockReturnValue({
+        entry: {} as never,
+        pagination: {} as never,
+        breadcrumbs: [],
+      });
+
+      const Page = await SlugExperiencePage({
+        params: Promise.resolve({ slug: 'my-job' }),
+      });
+      render(Page as React.ReactElement);
+
+      expect(screen.getByTestId('post-detail')).toBeInTheDocument();
+    });
+
+    it('redirects when experience entry is not found', async () => {
+      mockGetPostDetailProps.mockReturnValue(null);
+
+      await SlugExperiencePage({
+        params: Promise.resolve({ slug: 'nonexistent' }),
+      });
+
+      expect(redirect).toHaveBeenCalled();
+    });
+  });
+
+  describe('generateStaticParams', () => {
+    it('returns slug params for all experience entries', () => {
+      mockGetContentSlugs.mockReturnValue(['job-1', 'job-2']);
+
+      const result = generateStaticParams();
+
+      expect(result).toEqual([{ slug: 'job-1' }, { slug: 'job-2' }]);
+    });
+  });
+});

--- a/apps/root/src/app/projects/__tests__/page.spec.tsx
+++ b/apps/root/src/app/projects/__tests__/page.spec.tsx
@@ -1,0 +1,75 @@
+import { render, screen } from '@testing-library/react';
+import Projects from '../page';
+
+jest.mock('@/data/contentRegistry', () => ({
+  getContentByType: jest.fn(() => [
+    {
+      thumbnail: {
+        title: 'Project A',
+        slug: 'project-a',
+        excerpt: 'Desc A',
+        src: '/photo-1',
+        alt: 'A',
+      },
+      readingTime: '3 min',
+    },
+    {
+      thumbnail: {
+        title: 'Project B',
+        slug: 'project-b',
+        excerpt: 'Desc B',
+        src: '/photo-2',
+        alt: 'B',
+      },
+      readingTime: '5 min',
+    },
+  ]),
+}));
+
+jest.mock('@/data/metadata/project', () => ({
+  projectRootMetadata: { title: 'Projects' },
+}));
+
+jest.mock('@/data/structuredData/project', () => ({
+  projectsRootStructuredData: {},
+}));
+
+jest.mock('@/utils/constants', () => ({
+  GITHUB_REPO_URL: 'https://github.com/test',
+  STORYBOOK_URL: 'https://storybook.test',
+}));
+
+jest.mock('@/lib/layoutStyles', () => ({
+  cardBase: 'mock-card-base',
+}));
+
+jest.mock('@/components/kit', () => ({
+  PostCard: ({ post }: { post: { title: string; slug: string } }) => (
+    <div data-testid={`post-card-${post.slug}`}>{post.title}</div>
+  ),
+}));
+
+describe('Projects page', () => {
+  it('renders hero heading', () => {
+    render(<Projects />);
+    expect(screen.getByText('Case studies from the field')).toBeInTheDocument();
+  });
+
+  it('renders project cards', () => {
+    render(<Projects />);
+    expect(screen.getByTestId('post-card-project-a')).toBeInTheDocument();
+    expect(screen.getByTestId('post-card-project-b')).toBeInTheDocument();
+  });
+
+  it('renders GitHub and Storybook links', () => {
+    render(<Projects />);
+    expect(screen.getByRole('link', { name: /github/i })).toHaveAttribute(
+      'href',
+      'https://github.com/test'
+    );
+    expect(screen.getByRole('link', { name: /storybook/i })).toHaveAttribute(
+      'href',
+      'https://storybook.test'
+    );
+  });
+});

--- a/apps/root/src/components/Nav/__tests__/MobileNav.spec.tsx
+++ b/apps/root/src/components/Nav/__tests__/MobileNav.spec.tsx
@@ -1,0 +1,101 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import MobileNav from '../MobileNav';
+
+const mockPush = jest.fn();
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+jest.mock('@/hooks/useFocusTrap', () => ({
+  useFocusTrap: () => ({ current: null }),
+}));
+
+jest.mock('@/lib/analytics', () => ({
+  analytics: {
+    mobileMenuToggle: jest.fn(),
+    navClick: jest.fn(),
+    formStart: jest.fn(),
+  },
+}));
+
+jest.mock('@/utils/constants', () => ({
+  HOME_LINK: { href: '/', label: 'Home' },
+  PRIMARY_NAV_LINKS: [
+    { href: '/services', label: 'Services' },
+    { href: '/projects', label: 'Projects' },
+  ],
+  MORE_NAV_LINKS: [
+    { href: '/about', label: 'About' },
+    { href: '/blog', label: 'Blog' },
+  ],
+  AUDIT_LINK: { href: '/audit', label: 'Audit' },
+}));
+
+jest.mock('../DarkModeToggle', () => {
+  return function MockDarkModeToggle() {
+    return <button name='dark-mode'>Dark</button>;
+  };
+});
+
+describe('MobileNav', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the bottom nav with home and primary links', () => {
+    render(<MobileNav pathname='/' />);
+
+    expect(screen.getByText('Home')).toBeInTheDocument();
+    expect(screen.getByText('Services')).toBeInTheDocument();
+    expect(screen.getByText('Projects')).toBeInTheDocument();
+  });
+
+  it('renders search and more buttons', () => {
+    render(<MobileNav pathname='/' />);
+
+    expect(screen.getByRole('button', { name: /search/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /open more menu/i })
+    ).toBeInTheDocument();
+  });
+
+  it('highlights home link when on home page', () => {
+    render(<MobileNav pathname='/' />);
+
+    const homeLink = screen.getByRole('link', { name: 'Home' });
+    expect(homeLink).toHaveAttribute('aria-current', 'page');
+  });
+
+  it('opens more sheet when More button is clicked', () => {
+    render(<MobileNav pathname='/' />);
+
+    fireEvent.click(screen.getByRole('button', { name: /open more menu/i }));
+
+    expect(
+      screen.getByRole('dialog', { name: /more navigation/i })
+    ).not.toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('shows more sheet links (About, Blog, Audit)', () => {
+    render(<MobileNav pathname='/' />);
+
+    fireEvent.click(screen.getByRole('button', { name: /open more menu/i }));
+
+    // Sheet links render as buttons with link labels
+    expect(screen.getByText('About')).toBeInTheDocument();
+    expect(screen.getByText('Blog')).toBeInTheDocument();
+    expect(screen.getByText('Audit')).toBeInTheDocument();
+  });
+
+  it('closes sheet on Escape key', () => {
+    render(<MobileNav pathname='/' />);
+
+    fireEvent.click(screen.getByRole('button', { name: /open more menu/i }));
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+
+    expect(
+      screen.getByRole('button', { name: /open more menu/i })
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/root/src/components/kit/__tests__/TableOfContents.spec.tsx
+++ b/apps/root/src/components/kit/__tests__/TableOfContents.spec.tsx
@@ -1,0 +1,172 @@
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { TableOfContents } from '../TableOfContents';
+
+// Mock useFocusTrap
+jest.mock('@/hooks/useFocusTrap', () => ({
+  useFocusTrap: () => ({ current: null }),
+}));
+
+// Mock IntersectionObserver
+const mockObserve = jest.fn();
+const mockDisconnect = jest.fn();
+
+class MockIntersectionObserver {
+  callback: IntersectionObserverCallback;
+  constructor(callback: IntersectionObserverCallback) {
+    this.callback = callback;
+  }
+  observe = mockObserve;
+  unobserve = jest.fn();
+  disconnect = mockDisconnect;
+}
+
+Object.defineProperty(window, 'IntersectionObserver', {
+  writable: true,
+  value: MockIntersectionObserver,
+});
+
+// Mock matchMedia for reduced motion
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: jest.fn().mockImplementation(() => ({
+    matches: false,
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+  })),
+});
+
+function setupHeadings() {
+  const container = document.createElement('article');
+  const h2 = document.createElement('h2');
+  h2.id = 'introduction';
+  h2.textContent = 'Introduction';
+  container.appendChild(h2);
+
+  const h3 = document.createElement('h3');
+  h3.id = 'details';
+  h3.textContent = 'Details';
+  container.appendChild(h3);
+
+  const h2b = document.createElement('h2');
+  h2b.id = 'conclusion';
+  h2b.textContent = 'Conclusion';
+  container.appendChild(h2b);
+
+  document.body.appendChild(container);
+  return container;
+}
+
+describe('TableOfContents', () => {
+  let container: HTMLElement;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    container = setupHeadings();
+  });
+
+  afterEach(() => {
+    container.remove();
+  });
+
+  it('renders nothing when no headings are found', async () => {
+    container.remove();
+    const emptyContainer = document.createElement('article');
+    document.body.appendChild(emptyContainer);
+
+    const { container: wrapper } = render(<TableOfContents />);
+    await act(() => Promise.resolve());
+
+    expect(wrapper.innerHTML).toBe('');
+    emptyContainer.remove();
+  });
+
+  it('renders desktop TOC with heading links', async () => {
+    render(<TableOfContents desktop />);
+    await act(() => Promise.resolve());
+
+    expect(screen.getByText('On this page')).toBeInTheDocument();
+    // Headings appear both in DOM and TOC buttons; verify at least 2 instances
+    expect(screen.getAllByText('Introduction').length).toBeGreaterThanOrEqual(
+      2
+    );
+    expect(screen.getAllByText('Details').length).toBeGreaterThanOrEqual(2);
+    expect(screen.getAllByText('Conclusion').length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('scrolls to heading when TOC link is clicked', async () => {
+    const scrollIntoViewMock = jest.fn();
+    const heading = document.getElementById('introduction')!;
+    heading.scrollIntoView = scrollIntoViewMock;
+
+    render(<TableOfContents desktop />);
+    await act(() => Promise.resolve());
+
+    // The heading text appears both in the DOM heading and the TOC button.
+    // Click the TOC button (role=button), not the heading element.
+    const tocButtons = screen.getAllByRole('button');
+    const introButton = tocButtons.find(
+      btn => btn.textContent === 'Introduction'
+    );
+    expect(introButton).toBeDefined();
+    fireEvent.click(introButton!);
+
+    expect(scrollIntoViewMock).toHaveBeenCalledWith(
+      expect.objectContaining({ behavior: 'smooth' })
+    );
+  });
+
+  it('renders mobile FAB button', async () => {
+    render(<TableOfContents mobile />);
+    await act(() => Promise.resolve());
+
+    expect(
+      screen.getByRole('button', { name: /open table of contents/i })
+    ).toBeInTheDocument();
+  });
+
+  it('opens mobile sheet when FAB is clicked', async () => {
+    render(<TableOfContents mobile />);
+    await act(() => Promise.resolve());
+
+    const fab = screen.getByRole('button', {
+      name: /open table of contents/i,
+    });
+    fireEvent.click(fab);
+
+    expect(
+      screen.getByRole('dialog', { name: /table of contents/i })
+    ).toBeInTheDocument();
+  });
+
+  it('closes mobile sheet on Escape', async () => {
+    render(<TableOfContents mobile />);
+    await act(() => Promise.resolve());
+
+    // Open the sheet
+    fireEvent.click(
+      screen.getByRole('button', { name: /open table of contents/i })
+    );
+
+    // Press Escape
+    fireEvent.keyDown(document, { key: 'Escape' });
+
+    // FAB label should revert to "Open"
+    expect(
+      screen.getByRole('button', { name: /open table of contents/i })
+    ).toBeInTheDocument();
+  });
+
+  it('renders both desktop and mobile when no prop specified', async () => {
+    render(<TableOfContents />);
+    await act(() => Promise.resolve());
+
+    // Desktop nav
+    expect(
+      screen.getByRole('navigation', { name: /table of contents/i })
+    ).toBeInTheDocument();
+    // Mobile FAB
+    expect(
+      screen.getByRole('button', { name: /open table of contents/i })
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/root/src/hooks/__tests__/useKeyboardShortcut.spec.ts
+++ b/apps/root/src/hooks/__tests__/useKeyboardShortcut.spec.ts
@@ -1,0 +1,111 @@
+import { renderHook } from '@testing-library/react';
+import { useKeyboardShortcut } from '../useKeyboardShortcut';
+
+function fireKeyDown(
+  key: string,
+  options: Partial<KeyboardEvent> = {},
+  target?: HTMLElement
+) {
+  const event = new KeyboardEvent('keydown', {
+    key,
+    bubbles: true,
+    ...options,
+  });
+  if (target) {
+    Object.defineProperty(event, 'target', { value: target });
+  }
+  document.dispatchEvent(event);
+}
+
+describe('useKeyboardShortcut', () => {
+  it('fires callback when the key is pressed', () => {
+    const callback = jest.fn();
+    renderHook(() => useKeyboardShortcut('k', callback));
+
+    fireKeyDown('k');
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it('is case-insensitive', () => {
+    const callback = jest.fn();
+    renderHook(() => useKeyboardShortcut('k', callback));
+
+    fireKeyDown('K');
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores when a different key is pressed', () => {
+    const callback = jest.fn();
+    renderHook(() => useKeyboardShortcut('k', callback));
+
+    fireKeyDown('j');
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('ignores when meta key is held', () => {
+    const callback = jest.fn();
+    renderHook(() => useKeyboardShortcut('k', callback));
+
+    fireKeyDown('k', { metaKey: true });
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('ignores when ctrl key is held', () => {
+    const callback = jest.fn();
+    renderHook(() => useKeyboardShortcut('k', callback));
+
+    fireKeyDown('k', { ctrlKey: true });
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('ignores when alt key is held', () => {
+    const callback = jest.fn();
+    renderHook(() => useKeyboardShortcut('k', callback));
+
+    fireKeyDown('k', { altKey: true });
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('ignores when an input is focused', () => {
+    const callback = jest.fn();
+    renderHook(() => useKeyboardShortcut('k', callback));
+
+    const input = document.createElement('input');
+    fireKeyDown('k', {}, input);
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('ignores when a textarea is focused', () => {
+    const callback = jest.fn();
+    renderHook(() => useKeyboardShortcut('k', callback));
+
+    const textarea = document.createElement('textarea');
+    fireKeyDown('k', {}, textarea);
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('ignores when a select is focused', () => {
+    const callback = jest.fn();
+    renderHook(() => useKeyboardShortcut('k', callback));
+
+    const select = document.createElement('select');
+    fireKeyDown('k', {}, select);
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('cleans up event listener on unmount', () => {
+    const callback = jest.fn();
+    const { unmount } = renderHook(() => useKeyboardShortcut('k', callback));
+
+    // Verify it works before unmount
+    fireKeyDown('k');
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    callback.mockClear();
+    unmount();
+
+    // After unmount, callback should not fire
+    fireKeyDown('k');
+    expect(callback).toHaveBeenCalledTimes(0);
+  });
+});

--- a/apps/root/src/lib/__tests__/getPostDetailProps.spec.ts
+++ b/apps/root/src/lib/__tests__/getPostDetailProps.spec.ts
@@ -1,0 +1,93 @@
+import { getContentBySlug, getContentPagination } from '@/data/contentRegistry';
+import { getPostDetailProps } from '../getPostDetailProps';
+
+jest.mock('@/data/contentRegistry');
+jest.mock('@/data/contentTypeConfig', () => ({
+  contentTypeConfigs: {
+    project: {
+      basePath: '/projects',
+      label: 'Projects',
+      contentDir: 'projects',
+    },
+    blog: { basePath: '/blog', label: 'Blog', contentDir: 'blog' },
+    experience: {
+      basePath: '/experience',
+      label: 'Experience',
+      contentDir: 'experience',
+    },
+  },
+}));
+
+const mockGetContentBySlug = getContentBySlug as jest.MockedFunction<
+  typeof getContentBySlug
+>;
+const mockGetContentPagination = getContentPagination as jest.MockedFunction<
+  typeof getContentPagination
+>;
+
+describe('getPostDetailProps', () => {
+  const mockEntry = {
+    slug: 'test-project',
+    type: 'project' as const,
+    thumbnail: {
+      title: 'Test Project',
+      excerpt: 'A test',
+      src: '/photo-123',
+      alt: 'test',
+    },
+    component: () => null,
+    metadata: { title: 'Test Project' },
+    structuredData: {},
+    readingTime: '3 min',
+  };
+
+  const mockPagination = {
+    prev: { slug: 'prev-project', title: 'Previous' },
+    next: { slug: 'next-project', title: 'Next' },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns null when slug does not exist', () => {
+    mockGetContentBySlug.mockReturnValue(undefined);
+    expect(getPostDetailProps('project', 'nonexistent')).toBeNull();
+  });
+
+  it('returns entry, pagination, and breadcrumbs for a valid slug', () => {
+    mockGetContentBySlug.mockReturnValue(mockEntry as never);
+    mockGetContentPagination.mockReturnValue(mockPagination as never);
+
+    const result = getPostDetailProps('project', 'test-project');
+
+    expect(result).not.toBeNull();
+    expect(result!.entry).toBe(mockEntry);
+    expect(result!.pagination).toBe(mockPagination);
+  });
+
+  it('builds breadcrumbs with correct paths and labels', () => {
+    mockGetContentBySlug.mockReturnValue(mockEntry as never);
+    mockGetContentPagination.mockReturnValue(mockPagination as never);
+
+    const result = getPostDetailProps('project', 'test-project');
+
+    expect(result!.breadcrumbs).toEqual([
+      { href: '/projects', label: 'Projects' },
+      { href: '/projects/test-project', label: 'Test Project' },
+    ]);
+  });
+
+  it('uses the correct content type config', () => {
+    mockGetContentBySlug.mockReturnValue(mockEntry as never);
+    mockGetContentPagination.mockReturnValue(mockPagination as never);
+
+    getPostDetailProps('blog', 'test-project');
+
+    expect(mockGetContentBySlug).toHaveBeenCalledWith('blog', 'test-project');
+    expect(mockGetContentPagination).toHaveBeenCalledWith(
+      'blog',
+      'test-project'
+    );
+  });
+});

--- a/apps/root/src/lib/email/__tests__/resend.spec.ts
+++ b/apps/root/src/lib/email/__tests__/resend.spec.ts
@@ -1,0 +1,43 @@
+jest.mock('resend', () => ({
+  Resend: jest.fn().mockImplementation((key: string) => ({ key })),
+}));
+
+describe('createResendClient', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env = { ...originalEnv };
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it('returns null when RESEND_API_KEY is missing', () => {
+    delete process.env['RESEND_API_KEY'];
+
+    jest.isolateModules(() => {
+      const { createResendClient } = require('../resend');
+      expect(createResendClient()).toBeNull();
+    });
+  });
+
+  it('creates a Resend client when API key is set', () => {
+    process.env['RESEND_API_KEY'] = 'test-api-key';
+
+    jest.isolateModules(() => {
+      const { createResendClient } = require('../resend');
+      const client = createResendClient();
+      expect(client).toBeDefined();
+    });
+  });
+
+  it('exports email constants', () => {
+    jest.isolateModules(() => {
+      const { EMAIL_FROM, EMAIL_TO } = require('../resend');
+      expect(EMAIL_FROM).toContain('Daniel Joffe');
+      expect(EMAIL_TO).toBe('hello@danieljoffe.com');
+    });
+  });
+});

--- a/apps/root/src/lib/supabase/__tests__/client.spec.ts
+++ b/apps/root/src/lib/supabase/__tests__/client.spec.ts
@@ -1,0 +1,40 @@
+const mockCreateClient = jest.fn().mockReturnValue({ from: jest.fn() });
+jest.mock('@supabase/supabase-js', () => ({
+  createClient: (...args: unknown[]) => mockCreateClient(...args),
+}));
+
+describe('createBrowserSupabaseClient', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.resetModules();
+    process.env = { ...originalEnv };
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it('throws when environment variables are missing', () => {
+    delete process.env['NEXT_PUBLIC_SUPABASE_URL'];
+    delete process.env['NEXT_PUBLIC_SUPABASE_ANON_ID'];
+
+    // Re-import to get fresh module with cleared env
+    jest.isolateModules(() => {
+      const { createBrowserSupabaseClient: freshCreate } = require('../client');
+      expect(() => freshCreate()).toThrow(/missing/i);
+    });
+  });
+
+  it('creates a client when environment variables are set', () => {
+    process.env['NEXT_PUBLIC_SUPABASE_URL'] = 'https://test.supabase.co';
+    process.env['NEXT_PUBLIC_SUPABASE_ANON_ID'] = 'test-anon-key';
+
+    jest.isolateModules(() => {
+      const { createBrowserSupabaseClient: freshCreate } = require('../client');
+      const client = freshCreate();
+      expect(client).toBeDefined();
+    });
+  });
+});

--- a/apps/root/src/lib/supabase/__tests__/server.spec.ts
+++ b/apps/root/src/lib/supabase/__tests__/server.spec.ts
@@ -1,0 +1,49 @@
+const mockCreateClient = jest.fn().mockReturnValue({ from: jest.fn() });
+jest.mock('@supabase/supabase-js', () => ({
+  createClient: (...args: unknown[]) => mockCreateClient(...args),
+}));
+
+jest.mock('@/utils/helpers', () => ({
+  devLog: jest.fn(),
+}));
+
+describe('createServerSupabaseClient', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env = { ...originalEnv };
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it('returns null when environment variables are missing', () => {
+    delete process.env['NEXT_PUBLIC_SUPABASE_URL'];
+    delete process.env['SUPABASE_SERVICE_ROLE_KEY'];
+
+    jest.isolateModules(() => {
+      const { createServerSupabaseClient } = require('../server');
+      expect(createServerSupabaseClient()).toBeNull();
+    });
+  });
+
+  it('creates a client with auth options when env vars are set', () => {
+    process.env['NEXT_PUBLIC_SUPABASE_URL'] = 'https://test.supabase.co';
+    process.env['SUPABASE_SERVICE_ROLE_KEY'] = 'test-service-key';
+
+    jest.isolateModules(() => {
+      const { createServerSupabaseClient } = require('../server');
+      const client = createServerSupabaseClient();
+      expect(client).toBeDefined();
+      expect(mockCreateClient).toHaveBeenCalledWith(
+        'https://test.supabase.co',
+        'test-service-key',
+        expect.objectContaining({
+          auth: { autoRefreshToken: false, persistSession: false },
+        })
+      );
+    });
+  });
+});

--- a/apps/root/src/state/Modal/__tests__/ModalProvider.spec.tsx
+++ b/apps/root/src/state/Modal/__tests__/ModalProvider.spec.tsx
@@ -1,0 +1,92 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import ModalProvider, { useModal } from '../ModalProvider';
+
+function TestConsumer() {
+  const { isModalOpen, toggleModal, modalContent, setModalContent } =
+    useModal();
+  return (
+    <div>
+      <span data-testid='open'>{String(isModalOpen)}</span>
+      <span data-testid='content'>{modalContent}</span>
+      <button name='toggle' onClick={toggleModal}>
+        Toggle
+      </button>
+      <button name='set' onClick={() => setModalContent(<p>Hello</p>)}>
+        Set
+      </button>
+      <button name='clear' onClick={() => setModalContent(null)}>
+        Clear
+      </button>
+    </div>
+  );
+}
+
+describe('ModalProvider', () => {
+  beforeEach(() => {
+    document.body.classList.remove('overflow-y-hidden');
+  });
+
+  it('provides default context values', () => {
+    render(
+      <ModalProvider>
+        <TestConsumer />
+      </ModalProvider>
+    );
+
+    expect(screen.getByTestId('open')).toHaveTextContent('false');
+  });
+
+  it('toggles modal open state', () => {
+    render(
+      <ModalProvider>
+        <TestConsumer />
+      </ModalProvider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Toggle' }));
+    expect(screen.getByTestId('open')).toHaveTextContent('true');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Toggle' }));
+    expect(screen.getByTestId('open')).toHaveTextContent('false');
+  });
+
+  it('sets modal content and opens the modal', () => {
+    render(
+      <ModalProvider>
+        <TestConsumer />
+      </ModalProvider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Set' }));
+    expect(screen.getByTestId('open')).toHaveTextContent('true');
+    expect(screen.getByText('Hello')).toBeInTheDocument();
+  });
+
+  it('clears modal content and closes the modal', () => {
+    render(
+      <ModalProvider>
+        <TestConsumer />
+      </ModalProvider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Set' }));
+    expect(screen.getByTestId('open')).toHaveTextContent('true');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Clear' }));
+    expect(screen.getByTestId('open')).toHaveTextContent('false');
+  });
+
+  it('syncs body overflow with modal state', () => {
+    render(
+      <ModalProvider>
+        <TestConsumer />
+      </ModalProvider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Toggle' }));
+    expect(document.body.classList.contains('overflow-y-hidden')).toBe(true);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Toggle' }));
+    expect(document.body.classList.contains('overflow-y-hidden')).toBe(false);
+  });
+});

--- a/apps/root/src/state/Theme/__tests__/ThemeProvider.spec.tsx
+++ b/apps/root/src/state/Theme/__tests__/ThemeProvider.spec.tsx
@@ -1,0 +1,133 @@
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { ThemeProvider, useTheme } from '../ThemeProvider';
+
+let mockMatchesState = false;
+const mockListeners: Array<(e: { matches: boolean }) => void> = [];
+
+const mockMatchMedia = jest.fn().mockImplementation(() => ({
+  matches: mockMatchesState,
+  addEventListener: jest.fn((_, handler) => mockListeners.push(handler)),
+  removeEventListener: jest.fn(),
+}));
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: mockMatchMedia,
+});
+
+function TestConsumer() {
+  const { theme, resolvedTheme, isDarkMode, setTheme, toggleDarkMode } =
+    useTheme();
+  return (
+    <div>
+      <span data-testid='theme'>{theme}</span>
+      <span data-testid='resolved'>{resolvedTheme}</span>
+      <span data-testid='dark'>{String(isDarkMode)}</span>
+      <button name='light' onClick={() => setTheme('light')}>
+        Light
+      </button>
+      <button name='dark' onClick={() => setTheme('dark')}>
+        Dark
+      </button>
+      <button name='system' onClick={() => setTheme('system')}>
+        System
+      </button>
+      <button name='toggle' onClick={toggleDarkMode}>
+        Toggle
+      </button>
+    </div>
+  );
+}
+
+describe('ThemeProvider', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockMatchesState = false;
+    mockListeners.length = 0;
+    localStorage.clear();
+    document.documentElement.classList.remove('dark');
+  });
+
+  it('defaults to system theme', async () => {
+    render(
+      <ThemeProvider>
+        <TestConsumer />
+      </ThemeProvider>
+    );
+
+    // After microtask, loads stored theme
+    await act(() => Promise.resolve());
+    expect(screen.getByTestId('theme')).toHaveTextContent('system');
+  });
+
+  it('sets theme and persists to localStorage', async () => {
+    render(
+      <ThemeProvider>
+        <TestConsumer />
+      </ThemeProvider>
+    );
+
+    await act(() => Promise.resolve());
+    fireEvent.click(screen.getByRole('button', { name: 'Dark' }));
+
+    expect(screen.getByTestId('theme')).toHaveTextContent('dark');
+    expect(screen.getByTestId('dark')).toHaveTextContent('true');
+    expect(localStorage.getItem('theme')).toBe('dark');
+  });
+
+  it('toggles dark mode', async () => {
+    render(
+      <ThemeProvider>
+        <TestConsumer />
+      </ThemeProvider>
+    );
+
+    await act(() => Promise.resolve());
+
+    // Default is light (system with no dark preference)
+    expect(screen.getByTestId('dark')).toHaveTextContent('false');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Toggle' }));
+    expect(screen.getByTestId('dark')).toHaveTextContent('true');
+  });
+
+  it('adds dark class to documentElement when dark mode', async () => {
+    render(
+      <ThemeProvider>
+        <TestConsumer />
+      </ThemeProvider>
+    );
+
+    await act(() => Promise.resolve());
+    fireEvent.click(screen.getByRole('button', { name: 'Dark' }));
+
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+  });
+
+  it('reads stored theme from localStorage', async () => {
+    localStorage.setItem('theme', 'dark');
+
+    render(
+      <ThemeProvider>
+        <TestConsumer />
+      </ThemeProvider>
+    );
+
+    await act(() => Promise.resolve());
+    expect(screen.getByTestId('theme')).toHaveTextContent('dark');
+  });
+
+  it('resolves system theme based on media query', async () => {
+    mockMatchesState = true;
+
+    render(
+      <ThemeProvider>
+        <TestConsumer />
+      </ThemeProvider>
+    );
+
+    await act(() => Promise.resolve());
+    expect(screen.getByTestId('dark')).toHaveTextContent('true');
+    expect(screen.getByTestId('resolved')).toHaveTextContent('dark');
+  });
+});

--- a/apps/root/src/state/Toast/__tests__/ToastProvider.spec.tsx
+++ b/apps/root/src/state/Toast/__tests__/ToastProvider.spec.tsx
@@ -1,0 +1,118 @@
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { ToastProvider, useToast } from '../ToastProvider';
+
+jest.useFakeTimers();
+
+function TestConsumer() {
+  const { toast } = useToast();
+  return (
+    <div>
+      <button
+        name='success'
+        onClick={() => toast({ variant: 'success', title: 'Saved!' })}
+      >
+        Success
+      </button>
+      <button
+        name='error'
+        onClick={() =>
+          toast({
+            variant: 'error',
+            title: 'Failed',
+            description: 'Something broke',
+          })
+        }
+      >
+        Error
+      </button>
+    </div>
+  );
+}
+
+describe('ToastProvider', () => {
+  it('renders children', () => {
+    render(
+      <ToastProvider>
+        <p>Content</p>
+      </ToastProvider>
+    );
+    expect(screen.getByText('Content')).toBeInTheDocument();
+  });
+
+  it('shows a toast when triggered', () => {
+    render(
+      <ToastProvider>
+        <TestConsumer />
+      </ToastProvider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Success' }));
+    expect(screen.getByText('Saved!')).toBeInTheDocument();
+  });
+
+  it('shows toast with description', () => {
+    render(
+      <ToastProvider>
+        <TestConsumer />
+      </ToastProvider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Error' }));
+    expect(screen.getByText('Failed')).toBeInTheDocument();
+    expect(screen.getByText('Something broke')).toBeInTheDocument();
+  });
+
+  it('auto-dismisses toast after 4 seconds', () => {
+    render(
+      <ToastProvider>
+        <TestConsumer />
+      </ToastProvider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Success' }));
+    expect(screen.getByText('Saved!')).toBeInTheDocument();
+
+    act(() => {
+      jest.advanceTimersByTime(4000);
+    });
+
+    expect(screen.queryByText('Saved!')).not.toBeInTheDocument();
+  });
+
+  it('dismisses toast when X button is clicked', () => {
+    render(
+      <ToastProvider>
+        <TestConsumer />
+      </ToastProvider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Success' }));
+    expect(screen.getByText('Saved!')).toBeInTheDocument();
+
+    // The dismiss button is the X icon button inside the toast
+    const dismissButtons = screen.getAllByRole('button');
+    const dismissBtn = dismissButtons.find(
+      btn =>
+        btn !== screen.getByRole('button', { name: 'Success' }) &&
+        btn !== screen.getByRole('button', { name: 'Error' })
+    );
+    expect(dismissBtn).toBeDefined();
+    fireEvent.click(dismissBtn!);
+
+    expect(screen.queryByText('Saved!')).not.toBeInTheDocument();
+  });
+
+  it('supports multiple simultaneous toasts', () => {
+    render(
+      <ToastProvider>
+        <TestConsumer />
+      </ToastProvider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Success' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Error' }));
+
+    expect(screen.getByText('Saved!')).toBeInTheDocument();
+    expect(screen.getByText('Failed')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

- Add 17 test files covering utilities, state providers, hooks, page components, and navigation
- Raise coverage threshold from 50% to 65% in `jest.config.ts`
- Update documented threshold in `CLAUDE.md`

Coverage improvement:

| Metric | Before | After | Threshold |
|--------|--------|-------|-----------|
| Branches | 61% | **71%** | 65% |
| Functions | 59% | **67%** | 65% |
| Lines | 53% | **67%** | 65% |
| Statements | 63% | **72%** | 65% |

## Test plan

- [x] `pnpm tsc --noEmit` passes
- [x] `pnpm nx test root` passes (84 suites, 770+ tests)
- [x] `pnpm nx test root -- --coverage` passes with 65% threshold
- [x] All 17 new test files pass individually

Closes #358

https://claude.ai/code/session_01HxJNXEQVJ97NYA7dCZPdt3