### PR TITLE
feat(content): two blog posts on Zod validation and monorepo tooling

### DIFF
--- a/apps/root/src/data/__tests__/contentRegistry.spec.ts
+++ b/apps/root/src/data/__tests__/contentRegistry.spec.ts
@@ -26,7 +26,7 @@ describe('contentRegistry', () => {
 
     it('returns all blog entries in order', () => {
       const blogs = getContentByType('blog');
-      expect(blogs.length).toBe(35);
+      expect(blogs.length).toBe(37);
       expect(blogs[0].type).toBe('blog');
       expect(blogs[0].slug).toBe('unified-content-pipeline');
       expect(blogs[1].slug).toBe('auto-generated-toc-scroll-spy');
@@ -97,7 +97,7 @@ describe('contentRegistry', () => {
       expect(slugs).toContain('accessible-dropdown-keyboard-nav');
       expect(slugs).toContain('toast-pause-on-hover');
       expect(slugs).toContain('keyboard-navigable-data-tables');
-      expect(slugs.length).toBe(35);
+      expect(slugs.length).toBe(37);
     });
   });
 
@@ -145,7 +145,7 @@ describe('contentRegistry', () => {
   describe('getAllContent', () => {
     it('returns all entries (projects + experience)', () => {
       const all = getAllContent();
-      expect(all.length).toBe(50); // 10 projects + 5 experiences + 35 blogs
+      expect(all.length).toBe(52); // 10 projects + 5 experiences + 37 blogs
     });
 
     it('contains entries of all types', () => {

--- a/apps/root/src/data/blog.ts
+++ b/apps/root/src/data/blog.ts
@@ -36,6 +36,8 @@ export const blogSlugs = {
   mdxSingleSourceOfTruth: 'mdx-single-source-of-truth',
   clientSideTagFilteringSeo: 'client-side-tag-filtering-seo',
   storybookInteractionTestsAria: 'storybook-interaction-tests-aria',
+  executableStyleGuideZod: 'executable-style-guide-zod',
+  threeToolsMonorepoHygiene: 'three-tools-monorepo-hygiene',
 } as const;
 
 export const blogPageSlugs = [...Object.values(blogSlugs)];

--- a/apps/root/src/data/content/blog/executable-style-guide-zod.mdx
+++ b/apps/root/src/data/content/blog/executable-style-guide-zod.mdx
@@ -1,0 +1,94 @@
+export const metadata = {
+  title: 'Turning a Prose Style Guide into Zod Build Checks',
+  date: '2026-04-13',
+  excerpt:
+    'Character limits, canonical tags, and em dash rules encoded as a Zod discriminated union. The script caught a duplicate cover image on its first run.',
+  author: 'Daniel Joffe',
+  category: 'Tooling & CI',
+  tags: ['TypeScript', 'Nx', 'Monorepo', 'MDX', 'CI/CD', 'Architecture'],
+  slug: 'executable-style-guide-zod',
+  type: 'blog',
+  cover: {
+    alt: 'A ruler and measuring tools on a wooden surface',
+    src: '/photo-1502780809386-f4ed7a4a4c59',
+    origin: 'https://unsplash.com/photos/ruler-measuring-tools',
+    creator: '@williambout',
+  },
+};
+
+## The Problem: Rules Nobody Reads
+
+My content style guide defines 9 canonical categories, 53 canonical tags, character limits for titles and excerpts, an em dash ban on short-form surfaces, and a requirement that every post has a unique cover image. After 50 MDX files across three content types, the guide had drifted. Tags appeared in non-canonical forms. Two project case studies shared the same Unsplash photo. An excerpt crept past 160 characters. The rules existed; enforcement did not.
+
+The question was whether to check these rules with an LLM reviewer or with deterministic code. A language model can catch subjective tone issues, but character counts and enum membership are not subjective. They are boolean. I chose Zod.
+
+## The Schema
+
+The schema encodes every machine-checkable rule from the style guide as a type constraint. The core structure is a discriminated union on the `type` field:
+
+```ts
+const baseSchema = z.object({
+  title: z.string().min(1).max(60, 'Title must be ≤ 60 characters'),
+  excerpt: z
+    .string()
+    .max(160, 'Excerpt must be ≤ 160 characters')
+    .refine(
+      val => !val.includes('\u2014'),
+      'Excerpt must not contain em dashes (per style guide)'
+    ),
+  category: z.enum(CATEGORIES),
+  tags: z
+    .array(z.string())
+    .min(3)
+    .max(8)
+    .refine(
+      tags => tags.every(t => canonicalTagSet.has(t)),
+      'All tags must be from the canonical tag set'
+    ),
+  cover: coverSchema,
+  // ... date, author, slug, type
+});
+
+export const postMetadataSchema = z.discriminatedUnion('type', [
+  blogSchema,
+  projectSchema,
+  experienceSchema,
+]);
+```
+
+Blog entries need nothing beyond the base fields. Project entries accept optional `featured`, `company`, `role`, and `duration`. Experience entries require `company`, `role`, `duration`, `industry`, `logo`, and `invert`. The discriminated union means Zod selects the right branch based on `type` before validating the rest.
+
+The canonical vocabularies are literal arrays: 9 categories, 53 tags. A tag merge map handles known synonyms (`a11y` to `Accessibility`, `CSS3` to `CSS`). New categories or tags require updating the schema, which means updating the style guide first. That is the point: vocabulary changes are deliberate, not accidental.
+
+## The Runner
+
+The validation script discovers every `.mdx` file under `data/content/`, extracts the `export const metadata` block via regex, and feeds each one through `safeParse`:
+
+```ts
+function extractMetadata(filePath: string): unknown {
+  const content = fs.readFileSync(filePath, 'utf-8');
+  const match = content.match(
+    /export\s+const\s+metadata\s*=\s*(\{[\s\S]*?\n\});?/
+  );
+  if (!match) throw new Error(`No metadata export found in ${filePath}`);
+  return new Function(`return ${match[1]}`)();
+}
+```
+
+After schema validation, the runner performs cross-file checks that Zod cannot express: unique `cover.src` across all 50 files, unique slug within each content type, slug-filename match, and a warning when a category appears in the same entry's tags.
+
+The script wires into the Nx build pipeline as a `validate-content` target that runs before every `build`. A content error fails the build, not just the lint step.
+
+## What It Caught on Day One
+
+The first run surfaced a duplicate cover image: `ui-components-v1` and `ui-components-v2` shared the same Unsplash photo ID. Both posts had been reviewed individually. Neither review caught the cross-file collision because no human was comparing cover images across 50 files. The script compared them in a `Map` lookup.
+
+It also surfaced tag synonym warnings for entries using `a11y` instead of `Accessibility` and `CSS3` instead of `CSS`. These were not errors (the merge map handles them), but the warnings flag entries that should be updated to canonical forms.
+
+## The Decision Framework
+
+Not everything in the style guide belongs in a schema. "Lead with the problem, not preamble" is a judgment call. "Title must be ≤ 60 characters" is a boolean. The rule I follow: if a rule can be expressed as a type constraint, regex, or set membership check, encode it. If it requires reading comprehension, leave it to human review.
+
+The executable style guide now validates 12 distinct rules across 50 files in under a second. The prose guide still exists for tone, structure, and voice. They complement each other: the schema catches what machines check well, the prose guides what humans judge well.
+
+Rules that run on every build do not drift.

--- a/apps/root/src/data/content/blog/index.ts
+++ b/apps/root/src/data/content/blog/index.ts
@@ -106,6 +106,12 @@ import ClientSideTagFilteringSeo, {
 import StorybookInteractionTestsAria, {
   metadata as storybookInteractionTestsAriaMeta,
 } from './storybook-interaction-tests-aria.mdx';
+import ExecutableStyleGuideZod, {
+  metadata as executableStyleGuideZodMeta,
+} from './executable-style-guide-zod.mdx';
+import ThreeToolsMonorepoHygiene, {
+  metadata as threeToolsMonorepoHygieneMeta,
+} from './three-tools-monorepo-hygiene.mdx';
 
 export const blogMdxComponents: Record<AllowedBlogSlugs, ComponentType> = {
   'unified-content-pipeline': UnifiedContentPipeline,
@@ -145,6 +151,8 @@ export const blogMdxComponents: Record<AllowedBlogSlugs, ComponentType> = {
   'mdx-single-source-of-truth': MdxSingleSourceOfTruth,
   'client-side-tag-filtering-seo': ClientSideTagFilteringSeo,
   'storybook-interaction-tests-aria': StorybookInteractionTestsAria,
+  'executable-style-guide-zod': ExecutableStyleGuideZod,
+  'three-tools-monorepo-hygiene': ThreeToolsMonorepoHygiene,
 };
 
 export const blogMdxMetadata: Record<AllowedBlogSlugs, PostMetadata> = {
@@ -183,4 +191,6 @@ export const blogMdxMetadata: Record<AllowedBlogSlugs, PostMetadata> = {
   'mdx-single-source-of-truth': mdxSingleSourceOfTruthMeta,
   'client-side-tag-filtering-seo': clientSideTagFilteringSeoMeta,
   'storybook-interaction-tests-aria': storybookInteractionTestsAriaMeta,
+  'executable-style-guide-zod': executableStyleGuideZodMeta,
+  'three-tools-monorepo-hygiene': threeToolsMonorepoHygieneMeta,
 };

--- a/apps/root/src/data/content/blog/three-tools-monorepo-hygiene.mdx
+++ b/apps/root/src/data/content/blog/three-tools-monorepo-hygiene.mdx
@@ -1,0 +1,147 @@
+export const metadata = {
+  title: 'Three Tools I Add to Every Monorepo Now',
+  date: '2026-04-13',
+  excerpt:
+    'Knip finds dead code, Renovate updates dependencies with cooldowns, and size-limit tracks bundle cost. Each took under an hour to configure for Nx.',
+  author: 'Daniel Joffe',
+  category: 'Tooling & CI',
+  tags: ['Nx', 'Monorepo', 'pnpm', 'CI/CD', 'GitHub Actions', 'TypeScript'],
+  slug: 'three-tools-monorepo-hygiene',
+  type: 'blog',
+  cover: {
+    alt: 'Organized tools hanging on a workshop pegboard',
+    src: '/photo-1530124566582-a45a7e3ff064',
+    origin: 'https://unsplash.com/photos/tools-workshop-pegboard',
+    creator: '@toddquackenbush',
+  },
+};
+
+## The Trigger
+
+After 375 pull requests, my Nx monorepo had six workspaces, 50 MDX content files, and a shared component library shipping to production. I had no way to know if an exported type was still consumed, whether a dependency had a known vulnerability, or how much a new component would cost in bundle size. These are three different failure modes. Each has a dedicated tool.
+
+## Knip: Dead Code Detection
+
+Knip v6 uses oxc for fast AST parsing and ships with plugins for Nx, Next.js, Jest, Storybook, and Playwright. The configuration is a single `knip.ts` file with per-workspace entry points:
+
+```ts
+const config: KnipConfig = {
+  workspaces: {
+    '.': {
+      entry: ['scripts/*.ts'],
+      jest: false, // root jest.config delegates to Nx projects
+      ignoreDependencies: ['tailwindcss', 'caniuse-lite'],
+    },
+    'apps/root': {
+      entry: [
+        'src/app/**/page.tsx',
+        'src/app/**/layout.tsx',
+        'src/app/**/route.ts',
+      ],
+      ignoreDependencies: ['gsap', '@gsap/react'],
+    },
+    'libs/shared/ui': {
+      project: ['src/**/*.{ts,tsx}'],
+    },
+  },
+};
+```
+
+The first scan surfaced 6 unused files, 10 unused dependencies, 33 unused exports, and 26 unused exported types. Some are false positives: `test-setup.ts` is referenced by Jest config, not by imports. GSAP loads dynamically. But several were real: dead components from a refactor, a `focus-trap-react` dependency I removed the code for but forgot to uninstall.
+
+The key configuration decisions: disable the Jest plugin at root (it tries to read Next.js pages-dir config and errors), ignore CSS-only dependencies like Tailwind (no JS import to trace), and set explicit entry points for App Router (pages, layouts, routes, error boundaries).
+
+I run `pnpm knip --no-exit-code` for now. The plan is to phase into CI: report-only first, then fail on unused dependencies, then full enforcement.
+
+## Renovate: Dependency Updates with Cooldowns
+
+Renovate runs as a GitHub App and opens PRs for outdated dependencies. The configuration I care about most is `minimumReleaseAge`: a cooling period before Renovate proposes an update.
+
+```json
+{
+  "minimumReleaseAge": "3 days",
+  "packageRules": [
+    {
+      "matchDepTypes": ["dependencies"],
+      "matchUpdateTypes": ["patch"],
+      "minimumReleaseAge": "7 days",
+      "automerge": true,
+      "platformAutomerge": true
+    },
+    {
+      "matchUpdateTypes": ["major"],
+      "minimumReleaseAge": "14 days",
+      "automerge": false
+    }
+  ]
+}
+```
+
+Three days for devDependencies, seven for production, fourteen for majors. Most malicious npm packages get reported and yanked within 72 hours. A three-day cooldown would have caught the majority of 2025 supply chain attacks. It is not a security guarantee; it is a probability filter.
+
+The other critical setting is package grouping. Nx has eight packages that must stay in lockstep. Storybook has eight. TypeScript and ESLint are pinned together via overrides. Without grouping, Renovate opens eight separate PRs for one Nx version bump, each of which breaks until all eight merge. Grouping collapses them into one PR:
+
+```json
+{
+  "matchPackagePatterns": ["^@nx/", "^nx$"],
+  "groupName": "Nx",
+  "automerge": false
+}
+```
+
+GitHub Actions get pinned to digest hashes, not version tags. A compromised tag can be force-pushed; a digest cannot.
+
+## Size-Limit: Bundle Cost Tracking
+
+Size-limit measures the minified-and-compressed cost of specific imports. I track five entry points in the shared-ui library:
+
+```json
+[
+  {
+    "name": "shared-ui (all exports)",
+    "path": "libs/shared/ui/src/index.ts",
+    "import": "*",
+    "limit": "25 kB"
+  },
+  {
+    "name": "Button",
+    "path": "libs/shared/ui/src/lib/Button.tsx",
+    "import": "{ Button }",
+    "limit": "10 kB"
+  },
+  {
+    "name": "Modal",
+    "path": "libs/shared/ui/src/lib/Modal.tsx",
+    "import": "{ Modal }",
+    "limit": "15 kB"
+  },
+  {
+    "name": "Toast",
+    "path": "libs/shared/ui/src/lib/Toast.tsx",
+    "import": "{ ToastProvider, useToast }",
+    "limit": "15 kB"
+  },
+  {
+    "name": "Dropdown",
+    "path": "libs/shared/ui/src/lib/Dropdown.tsx",
+    "import": "{ Dropdown }",
+    "limit": "13 kB"
+  }
+]
+```
+
+Budgets sit about 15% above current sizes. The `@size-limit/preset-small-lib` preset uses esbuild for fast bundling. On PRs, a GitHub Action compares sizes against the base branch and posts a table comment showing deltas. Locally, `pnpm size` checks budgets and `pnpm size:why` opens a treemap.
+
+The entry-point approach matters. Tracking only the barrel export hides component-level bloat. If `Modal` gains a heavy dependency, the "all exports" number might grow 3% (within budget), but the `Modal` entry jumps 40% (over budget). Per-component budgets catch regressions that aggregate budgets mask.
+
+## The Pattern
+
+Each tool addresses a specific failure mode that compounds over time:
+
+- **Knip**: dead code accumulates silently after refactors
+- **Renovate**: dependencies go stale, then vulnerable, then breaking
+- **Size-limit**: bundle size creeps one import at a time
+
+None required more than an hour to configure. All three run without ongoing attention. The cost of adding them is a config file; the cost of skipping them is eventual cleanup sprints that take days.
+
+Tools that run automatically find problems that code reviews miss.

--- a/apps/root/src/data/contentOrder.ts
+++ b/apps/root/src/data/contentOrder.ts
@@ -98,4 +98,6 @@ export const blogHistory: AllowedBlogSlugs[] = [
   blogSlugs.mdxSingleSourceOfTruth, // 2026-04-11
   blogSlugs.clientSideTagFilteringSeo, // 2026-04-13
   blogSlugs.storybookInteractionTestsAria, // 2026-04-13
+  blogSlugs.executableStyleGuideZod, // 2026-04-13
+  blogSlugs.threeToolsMonorepoHygiene, // 2026-04-13
 ];


### PR DESCRIPTION
## Summary

- **"Turning a Prose Style Guide into Zod Build Checks"** — how the content style guide's character limits, canonical tags, and em dash rules became a Zod discriminated union that runs on every build. Covers schema design, the validation runner, cross-file checks, and what the script caught on its first run (duplicate cover image). From #369.
- **"Three Tools I Add to Every Monorepo Now"** — Knip for dead code detection, Renovate with release age cooldowns for supply chain safety, and size-limit for per-component bundle budgets. Each tool's configuration for an Nx workspace with real code examples. From #371, #374, #375.

Both posts follow the content style guide voice (first-person singular, present tense, evidence-backed) and pass the `validate-content` Zod check.

## Test plan
- [x] `pnpm tsc --noEmit` — zero errors
- [x] `pnpm nx test root` — 797 tests pass (updated contentRegistry counts)
- [x] `pnpm nx validate-content root` — all 52 content files pass
- [ ] Verify posts render correctly on dev server at `/blog/executable-style-guide-zod` and `/blog/three-tools-monorepo-hygiene`

🤖 Generated with [Claude Code](https://claude.com/claude-code)