### PR TITLE
docs(shared-ui): add MDX guide pages for 5 complex components

### DIFF
--- a/libs/shared/ui/src/lib/Dropdown.mdx
+++ b/libs/shared/ui/src/lib/Dropdown.mdx
@@ -1,0 +1,405 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+import { Dropdown } from './Dropdown';
+
+<Meta title='Navigation/Dropdown/Guide' />
+
+<style>
+  {`
+    .doc-wrap {
+      max-width: 860px;
+      margin: -1rem auto 0;
+      padding: 2rem 2rem 4rem;
+      font-family: var(--font-sans);
+      color: var(--color-text-primary);
+      background: var(--color-surface);
+      border-radius: var(--radius);
+    }
+
+    .doc-title {
+      font-family: var(--font-sans);
+      font-size: var(--font-size-h2);
+      font-weight: 400;
+      margin: 0 0 0.5rem !important;
+      color: var(--color-text-primary);
+      font-variation-settings: 'opsz' 72, 'WONK' 1;
+      border: none !important;
+      padding: 0 !important;
+    }
+
+    .doc-lead {
+      font-size: 1.125rem;
+      color: var(--color-text-secondary);
+      margin: 0 0 2.5rem !important;
+      line-height: 1.6;
+    }
+
+    .doc-section {
+      font-family: var(--font-sans);
+      font-size: var(--font-size-h3);
+      font-weight: 400;
+      color: var(--color-text-primary);
+      margin: 2.5rem 0 1rem !important;
+      padding-bottom: 0.5rem !important;
+      border-bottom: 1px solid var(--color-border) !important;
+      font-variation-settings: 'opsz' 36, 'WONK' 0;
+    }
+
+    .doc-sub {
+      font-family: var(--font-sans);
+      font-size: var(--font-size-h4);
+      font-weight: 400;
+      color: var(--color-text-primary);
+      margin: 1.5rem 0 0.75rem !important;
+      border: none !important;
+      padding: 0 !important;
+      font-variation-settings: 'opsz' 24, 'WONK' 0;
+    }
+
+    .doc-p {
+      color: var(--color-text-secondary);
+      line-height: 1.7;
+      margin: 0 0 1rem;
+      font-size: 0.9375rem;
+    }
+
+    .doc-table {
+      width: 100%;
+      border-collapse: collapse;
+      margin-bottom: 1.5rem;
+      font-size: 0.875rem;
+    }
+
+    .doc-table th {
+      text-align: left;
+      padding: 0.75rem 1rem;
+      border-bottom: 2px solid var(--color-border);
+      color: var(--color-text-primary);
+      font-weight: 500;
+      font-size: 0.8125rem;
+    }
+
+    .doc-table td {
+      padding: 0.75rem 1rem;
+      border-bottom: 1px solid var(--color-border);
+      color: var(--color-text-secondary);
+    }
+
+    .doc-table code {
+      font-family: var(--font-mono);
+      font-size: 0.8125rem;
+      color: var(--color-brand-500);
+      background: var(--color-surface-secondary);
+      padding: 0.125rem 0.375rem;
+      border-radius: var(--radius-sm);
+    }
+
+    .doc-do-dont {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 1rem;
+      margin-bottom: 1.5rem;
+    }
+
+    .doc-do, .doc-dont {
+      padding: 1rem 1.25rem;
+      border-radius: var(--radius);
+      border: 1px solid var(--color-border);
+    }
+
+    .doc-do {
+      border-left: 3px solid var(--color-success);
+    }
+
+    .doc-dont {
+      border-left: 3px solid var(--color-error);
+    }
+
+    .doc-do-label, .doc-dont-label {
+      font-size: 0.75rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      margin-bottom: 0.5rem;
+    }
+
+    .doc-do-label { color: var(--color-success); }
+    .doc-dont-label { color: var(--color-error); }
+
+    .doc-do-body, .doc-dont-body {
+      font-size: 0.875rem;
+      color: var(--color-text-secondary);
+      line-height: 1.6;
+      margin: 0;
+    }
+
+    .doc-do-body code, .doc-dont-body code {
+      font-family: var(--font-mono);
+      font-size: 0.8125rem;
+      color: var(--color-brand-500);
+      background: var(--color-surface-secondary);
+      padding: 0.125rem 0.375rem;
+      border-radius: var(--radius-sm);
+    }
+
+    .doc-kbd {
+      display: inline-block;
+      padding: 0.125rem 0.5rem;
+      font-family: var(--font-mono);
+      font-size: 0.75rem;
+      color: var(--color-text-primary);
+      background: var(--color-surface-secondary);
+      border: 1px solid var(--color-border);
+      border-radius: var(--radius-sm);
+    }
+  `}
+</style>
+
+<div class="sb-unstyled">
+<div className="doc-wrap">
+
+<h1 className='doc-title'>Dropdown</h1>
+<p className='doc-lead'>
+  A menu of actions triggered by a button. Implements the WAI-ARIA Menu Button
+  pattern with full keyboard navigation.
+</p>
+
+<h2 className='doc-section'>When to Use</h2>
+
+<p className='doc-p'>
+  Use Dropdown for a set of actions that share a common context but don't need to be
+  visible at all times. The trigger should describe what the menu contains, not just
+  say "menu."
+</p>
+
+<table className='doc-table'>
+  <thead>
+    <tr>
+      <th>Use Dropdown for</th>
+      <th>Use something else for</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Action menus (Edit, Delete, Share)</td>
+      <td>Form field selection (use Select)</td>
+    </tr>
+    <tr>
+      <td>Overflow actions behind a "more" button</td>
+      <td>Navigation links (use Nav or Tabs)</td>
+    </tr>
+    <tr>
+      <td>Contextual actions on a row or card</td>
+      <td>Single toggle actions (use Switch or Button)</td>
+    </tr>
+  </tbody>
+</table>
+
+<h2 className='doc-section'>Props</h2>
+
+<h3 className='doc-sub'>DropdownProps</h3>
+
+<table className='doc-table'>
+  <thead>
+    <tr>
+      <th>Prop</th>
+      <th>Type</th>
+      <th>Default</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>trigger</code></td>
+      <td><code>ReactNode</code></td>
+      <td>—</td>
+      <td>Content rendered inside the trigger button.</td>
+    </tr>
+    <tr>
+      <td><code>items</code></td>
+      <td><code>DropdownItem[]</code></td>
+      <td>—</td>
+      <td>Array of menu items (see below).</td>
+    </tr>
+    <tr>
+      <td><code>align</code></td>
+      <td><code>'left' | 'right'</code></td>
+      <td><code>'left'</code></td>
+      <td>Which edge the menu aligns to.</td>
+    </tr>
+    <tr>
+      <td><code>className</code></td>
+      <td><code>string</code></td>
+      <td><code>undefined</code></td>
+      <td>Additional classes on the wrapper div.</td>
+    </tr>
+  </tbody>
+</table>
+
+<h3 className='doc-sub'>DropdownItem</h3>
+
+<table className='doc-table'>
+  <thead>
+    <tr>
+      <th>Property</th>
+      <th>Type</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>label</code></td>
+      <td><code>string</code></td>
+      <td>Visible text of the menu item.</td>
+    </tr>
+    <tr>
+      <td><code>icon</code></td>
+      <td><code>ReactNode</code></td>
+      <td>Optional leading icon (rendered at 16x16).</td>
+    </tr>
+    <tr>
+      <td><code>onClick</code></td>
+      <td><code>() =&gt; void</code></td>
+      <td>Action triggered on activation.</td>
+    </tr>
+    <tr>
+      <td><code>danger</code></td>
+      <td><code>boolean</code></td>
+      <td>Renders the item in error color.</td>
+    </tr>
+    <tr>
+      <td><code>divider</code></td>
+      <td><code>boolean</code></td>
+      <td>Renders a visual separator instead of a menu item.</td>
+    </tr>
+    <tr>
+      <td><code>disabled</code></td>
+      <td><code>boolean</code></td>
+      <td>Prevents activation and skips during keyboard navigation.</td>
+    </tr>
+  </tbody>
+</table>
+
+<h2 className='doc-section'>Common Patterns</h2>
+
+<h3 className='doc-sub'>Actions with Divider</h3>
+
+<p className='doc-p'>
+  Group related actions and separate destructive actions with a divider.
+</p>
+
+```jsx
+<Dropdown
+  trigger={<>Actions ▾</>}
+  items={[
+    { label: 'Edit', icon: <PencilIcon />, onClick: handleEdit },
+    { label: 'Duplicate', icon: <CopyIcon />, onClick: handleDuplicate },
+    { divider: true, label: '' },
+    { label: 'Delete', icon: <TrashIcon />, danger: true, onClick: handleDelete },
+  ]}
+/>
+```
+
+<h3 className='doc-sub'>Right-Aligned Menu</h3>
+
+<p className='doc-p'>
+  Use <code>align="right"</code> when the trigger is positioned near the right edge
+  of the viewport to prevent the menu from overflowing.
+</p>
+
+<h2 className='doc-section'>Accessibility</h2>
+
+<p className='doc-p'>
+  The trigger renders with <code>aria-haspopup="menu"</code> and toggles{' '}
+  <code>aria-expanded</code>. The menu panel has <code>role="menu"</code> with items
+  using <code>role="menuitem"</code>. Dividers use <code>role="separator"</code>.
+  Disabled items set <code>aria-disabled</code> and are skipped during keyboard
+  navigation.
+</p>
+
+<h3 className='doc-sub'>Keyboard</h3>
+
+<table className='doc-table'>
+  <thead>
+    <tr>
+      <th>Key</th>
+      <th>Context</th>
+      <th>Action</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><span className='doc-kbd'>Enter</span> / <span className='doc-kbd'>Space</span></td>
+      <td>Trigger focused</td>
+      <td>Toggles the menu open/closed</td>
+    </tr>
+    <tr>
+      <td><span className='doc-kbd'>↓</span></td>
+      <td>Trigger focused</td>
+      <td>Opens menu and focuses first item</td>
+    </tr>
+    <tr>
+      <td><span className='doc-kbd'>↓</span> / <span className='doc-kbd'>↑</span></td>
+      <td>Menu open</td>
+      <td>Moves focus between items (wraps around)</td>
+    </tr>
+    <tr>
+      <td><span className='doc-kbd'>Home</span> / <span className='doc-kbd'>End</span></td>
+      <td>Menu open</td>
+      <td>Jumps to first / last item</td>
+    </tr>
+    <tr>
+      <td><span className='doc-kbd'>Enter</span> / <span className='doc-kbd'>Space</span></td>
+      <td>Item focused</td>
+      <td>Activates the item and closes the menu</td>
+    </tr>
+    <tr>
+      <td><span className='doc-kbd'>Esc</span></td>
+      <td>Menu open</td>
+      <td>Closes menu and returns focus to trigger</td>
+    </tr>
+    <tr>
+      <td><span className='doc-kbd'>Tab</span></td>
+      <td>Menu open</td>
+      <td>Closes menu and moves focus naturally</td>
+    </tr>
+  </tbody>
+</table>
+
+<div className='doc-do-dont'>
+  <div className='doc-do'>
+    <div className='doc-do-label'>Do</div>
+    <p className='doc-do-body'>
+      Pass descriptive content as the <code>trigger</code>, like a label with an
+      icon. The trigger renders inside a <code>&lt;button&gt;</code> automatically,
+      so pass inline content, not another button.
+    </p>
+  </div>
+  <div className='doc-dont'>
+    <div className='doc-dont-label'>Don't</div>
+    <p className='doc-dont-body'>
+      Don't pass a <code>&lt;Button&gt;</code> component as the trigger. The
+      Dropdown already wraps the trigger in a native button element. Nesting buttons
+      is invalid HTML and breaks accessibility.
+    </p>
+  </div>
+</div>
+
+<div className='doc-do-dont'>
+  <div className='doc-do'>
+    <div className='doc-do-label'>Do</div>
+    <p className='doc-do-body'>
+      Place destructive actions (delete, remove) last, separated by a divider, and
+      mark them with <code>danger: true</code> so users can distinguish them.
+    </p>
+  </div>
+  <div className='doc-dont'>
+    <div className='doc-dont-label'>Don't</div>
+    <p className='doc-dont-body'>
+      Don't use Dropdown for navigation. Menu items trigger actions; they don't
+      navigate. For navigation, use links or a dedicated Nav component.
+    </p>
+  </div>
+</div>
+
+</div>
+</div>

