### PR TITLE
fix(job-api): install types-bleach and fix mypy no-any-return

### DIFF
--- a/apps/job-api/app/services/sanitize.py
+++ b/apps/job-api/app/services/sanitize.py
@@ -37,10 +37,11 @@ ALLOWED_PROTOCOLS = ["http", "https", "mailto"]
 def sanitize_html(raw: str) -> str:
     if not raw:
         return ""
-    return bleach.clean(
+    cleaned: str = bleach.clean(
         raw,
         tags=ALLOWED_TAGS,
         attributes=ALLOWED_ATTRS,
         protocols=ALLOWED_PROTOCOLS,
         strip=True,
     )
+    return cleaned

--- a/apps/job-api/pyproject.toml
+++ b/apps/job-api/pyproject.toml
@@ -22,6 +22,7 @@ dev = [
   "pytest-asyncio>=0.25",
   "ruff>=0.11",
   "mypy>=1.15",
+  "types-bleach>=6.2",
 ]
 
 [tool.ruff]

--- a/uv.lock
+++ b/uv.lock
@@ -511,6 +511,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "ruff" },
+    { name = "types-bleach" },
 ]
 
 [package.metadata]
@@ -531,6 +532,7 @@ dev = [
     { name = "pytest", specifier = ">=8.3" },
     { name = "pytest-asyncio", specifier = ">=0.25" },
     { name = "ruff", specifier = ">=0.11" },
+    { name = "types-bleach", specifier = ">=6.2" },
 ]
 
 [[package]]
@@ -1613,6 +1615,39 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
+]
+
+[[package]]
+name = "types-bleach"
+version = "6.3.0.20260408"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "types-html5lib" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c4/a0/2a861f96e70ce1966c51693ae1549e0a1f0dbf3e948b8194af71e9530e1f/types_bleach-6.3.0.20260408.tar.gz", hash = "sha256:05d8e0cbb8ee4ffd81f4b242818beaa7fe81c3b203c1cee154564a18fbb2d537", size = 11618, upload-time = "2026-04-08T04:37:14.744Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/9b/7a3692601cad18bee42dfacf7e1a845742e044b3eec82e2c05abfee60dc7/types_bleach-6.3.0.20260408-py3-none-any.whl", hash = "sha256:1c1b68b5fe230d3a054d064eb1b9e52ce119c95b03269a07773f48d80f783062", size = 12016, upload-time = "2026-04-08T04:37:13.417Z" },
+]
+
+[[package]]
+name = "types-html5lib"
+version = "1.1.11.20260408"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "types-webencodings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/16/59/914d00107c770e49fa57d4c4572e0371bbce14321385fd2ea3e06691b62d/types_html5lib-1.1.11.20260408.tar.gz", hash = "sha256:8a281aa367bc77dbc758358cd9bef79530f2d154eeed9b33705bb035a0dab9e4", size = 18316, upload-time = "2026-04-08T04:35:49.581Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/61/19/12d95e98e42e120522665ec6850b38df8d2c1cca94e21c4d7f8578acb64e/types_html5lib-1.1.11.20260408-py3-none-any.whl", hash = "sha256:d18dc4b90d6d6745585790b920db13ede43e1f8ff6ee1ac0ceb0dec4223a06fa", size = 24313, upload-time = "2026-04-08T04:35:48.679Z" },
+]
+
+[[package]]
+name = "types-webencodings"
+version = "0.5.0.20260408"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1c/d2/21567fac142315580ce3ee37d08a4e8819921dae833bbcd27b9f8b373799/types_webencodings-0.5.0.20260408.tar.gz", hash = "sha256:28c596619f367e43eee393d85f63e8d2fdb6874c654a8d441c37f8afe29c6d0d", size = 7504, upload-time = "2026-04-08T04:28:51.735Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8f/e4/f13be8f6d9a561166f7d963012d0ccc833e13aee3044c4f1a8fb1fee462a/types_webencodings-0.5.0.20260408-py3-none-any.whl", hash = "sha256:19a2afe5c22d9b1e880b49ff823c7b531f473a390fe47ac903c0bdb5cd677dd9", size = 8717, upload-time = "2026-04-08T04:28:50.943Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add `types-bleach` to job-api dev dependencies so mypy can resolve bleach stubs
- Assign `bleach.clean()` result to a typed local in `sanitize_html` to satisfy `warn_return_any`
- Regenerate `uv.lock`

## Why
CI `nx run job-api:mypy` was failing:
- `Library stubs not installed for "bleach"`
- `Returning Any from function declared to return "str"`

## Test plan
- [x] `uv run mypy app/` passes locally (19 source files, 0 errors)
- [ ] CI `job-api:mypy` passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)