### PR TITLE
fix(e2e): restore explicit loading attr on priority cover images

### DIFF
--- a/apps/root/src/components/kit/CoverImage.tsx
+++ b/apps/root/src/components/kit/CoverImage.tsx
@@ -17,6 +17,8 @@ export function CoverImage({
         fill
         sizes='(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw'
         priority={priority}
+        loading={priority ? 'eager' : 'lazy'}
+        fetchPriority={priority ? 'high' : 'low'}
         className='object-cover'
       />
       <div className='absolute inset-0 bg-gradient-to-t from-black/60 to-transparent' />


### PR DESCRIPTION
## Summary
- Fix failing e2e test `performance.spec.ts:9 › images are optimized and load efficiently` on PR #392
- PR #391 replaced `UnsplashImg` (which set `loading='eager'` when `priority=true`) with a bare `next/image`. Next.js omits the `loading` attribute entirely for priority images, causing the test's `expect(loading).toBe('lazy')` to fail with `null`.
- Restore explicit `loading` and `fetchPriority` props in `CoverImage` to match the pre-#391 behavior.

## Root cause
In `node_modules/next/dist/shared/lib/get-img-props.js`:
```
isLazy = !priority && !preload && (loading === 'lazy' || typeof loading === 'undefined');
loadingFinal = isLazy ? 'lazy' : loading; // undefined when priority && loading undefined
```
Featured projects on `/` use `priority={i < 3}`, so their covers rendered with no `loading` attribute.

## Test plan
- [x] `pnpm tsc --noEmit` passes
- [x] `pnpm nx test root` passes (779/779)
- [x] `CoverImage.spec.tsx` passes
- [ ] E2E `performance.spec.ts` passes in CI

https://claude.ai/code/session_01Gu48aLjPvEZa5C4fSzUtDc