--- a/libs/shared/ui/src/lib/Modal.mdx
+++ b/libs/shared/ui/src/lib/Modal.mdx
@@ -1,0 +1,416 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+import { Modal } from './Modal';
+import { Button } from './Button';
+
+<Meta title='Overlays/Modal/Guide' />
+
+<style>
+  {`
+    .doc-wrap {
+      max-width: 860px;
+      margin: -1rem auto 0;
+      padding: 2rem 2rem 4rem;
+      font-family: var(--font-sans);
+      color: var(--color-text-primary);
+      background: var(--color-surface);
+      border-radius: var(--radius);
+    }
+
+    .doc-title {
+      font-family: var(--font-sans);
+      font-size: var(--font-size-h2);
+      font-weight: 400;
+      margin: 0 0 0.5rem !important;
+      color: var(--color-text-primary);
+      font-variation-settings: 'opsz' 72, 'WONK' 1;
+      border: none !important;
+      padding: 0 !important;
+    }
+
+    .doc-lead {
+      font-size: 1.125rem;
+      color: var(--color-text-secondary);
+      margin: 0 0 2.5rem !important;
+      line-height: 1.6;
+    }
+
+    .doc-section {
+      font-family: var(--font-sans);
+      font-size: var(--font-size-h3);
+      font-weight: 400;
+      color: var(--color-text-primary);
+      margin: 2.5rem 0 1rem !important;
+      padding-bottom: 0.5rem !important;
+      border-bottom: 1px solid var(--color-border) !important;
+      font-variation-settings: 'opsz' 36, 'WONK' 0;
+    }
+
+    .doc-sub {
+      font-family: var(--font-sans);
+      font-size: var(--font-size-h4);
+      font-weight: 400;
+      color: var(--color-text-primary);
+      margin: 1.5rem 0 0.75rem !important;
+      border: none !important;
+      padding: 0 !important;
+      font-variation-settings: 'opsz' 24, 'WONK' 0;
+    }
+
+    .doc-p {
+      color: var(--color-text-secondary);
+      line-height: 1.7;
+      margin: 0 0 1rem;
+      font-size: 0.9375rem;
+    }
+
+    .doc-table {
+      width: 100%;
+      border-collapse: collapse;
+      margin-bottom: 1.5rem;
+      font-size: 0.875rem;
+    }
+
+    .doc-table th {
+      text-align: left;
+      padding: 0.75rem 1rem;
+      border-bottom: 2px solid var(--color-border);
+      color: var(--color-text-primary);
+      font-weight: 500;
+      font-size: 0.8125rem;
+    }
+
+    .doc-table td {
+      padding: 0.75rem 1rem;
+      border-bottom: 1px solid var(--color-border);
+      color: var(--color-text-secondary);
+    }
+
+    .doc-table code {
+      font-family: var(--font-mono);
+      font-size: 0.8125rem;
+      color: var(--color-brand-500);
+      background: var(--color-surface-secondary);
+      padding: 0.125rem 0.375rem;
+      border-radius: var(--radius-sm);
+    }
+
+    .doc-do-dont {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 1rem;
+      margin-bottom: 1.5rem;
+    }
+
+    .doc-do, .doc-dont {
+      padding: 1rem 1.25rem;
+      border-radius: var(--radius);
+      border: 1px solid var(--color-border);
+    }
+
+    .doc-do {
+      border-left: 3px solid var(--color-success);
+    }
+
+    .doc-dont {
+      border-left: 3px solid var(--color-error);
+    }
+
+    .doc-do-label, .doc-dont-label {
+      font-size: 0.75rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      margin-bottom: 0.5rem;
+    }
+
+    .doc-do-label { color: var(--color-success); }
+    .doc-dont-label { color: var(--color-error); }
+
+    .doc-do-body, .doc-dont-body {
+      font-size: 0.875rem;
+      color: var(--color-text-secondary);
+      line-height: 1.6;
+      margin: 0;
+    }
+
+    .doc-do-body code, .doc-dont-body code {
+      font-family: var(--font-mono);
+      font-size: 0.8125rem;
+      color: var(--color-brand-500);
+      background: var(--color-surface-secondary);
+      padding: 0.125rem 0.375rem;
+      border-radius: var(--radius-sm);
+    }
+
+    .doc-kbd {
+      display: inline-block;
+      padding: 0.125rem 0.5rem;
+      font-family: var(--font-mono);
+      font-size: 0.75rem;
+      color: var(--color-text-primary);
+      background: var(--color-surface-secondary);
+      border: 1px solid var(--color-border);
+      border-radius: var(--radius-sm);
+    }
+  `}
+</style>
+
+<div class="sb-unstyled">
+<div className="doc-wrap">
+
+<h1 className='doc-title'>Modal</h1>
+<p className='doc-lead'>
+  A dialog overlay for focused tasks. Blocks interaction with the page behind it,
+  traps focus, and returns it to the trigger on close.
+</p>
+
+<h2 className='doc-section'>When to Use</h2>
+
+<p className='doc-p'>
+  Use Modal when the user needs to complete a task or acknowledge information before
+  continuing. Modals interrupt flow by design; only use them when that interruption
+  is justified.
+</p>
+
+<table className='doc-table'>
+  <thead>
+    <tr>
+      <th>Use Modal for</th>
+      <th>Use something else for</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Confirmation dialogs (delete, discard)</td>
+      <td>Inline warnings or undo patterns</td>
+    </tr>
+    <tr>
+      <td>Forms that need focus isolation</td>
+      <td>Simple inline forms</td>
+    </tr>
+    <tr>
+      <td>Content previews or detail views</td>
+      <td>Expandable rows or side panels</td>
+    </tr>
+  </tbody>
+</table>
+
+<h2 className='doc-section'>Sizes</h2>
+
+<p className='doc-p'>
+  Choose a size based on content width, not importance. <code>sm</code> for
+  confirmations, <code>md</code> for short forms, <code>lg</code> for content-heavy
+  dialogs, <code>xl</code> for data tables or multi-column layouts.
+</p>
+
+<table className='doc-table'>
+  <thead>
+    <tr>
+      <th>Size</th>
+      <th>Max width</th>
+      <th>Use when</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>sm</code></td>
+      <td>28rem (448px)</td>
+      <td>Confirmation dialogs, simple alerts</td>
+    </tr>
+    <tr>
+      <td><code>md</code></td>
+      <td>32rem (512px)</td>
+      <td>Short forms, detail previews (default)</td>
+    </tr>
+    <tr>
+      <td><code>lg</code></td>
+      <td>42rem (672px)</td>
+      <td>Multi-field forms, content previews</td>
+    </tr>
+    <tr>
+      <td><code>xl</code></td>
+      <td>56rem (896px)</td>
+      <td>Data tables, multi-column layouts</td>
+    </tr>
+  </tbody>
+</table>
+
+<h2 className='doc-section'>Props</h2>
+
+<table className='doc-table'>
+  <thead>
+    <tr>
+      <th>Prop</th>
+      <th>Type</th>
+      <th>Default</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>isOpen</code></td>
+      <td><code>boolean</code></td>
+      <td>—</td>
+      <td>Controls visibility. Modal is always controlled.</td>
+    </tr>
+    <tr>
+      <td><code>onClose</code></td>
+      <td><code>() =&gt; void</code></td>
+      <td>—</td>
+      <td>Called on Escape, backdrop click, or close button.</td>
+    </tr>
+    <tr>
+      <td><code>title</code></td>
+      <td><code>string</code></td>
+      <td><code>undefined</code></td>
+      <td>Rendered as a heading. Sets <code>aria-labelledby</code> automatically.</td>
+    </tr>
+    <tr>
+      <td><code>children</code></td>
+      <td><code>ReactNode</code></td>
+      <td>—</td>
+      <td>Modal body content.</td>
+    </tr>
+    <tr>
+      <td><code>size</code></td>
+      <td><code>'sm' | 'md' | 'lg' | 'xl'</code></td>
+      <td><code>'md'</code></td>
+      <td>Controls maximum width of the dialog.</td>
+    </tr>
+    <tr>
+      <td><code>footer</code></td>
+      <td><code>ReactNode</code></td>
+      <td><code>undefined</code></td>
+      <td>Rendered in a right-aligned footer bar with a top border.</td>
+    </tr>
+    <tr>
+      <td><code>closeOnBackdropClick</code></td>
+      <td><code>boolean</code></td>
+      <td><code>true</code></td>
+      <td>Set to <code>false</code> for forms with unsaved state.</td>
+    </tr>
+    <tr>
+      <td><code>className</code></td>
+      <td><code>string</code></td>
+      <td><code>undefined</code></td>
+      <td>Additional classes on the dialog container.</td>
+    </tr>
+  </tbody>
+</table>
+
+<h2 className='doc-section'>Common Patterns</h2>
+
+<h3 className='doc-sub'>Confirmation Dialog</h3>
+
+<p className='doc-p'>
+  Use <code>size="sm"</code> with a footer containing a primary destructive action
+  and a secondary cancel. Keep the body to one or two sentences.
+</p>
+
+```jsx
+<Modal
+  isOpen={open}
+  onClose={() => setOpen(false)}
+  title="Delete project?"
+  size="sm"
+  footer={
+    <>
+      <Button variant="secondary" onClick={() => setOpen(false)}>
+        Cancel
+      </Button>
+      <Button variant="error" onClick={handleDelete}>
+        Delete
+      </Button>
+    </>
+  }
+>
+  <p>This action cannot be undone. All data will be permanently removed.</p>
+</Modal>
+```
+
+<h3 className='doc-sub'>Form Modal</h3>
+
+<p className='doc-p'>
+  Disable backdrop click with <code>closeOnBackdropClick=&#123;false&#125;</code> to
+  prevent accidental dismissal when users have entered data.
+</p>
+
+<h2 className='doc-section'>Accessibility</h2>
+
+<p className='doc-p'>
+  Modal sets <code>role="dialog"</code> and <code>aria-modal="true"</code>
+  automatically. When <code>title</code> is provided, it generates a unique ID and
+  wires <code>aria-labelledby</code>. Without a title, it falls back to{' '}
+  <code>aria-label="Dialog"</code>.
+</p>
+
+<h3 className='doc-sub'>Focus Management</h3>
+
+<p className='doc-p'>
+  On open, focus moves to the first focusable element inside the dialog. Tab and
+  Shift+Tab cycle within the dialog (focus trap). On close, focus returns to the
+  element that triggered the modal.
+</p>
+
+<h3 className='doc-sub'>Keyboard</h3>
+
+<table className='doc-table'>
+  <thead>
+    <tr>
+      <th>Key</th>
+      <th>Action</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><span className='doc-kbd'>Esc</span></td>
+      <td>Closes the modal and returns focus to the trigger</td>
+    </tr>
+    <tr>
+      <td><span className='doc-kbd'>Tab</span></td>
+      <td>Moves focus to the next focusable element (trapped within dialog)</td>
+    </tr>
+    <tr>
+      <td><span className='doc-kbd'>Shift</span> + <span className='doc-kbd'>Tab</span></td>
+      <td>Moves focus to the previous focusable element (trapped within dialog)</td>
+    </tr>
+  </tbody>
+</table>
+
+<div className='doc-do-dont'>
+  <div className='doc-do'>
+    <div className='doc-do-label'>Do</div>
+    <p className='doc-do-body'>
+      Always provide a <code>title</code> or <code>aria-label</code> so screen
+      readers announce the dialog purpose. Use the <code>footer</code> prop for
+      action buttons to maintain consistent layout.
+    </p>
+  </div>
+  <div className='doc-dont'>
+    <div className='doc-dont-label'>Don't</div>
+    <p className='doc-dont-body'>
+      Don't nest modals. Don't use modals for content that should live on its own
+      page. Don't disable Escape key handling; users expect it to close the dialog.
+    </p>
+  </div>
+</div>
+
+<div className='doc-do-dont'>
+  <div className='doc-do'>
+    <div className='doc-do-label'>Do</div>
+    <p className='doc-do-body'>
+      Use <code>closeOnBackdropClick=&#123;false&#125;</code> for modals with
+      unsaved form state. This prevents accidental data loss.
+    </p>
+  </div>
+  <div className='doc-dont'>
+    <div className='doc-dont-label'>Don't</div>
+    <p className='doc-dont-body'>
+      Don't put long scrollable content in a modal. If the content needs scrolling,
+      consider a dedicated page or a side panel instead.
+    </p>
+  </div>
+</div>
+
+</div>
+</div>

