### PR TITLE
feat(hooks): session persistence across Claude Code sessions

### DIFF
--- a/.claude/docs/decisions.md
+++ b/.claude/docs/decisions.md
@@ -1,0 +1,41 @@
+# Decisions Log
+
+Append-only log of architectural and convention decisions.
+Each entry records what was decided and why, so future sessions
+have context without re-discovering the reasoning.
+
+Format: newest entries at the bottom.
+
+---
+
+## 2026-04-13: Session persistence via Claude Code hooks over ruflo
+
+**Context:** Investigated ruflo (claude-flow) as an AI orchestration platform for persistent codebase memory, multi-agent coordination, and security auditing. Found it adds significant complexity (daemon process, 313 MCP tools, vector database) for a single-developer portfolio.
+
+**Decision:** Use Claude Code's built-in hooks system (SessionStart, PreCompact, SessionEnd) with lightweight markdown files instead of ruflo's orchestration layer. Session notes and a decisions log provide persistent context across sessions without external dependencies.
+
+**Consequence:** No daemon process or vector database to maintain. Context persistence depends on hook scripts and markdown files, which are transparent, grep-able, and version-controlled. Trade-off: no semantic search over past decisions (would need manual grep or reading the file).
+
+## 2026-04-13: Convention enforcement via deterministic checks over AI inference
+
+**Context:** Evaluated how to enforce content style guide rules (canonical tags, character limits, em dash restrictions) and coding conventions. Ruflo's approach uses AI agents to review code; the alternative is Zod schemas and lint rules.
+
+**Decision:** Encode enforceable conventions as deterministic checks (Zod validation script, custom ESLint rules) rather than relying on AI inference. Reserve AI judgment for genuinely ambiguous decisions.
+
+**Consequence:** Rules that can be machine-checked (title length, canonical tags, duplicate cover images) are enforced at build time. This is faster, cheaper, and more predictable than LLM-based review. The content style guide becomes executable, not just prose.
+
+## 2026-04-13: Knip v6 for dead code detection
+
+**Context:** After 349+ PRs, unused exports, files, and dependencies have likely accumulated. No tooling currently catches this.
+
+**Decision:** Adopt Knip v6 (oxc-based, 5M+ weekly downloads) with per-workspace configuration for the Nx monorepo. Phase into CI gradually: report-only first, then fail on unused dependencies, then full enforcement.
+
+**Consequence:** Dead code gets surfaced automatically. Knip's Nx/Next.js/Jest/Storybook/Playwright plugins understand the workspace structure. The MDX compiler config handles metadata exports.
+
+## 2026-04-13: Renovate with dependency cooldowns for supply chain safety
+
+**Context:** No automated dependency updates exist. No supply chain security scanning.
+
+**Decision:** Adopt Renovate (not Dependabot) with `minimumReleaseAge: "3 days"` for devDeps, 7 days for production deps, 14 days for majors. Pair with Socket.dev for behavioral analysis.
+
+**Consequence:** Dependency updates happen automatically with a safety buffer. A 3-day cooldown would have prevented most 2025 supply chain attacks. Tightly coupled packages (Nx, Storybook, TypeScript-ESLint) are grouped into single PRs.

--- a/.claude/hooks/pre-compact.sh
+++ b/.claude/hooks/pre-compact.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# PreCompact hook: reminds Claude to save session state before context compression
+#
+# Fires right before conversation compaction (manual or auto).
+# Outputs instructions that get included in the compaction context,
+# ensuring key information survives the compression.
+
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-.}"
+SESSIONS_DIR="$PROJECT_DIR/.claude/sessions"
+
+echo "[SESSION PERSISTENCE] Context is about to be compacted."
+echo ""
+echo "Before proceeding, update .claude/sessions/latest.md with:"
+echo "  - Current branch and git state"
+echo "  - What was accomplished so far this session"
+echo "  - Any decisions made (also append to .claude/docs/decisions.md)"
+echo "  - Open questions or unresolved issues"
+echo "  - Immediate next steps"
+echo ""
+
+# Show current session notes so Claude knows what's already captured
+if [ -f "$SESSIONS_DIR/latest.md" ]; then
+  echo "Current session notes:"
+  echo "---"
+  cat "$SESSIONS_DIR/latest.md"
+  echo "---"
+fi
+
+exit 0

