### PR TITLE
fix: restore audit-scan-service runtime deps to root package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "not kaios > 0"
   ],
   "dependencies": {
+    "@axe-core/puppeteer": "^4.11.1",
     "@hcaptcha/react-hcaptcha": "^2.0.2",
     "@headlessui/react": "^2.2.9",
     "@hookform/resolvers": "^5.2.2",
@@ -59,10 +60,14 @@
     "caniuse-lite": "1.0.30001776",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
+    "cors": "^2.8.5",
+    "express": "^5.2.1",
     "isomorphic-dompurify": "2.26.0",
+    "lighthouse": "^13.0.3",
     "lucide-react": "0.577.0",
     "minisearch": "^7.2.0",
     "next": "16.1.6",
+    "puppeteer": "^24.38.0",
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "react-hook-form": "7.71.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
 
   .:
     dependencies:
+      '@axe-core/puppeteer':
+        specifier: ^4.11.1
+        version: 4.11.1(puppeteer@24.38.0(typescript@5.9.3))
       '@hcaptcha/react-hcaptcha':
         specifier: ^2.0.2
         version: 2.0.2
@@ -71,9 +74,18 @@ importers:
       cmdk:
         specifier: ^1.1.1
         version: 1.1.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      cors:
+        specifier: ^2.8.5
+        version: 2.8.6
+      express:
+        specifier: ^5.2.1
+        version: 5.2.1
       isomorphic-dompurify:
         specifier: 2.26.0
         version: 2.26.0
+      lighthouse:
+        specifier: ^13.0.3
+        version: 13.0.3
       lucide-react:
         specifier: 0.577.0
         version: 0.577.0(react@19.2.4)
@@ -83,6 +95,9 @@ importers:
       next:
         specifier: 16.1.6
         version: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-macros@3.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.89.2)
+      puppeteer:
+        specifier: ^24.38.0
+        version: 24.38.0(typescript@5.9.3)
       react:
         specifier: 19.2.4
         version: 19.2.4


### PR DESCRIPTION
## Summary
- Restores `express`, `cors`, `lighthouse`, `puppeteer`, and `@axe-core/puppeteer` to root `package.json` dependencies
- These were incorrectly removed in #383 (Knip dep cleanup) — Knip flagged them as unused from the root app, but they're required by audit-scan-service at runtime
- The esbuild config uses `thirdParty: false`, so these packages aren't bundled and must be installed via the pruned lockfile generated from root

**Root cause:** Railway deployment failed with `Cannot find module 'express'` because the Nx `@nx/js:prune-lockfile` executor derives its install list from root `package.json`. Per Nx single version policy, root is the version authority.

## Test plan
- [x] `pnpm tsc --noEmit` — zero errors
- [x] `pnpm nx test root` — 89 suites, 797 tests passing
- [ ] Railway redeploy after merge — verify audit-scan-service starts successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)