--- a/libs/shared/ui/src/lib/Table.mdx
+++ b/libs/shared/ui/src/lib/Table.mdx
@@ -1,0 +1,420 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+import { Table } from './Table';
+
+<Meta title='Data Display/Table/Guide' />
+
+<style>
+  {`
+    .doc-wrap {
+      max-width: 860px;
+      margin: -1rem auto 0;
+      padding: 2rem 2rem 4rem;
+      font-family: var(--font-sans);
+      color: var(--color-text-primary);
+      background: var(--color-surface);
+      border-radius: var(--radius);
+    }
+
+    .doc-title {
+      font-family: var(--font-sans);
+      font-size: var(--font-size-h2);
+      font-weight: 400;
+      margin: 0 0 0.5rem !important;
+      color: var(--color-text-primary);
+      font-variation-settings: 'opsz' 72, 'WONK' 1;
+      border: none !important;
+      padding: 0 !important;
+    }
+
+    .doc-lead {
+      font-size: 1.125rem;
+      color: var(--color-text-secondary);
+      margin: 0 0 2.5rem !important;
+      line-height: 1.6;
+    }
+
+    .doc-section {
+      font-family: var(--font-sans);
+      font-size: var(--font-size-h3);
+      font-weight: 400;
+      color: var(--color-text-primary);
+      margin: 2.5rem 0 1rem !important;
+      padding-bottom: 0.5rem !important;
+      border-bottom: 1px solid var(--color-border) !important;
+      font-variation-settings: 'opsz' 36, 'WONK' 0;
+    }
+
+    .doc-sub {
+      font-family: var(--font-sans);
+      font-size: var(--font-size-h4);
+      font-weight: 400;
+      color: var(--color-text-primary);
+      margin: 1.5rem 0 0.75rem !important;
+      border: none !important;
+      padding: 0 !important;
+      font-variation-settings: 'opsz' 24, 'WONK' 0;
+    }
+
+    .doc-p {
+      color: var(--color-text-secondary);
+      line-height: 1.7;
+      margin: 0 0 1rem;
+      font-size: 0.9375rem;
+    }
+
+    .doc-table {
+      width: 100%;
+      border-collapse: collapse;
+      margin-bottom: 1.5rem;
+      font-size: 0.875rem;
+    }
+
+    .doc-table th {
+      text-align: left;
+      padding: 0.75rem 1rem;
+      border-bottom: 2px solid var(--color-border);
+      color: var(--color-text-primary);
+      font-weight: 500;
+      font-size: 0.8125rem;
+    }
+
+    .doc-table td {
+      padding: 0.75rem 1rem;
+      border-bottom: 1px solid var(--color-border);
+      color: var(--color-text-secondary);
+    }
+
+    .doc-table code {
+      font-family: var(--font-mono);
+      font-size: 0.8125rem;
+      color: var(--color-brand-500);
+      background: var(--color-surface-secondary);
+      padding: 0.125rem 0.375rem;
+      border-radius: var(--radius-sm);
+    }
+
+    .doc-do-dont {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 1rem;
+      margin-bottom: 1.5rem;
+    }
+
+    .doc-do, .doc-dont {
+      padding: 1rem 1.25rem;
+      border-radius: var(--radius);
+      border: 1px solid var(--color-border);
+    }
+
+    .doc-do {
+      border-left: 3px solid var(--color-success);
+    }
+
+    .doc-dont {
+      border-left: 3px solid var(--color-error);
+    }
+
+    .doc-do-label, .doc-dont-label {
+      font-size: 0.75rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      margin-bottom: 0.5rem;
+    }
+
+    .doc-do-label { color: var(--color-success); }
+    .doc-dont-label { color: var(--color-error); }
+
+    .doc-do-body, .doc-dont-body {
+      font-size: 0.875rem;
+      color: var(--color-text-secondary);
+      line-height: 1.6;
+      margin: 0;
+    }
+
+    .doc-do-body code, .doc-dont-body code {
+      font-family: var(--font-mono);
+      font-size: 0.8125rem;
+      color: var(--color-brand-500);
+      background: var(--color-surface-secondary);
+      padding: 0.125rem 0.375rem;
+      border-radius: var(--radius-sm);
+    }
+
+    .doc-kbd {
+      display: inline-block;
+      padding: 0.125rem 0.5rem;
+      font-family: var(--font-mono);
+      font-size: 0.75rem;
+      color: var(--color-text-primary);
+      background: var(--color-surface-secondary);
+      border: 1px solid var(--color-border);
+      border-radius: var(--radius-sm);
+    }
+  `}
+</style>
+
+<div class="sb-unstyled">
+<div className="doc-wrap">
+
+<h1 className='doc-title'>Table</h1>
+<p className='doc-lead'>
+  Renders tabular data with optional row clicks, striping, sorting support, and
+  custom cell rendering. Built on semantic HTML with proper column scoping.
+</p>
+
+<h2 className='doc-section'>When to Use</h2>
+
+<p className='doc-p'>
+  Use Table for structured data with multiple fields per record. If each item has
+  only one or two fields, a list or grid is probably a better fit.
+</p>
+
+<table className='doc-table'>
+  <thead>
+    <tr>
+      <th>Use Table for</th>
+      <th>Use something else for</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Multi-column data with clear headers</td>
+      <td>Single-value lists (use a list or grid)</td>
+    </tr>
+    <tr>
+      <td>Sortable or filterable datasets</td>
+      <td>Key-value pairs (use a description list)</td>
+    </tr>
+    <tr>
+      <td>Admin dashboards and data views</td>
+      <td>Card layouts with mixed content types</td>
+    </tr>
+  </tbody>
+</table>
+
+<h2 className='doc-section'>Props</h2>
+
+<h3 className='doc-sub'>TableProps</h3>
+
+<table className='doc-table'>
+  <thead>
+    <tr>
+      <th>Prop</th>
+      <th>Type</th>
+      <th>Default</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>columns</code></td>
+      <td><code>Column&lt;T&gt;[]</code></td>
+      <td>—</td>
+      <td>Column definitions (see below).</td>
+    </tr>
+    <tr>
+      <td><code>data</code></td>
+      <td><code>T[]</code></td>
+      <td>—</td>
+      <td>Array of row data objects.</td>
+    </tr>
+    <tr>
+      <td><code>onRowClick</code></td>
+      <td><code>(row: T) =&gt; void</code></td>
+      <td><code>undefined</code></td>
+      <td>Makes rows clickable. Adds hover styles and keyboard activation.</td>
+    </tr>
+    <tr>
+      <td><code>striped</code></td>
+      <td><code>boolean</code></td>
+      <td><code>false</code></td>
+      <td>Applies alternating row backgrounds for readability.</td>
+    </tr>
+    <tr>
+      <td><code>caption</code></td>
+      <td><code>string</code></td>
+      <td><code>undefined</code></td>
+      <td>Visible caption above the table. Preferred over <code>ariaLabel</code>.</td>
+    </tr>
+    <tr>
+      <td><code>ariaLabel</code></td>
+      <td><code>string</code></td>
+      <td><code>undefined</code></td>
+      <td>Invisible label for the table. Used when <code>caption</code> is not provided.</td>
+    </tr>
+    <tr>
+      <td><code>rowKey</code></td>
+      <td><code>(row: T) =&gt; string | number</code></td>
+      <td><code>undefined</code></td>
+      <td>Derives a stable React key from each row. Falls back to array index.</td>
+    </tr>
+    <tr>
+      <td><code>getRowAriaLabel</code></td>
+      <td><code>(row: T) =&gt; string</code></td>
+      <td><code>undefined</code></td>
+      <td>Generates an accessible label for clickable rows.</td>
+    </tr>
+    <tr>
+      <td><code>className</code></td>
+      <td><code>string</code></td>
+      <td><code>undefined</code></td>
+      <td>Additional classes on the outer container.</td>
+    </tr>
+  </tbody>
+</table>
+
+<h3 className='doc-sub'>Column&lt;T&gt;</h3>
+
+<table className='doc-table'>
+  <thead>
+    <tr>
+      <th>Property</th>
+      <th>Type</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>key</code></td>
+      <td><code>string</code></td>
+      <td>Property name on the data object, or a unique identifier when using <code>render</code>.</td>
+    </tr>
+    <tr>
+      <td><code>header</code></td>
+      <td><code>string</code></td>
+      <td>Column header text. Rendered in a <code>&lt;th scope="col"&gt;</code>.</td>
+    </tr>
+    <tr>
+      <td><code>render</code></td>
+      <td><code>(row: T) =&gt; ReactNode</code></td>
+      <td>Custom cell renderer. Overrides default property lookup.</td>
+    </tr>
+    <tr>
+      <td><code>align</code></td>
+      <td><code>'left' | 'center' | 'right'</code></td>
+      <td>Text alignment for header and cells. Default: <code>'left'</code>.</td>
+    </tr>
+    <tr>
+      <td><code>width</code></td>
+      <td><code>string</code></td>
+      <td>Fixed column width (e.g. <code>'120px'</code>, <code>'20%'</code>).</td>
+    </tr>
+  </tbody>
+</table>
+
+<h2 className='doc-section'>Common Patterns</h2>
+
+<h3 className='doc-sub'>Clickable Rows</h3>
+
+<p className='doc-p'>
+  When <code>onRowClick</code> is provided, each row becomes interactive: it gets
+  hover styles, a pointer cursor, <code>role="button"</code>, and{' '}
+  <code>tabIndex=&#123;0&#125;</code>. Always pair with <code>getRowAriaLabel</code>{' '}
+  so screen readers announce what each row does.
+</p>
+
+```jsx
+<Table
+  columns={columns}
+  data={users}
+  onRowClick={(user) => router.push(`/users/${user.id}`)}
+  rowKey={(user) => user.id}
+  getRowAriaLabel={(user) => `View profile for ${user.name}`}
+  ariaLabel="User directory"
+/>
+```
+
+<h3 className='doc-sub'>Custom Cell Rendering</h3>
+
+<p className='doc-p'>
+  Use the <code>render</code> function on a column to display badges, icons, or
+  formatted values instead of raw strings.
+</p>
+
+```jsx
+const columns = [
+  { key: 'name', header: 'Name' },
+  { key: 'status', header: 'Status', render: (row) => <Badge>{row.status}</Badge> },
+  { key: 'score', header: 'Score', align: 'right', render: (row) => `${row.score}%` },
+];
+```
+
+<h2 className='doc-section'>Accessibility</h2>
+
+<p className='doc-p'>
+  The table uses semantic HTML: <code>&lt;table&gt;</code>, <code>&lt;thead&gt;</code>,
+  <code>&lt;th scope="col"&gt;</code>. Provide either a visible <code>caption</code>{' '}
+  (preferred) or an <code>ariaLabel</code> so screen readers can identify the table.
+</p>
+
+<h3 className='doc-sub'>Clickable Row Behavior</h3>
+
+<p className='doc-p'>
+  Clickable rows receive <code>role="button"</code> and respond to{' '}
+  <span className='doc-kbd'>Enter</span> and <span className='doc-kbd'>Space</span>{' '}
+  key presses. Provide <code>getRowAriaLabel</code> to give each row a meaningful
+  accessible name; without it, screen reader users hear "button" with no context.
+</p>
+
+<h3 className='doc-sub'>Keyboard</h3>
+
+<table className='doc-table'>
+  <thead>
+    <tr>
+      <th>Key</th>
+      <th>Context</th>
+      <th>Action</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><span className='doc-kbd'>Tab</span></td>
+      <td>Page</td>
+      <td>Moves focus to clickable rows (when <code>onRowClick</code> is set)</td>
+    </tr>
+    <tr>
+      <td><span className='doc-kbd'>Enter</span> / <span className='doc-kbd'>Space</span></td>
+      <td>Row focused</td>
+      <td>Activates the row click handler</td>
+    </tr>
+  </tbody>
+</table>
+
+<div className='doc-do-dont'>
+  <div className='doc-do'>
+    <div className='doc-do-label'>Do</div>
+    <p className='doc-do-body'>
+      Always provide <code>rowKey</code> when data has a natural unique identifier.
+      This prevents React reconciliation bugs when rows are reordered or filtered.
+    </p>
+  </div>
+  <div className='doc-dont'>
+    <div className='doc-dont-label'>Don't</div>
+    <p className='doc-dont-body'>
+      Don't rely on array indices for row identity. If data can be sorted, filtered,
+      or paginated, index-based keys cause incorrect UI state.
+    </p>
+  </div>
+</div>
+
+<div className='doc-do-dont'>
+  <div className='doc-do'>
+    <div className='doc-do-label'>Do</div>
+    <p className='doc-do-body'>
+      Use <code>caption</code> for visible table descriptions. Use{' '}
+      <code>ariaLabel</code> only when a visible caption would be redundant with
+      surrounding headings.
+    </p>
+  </div>
+  <div className='doc-dont'>
+    <div className='doc-dont-label'>Don't</div>
+    <p className='doc-dont-body'>
+      Don't omit both <code>caption</code> and <code>ariaLabel</code>. Screen
+      readers need at least one to identify the table's purpose.
+    </p>
+  </div>
+</div>
+
+</div>
+</div>

