### PR TITLE
refactor(ci): split CI into fast/full stages with Nx Cloud caching

### DIFF
--- a/.github/actions/ci/action.yml
+++ b/.github/actions/ci/action.yml
@@ -14,6 +14,9 @@ inputs:
   chromatic-project-token:
     description: Chromatic project token for visual regression testing
     default: ''
+  nx-cloud-token:
+    description: Nx Cloud access token for remote caching
+    default: ''
 
 runs:
   using: composite
@@ -29,6 +32,15 @@ runs:
       shell: bash
       run: pnpm install --frozen-lockfile
 
+    - name: Cache Nx
+      uses: actions/cache@v4
+      with:
+        path: .nx/cache
+        key: ${{ runner.os }}-nx-${{ hashFiles('**/pnpm-lock.yaml') }}-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-nx-${{ hashFiles('**/pnpm-lock.yaml') }}-
+          ${{ runner.os }}-nx-
+
     - uses: nrwl/nx-set-shas@v5
       with:
         main-branch-name: ${{ inputs.base-branch }}
@@ -37,7 +49,20 @@ runs:
       shell: bash
       run: pnpm nx affected -t lint test build typecheck build-storybook --nxBail
       env:
-        NX_NO_CLOUD: 'true'
+        NX_CLOUD_ACCESS_TOKEN: ${{ inputs.nx-cloud-token }}
+
+    - name: Get Playwright version
+      if: ${{ inputs.run-e2e == 'true' }}
+      id: playwright-version
+      shell: bash
+      run: echo "version=$(node -e "console.log(require('@playwright/test/package.json').version)")" >> "$GITHUB_OUTPUT"
+
+    - name: Cache Playwright browsers
+      if: ${{ inputs.run-e2e == 'true' }}
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/ms-playwright
+        key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
 
     - name: Install Playwright
       if: ${{ inputs.run-e2e == 'true' }}
@@ -49,7 +74,7 @@ runs:
       shell: bash
       run: pnpm nx affected -t e2e --nxBail
       env:
-        NX_NO_CLOUD: 'true'
+        NX_CLOUD_ACCESS_TOKEN: ${{ inputs.nx-cloud-token }}
 
     - name: Run Chromatic visual tests
       if: ${{ inputs.chromatic-project-token != '' }}
@@ -63,7 +88,7 @@ runs:
       shell: bash
       run: pnpm nx build root
       env:
-        NX_NO_CLOUD: 'true'
+        NX_CLOUD_ACCESS_TOKEN: ${{ inputs.nx-cloud-token }}
 
     - name: Run Lighthouse CI
       if: ${{ inputs.run-e2e == 'true' }}

--- a/.github/actions/ci/action.yml
+++ b/.github/actions/ci/action.yml
@@ -17,6 +17,9 @@ inputs:
   nx-cloud-token:
     description: Nx Cloud access token for remote caching
     default: ''
+  nx-cloud-id:
+    description: Nx Cloud workspace ID
+    default: ''
 
 runs:
   using: composite
@@ -50,6 +53,7 @@ runs:
       run: pnpm nx affected -t lint test build typecheck build-storybook --nxBail
       env:
         NX_CLOUD_ACCESS_TOKEN: ${{ inputs.nx-cloud-token }}
+        NX_CLOUD_ID: ${{ inputs.nx-cloud-id }}
 
     - name: Get Playwright version
       if: ${{ inputs.run-e2e == 'true' }}
@@ -75,6 +79,7 @@ runs:
       run: pnpm nx affected -t e2e --nxBail
       env:
         NX_CLOUD_ACCESS_TOKEN: ${{ inputs.nx-cloud-token }}
+        NX_CLOUD_ID: ${{ inputs.nx-cloud-id }}
 
     - name: Run Chromatic visual tests
       if: ${{ inputs.chromatic-project-token != '' }}
@@ -89,6 +94,7 @@ runs:
       run: pnpm nx build root
       env:
         NX_CLOUD_ACCESS_TOKEN: ${{ inputs.nx-cloud-token }}
+        NX_CLOUD_ID: ${{ inputs.nx-cloud-id }}
 
     - name: Run Lighthouse CI
       if: ${{ inputs.run-e2e == 'true' }}

