### PR TITLE
feat(content): two blog posts on tag filtering and Storybook testing

### DIFF
--- a/apps/root/src/app/__tests__/sitemap.spec.ts
+++ b/apps/root/src/app/__tests__/sitemap.spec.ts
@@ -5,9 +5,18 @@ jest.mock('@/utils/constants', () => ({
   ABOUT_LINK: { href: '/about' },
   AUDIT_LINK: { href: '/audit' },
   BLOG_LINK: { href: '/blog' },
+  BLOG_TAGS_LINK: { href: '/blog/tags' },
   EXPERIENCE_LINK: { href: '/experience' },
+  POSTS_PER_PAGE: 12,
   PROJECTS_LINK: { href: '/projects' },
+  PROJECTS_TAGS_LINK: { href: '/projects/tags' },
   SERVICES_LINK: { href: '/services' },
+}));
+
+jest.mock('@/lib/tags', () => ({
+  getAllTags: (type: string) =>
+    type === 'blog' ? ['React', 'TypeScript'] : ['React'],
+  tagToSlug: (tag: string) => tag.toLowerCase().replace(/\s+/g, '-'),
 }));
 
 jest.mock('@/data/experience', () => ({

--- a/apps/root/src/app/projects/__tests__/page.spec.tsx
+++ b/apps/root/src/app/projects/__tests__/page.spec.tsx
@@ -37,15 +37,31 @@ jest.mock('@/data/structuredData/project', () => ({
 jest.mock('@/utils/constants', () => ({
   GITHUB_REPO_URL: 'https://github.com/test',
   STORYBOOK_URL: 'https://storybook.test',
+  PROJECTS_TAGS_LINK: { href: '/projects/tags' },
+}));
+
+jest.mock('@/lib/tags', () => ({
+  getTopTags: () => [{ name: 'React', count: 5 }],
+  tagToSlug: (tag: string) => tag.toLowerCase(),
 }));
 
 jest.mock('@/lib/layoutStyles', () => ({
   cardBase: 'mock-card-base',
 }));
 
-jest.mock('@/components/kit', () => ({
-  PostCard: ({ post }: { post: { title: string; slug: string } }) => (
-    <div data-testid={`post-card-${post.slug}`}>{post.title}</div>
+jest.mock('@/components/ProjectsGridWithTags', () => ({
+  ProjectsGridWithTags: ({
+    allProjects,
+  }: {
+    allProjects: { title: string; slug: string }[];
+  }) => (
+    <div data-testid='projects-grid'>
+      {allProjects.map(p => (
+        <div key={p.slug} data-testid={`post-card-${p.slug}`}>
+          {p.title}
+        </div>
+      ))}
+    </div>
   ),
 }));
 

--- a/apps/root/src/data/__tests__/contentRegistry.spec.ts
+++ b/apps/root/src/data/__tests__/contentRegistry.spec.ts
@@ -26,7 +26,7 @@ describe('contentRegistry', () => {
 
     it('returns all blog entries in order', () => {
       const blogs = getContentByType('blog');
-      expect(blogs.length).toBe(33);
+      expect(blogs.length).toBe(35);
       expect(blogs[0].type).toBe('blog');
       expect(blogs[0].slug).toBe('unified-content-pipeline');
       expect(blogs[1].slug).toBe('auto-generated-toc-scroll-spy');
@@ -97,7 +97,7 @@ describe('contentRegistry', () => {
       expect(slugs).toContain('accessible-dropdown-keyboard-nav');
       expect(slugs).toContain('toast-pause-on-hover');
       expect(slugs).toContain('keyboard-navigable-data-tables');
-      expect(slugs.length).toBe(33);
+      expect(slugs.length).toBe(35);
     });
   });
 
@@ -145,7 +145,7 @@ describe('contentRegistry', () => {
   describe('getAllContent', () => {
     it('returns all entries (projects + experience)', () => {
       const all = getAllContent();
-      expect(all.length).toBe(48); // 10 projects + 5 experiences + 33 blogs
+      expect(all.length).toBe(50); // 10 projects + 5 experiences + 35 blogs
     });
 
     it('contains entries of all types', () => {

--- a/apps/root/src/data/blog.ts
+++ b/apps/root/src/data/blog.ts
@@ -34,6 +34,8 @@ export const blogSlugs = {
   mobileVrDataDrivenPlaywright: 'mobile-vr-data-driven-playwright',
   sentrySkipWithoutDsn: 'sentry-skip-without-dsn',
   mdxSingleSourceOfTruth: 'mdx-single-source-of-truth',
+  clientSideTagFilteringSeo: 'client-side-tag-filtering-seo',
+  storybookInteractionTestsAria: 'storybook-interaction-tests-aria',
 } as const;
 
 export const blogPageSlugs = [...Object.values(blogSlugs)];

--- a/apps/root/src/data/content/blog/client-side-tag-filtering-seo.mdx
+++ b/apps/root/src/data/content/blog/client-side-tag-filtering-seo.mdx
@@ -1,0 +1,123 @@
+export const metadata = {
+  title: 'Client-Side Tag Filtering Without Losing SEO URLs',
+  date: '2026-04-13',
+  excerpt:
+    'One component renders Link for crawlable tag pages or button for instant client filtering. The same TagChipStrip serves both without duplicating code.',
+  author: 'Daniel Joffe',
+  category: 'Frontend Engineering',
+  tags: ['React', 'Next.js', 'TypeScript', 'Search', 'SSR', 'Architecture'],
+  slug: 'client-side-tag-filtering-seo',
+  type: 'blog',
+  cover: {
+    alt: 'Colorful tags and labels sorted into rows',
+    src: '/photo-1633526544525-2f268e58e09d',
+    origin: 'https://unsplash.com/photos/colorful-tags-sorted',
+    creator: '@markuswinkler',
+  },
+};
+
+## The Problem: Tags That Navigate Away
+
+My blog and projects pages had tag routes: `/blog/tags/react`, `/projects/tags/next-js`. Server-rendered, crawlable, good for SEO. The problem was UX. Clicking a tag on the listing page navigated away, loaded a new page, and lost your scroll position. For a portfolio site with 33 blog posts and 10 projects, that round-trip felt heavy.
+
+I wanted instant filtering on the listing page while keeping the server-rendered tag routes as canonical URLs for search engines. The naive fix is two components: one with `<Link>` for the tag index pages, one with `<button>` for the listing pages. That doubles the surface area for every style change, accessibility fix, and new badge variant.
+
+## One Component, Two Modes
+
+`TagChipStrip` accepts optional `onTagClick` and `activeTag` props. When `onTagClick` is present, chips render as buttons with `aria-pressed`. When absent, they render as Next.js `<Link>` elements.
+
+```tsx
+{
+  tags.map(tag => {
+    const isActive = activeTag === tag.name;
+    const badgeVariant = isActive ? 'info' : 'default';
+
+    return onTagClick ? (
+      <button
+        key={tag.name}
+        onClick={() => onTagClick(tag.name)}
+        aria-pressed={isActive}
+      >
+        <Badge variant={badgeVariant}>{tag.name}</Badge>
+      </button>
+    ) : (
+      <Link key={tag.name} href={tag.href}>
+        <Badge variant={badgeVariant}>{tag.name}</Badge>
+      </Link>
+    );
+  });
+}
+```
+
+The tag detail pages (`/blog/tags/[tag]`) use `TagChipStrip` without the callback. The listing pages (`/blog`, `/projects`) pass `onTagClick` and `activeTag` to get client-side filtering. Same component, same styles, same accessibility attributes. The rendering mode is a function of the props, not a separate component.
+
+## The Client Island
+
+In App Router, the listing page is a server component. Tag filtering needs state. The solution is a client island that wraps the grid.
+
+`BlogSearchAndList` manages three view states: paginated default, search results (from the existing MiniSearch integration), and tag-filtered results. The key constraint is mutual exclusivity: selecting a tag clears the search query, and typing a search query clears the active tag.
+
+```tsx
+const handleTagClick = (tagName: string) => {
+  setActiveTag(prev => (prev === tagName ? null : tagName));
+  setQuery('');
+};
+
+const handleSearch = (value: string) => {
+  setQuery(value);
+  setActiveTag(null);
+};
+```
+
+When either filter is active, pagination hides. The `showPagination` flag is a single expression:
+
+```tsx
+const showPagination = !query && !activeTag;
+```
+
+`ProjectsGridWithTags` follows the same pattern but without search, since the projects page has 10 entries and no MiniSearch integration.
+
+## Server-Routed Pagination
+
+The blog listing splits into pages at 12 posts per page: `/blog`, `/blog/page/2`, `/blog/page/3`. Each page is a server component with a `ListPagination` kit component rendering real `<Link>`-backed page numbers.
+
+Next.js metadata API supports `alternates.canonical` but has no first-class shape for `rel=prev` and `rel=next`. React 19 solves this: bare `<link>` elements rendered in server components hoist into the document `<head>` automatically.
+
+```tsx
+{
+  /* React 19 hoists bare <link> into <head> */
+}
+<link rel='prev' href={prevHref} />;
+{
+  nextHref && <link rel='next' href={nextHref} />;
+}
+```
+
+No `next/head`, no metadata API workaround. The link element renders in JSX and ends up in the right place.
+
+## Scoping Tags to Content Type
+
+The tag routes had a quiet bug. `/blog/tags` listed tags from all content types: blog, projects, and experience. The page called `getAllTags()` without a type parameter, then linked each tag to `/blog/tags/{slug}`. Tags like "Angular" existed on experience entries but not blog posts, so `/blog/tags/angular` returned zero results.
+
+The fix was a type parameter on every tag helper:
+
+```ts
+export function getAllTags(type?: TagEntryType): string[] {
+  const entries = type ? getContentByType(type) : getAllContent();
+  const tagSet = new Set<string>();
+  for (const entry of entries) {
+    entry.metadata.tags?.forEach(t => tagSet.add(t));
+  }
+  return [...tagSet].sort();
+}
+```
+
+Every route-level caller now scopes explicitly: `getAllTags('blog')` on blog routes, `getAllTags('project')` on project routes. The parameter is optional for backward compatibility, but the convention is clear: if you are rendering a route, scope the query.
+
+## The Result
+
+Tag chips on `/blog` and `/projects` filter content instantly. The existing `/blog/tags/{slug}` and `/projects/tags/{slug}` routes remain as canonical SEO URLs. `TagChipStrip` handles both modes from one component. Pagination appears when no filter is active and hides when one is, with `rel=prev/next` hoisted via React 19 for crawlers.
+
+The scoping fix eliminated the cross-type tag leakage and the zero-result pages it produced. The type parameter on tag helpers now enforces that at the function signature level rather than relying on callers to filter after the fact.
+
+One component, two rendering modes, zero duplicated code. The server routes exist for search engines; the client filtering exists for humans browsing the page.

--- a/apps/root/src/data/content/blog/index.ts
+++ b/apps/root/src/data/content/blog/index.ts
@@ -100,6 +100,12 @@ import SentrySkipWithoutDsn, {
 import MdxSingleSourceOfTruth, {
   metadata as mdxSingleSourceOfTruthMeta,
 } from './mdx-single-source-of-truth.mdx';
+import ClientSideTagFilteringSeo, {
+  metadata as clientSideTagFilteringSeoMeta,
+} from './client-side-tag-filtering-seo.mdx';
+import StorybookInteractionTestsAria, {
+  metadata as storybookInteractionTestsAriaMeta,
+} from './storybook-interaction-tests-aria.mdx';
 
 export const blogMdxComponents: Record<AllowedBlogSlugs, ComponentType> = {
   'unified-content-pipeline': UnifiedContentPipeline,
@@ -137,6 +143,8 @@ export const blogMdxComponents: Record<AllowedBlogSlugs, ComponentType> = {
   'mobile-vr-data-driven-playwright': MobileVrDataDrivenPlaywright,
   'sentry-skip-without-dsn': SentrySkipWithoutDsn,
   'mdx-single-source-of-truth': MdxSingleSourceOfTruth,
+  'client-side-tag-filtering-seo': ClientSideTagFilteringSeo,
+  'storybook-interaction-tests-aria': StorybookInteractionTestsAria,
 };
 
 export const blogMdxMetadata: Record<AllowedBlogSlugs, PostMetadata> = {
@@ -173,4 +181,6 @@ export const blogMdxMetadata: Record<AllowedBlogSlugs, PostMetadata> = {
   'mobile-vr-data-driven-playwright': mobileVrDataDrivenPlaywrightMeta,
   'sentry-skip-without-dsn': sentrySkipWithoutDsnMeta,
   'mdx-single-source-of-truth': mdxSingleSourceOfTruthMeta,
+  'client-side-tag-filtering-seo': clientSideTagFilteringSeoMeta,
+  'storybook-interaction-tests-aria': storybookInteractionTestsAriaMeta,
 };

--- a/apps/root/src/data/content/blog/storybook-interaction-tests-aria.mdx
+++ b/apps/root/src/data/content/blog/storybook-interaction-tests-aria.mdx
@@ -1,0 +1,140 @@
+export const metadata = {
+  title: 'Replacing CSS Class Assertions with ARIA in Storybook',
+  date: '2026-04-13',
+  excerpt:
+    'CSS classes break when Tailwind configs change. ARIA attributes are the semantic contract. Six rules for interaction tests that survive refactors.',
+  author: 'Daniel Joffe',
+  category: 'Testing',
+  tags: [
+    'Storybook',
+    'ARIA',
+    'Accessibility',
+    'React',
+    'Design Systems',
+    'TypeScript',
+  ],
+  slug: 'storybook-interaction-tests-aria',
+  type: 'blog',
+  cover: {
+    alt: 'Checklist with green checkmarks on a clipboard',
+    src: '/photo-1586281380349-632531db7ed4',
+    origin: 'https://unsplash.com/photos/checklist-clipboard',
+    creator: '@glenncarstenspeters',
+  },
+};
+
+## The Failure Mode
+
+A Storybook interaction test for `ThemeToggle` asserted the active button had a specific background class:
+
+```tsx
+await expect(lightButton).toHaveClass('bg-surface');
+```
+
+It passed. Then I updated the design tokens. `bg-surface` became `bg-surface-primary`. The component worked perfectly. The test failed. The assertion was testing an implementation detail, not the behavior users interact with.
+
+This pattern was scattered across the component library: `toHaveClass('opacity-0')` on hidden tooltips, `toHaveClass('bg-surface')` on active themes, `.tagName` checks on breadcrumb items. Every Tailwind refactor risked breaking tests that had nothing to do with the change.
+
+## Six Rules
+
+I codified six rules for interaction tests and applied them across the library in one pass. The rules target the gap between what a test checks and what a user experiences.
+
+### 1. Query by role first
+
+`getByRole('button', { name: 'Label' })` over `getByText('Label')` for interactive elements. `getByText` is for non-interactive content: headings, paragraphs, empty-state messages. The distinction matters because role queries verify the element is interactive, not just visible.
+
+### 2. Always `waitFor` after state changes
+
+Any `userEvent` that triggers React state needs `waitFor` on subsequent assertions. Without it, the test reads stale DOM. This is the most common source of CI flakes in Storybook interaction tests.
+
+```tsx
+await userEvent.click(button);
+// Wrong: assertion may read pre-click DOM
+expect(menu).toBeInTheDocument();
+
+// Right: wait for React to flush
+await waitFor(() => expect(menu).toBeInTheDocument());
+```
+
+### 3. Never assert CSS classes
+
+This is the rule that triggered the audit. The fix is ARIA attributes: `aria-hidden`, `aria-pressed`, `aria-expanded`, `aria-selected`. If the component does not expose a semantic attribute for the state being tested, fix the component first.
+
+### 4. No `.tagName` checks
+
+Instead of `expect(el.tagName).toBe('SPAN')`, assert the absence of a role:
+
+```tsx
+// Before
+const currentPage = canvas.getByText('Current Page');
+await expect(currentPage.tagName).toBe('SPAN');
+
+// After
+await expect(
+  canvas.queryByRole('link', { name: 'Current Page' })
+).not.toBeInTheDocument();
+```
+
+The test now verifies that the current page is not a link, which is the actual requirement. Whether it renders as a `<span>` or a `<div>` is irrelevant.
+
+### 5. Use `step()` for three or more sequential interactions
+
+Group related phases so the Storybook Interactions panel is self-documenting:
+
+```tsx
+await step('Open menu', async () => {
+  await userEvent.click(trigger);
+  await waitFor(() => expect(menu).toBeInTheDocument());
+});
+
+await step('Navigate items', async () => {
+  await userEvent.keyboard('{ArrowDown}');
+  await waitFor(() => expect(items[0]).toHaveFocus());
+});
+
+await step('Close menu', async () => {
+  await userEvent.keyboard('{Escape}');
+  await waitFor(() => expect(menu).not.toBeInTheDocument());
+});
+```
+
+### 6. Every `fn()` spy must be asserted
+
+If a story defines `onClick: fn()` in args, the play function must assert it. Dead spies are noise: they suggest the test verifies click behavior when it does not. Remove the spy or assert it.
+
+## Before and After
+
+The ThemeToggle fix required a one-line production code change. The component did not expose `aria-pressed`, so there was nothing semantic to assert. Adding it fixed both the test and the accessibility:
+
+```tsx
+// ThemeToggle.tsx — added aria-pressed
+<button aria-pressed={theme === value} onClick={() => setTheme(value)}>
+
+// ThemeToggle.stories.tsx — before
+await expect(lightButton).toHaveClass('bg-surface');
+
+// ThemeToggle.stories.tsx — after
+await waitFor(() =>
+  expect(lightButton).toHaveAttribute('aria-pressed', 'true')
+);
+```
+
+The Tooltip followed the same pattern. `opacity-0` and `opacity-100` became `aria-hidden`:
+
+```tsx
+// Before
+await expect(tooltip).toHaveClass('opacity-0');
+await waitFor(() => expect(tooltip).toHaveClass('opacity-100'));
+
+// After
+await expect(tooltip).toHaveAttribute('aria-hidden', 'true');
+await waitFor(() => expect(tooltip).toHaveAttribute('aria-hidden', 'false'));
+```
+
+## The Result
+
+One commit touched 11 files: +123 lines, -88 lines. Every CSS class assertion was replaced with a semantic equivalent. Three components gained ARIA attributes they should have had from the start. Zero interaction tests now depend on Tailwind class names.
+
+The tests are more stable because they assert behavior, not styling. They are also better accessibility tests by accident: if `aria-pressed` ever gets removed from `ThemeToggle`, the interaction test catches it before a screen reader user does.
+
+Tests should verify the contract between a component and its users. CSS classes are not part of that contract. ARIA attributes are.

--- a/apps/root/src/data/contentOrder.ts
+++ b/apps/root/src/data/contentOrder.ts
@@ -96,4 +96,6 @@ export const blogHistory: AllowedBlogSlugs[] = [
   blogSlugs.mobileVrDataDrivenPlaywright, // 2026-04-10
   blogSlugs.sentrySkipWithoutDsn, // 2026-04-10
   blogSlugs.mdxSingleSourceOfTruth, // 2026-04-11
+  blogSlugs.clientSideTagFilteringSeo, // 2026-04-13
+  blogSlugs.storybookInteractionTestsAria, // 2026-04-13
 ];


### PR DESCRIPTION
## Summary

Two new blog posts drafted from work completed between `develop` and `main`:

- **"Client-Side Tag Filtering Without Losing SEO URLs"** (`client-side-tag-filtering-seo`) — covers the dual-mode `TagChipStrip` component (Link for SEO, button for client filtering), server-routed pagination with React 19 `<link>` head hoisting for `rel=prev/next`, and the tag scoping bug fix. Folds proposals #1, #2, and #4 from the `/write-content` analysis into one cohesive post.

- **"Replacing CSS Class Assertions with ARIA in Storybook"** (`storybook-interaction-tests-aria`) — six rules for hardening interaction tests: query by role, `waitFor` after state changes, assert ARIA not CSS classes, no `.tagName` checks, `step()` grouping, assert every spy. Includes before/after code from the actual commit.

Also includes test mock fixes for `sitemap.spec.ts` and `projects/page.spec.tsx` (same changes as #364, needed on this branch).

## Test plan

- [x] `pnpm tsc --noEmit` — clean
- [x] `pnpm nx test root` — 89 suites, 797 tests pass
- [ ] Verify posts render at `/blog/client-side-tag-filtering-seo` and `/blog/storybook-interaction-tests-aria`
- [ ] Verify blog index shows 35 posts (was 33)
- [ ] Review post content for voice/style guide compliance

🤖 Generated with [Claude Code](https://claude.com/claude-code)