--- a/libs/shared/ui/src/lib/Tabs.mdx
+++ b/libs/shared/ui/src/lib/Tabs.mdx
@@ -1,0 +1,439 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+import { Tabs } from './Tabs';
+
+<Meta title='Navigation/Tabs/Guide' />
+
+<style>
+  {`
+    .doc-wrap {
+      max-width: 860px;
+      margin: -1rem auto 0;
+      padding: 2rem 2rem 4rem;
+      font-family: var(--font-sans);
+      color: var(--color-text-primary);
+      background: var(--color-surface);
+      border-radius: var(--radius);
+    }
+
+    .doc-title {
+      font-family: var(--font-sans);
+      font-size: var(--font-size-h2);
+      font-weight: 400;
+      margin: 0 0 0.5rem !important;
+      color: var(--color-text-primary);
+      font-variation-settings: 'opsz' 72, 'WONK' 1;
+      border: none !important;
+      padding: 0 !important;
+    }
+
+    .doc-lead {
+      font-size: 1.125rem;
+      color: var(--color-text-secondary);
+      margin: 0 0 2.5rem !important;
+      line-height: 1.6;
+    }
+
+    .doc-section {
+      font-family: var(--font-sans);
+      font-size: var(--font-size-h3);
+      font-weight: 400;
+      color: var(--color-text-primary);
+      margin: 2.5rem 0 1rem !important;
+      padding-bottom: 0.5rem !important;
+      border-bottom: 1px solid var(--color-border) !important;
+      font-variation-settings: 'opsz' 36, 'WONK' 0;
+    }
+
+    .doc-sub {
+      font-family: var(--font-sans);
+      font-size: var(--font-size-h4);
+      font-weight: 400;
+      color: var(--color-text-primary);
+      margin: 1.5rem 0 0.75rem !important;
+      border: none !important;
+      padding: 0 !important;
+      font-variation-settings: 'opsz' 24, 'WONK' 0;
+    }
+
+    .doc-p {
+      color: var(--color-text-secondary);
+      line-height: 1.7;
+      margin: 0 0 1rem;
+      font-size: 0.9375rem;
+    }
+
+    .doc-grid {
+      display: flex;
+      gap: 0.75rem;
+      flex-wrap: wrap;
+      margin-bottom: 1.5rem;
+      align-items: center;
+    }
+
+    .doc-table {
+      width: 100%;
+      border-collapse: collapse;
+      margin-bottom: 1.5rem;
+      font-size: 0.875rem;
+    }
+
+    .doc-table th {
+      text-align: left;
+      padding: 0.75rem 1rem;
+      border-bottom: 2px solid var(--color-border);
+      color: var(--color-text-primary);
+      font-weight: 500;
+      font-size: 0.8125rem;
+    }
+
+    .doc-table td {
+      padding: 0.75rem 1rem;
+      border-bottom: 1px solid var(--color-border);
+      color: var(--color-text-secondary);
+    }
+
+    .doc-table code {
+      font-family: var(--font-mono);
+      font-size: 0.8125rem;
+      color: var(--color-brand-500);
+      background: var(--color-surface-secondary);
+      padding: 0.125rem 0.375rem;
+      border-radius: var(--radius-sm);
+    }
+
+    .doc-do-dont {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 1rem;
+      margin-bottom: 1.5rem;
+    }
+
+    .doc-do, .doc-dont {
+      padding: 1rem 1.25rem;
+      border-radius: var(--radius);
+      border: 1px solid var(--color-border);
+    }
+
+    .doc-do {
+      border-left: 3px solid var(--color-success);
+    }
+
+    .doc-dont {
+      border-left: 3px solid var(--color-error);
+    }
+
+    .doc-do-label, .doc-dont-label {
+      font-size: 0.75rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      margin-bottom: 0.5rem;
+    }
+
+    .doc-do-label { color: var(--color-success); }
+    .doc-dont-label { color: var(--color-error); }
+
+    .doc-do-body, .doc-dont-body {
+      font-size: 0.875rem;
+      color: var(--color-text-secondary);
+      line-height: 1.6;
+      margin: 0;
+    }
+
+    .doc-do-body code, .doc-dont-body code {
+      font-family: var(--font-mono);
+      font-size: 0.8125rem;
+      color: var(--color-brand-500);
+      background: var(--color-surface-secondary);
+      padding: 0.125rem 0.375rem;
+      border-radius: var(--radius-sm);
+    }
+
+    .doc-kbd {
+      display: inline-block;
+      padding: 0.125rem 0.5rem;
+      font-family: var(--font-mono);
+      font-size: 0.75rem;
+      color: var(--color-text-primary);
+      background: var(--color-surface-secondary);
+      border: 1px solid var(--color-border);
+      border-radius: var(--radius-sm);
+    }
+  `}
+</style>
+
+<div class="sb-unstyled">
+<div className="doc-wrap">
+
+<h1 className='doc-title'>Tabs</h1>
+<p className='doc-lead'>
+  Switch between related content panels. Implements the WAI-ARIA Tabs pattern with
+  arrow key navigation, two visual variants, and controlled or uncontrolled state.
+</p>
+
+<h2 className='doc-section'>When to Use</h2>
+
+<p className='doc-p'>
+  Use Tabs when content naturally divides into parallel categories that share the same
+  context. Each tab should make sense on its own; if a user needs to see multiple
+  panels at once, consider an accordion or a single scrollable page.
+</p>
+
+<table className='doc-table'>
+  <thead>
+    <tr>
+      <th>Use Tabs for</th>
+      <th>Use something else for</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Switching between related views (Overview, Details, History)</td>
+      <td>Step-by-step flows (use a stepper or wizard)</td>
+    </tr>
+    <tr>
+      <td>Filtering content by category on a single page</td>
+      <td>Navigation between separate pages (use links or Nav)</td>
+    </tr>
+    <tr>
+      <td>Settings organized by section</td>
+      <td>Content that should all be visible (use sections or accordion)</td>
+    </tr>
+  </tbody>
+</table>
+
+<h2 className='doc-section'>Variants</h2>
+
+<p className='doc-p'>
+  Choose the variant that fits the surrounding UI density. Both variants behave
+  identically; only the visual treatment differs.
+</p>
+
+<table className='doc-table'>
+  <thead>
+    <tr>
+      <th>Variant</th>
+      <th>Appearance</th>
+      <th>Use when</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>underline</code></td>
+      <td>Bottom border highlight on the active tab</td>
+      <td>Page-level sections, content-heavy layouts (default)</td>
+    </tr>
+    <tr>
+      <td><code>pill</code></td>
+      <td>Filled background on the active tab, set in a tinted track</td>
+      <td>Compact areas, toolbars, card headers</td>
+    </tr>
+  </tbody>
+</table>
+
+<h2 className='doc-section'>Props</h2>
+
+<h3 className='doc-sub'>TabsProps</h3>
+
+<table className='doc-table'>
+  <thead>
+    <tr>
+      <th>Prop</th>
+      <th>Type</th>
+      <th>Default</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>tabs</code></td>
+      <td><code>Tab[]</code></td>
+      <td>—</td>
+      <td>Array of tab definitions (see below).</td>
+    </tr>
+    <tr>
+      <td><code>defaultTab</code></td>
+      <td><code>string</code></td>
+      <td>First tab's <code>id</code></td>
+      <td>Initially active tab. Component is uncontrolled by default.</td>
+    </tr>
+    <tr>
+      <td><code>onChange</code></td>
+      <td><code>(tabId: string) =&gt; void</code></td>
+      <td><code>undefined</code></td>
+      <td>Called when the active tab changes. Use to sync external state.</td>
+    </tr>
+    <tr>
+      <td><code>variant</code></td>
+      <td><code>'underline' | 'pill'</code></td>
+      <td><code>'underline'</code></td>
+      <td>Visual style of the tab bar.</td>
+    </tr>
+    <tr>
+      <td><code>className</code></td>
+      <td><code>string</code></td>
+      <td><code>undefined</code></td>
+      <td>Additional classes on the outer wrapper.</td>
+    </tr>
+  </tbody>
+</table>
+
+<h3 className='doc-sub'>Tab</h3>
+
+<table className='doc-table'>
+  <thead>
+    <tr>
+      <th>Property</th>
+      <th>Type</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>id</code></td>
+      <td><code>string</code></td>
+      <td>Unique identifier. Used for <code>defaultTab</code> and <code>onChange</code>.</td>
+    </tr>
+    <tr>
+      <td><code>label</code></td>
+      <td><code>string</code></td>
+      <td>Visible text on the tab button.</td>
+    </tr>
+    <tr>
+      <td><code>content</code></td>
+      <td><code>ReactNode</code></td>
+      <td>Panel content rendered when the tab is active.</td>
+    </tr>
+  </tbody>
+</table>
+
+<h2 className='doc-section'>Common Patterns</h2>
+
+<h3 className='doc-sub'>Basic Usage</h3>
+
+```jsx
+<Tabs
+  tabs={[
+    { id: 'overview', label: 'Overview', content: <OverviewPanel /> },
+    { id: 'details', label: 'Details', content: <DetailsPanel /> },
+    { id: 'history', label: 'History', content: <HistoryPanel /> },
+  ]}
+/>
+```
+
+<h3 className='doc-sub'>Controlled with External State</h3>
+
+<p className='doc-p'>
+  Use <code>defaultTab</code> and <code>onChange</code> together when you need to
+  sync the active tab with URL params, analytics, or other state.
+</p>
+
+```jsx
+const [activeTab, setActiveTab] = useState('overview');
+
+<Tabs
+  tabs={tabs}
+  defaultTab={activeTab}
+  onChange={(tabId) => {
+    setActiveTab(tabId);
+    trackEvent('tab_change', { tab: tabId });
+  }}
+/>
+```
+
+<h3 className='doc-sub'>Pill Variant in a Card Header</h3>
+
+```jsx
+<Card>
+  <Tabs variant="pill" tabs={settingsTabs} />
+</Card>
+```
+
+<h2 className='doc-section'>Accessibility</h2>
+
+<p className='doc-p'>
+  The tab list uses <code>role="tablist"</code>. Each tab button has{' '}
+  <code>role="tab"</code> with <code>aria-selected</code> and{' '}
+  <code>aria-controls</code> pointing to its panel. The active panel has{' '}
+  <code>role="tabpanel"</code> with <code>aria-labelledby</code> linking back to
+  its tab. Only the active tab is in the tab order (<code>tabIndex=0</code>); inactive
+  tabs use <code>tabIndex=-1</code> and are reached via arrow keys.
+</p>
+
+<h3 className='doc-sub'>Keyboard</h3>
+
+<table className='doc-table'>
+  <thead>
+    <tr>
+      <th>Key</th>
+      <th>Action</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><span className='doc-kbd'>→</span></td>
+      <td>Moves focus and activation to the next tab (wraps to first)</td>
+    </tr>
+    <tr>
+      <td><span className='doc-kbd'>←</span></td>
+      <td>Moves focus and activation to the previous tab (wraps to last)</td>
+    </tr>
+    <tr>
+      <td><span className='doc-kbd'>Home</span></td>
+      <td>Moves focus and activation to the first tab</td>
+    </tr>
+    <tr>
+      <td><span className='doc-kbd'>End</span></td>
+      <td>Moves focus and activation to the last tab</td>
+    </tr>
+    <tr>
+      <td><span className='doc-kbd'>Tab</span></td>
+      <td>Moves focus into the active tab panel</td>
+    </tr>
+  </tbody>
+</table>
+
+<p className='doc-p'>
+  This component uses <strong>automatic activation</strong>: arrow keys both move
+  focus and activate the tab immediately. This is the recommended WAI-ARIA pattern
+  when panel content loads instantly (no async fetch).
+</p>
+
+<div className='doc-do-dont'>
+  <div className='doc-do'>
+    <div className='doc-do-label'>Do</div>
+    <p className='doc-do-body'>
+      Give each tab a unique <code>id</code>. The component generates ARIA
+      relationships from these IDs. Duplicate IDs break the <code>aria-controls</code>{' '}
+      / <code>aria-labelledby</code> link between tab and panel.
+    </p>
+  </div>
+  <div className='doc-dont'>
+    <div className='doc-dont-label'>Don't</div>
+    <p className='doc-dont-body'>
+      Don't use Tabs for sequential steps or wizards. Tabs imply independent panels;
+      users expect to jump to any tab in any order. Steppers enforce order.
+    </p>
+  </div>
+</div>
+
+<div className='doc-do-dont'>
+  <div className='doc-do'>
+    <div className='doc-do-label'>Do</div>
+    <p className='doc-do-body'>
+      Keep tab labels short (one or two words). Long labels cause the tab bar to
+      wrap awkwardly on mobile. If labels are sentences, the content probably belongs
+      on separate pages.
+    </p>
+  </div>
+  <div className='doc-dont'>
+    <div className='doc-dont-label'>Don't</div>
+    <p className='doc-dont-body'>
+      Don't exceed 5-6 tabs. Beyond that, discoverability drops and the tab bar
+      becomes hard to navigate. Consider a different pattern for large sets.
+    </p>
+  </div>
+</div>
+
+</div>
+</div>