--- a/.github/actions/setup-workspace/action.yml
+++ b/.github/actions/setup-workspace/action.yml
@@ -1,0 +1,25 @@
+name: Setup Workspace
+description: Install pnpm, Node.js, dependencies, and restore Nx cache
+
+runs:
+  using: composite
+  steps:
+    - uses: pnpm/action-setup@v4
+
+    - uses: actions/setup-node@v5
+      with:
+        node-version-file: .nvmrc
+        cache: pnpm
+
+    - name: Install dependencies
+      shell: bash
+      run: pnpm install --frozen-lockfile
+
+    - name: Cache Nx
+      uses: actions/cache@v4
+      with:
+        path: .nx/cache
+        key: ${{ runner.os }}-nx-${{ hashFiles('**/pnpm-lock.yaml') }}-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-nx-${{ hashFiles('**/pnpm-lock.yaml') }}-
+          ${{ runner.os }}-nx-

--- a/.github/actions/vercel-deploy-storybook/action.yml
+++ b/.github/actions/vercel-deploy-storybook/action.yml
@@ -40,8 +40,6 @@ runs:
     - name: Build Storybook
       shell: bash
       run: pnpm nx build-storybook @danieljoffe.com/shared-ui
-      env:
-        NX_NO_CLOUD: 'true'
 
     - name: Install Vercel CLI
       shell: bash

--- a/.github/actions/vercel-deploy/action.yml
+++ b/.github/actions/vercel-deploy/action.yml
@@ -54,7 +54,6 @@ runs:
       env:
         VERCEL_ORG_ID: ${{ inputs.vercel-org-id }}
         VERCEL_PROJECT_ID: ${{ inputs.vercel-project-id }}
-        NX_NO_CLOUD: 'true'
 
     - name: Deploy
       id: deploy

--- a/.github/workflows/ci-fast.yml
+++ b/.github/workflows/ci-fast.yml
@@ -14,6 +14,8 @@ on:
     secrets:
       NX_CLOUD_ACCESS_TOKEN:
         required: false
+      NX_CLOUD_ID:
+        required: false
 
 jobs:
   lint:
@@ -33,6 +35,7 @@ jobs:
           NX_BASE: ${{ inputs.nx-base }}
           NX_HEAD: ${{ inputs.nx-head }}
           NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
+          NX_CLOUD_ID: ${{ secrets.NX_CLOUD_ID }}
 
   typecheck:
     runs-on: ubuntu-latest
@@ -51,6 +54,7 @@ jobs:
           NX_BASE: ${{ inputs.nx-base }}
           NX_HEAD: ${{ inputs.nx-head }}
           NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
+          NX_CLOUD_ID: ${{ secrets.NX_CLOUD_ID }}
 
   test:
     runs-on: ubuntu-latest
@@ -69,6 +73,7 @@ jobs:
           NX_BASE: ${{ inputs.nx-base }}
           NX_HEAD: ${{ inputs.nx-head }}
           NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
+          NX_CLOUD_ID: ${{ secrets.NX_CLOUD_ID }}
 
   build:
     runs-on: ubuntu-latest
@@ -87,6 +92,7 @@ jobs:
           NX_BASE: ${{ inputs.nx-base }}
           NX_HEAD: ${{ inputs.nx-head }}
           NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
+          NX_CLOUD_ID: ${{ secrets.NX_CLOUD_ID }}
 
   gate:
     if: always()