--- a/.claude/hooks/session-end.sh
+++ b/.claude/hooks/session-end.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# SessionEnd hook: archives session notes for future reference
+#
+# On session end, copies latest.md to the archive directory with a timestamp.
+# Must be fast — SessionEnd hooks have a 1.5s default timeout.
+
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-.}"
+SESSIONS_DIR="$PROJECT_DIR/.claude/sessions"
+ARCHIVE_DIR="$SESSIONS_DIR/archive"
+LATEST="$SESSIONS_DIR/latest.md"
+
+# Nothing to archive if no session notes exist
+[ -f "$LATEST" ] || exit 0
+
+# Only archive if the file has meaningful content (more than just the template)
+LINES=$(wc -l < "$LATEST" 2>/dev/null)
+[ "$LINES" -le 5 ] && exit 0
+
+# Create archive directory if needed
+mkdir -p "$ARCHIVE_DIR"
+
+# Archive with timestamp
+TIMESTAMP=$(date +%Y-%m-%d_%H%M%S)
+cp "$LATEST" "$ARCHIVE_DIR/${TIMESTAMP}.md"
+
+exit 0

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# SessionStart hook: injects previous session context and recent decisions
+#
+# On session start, outputs:
+# 1. The latest session handoff notes (if any)
+# 2. The most recent decisions from the decisions log
+#
+# This gives Claude immediate context about what happened in prior sessions.
+
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-.}"
+SESSIONS_DIR="$PROJECT_DIR/.claude/sessions"
+DECISIONS_FILE="$PROJECT_DIR/.claude/docs/decisions.md"
+
+# --- Session handoff notes ---
+if [ -f "$SESSIONS_DIR/latest.md" ]; then
+  CONTENT=$(cat "$SESSIONS_DIR/latest.md")
+  if [ -n "$CONTENT" ]; then
+    echo "<session-handoff>"
+    echo "$CONTENT"
+    echo "</session-handoff>"
+    echo ""
+  fi
+fi
+
+# --- Recent decisions (last 30 lines) ---
+if [ -f "$DECISIONS_FILE" ]; then
+  RECENT=$(tail -30 "$DECISIONS_FILE")
+  if [ -n "$RECENT" ]; then
+    echo "<recent-decisions>"
+    echo "$RECENT"
+    echo "</recent-decisions>"
+  fi
+fi
+
+exit 0

--- a/.claude/sessions/latest.md
+++ b/.claude/sessions/latest.md
@@ -1,0 +1,37 @@
+# Current Session Notes
+
+Updated by Claude Code during sessions. Archived on session end.
+
+## Branch
+
+claude/investigate-ruflo-tool-dPnw9
+
+## What was accomplished
+
+- Investigated ruflo (claude-flow) for multi-agent orchestration, codebase memory, security auditing
+- Installed ruflo as MCP server, ran diagnostics, initialized memory database
+- Concluded ruflo is overkill; identified simpler alternatives for each capability
+- Created GitHub issue #366 with 7 proposed tooling improvements + 3 detailed research comments
+- Built session persistence hooks (SessionStart, PreCompact, SessionEnd) as first implementation
+
+## Decisions made
+
+- See .claude/docs/decisions.md for full entries
+- Session persistence via hooks + markdown over ruflo's vector database
+- Convention enforcement via Zod + lint over AI inference
+- Knip v6 for dead code detection
+- Renovate + Socket.dev for dependency automation
+
+## Open questions
+
+- Should session archives (.claude/sessions/archive/) be committed or gitignored?
+- How to handle the ruflo-generated files on the branch (260 files in .claude/agents/, skills/, helpers/, commands/)? Keep, prune, or remove in a follow-up?
+- Content validation script: integrate as Nx target or prebuild script?
+
+## Next steps
+
+1. Content validation script (Zod) — highest-impact convention enforcement
+2. Knip v6 setup — install + config + first run
+3. Renovate config — renovate.json targeting develop branch
+4. Socket.dev GitHub App — zero-config install
+5. Bundle size tracking — hashicorp/nextjs-bundle-analysis + size-limit

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,6 +11,17 @@
     "nx@nx-claude-plugins": true
   },
   "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/session-start.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "matcher": "Edit|Write",