--- a/libs/shared/ui/src/lib/Toast.mdx
+++ b/libs/shared/ui/src/lib/Toast.mdx
@@ -1,0 +1,378 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title='Feedback/Toast/Guide' />
+
+<style>
+  {`
+    .doc-wrap {
+      max-width: 860px;
+      margin: -1rem auto 0;
+      padding: 2rem 2rem 4rem;
+      font-family: var(--font-sans);
+      color: var(--color-text-primary);
+      background: var(--color-surface);
+      border-radius: var(--radius);
+    }
+
+    .doc-title {
+      font-family: var(--font-sans);
+      font-size: var(--font-size-h2);
+      font-weight: 400;
+      margin: 0 0 0.5rem !important;
+      color: var(--color-text-primary);
+      font-variation-settings: 'opsz' 72, 'WONK' 1;
+      border: none !important;
+      padding: 0 !important;
+    }
+
+    .doc-lead {
+      font-size: 1.125rem;
+      color: var(--color-text-secondary);
+      margin: 0 0 2.5rem !important;
+      line-height: 1.6;
+    }
+
+    .doc-section {
+      font-family: var(--font-sans);
+      font-size: var(--font-size-h3);
+      font-weight: 400;
+      color: var(--color-text-primary);
+      margin: 2.5rem 0 1rem !important;
+      padding-bottom: 0.5rem !important;
+      border-bottom: 1px solid var(--color-border) !important;
+      font-variation-settings: 'opsz' 36, 'WONK' 0;
+    }
+
+    .doc-sub {
+      font-family: var(--font-sans);
+      font-size: var(--font-size-h4);
+      font-weight: 400;
+      color: var(--color-text-primary);
+      margin: 1.5rem 0 0.75rem !important;
+      border: none !important;
+      padding: 0 !important;
+      font-variation-settings: 'opsz' 24, 'WONK' 0;
+    }
+
+    .doc-p {
+      color: var(--color-text-secondary);
+      line-height: 1.7;
+      margin: 0 0 1rem;
+      font-size: 0.9375rem;
+    }
+
+    .doc-table {
+      width: 100%;
+      border-collapse: collapse;
+      margin-bottom: 1.5rem;
+      font-size: 0.875rem;
+    }
+
+    .doc-table th {
+      text-align: left;
+      padding: 0.75rem 1rem;
+      border-bottom: 2px solid var(--color-border);
+      color: var(--color-text-primary);
+      font-weight: 500;
+      font-size: 0.8125rem;
+    }
+
+    .doc-table td {
+      padding: 0.75rem 1rem;
+      border-bottom: 1px solid var(--color-border);
+      color: var(--color-text-secondary);
+    }
+
+    .doc-table code {
+      font-family: var(--font-mono);
+      font-size: 0.8125rem;
+      color: var(--color-brand-500);
+      background: var(--color-surface-secondary);
+      padding: 0.125rem 0.375rem;
+      border-radius: var(--radius-sm);
+    }
+
+    .doc-do-dont {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 1rem;
+      margin-bottom: 1.5rem;
+    }
+
+    .doc-do, .doc-dont {
+      padding: 1rem 1.25rem;
+      border-radius: var(--radius);
+      border: 1px solid var(--color-border);
+    }
+
+    .doc-do {
+      border-left: 3px solid var(--color-success);
+    }
+
+    .doc-dont {
+      border-left: 3px solid var(--color-error);
+    }
+
+    .doc-do-label, .doc-dont-label {
+      font-size: 0.75rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      margin-bottom: 0.5rem;
+    }
+
+    .doc-do-label { color: var(--color-success); }
+    .doc-dont-label { color: var(--color-error); }
+
+    .doc-do-body, .doc-dont-body {
+      font-size: 0.875rem;
+      color: var(--color-text-secondary);
+      line-height: 1.6;
+      margin: 0;
+    }
+
+    .doc-do-body code, .doc-dont-body code {
+      font-family: var(--font-mono);
+      font-size: 0.8125rem;
+      color: var(--color-brand-500);
+      background: var(--color-surface-secondary);
+      padding: 0.125rem 0.375rem;
+      border-radius: var(--radius-sm);
+    }
+  `}
+</style>
+
+<div class="sb-unstyled">
+<div className="doc-wrap">
+
+<h1 className='doc-title'>Toast</h1>
+<p className='doc-lead'>
+  Temporary, non-blocking notifications for async feedback. Auto-dismiss after 4
+  seconds, pause on hover, and stack in the bottom-right corner.
+</p>
+
+<h2 className='doc-section'>When to Use</h2>
+
+<p className='doc-p'>
+  Use Toast for transient feedback that doesn't require user action: a form submitted
+  successfully, a network error occurred, or a background task completed. Toasts
+  disappear on their own; they should never carry critical information that the user
+  must act on.
+</p>
+
+<table className='doc-table'>
+  <thead>
+    <tr>
+      <th>Use Toast for</th>
+      <th>Use something else for</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Success confirmation after a save or submit</td>
+      <td>Inline validation errors (use FormFieldError)</td>
+    </tr>
+    <tr>
+      <td>Network or server error notifications</td>
+      <td>Blocking confirmations (use Modal)</td>
+    </tr>
+    <tr>
+      <td>Background task completion</td>
+      <td>Persistent alerts or banners (use Alert)</td>
+    </tr>
+  </tbody>
+</table>
+
+<h2 className='doc-section'>Setup</h2>
+
+<p className='doc-p'>
+  Toast requires <code>ToastProvider</code> to be mounted in the component tree.
+  Place it near the root of your app, above any component that needs to trigger
+  toasts.
+</p>
+
+```jsx
+import { ToastProvider } from '@danieljoffe.com/shared-ui';
+
+function App({ children }) {
+  return (
+    <ToastProvider>
+      {children}
+    </ToastProvider>
+  );
+}
+```
+
+<h2 className='doc-section'>Usage</h2>
+
+<p className='doc-p'>
+  Call <code>toast()</code> from the <code>useToast()</code> hook. Every toast needs
+  a <code>variant</code> and a <code>title</code>. The <code>description</code> and{' '}
+  <code>duration</code> are optional.
+</p>
+
+```jsx
+import { useToast } from '@danieljoffe.com/shared-ui';
+
+function SaveButton() {
+  const { toast } = useToast();
+
+  const handleSave = async () => {
+    try {
+      await saveData();
+      toast({ variant: 'success', title: 'Changes saved' });
+    } catch {
+      toast({
+        variant: 'error',
+        title: 'Save failed',
+        description: 'Check your connection and try again.',
+      });
+    }
+  };
+
+  return <Button onClick={handleSave}>Save</Button>;
+}
+```
+
+<h2 className='doc-section'>Variants</h2>
+
+<table className='doc-table'>
+  <thead>
+    <tr>
+      <th>Variant</th>
+      <th>ARIA role</th>
+      <th>Use when</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>success</code></td>
+      <td><code>status</code></td>
+      <td>Action completed successfully.</td>
+    </tr>
+    <tr>
+      <td><code>error</code></td>
+      <td><code>alert</code></td>
+      <td>An operation failed. Keep the message actionable.</td>
+    </tr>
+    <tr>
+      <td><code>warning</code></td>
+      <td><code>alert</code></td>
+      <td>Something needs attention but isn't blocking.</td>
+    </tr>
+    <tr>
+      <td><code>info</code></td>
+      <td><code>status</code></td>
+      <td>Neutral informational feedback.</td>
+    </tr>
+  </tbody>
+</table>
+
+<h2 className='doc-section'>Toast Parameters</h2>
+
+<table className='doc-table'>
+  <thead>
+    <tr>
+      <th>Parameter</th>
+      <th>Type</th>
+      <th>Default</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>variant</code></td>
+      <td><code>'info' | 'success' | 'warning' | 'error'</code></td>
+      <td>—</td>
+      <td>Determines icon, color, and ARIA role.</td>
+    </tr>
+    <tr>
+      <td><code>title</code></td>
+      <td><code>string</code></td>
+      <td>—</td>
+      <td>Primary message. Keep it short (under 60 characters).</td>
+    </tr>
+    <tr>
+      <td><code>description</code></td>
+      <td><code>string</code></td>
+      <td><code>undefined</code></td>
+      <td>Secondary detail. Use for actionable guidance on errors.</td>
+    </tr>
+    <tr>
+      <td><code>duration</code></td>
+      <td><code>number</code></td>
+      <td><code>4000</code></td>
+      <td>Auto-dismiss time in milliseconds.</td>
+    </tr>
+  </tbody>
+</table>
+
+<h2 className='doc-section'>Behavior</h2>
+
+<h3 className='doc-sub'>Auto-Dismiss</h3>
+
+<p className='doc-p'>
+  Toasts dismiss after 4 seconds by default. Override with the <code>duration</code>{' '}
+  parameter. The timer pauses when the user hovers over or focuses the toast, then
+  resumes with the remaining time.
+</p>
+
+<h3 className='doc-sub'>Stacking</h3>
+
+<p className='doc-p'>
+  Multiple toasts stack vertically in the bottom-right corner. Newest toasts appear
+  at the bottom. Each has its own dismiss timer.
+</p>
+
+<h3 className='doc-sub'>Manual Dismiss</h3>
+
+<p className='doc-p'>
+  Every toast has a close button labeled "Dismiss notification" for screen readers.
+  Users can dismiss toasts before the timer expires.
+</p>
+
+<h2 className='doc-section'>Accessibility</h2>
+
+<p className='doc-p'>
+  The toast container uses <code>aria-live="polite"</code> with{' '}
+  <code>aria-atomic="true"</code> so screen readers announce new toasts. Error and
+  warning toasts use <code>role="alert"</code> for immediate announcement; success
+  and info toasts use <code>role="status"</code> which announces at the next pause.
+</p>
+
+<div className='doc-do-dont'>
+  <div className='doc-do'>
+    <div className='doc-do-label'>Do</div>
+    <p className='doc-do-body'>
+      Write toast titles that stand alone. "Changes saved" is better than "Success!"
+      because it tells the user what happened without needing the description.
+    </p>
+  </div>
+  <div className='doc-dont'>
+    <div className='doc-dont-label'>Don't</div>
+    <p className='doc-dont-body'>
+      Don't use toasts for information that requires user action. If the user needs
+      to fix something, use inline validation or a modal.
+    </p>
+  </div>
+</div>
+
+<div className='doc-do-dont'>
+  <div className='doc-do'>
+    <div className='doc-do-label'>Do</div>
+    <p className='doc-do-body'>
+      Increase <code>duration</code> for error toasts with longer descriptions so
+      users have time to read the guidance before the toast disappears.
+    </p>
+  </div>
+  <div className='doc-dont'>
+    <div className='doc-dont-label'>Don't</div>
+    <p className='doc-dont-body'>
+      Don't fire multiple toasts for a single action. One save should produce one
+      toast, not a success toast followed by an info toast.
+    </p>
+  </div>
+</div>
+
+</div>
+</div>


### PR DESCRIPTION
## Summary

Closes #353. Adds MDX guide pages for the 5 complex shared-ui components identified in the Storybook audit (#350):

- **Modal** — sizes, controlled state, focus trapping, Esc/Tab keyboard behavior
- **Dropdown** — trigger pattern (don't nest buttons), dividers, full WAI-ARIA menu keyboard nav
- **Table** — clickable rows with `rowKey`/`getRowAriaLabel`, custom cell rendering
- **Toast** — `ToastProvider` setup, `useToast()` usage, variants, auto-dismiss with pause-on-hover
- **Tabs** — underline vs pill variants, arrow key navigation, automatic activation

Each guide follows the existing `Button.mdx` template: when to use / when not to use, full props table, common patterns with code examples, accessibility notes (ARIA attributes + keyboard), and do/don't blocks.

## Test plan

- [x] `pnpm tsc --noEmit` passes (zero errors)
- [x] `pnpm nx test root` passes (89 suites, 797 tests)
- [ ] Verify MDX pages render in Storybook (`pnpm nx storybook @danieljoffe.com/shared-ui`)

https://claude.ai/code/session_01Gu48aLjPvEZa5C4fSzUtDc