--- a/.github/workflows/ci-fast.yml
+++ b/.github/workflows/ci-fast.yml
@@ -1,0 +1,110 @@
+name: CI Fast
+
+on:
+  workflow_call:
+    inputs:
+      nx-base:
+        description: NX_BASE SHA for affected detection
+        type: string
+        required: true
+      nx-head:
+        description: NX_HEAD SHA for affected detection
+        type: string
+        required: true
+    secrets:
+      NX_CLOUD_ACCESS_TOKEN:
+        required: false
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          filter: tree:0
+          fetch-depth: 0
+
+      - uses: ./.github/actions/setup-workspace
+
+      - name: Lint affected
+        run: pnpm nx affected -t lint --nxBail
+        env:
+          NX_BASE: ${{ inputs.nx-base }}
+          NX_HEAD: ${{ inputs.nx-head }}
+          NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
+
+  typecheck:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          filter: tree:0
+          fetch-depth: 0
+
+      - uses: ./.github/actions/setup-workspace
+
+      - name: Typecheck affected
+        run: pnpm nx affected -t typecheck --nxBail
+        env:
+          NX_BASE: ${{ inputs.nx-base }}
+          NX_HEAD: ${{ inputs.nx-head }}
+          NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
+
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          filter: tree:0
+          fetch-depth: 0
+
+      - uses: ./.github/actions/setup-workspace
+
+      - name: Test affected
+        run: pnpm nx affected -t test --nxBail
+        env:
+          NX_BASE: ${{ inputs.nx-base }}
+          NX_HEAD: ${{ inputs.nx-head }}
+          NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
+
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          filter: tree:0
+          fetch-depth: 0
+
+      - uses: ./.github/actions/setup-workspace
+
+      - name: Build affected
+        run: pnpm nx affected -t build --nxBail
+        env:
+          NX_BASE: ${{ inputs.nx-base }}
+          NX_HEAD: ${{ inputs.nx-head }}
+          NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
+
+  gate:
+    if: always()
+    needs: [lint, typecheck, test, build]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check results
+        run: |
+          if [ "${{ needs.lint.result }}" = "failure" ] || \
+             [ "${{ needs.typecheck.result }}" = "failure" ] || \
+             [ "${{ needs.test.result }}" = "failure" ] || \
+             [ "${{ needs.build.result }}" = "failure" ]; then
+            echo "CI fast checks failed"
+            echo "  lint: ${{ needs.lint.result }}"
+            echo "  typecheck: ${{ needs.typecheck.result }}"
+            echo "  test: ${{ needs.test.result }}"
+            echo "  build: ${{ needs.build.result }}"
+            exit 1
+          fi
+          echo "All CI fast checks passed"

--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -1,0 +1,116 @@
+name: CI Full
+
+on:
+  workflow_call:
+    inputs:
+      nx-base:
+        description: NX_BASE SHA for affected detection
+        type: string
+        required: true
+      nx-head:
+        description: NX_HEAD SHA for affected detection
+        type: string
+        required: true
+    secrets:
+      NX_CLOUD_ACCESS_TOKEN:
+        required: false
+      CHROMATIC_PROJECT_TOKEN:
+        required: false
+      GITHUB_TOKEN:
+        required: true
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          filter: tree:0
+          fetch-depth: 0
+
+      - uses: ./.github/actions/setup-workspace
+
+      - name: Get Playwright version
+        id: playwright-version
+        run: echo "version=$(node -e "console.log(require('@playwright/test/package.json').version)")" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
+
+      - name: Install Playwright
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Run e2e tests
+        run: pnpm nx affected -t e2e --nxBail
+        env:
+          NX_BASE: ${{ inputs.nx-base }}
+          NX_HEAD: ${{ inputs.nx-head }}
+          NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
+
+  lighthouse:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          filter: tree:0
+          fetch-depth: 0
+
+      - uses: ./.github/actions/setup-workspace
+
+      - name: Build app (remote cache hit from ci-fast)
+        run: pnpm nx build root
+        env:
+          NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
+
+      - name: Run Lighthouse CI
+        run: pnpm test:lighthouse
+        env:
+          LHCI_GITHUB_APP_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  storybook-and-chromatic:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          filter: tree:0
+          fetch-depth: 0
+
+      - uses: ./.github/actions/setup-workspace
+
+      - name: Build Storybook affected
+        run: pnpm nx affected -t build-storybook --nxBail
+        env:
+          NX_BASE: ${{ inputs.nx-base }}
+          NX_HEAD: ${{ inputs.nx-head }}
+          NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
+
+      - name: Run Chromatic visual tests
+        if: ${{ secrets.CHROMATIC_PROJECT_TOKEN != '' }}
+        run: pnpm chromatic:ui --exit-zero-on-changes --exit-once-sent
+        env:
+          CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+
+  gate:
+    if: always()
+    needs: [e2e, lighthouse, storybook-and-chromatic]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check results
+        run: |
+          if [ "${{ needs.e2e.result }}" = "failure" ] || \
+             [ "${{ needs.lighthouse.result }}" = "failure" ] || \
+             [ "${{ needs.storybook-and-chromatic.result }}" = "failure" ]; then
+            echo "CI full checks failed"
+            echo "  e2e: ${{ needs.e2e.result }}"
+            echo "  lighthouse: ${{ needs.lighthouse.result }}"
+            echo "  storybook-and-chromatic: ${{ needs.storybook-and-chromatic.result }}"
+            exit 1
+          fi
+          echo "All CI full checks passed"