@@ -30,6 +41,27 @@
             "type": "command",
             "command": "bash .claude/hooks/run-spec-tests.sh",
             "statusMessage": "Running related unit tests..."
+          }
+        ]
+      }
+    ],
+    "PreCompact": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/pre-compact.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/session-end.sh"
           }
         ]
       }

--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,10 @@ Thumbs.db
 .github/instructions/nx.instructions.md
 .claude/worktrees/
 .claude/sessions/archive/
+.claude-flow/
+.swarm/
+.claude/memory.db
+ruvector.db
 
 # Next.js
 .next

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ Thumbs.db
 .cursor/rules/nx-rules.mdc
 .github/instructions/nx.instructions.md
 .claude/worktrees/
+.claude/sessions/archive/
 
 # Next.js
 .next


### PR DESCRIPTION
## Summary

- Add SessionStart, PreCompact, and SessionEnd hooks that maintain persistent context across Claude Code sessions
- Create a decisions log and session handoff notes system so future sessions inherit context from past ones
- Solves the "cold start" problem where each new session loses all prior decisions and progress

## What's new

### Hook scripts

| File | Hook Event | What it does |
|------|-----------|-------------|
| `.claude/hooks/session-start.sh` | `SessionStart` | Injects previous session's handoff notes + recent decisions into context |
| `.claude/hooks/pre-compact.sh` | `PreCompact` | Reminds Claude to save state before context compression |
| `.claude/hooks/session-end.sh` | `SessionEnd` | Archives session notes with timestamp to `.claude/sessions/archive/` |

### Supporting files

| File | Purpose |
|------|---------|
| `.claude/docs/decisions.md` | Living, append-only log of architectural decisions with rationale |
| `.claude/sessions/latest.md` | Current session handoff notes (branch, accomplishments, open questions, next steps) |
| `.claude/settings.json` | Updated to register the 3 new hooks alongside existing `block-snapshot-edits` and `run-spec-tests` |
| `.gitignore` | Session archives (`.claude/sessions/archive/`) are gitignored — ephemeral per-developer data |

### How it works

1. **Session starts** → `session-start.sh` reads `latest.md` + tail of `decisions.md` and outputs them as context. Claude immediately knows what happened last time.
2. **Context compacts** → `pre-compact.sh` outputs a reminder to save state before compression. Prevents losing in-progress work to auto-compaction.
3. **Session ends** → `session-end.sh` copies `latest.md` to `archive/YYYY-MM-DD_HHMMSS.md` for historical reference.

Between sessions, Claude updates `latest.md` with current progress and appends to `decisions.md` when conventions or architectural choices are made. The next session picks up where the last one left off.

### Decisions log seeded with

Four decisions from the investigation in #366:
1. Session persistence via hooks + markdown over ruflo's vector database
2. Convention enforcement via deterministic checks over AI inference
3. Knip v6 for dead code detection
4. Renovate with dependency cooldowns for supply chain safety

## Test plan

- [x] Typecheck passes (`pnpm tsc --noEmit`)
- [x] All 711 unit tests pass (1 pre-existing failure in `searchIndex.spec.ts` — unrelated)
- [x] `session-start.sh` outputs handoff notes wrapped in `<session-handoff>` tags + recent decisions in `<recent-decisions>` tags
- [x] `pre-compact.sh` outputs state-saving reminder with current notes
- [x] `session-end.sh` archives notes when content is substantive, skips when minimal
- [x] Existing hooks (`block-snapshot-edits.sh`, `run-spec-tests.sh`) preserved unchanged
- [x] No ruflo/claude-flow files included — clean branch from develop

https://claude.ai/code/session_01621GoZRtAYJ5zcUbSDNa9a