### PR TITLE
fix(ci): bump actions/cache to v5 and pnpm/action-setup to v5

### DIFF
--- a/.github/actions/ci/action.yml
+++ b/.github/actions/ci/action.yml
@@ -24,7 +24,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: pnpm/action-setup@v4
+    - uses: pnpm/action-setup@v5
 
     - uses: actions/setup-node@v5
       with:
@@ -36,7 +36,7 @@ runs:
       run: pnpm install --frozen-lockfile
 
     - name: Cache Nx
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: .nx/cache
         key: ${{ runner.os }}-nx-${{ hashFiles('**/pnpm-lock.yaml') }}-${{ github.sha }}
@@ -63,7 +63,7 @@ runs:
 
     - name: Cache Playwright browsers
       if: ${{ inputs.run-e2e == 'true' }}
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/.cache/ms-playwright
         key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}

--- a/.github/actions/setup-workspace/action.yml
+++ b/.github/actions/setup-workspace/action.yml
@@ -4,7 +4,7 @@ description: Install pnpm, Node.js, dependencies, and restore Nx cache
 runs:
   using: composite
   steps:
-    - uses: pnpm/action-setup@v4
+    - uses: pnpm/action-setup@v5
 
     - uses: actions/setup-node@v5
       with:
@@ -16,7 +16,7 @@ runs:
       run: pnpm install --frozen-lockfile
 
     - name: Cache Nx
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: .nx/cache
         key: ${{ runner.os }}-nx-${{ hashFiles('**/pnpm-lock.yaml') }}-${{ github.sha }}

--- a/.github/actions/vercel-deploy-storybook/action.yml
+++ b/.github/actions/vercel-deploy-storybook/action.yml
@@ -26,7 +26,7 @@ outputs:
 runs:
   using: composite
   steps:
-    - uses: pnpm/action-setup@v4
+    - uses: pnpm/action-setup@v5
 
     - uses: actions/setup-node@v5
       with:

--- a/.github/actions/vercel-deploy/action.yml
+++ b/.github/actions/vercel-deploy/action.yml
@@ -26,7 +26,7 @@ outputs:
 runs:
   using: composite
   steps:
-    - uses: pnpm/action-setup@v4
+    - uses: pnpm/action-setup@v5
 
     - uses: actions/setup-node@v5
       with:

--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -36,7 +36,7 @@ jobs:
         run: echo "version=$(node -e "console.log(require('@playwright/test/package.json').version)")" >> "$GITHUB_OUTPUT"
 
       - name: Cache Playwright browsers
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,7 +151,7 @@ jobs:
         run: echo "version=$(node -e "console.log(require('@playwright/test/package.json').version)")" >> "$GITHUB_OUTPUT"
 
       - name: Cache Playwright browsers
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}

--- a/.github/workflows/size-limit.yml
+++ b/.github/workflows/size-limit.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
 
       - uses: actions/setup-node@v5
         with:


### PR DESCRIPTION
## Summary
- Bump `actions/cache` from v4 to v5 across all CI workflows and composite actions
- Bump `pnpm/action-setup` from v4 to v5 across all CI workflows and composite actions

**Files changed:** `.github/actions/ci/action.yml`, `.github/actions/setup-workspace/action.yml`, `.github/actions/vercel-deploy/action.yml`, `.github/actions/vercel-deploy-storybook/action.yml`, `.github/workflows/ci.yml`, `.github/workflows/ci-full.yml`, `.github/workflows/size-limit.yml`

## Test plan
- [ ] CI passes on this PR (the actions themselves are the test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)