--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -18,8 +18,6 @@ on:
         required: false
       CHROMATIC_PROJECT_TOKEN:
         required: false
-      GITHUB_TOKEN:
-        required: true
 
 jobs:
   e2e:
@@ -74,7 +72,7 @@ jobs:
       - name: Run Lighthouse CI
         run: pnpm test:lighthouse
         env:
-          LHCI_GITHUB_APP_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LHCI_GITHUB_APP_TOKEN: ${{ github.token }}
 
   storybook-and-chromatic:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -14,6 +14,8 @@ on:
     secrets:
       NX_CLOUD_ACCESS_TOKEN:
         required: false
+      NX_CLOUD_ID:
+        required: false
       CHROMATIC_PROJECT_TOKEN:
         required: false
       GITHUB_TOKEN:
@@ -50,6 +52,7 @@ jobs:
           NX_BASE: ${{ inputs.nx-base }}
           NX_HEAD: ${{ inputs.nx-head }}
           NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
+          NX_CLOUD_ID: ${{ secrets.NX_CLOUD_ID }}
 
   lighthouse:
     runs-on: ubuntu-latest
@@ -66,6 +69,7 @@ jobs:
         run: pnpm nx build root
         env:
           NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
+          NX_CLOUD_ID: ${{ secrets.NX_CLOUD_ID }}
 
       - name: Run Lighthouse CI
         run: pnpm test:lighthouse
@@ -89,6 +93,7 @@ jobs:
           NX_BASE: ${{ inputs.nx-base }}
           NX_HEAD: ${{ inputs.nx-head }}
           NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
+          NX_CLOUD_ID: ${{ secrets.NX_CLOUD_ID }}
 
       - name: Run Chromatic visual tests
         if: ${{ secrets.CHROMATIC_PROJECT_TOKEN != '' }}

--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -79,6 +79,8 @@ jobs:
   storybook-and-chromatic:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    env:
+      CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -96,10 +98,8 @@ jobs:
           NX_CLOUD_ID: ${{ secrets.NX_CLOUD_ID }}
 
       - name: Run Chromatic visual tests
-        if: ${{ secrets.CHROMATIC_PROJECT_TOKEN != '' }}
+        if: env.CHROMATIC_PROJECT_TOKEN != ''
         run: pnpm chromatic:ui --exit-zero-on-changes --exit-once-sent
-        env:
-          CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
 
   gate:
     if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,6 +144,7 @@ jobs:
         run: pnpm nx affected -t lint test build typecheck build-storybook --nxBail
         env:
           NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
+          NX_CLOUD_ID: ${{ secrets.NX_CLOUD_ID }}
 
       - name: Get Playwright version
         id: playwright-version
@@ -162,6 +163,7 @@ jobs:
         run: pnpm nx build root
         env:
           NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
+          NX_CLOUD_ID: ${{ secrets.NX_CLOUD_ID }}
 
       - name: Regenerate VR snapshots
         working-directory: apps/root-e2e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,13 +28,19 @@ permissions:
   statuses: write
 
 jobs:
-  changes:
+  preflight:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
       docs-only: ${{ steps.check.outputs.docs-only }}
+      nx-base: ${{ steps.shas.outputs.base }}
+      nx-head: ${{ steps.shas.outputs.head }}
     steps:
       - uses: actions/checkout@v5
+        with:
+          filter: tree:0
+          fetch-depth: 0
+
       - name: Check for docs-only changes
         id: check
         env:
