### PR TITLE
fix(test): add missing mocks for tag route constants

### DIFF
--- a/apps/root/src/app/__tests__/sitemap.spec.ts
+++ b/apps/root/src/app/__tests__/sitemap.spec.ts
@@ -5,9 +5,18 @@ jest.mock('@/utils/constants', () => ({
   ABOUT_LINK: { href: '/about' },
   AUDIT_LINK: { href: '/audit' },
   BLOG_LINK: { href: '/blog' },
+  BLOG_TAGS_LINK: { href: '/blog/tags' },
   EXPERIENCE_LINK: { href: '/experience' },
+  POSTS_PER_PAGE: 12,
   PROJECTS_LINK: { href: '/projects' },
+  PROJECTS_TAGS_LINK: { href: '/projects/tags' },
   SERVICES_LINK: { href: '/services' },
+}));
+
+jest.mock('@/lib/tags', () => ({
+  getAllTags: (type: string) =>
+    type === 'blog' ? ['React', 'TypeScript'] : ['React'],
+  tagToSlug: (tag: string) => tag.toLowerCase().replace(/\s+/g, '-'),
 }));
 
 jest.mock('@/data/experience', () => ({

--- a/apps/root/src/app/projects/__tests__/page.spec.tsx
+++ b/apps/root/src/app/projects/__tests__/page.spec.tsx
@@ -37,15 +37,31 @@ jest.mock('@/data/structuredData/project', () => ({
 jest.mock('@/utils/constants', () => ({
   GITHUB_REPO_URL: 'https://github.com/test',
   STORYBOOK_URL: 'https://storybook.test',
+  PROJECTS_TAGS_LINK: { href: '/projects/tags' },
+}));
+
+jest.mock('@/lib/tags', () => ({
+  getTopTags: () => [{ name: 'React', count: 5 }],
+  tagToSlug: (tag: string) => tag.toLowerCase(),
 }));
 
 jest.mock('@/lib/layoutStyles', () => ({
   cardBase: 'mock-card-base',
 }));
 
-jest.mock('@/components/kit', () => ({
-  PostCard: ({ post }: { post: { title: string; slug: string } }) => (
-    <div data-testid={`post-card-${post.slug}`}>{post.title}</div>
+jest.mock('@/components/ProjectsGridWithTags', () => ({
+  ProjectsGridWithTags: ({
+    allProjects,
+  }: {
+    allProjects: { title: string; slug: string }[];
+  }) => (
+    <div data-testid='projects-grid'>
+      {allProjects.map(p => (
+        <div key={p.slug} data-testid={`post-card-${p.slug}`}>
+          {p.title}
+        </div>
+      ))}
+    </div>
   ),
 }));
 


### PR DESCRIPTION
## Summary

- Sitemap test was missing `BLOG_TAGS_LINK`, `PROJECTS_TAGS_LINK`, `POSTS_PER_PAGE`, and `@/lib/tags` mocks added in #349
- Projects page test was missing `PROJECTS_TAGS_LINK`, `@/lib/tags`, and `@/components/ProjectsGridWithTags` mocks added in #349

Both tests now pass with the tag filtering feature's new imports properly mocked.

## Test plan

- [x] `sitemap.spec.ts` — 7 tests pass
- [x] `page.spec.tsx` (projects) — 3 tests pass
- [x] Full test suite — 89 suites, 797 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)