@@ -58,43 +64,64 @@ jobs:
               .vscode/*) ;;
               .github/ISSUE_TEMPLATE/*|.github/workflows/*) ;;
               .husky/*) ;;
-              .prettierrc|.nvmrc|.sentryclirc|.editorconfig|.nxignore|LICENSE|renovate.json) ;;
+              .prettierrc|.nvmrc|.sentryclirc|.editorconfig|.nxignore|LICENSE|renovate.json|opencode.json) ;;
+              .size-limit.json|knip.ts) ;;
               *) DOCS_ONLY=false; break ;;
             esac
           done <<< "$CHANGED"
 
           echo "docs-only=$DOCS_ONLY" >> "$GITHUB_OUTPUT"
 
-  ci:
-    needs: changes
-    if: ${{ needs.changes.outputs.docs-only != 'true' && !inputs.update-snapshots }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 25
-    steps:
-      - uses: actions/checkout@v5
+      - uses: nrwl/nx-set-shas@v5
+        id: shas
+        if: steps.check.outputs.docs-only != 'true'
         with:
-          filter: tree:0
-          fetch-depth: 0
+          main-branch-name: ${{ github.base_ref || 'main' }}
 
-      - uses: ./.github/actions/ci
-        with:
-          run-e2e: ${{ github.event_name != 'push' }}
-          base-branch: ${{ github.base_ref || 'main' }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          chromatic-project-token: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+  fast:
+    needs: preflight
+    if: ${{ needs.preflight.outputs.docs-only != 'true' && !inputs.update-snapshots }}
+    uses: ./.github/workflows/ci-fast.yml
+    with:
+      nx-base: ${{ needs.preflight.outputs.nx-base }}
+      nx-head: ${{ needs.preflight.outputs.nx-head }}
+    secrets: inherit
+
+  full:
+    needs: [preflight, fast]
+    if: ${{ needs.preflight.outputs.docs-only != 'true' && !inputs.update-snapshots && github.event_name == 'push' }}
+    uses: ./.github/workflows/ci-full.yml
+    with:
+      nx-base: ${{ needs.preflight.outputs.nx-base }}
+      nx-head: ${{ needs.preflight.outputs.nx-head }}
+    secrets: inherit
 
   ci-status:
     if: always()
-    needs: [changes, ci]
+    needs: [preflight, fast, full]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: CI succeeded or was skipped
+      - name: CI gate
         run: |
-          if [ "${{ needs.ci.result }}" = "failure" ] || [ "${{ needs.ci.result }}" = "cancelled" ]; then
-            echo "CI failed"
+          echo "preflight: ${{ needs.preflight.result }}"
+          echo "fast: ${{ needs.fast.result }}"
+          echo "full: ${{ needs.full.result }}"
+
+          # fast is required when it runs (non-docs PRs and pushes)
+          if [ "${{ needs.fast.result }}" = "failure" ] || [ "${{ needs.fast.result }}" = "cancelled" ]; then
+            echo "CI fast failed"
             exit 1
           fi
+
+          # full is required on push to develop
+          if [ "${{ github.event_name }}" = "push" ]; then
+            if [ "${{ needs.full.result }}" = "failure" ] || [ "${{ needs.full.result }}" = "cancelled" ]; then
+              echo "CI full failed"
+              exit 1
+            fi
+          fi
+
           echo "CI passed or was skipped (docs-only change)"
 
   update-snapshots:
@@ -111,15 +138,30 @@ jobs:
           ref: ${{ inputs.snapshot-branch || github.ref }}
           token: ${{ secrets.PAT_TOKEN }}
 
-      - uses: ./.github/actions/ci
+      - uses: ./.github/actions/setup-workspace
+
+      - name: Run affected tasks
+        run: pnpm nx affected -t lint test build typecheck build-storybook --nxBail
+        env:
+          NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
+
+      - name: Get Playwright version
+        id: playwright-version
+        run: echo "version=$(node -e "console.log(require('@playwright/test/package.json').version)")" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
         with:
-          run-e2e: 'false'
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
 
       - name: Install Playwright browsers
         run: pnpm exec playwright install --with-deps chromium
 
       - name: Build app for snapshot generation
         run: pnpm nx build root
+        env:
+          NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
 
       - name: Regenerate VR snapshots
         working-directory: apps/root-e2e

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -9,6 +9,7 @@ on:
         required: true
 
 permissions:
+  actions: read
   contents: read
   statuses: write
 
@@ -17,11 +18,14 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  ci:
-    name: CI Checks
+  preflight:
+    name: Preflight
     if: github.ref == 'refs/heads/main' && github.event.inputs.confirm == 'deploy'
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 5
+    outputs:
+      nx-base: ${{ steps.shas.outputs.base }}
+      nx-head: ${{ steps.shas.outputs.head }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -29,13 +33,32 @@ jobs:
           filter: tree:0
           fetch-depth: 0
 
-      - uses: ./.github/actions/ci
+      - uses: nrwl/nx-set-shas@v5
+        id: shas
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          main-branch-name: main
+
+  fast:
+    name: CI Fast
+    needs: preflight
+    uses: ./.github/workflows/ci-fast.yml
+    with:
+      nx-base: ${{ needs.preflight.outputs.nx-base }}
+      nx-head: ${{ needs.preflight.outputs.nx-head }}
+    secrets: inherit
+
+  full:
+    name: CI Full
+    needs: [preflight, fast]
+    uses: ./.github/workflows/ci-full.yml
+    with:
+      nx-base: ${{ needs.preflight.outputs.nx-base }}
+      nx-head: ${{ needs.preflight.outputs.nx-head }}
+    secrets: inherit
 
   deploy:
     name: Production Deploy
-    needs: ci
+    needs: [fast, full]
     runs-on: ubuntu-latest
     timeout-minutes: 20
     environment:
@@ -63,7 +86,7 @@ jobs:
 
   deploy-storybook:
     name: Storybook Production Deploy
-    needs: ci
+    needs: [fast, full]
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:

--- a/apps/root/project.json
+++ b/apps/root/project.json
@@ -17,6 +17,9 @@
         "cwd": "{workspaceRoot}"
       }
     },
+    "test": {
+      "dependsOn": ["generate-search-index"]
+    },
     "build": {
       "dependsOn": ["generate-search-index", "validate-content"],
       "options": {

--- a/nx.json
+++ b/nx.json
@@ -131,7 +131,6 @@
       }
     }
   },
-  "nxCloudId": "REPLACE_WITH_NX_CLOUD_ID",
   "sync": {
     "applyChanges": true
   }

--- a/nx.json
+++ b/nx.json
@@ -131,7 +131,7 @@
       }
     }
   },
-  "neverConnectToCloud": true,
+  "nxCloudId": "REPLACE_WITH_NX_CLOUD_ID",
   "sync": {
     "applyChanges": true
   }


### PR DESCRIPTION
## Summary

Splits the monolithic CI pipeline (~20-25 min) into parallel reusable workflows with Nx Cloud remote caching.

- **ci-fast.yml**: lint, typecheck, test, build in 4 parallel jobs (~3-5 min)
- **ci-full.yml**: e2e, Lighthouse, Storybook+Chromatic in 3 parallel jobs (~8-10 min, develop push only)
- **Nx Cloud**: remote caching via `NX_CLOUD_ID` + `NX_CLOUD_ACCESS_TOKEN` env vars (no identifiers in repo)
- **Playwright browser caching**: `~/.cache/ms-playwright` keyed on version (~2 min saved)
- **`.nx/cache` local caching**: fallback layer via `actions/cache`
- **Expanded docs-only skip patterns**: `.size-limit.json`, `knip.ts`, `opencode.json`
- **deploy-production.yml**: migrated to ci-fast + ci-full reusable workflows
- **setup-workspace**: shared composite action for DRY job setup

### Pipeline flow

**PRs to develop**: `preflight` → `ci-fast` (parallel) → `ci-status`
**Push to develop**: `preflight` → `ci-fast` → `ci-full` (parallel) → `ci-status`
**Production deploy**: `preflight` → `ci-fast` → `ci-full` → deploy + deploy-storybook

### Expected impact

| Metric | Before | After |
|--------|--------|-------|
| PR feedback (cached) | ~20-25 min | ~2-3 min |
| PR feedback (cold) | ~20-25 min | ~4-5 min |
| Develop push | ~20-25 min | ~12-15 min |
| Playwright install | ~2-3 min | ~20s (cache hit) |

### Prerequisites (done)

- [x] `NX_CLOUD_ID` secret added to GitHub Actions
- [x] `NX_CLOUD_ACCESS_TOKEN` secret added to GitHub Actions

### Post-merge

- [ ] Add `size` job to branch protection required checks for `develop`
- [ ] Verify Nx Cloud dashboard shows cache entries after first CI run

Closes #376

https://claude.ai/code/session_01Bi6LZEFcaPgxbvKcKALpFj