### PR TITLE
feat(jobs): Workday, SmartRecruiters, and JSON-LD fetchers

### DIFF
--- a/apps/job-api/app/models/schemas.py
+++ b/apps/job-api/app/models/schemas.py
@@ -3,7 +3,7 @@ from typing import Literal
 
 from pydantic import BaseModel, Field
 
-BOARD_TOKEN_PATTERN = r"^[a-z0-9][a-z0-9-]{1,80}$"
+BOARD_TOKEN_PATTERN = r"^[a-zA-Z0-9][a-zA-Z0-9_.:/|@-]{1,250}$"
 
 
 class ScoreBreakdown(BaseModel):
@@ -21,7 +21,7 @@ class ScoreResult(BaseModel):
     excluded: bool
 
 
-Provider = Literal["greenhouse", "lever", "ashby"]
+Provider = Literal["greenhouse", "lever", "ashby", "workday", "smartrecruiters", "jsonld"]
 
 
 class JobPosting(BaseModel):
@@ -65,7 +65,7 @@ class StatusUpdate(BaseModel):
 
 class SourceAction(BaseModel):
     action: Literal["add", "remove", "toggle"]
-    board_token: str = Field(pattern=BOARD_TOKEN_PATTERN, max_length=80)
+    board_token: str = Field(pattern=BOARD_TOKEN_PATTERN, max_length=250)
     company_name: str | None = Field(default=None, max_length=200)
     provider: Provider = "greenhouse"
 

--- a/apps/job-api/app/services/ats_detect.py
+++ b/apps/job-api/app/services/ats_detect.py
@@ -8,6 +8,7 @@ import httpx
 from app.services.ashby import ASHBY_BASE
 from app.services.greenhouse import GREENHOUSE_BASE
 from app.services.lever import LEVER_BASE
+from app.services.smartrecruiters import SMARTRECRUITERS_BASE
 
 REQUEST_TIMEOUT = 8.0
 PROBE_DELAY = 0.1
@@ -29,6 +30,11 @@ _URL_PATTERNS: list[tuple[re.Pattern[str], str]] = [
     (re.compile(r"api\.lever\.co/v[01]/postings/([a-z0-9][a-z0-9-]+)", re.I), "lever"),
     (re.compile(r"jobs\.ashbyhq\.com/([a-z0-9][a-z0-9._-]+)", re.I), "ashby"),
     (re.compile(r"api\.ashbyhq\.com/posting-api/job-board/([a-z0-9][a-z0-9._-]+)", re.I), "ashby"),
+    (re.compile(r"([a-z0-9-]+)\.wd\d+\.myworkdayjobs\.com", re.I), "workday"),
+    (
+        re.compile(r"api\.smartrecruiters\.com/v1/companies/([a-zA-Z0-9-]+)", re.I),
+        "smartrecruiters",
+    ),
 ]
 
 # Slug must be URL-safe, lowercase, 2-80 chars
@@ -123,13 +129,37 @@ async def _probe_ashby(slug: str, client: httpx.AsyncClient) -> DetectResult | N
     )
 
 
+async def _probe_smartrecruiters(
+    slug: str, client: httpx.AsyncClient
+) -> DetectResult | None:
+    url = f"{SMARTRECRUITERS_BASE}/{slug}/postings?limit=1"
+    try:
+        resp = await client.get(url)
+    except httpx.HTTPError:
+        return None
+    if resp.status_code != 200:
+        return None
+    data = resp.json()
+    content = data.get("content", [])
+    if not isinstance(content, list) or len(content) == 0:
+        return None
+    total = data.get("totalFound", len(content))
+    return DetectResult(
+        provider="smartrecruiters",
+        board_token=slug,
+        company_name=slug.replace("-", " ").title(),
+        job_count=total,
+    )
+
+
 _PROBERS = {
     "greenhouse": _probe_greenhouse,
     "lever": _probe_lever,
     "ashby": _probe_ashby,
+    "smartrecruiters": _probe_smartrecruiters,
 }
 
-_PROBE_ORDER = ["greenhouse", "lever", "ashby"]
+_PROBE_ORDER = ["greenhouse", "lever", "ashby", "smartrecruiters"]
 
 
 async def detect_ats(raw_input: str) -> DetectResult | None:

--- a/apps/job-api/app/services/jsonld.py
+++ b/apps/job-api/app/services/jsonld.py
@@ -1,0 +1,153 @@
+import json
+import re
+from html.parser import HTMLParser
+
+import httpx
+
+from app.services.standard_job import StandardJob
+
+REQUEST_TIMEOUT = 10.0
+
+
+class _JsonLdExtractor(HTMLParser):
+    """Extract JSON-LD script blocks from HTML."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._in_jsonld = False
+        self._buf = ""
+        self.blocks: list[str] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if tag == "script":
+            attr_dict = dict(attrs)
+            if attr_dict.get("type") == "application/ld+json":
+                self._in_jsonld = True
+                self._buf = ""
+
+    def handle_data(self, data: str) -> None:
+        if self._in_jsonld:
+            self._buf += data
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag == "script" and self._in_jsonld:
+            self._in_jsonld = False
+            self.blocks.append(self._buf)
+
+
+def _extract_job_postings(html: str) -> list[dict[str, object]]:
+    """Parse HTML for JSON-LD blocks and return all JobPosting objects."""
+    parser = _JsonLdExtractor()
+    parser.feed(html)
+
+    postings: list[dict[str, object]] = []
+    for block in parser.blocks:
+        try:
+            data = json.loads(block)
+        except (json.JSONDecodeError, ValueError):
+            continue
+
+        if isinstance(data, list):
+            for item in data:
+                if isinstance(item, dict) and _is_job_posting(item):
+                    postings.append(item)
+        elif isinstance(data, dict):
+            if _is_job_posting(data):
+                postings.append(data)
+            # Handle @graph arrays
+            graph = data.get("@graph")
+            if isinstance(graph, list):
+                for item in graph:
+                    if isinstance(item, dict) and _is_job_posting(item):
+                        postings.append(item)
+
+    return postings
+
+
+def _is_job_posting(obj: dict[str, object]) -> bool:
+    obj_type = obj.get("@type", "")
+    if isinstance(obj_type, list):
+        return "JobPosting" in obj_type
+    return obj_type == "JobPosting"
+
+
+def _get_location(posting: dict[str, object]) -> str | None:
+    loc = posting.get("jobLocation")
+    if isinstance(loc, dict):
+        address = loc.get("address")
+        if isinstance(address, dict):
+            parts = [
+                address.get("addressLocality", ""),
+                address.get("addressRegion", ""),
+            ]
+            return ", ".join(p for p in parts if p) or None
+        return loc.get("name") if isinstance(loc.get("name"), str) else None
+    if isinstance(loc, list) and loc:
+        first = loc[0]
+        if isinstance(first, dict):
+            address = first.get("address")
+            if isinstance(address, dict):
+                parts = [
+                    address.get("addressLocality", ""),
+                    address.get("addressRegion", ""),
+                ]
+                return ", ".join(p for p in parts if p) or None
+    return None
+
+
+def _get_str(obj: dict[str, object], key: str) -> str:
+    val = obj.get(key, "")
+    return str(val) if val else ""
+
+
+_HTML_TAG_RE = re.compile(r"<[^>]+>")
+
+
+async def fetch_jsonld_jobs(careers_url: str) -> list[StandardJob]:
+    """Fetch a careers page and extract jobs from JSON-LD markup."""
+    async with httpx.AsyncClient(timeout=REQUEST_TIMEOUT) as client:
+        try:
+            resp = await client.get(careers_url, follow_redirects=True)
+            if resp.status_code != 200:
+                return []
+        except httpx.HTTPError:
+            return []
+
+    postings = _extract_job_postings(resp.text)
+
+    jobs: list[StandardJob] = []
+    for posting in postings:
+        title = _get_str(posting, "title") or _get_str(posting, "jobTitle")
+        if not title:
+            continue
+
+        description = _get_str(posting, "description")
+        # Strip HTML from description if present
+        clean_desc = _HTML_TAG_RE.sub("", description) if "<" in description else description
+
+        url = _get_str(posting, "url") or _get_str(posting, "sameAs")
+
+        # Build a stable ID from URL or title hash
+        import hashlib
+
+        id_source = url or f"{title}|{_get_location(posting) or ''}"
+        external_id = hashlib.sha256(id_source.encode()).hexdigest()[:16]
+
+        org = posting.get("hiringOrganization")
+        dept = ""
+        if isinstance(org, dict):
+            dept = _get_str(org, "department")
+
+        jobs.append(
+            StandardJob(
+                external_id=external_id,
+                title=title,
+                location_name=_get_location(posting),
+                department=dept or None,
+                content=clean_desc,
+                updated_at=_get_str(posting, "datePosted"),
+                absolute_url=url,
+            )
+        )
+
+    return jobs

--- a/apps/job-api/app/services/poller.py
+++ b/apps/job-api/app/services/poller.py
@@ -11,10 +11,13 @@ from app.models.schemas import PollResult
 from app.seed.keyword_config import keyword_config
 from app.services.ashby import fetch_ashby_jobs
 from app.services.greenhouse import fetch_board_jobs
+from app.services.jsonld import fetch_jsonld_jobs
 from app.services.lever import fetch_lever_jobs
 from app.services.sanitize import sanitize_html
 from app.services.scoring import score_job
+from app.services.smartrecruiters import fetch_smartrecruiters_jobs
 from app.services.standard_job import StandardJob
+from app.services.workday import fetch_workday_jobs
 
 logger = logging.getLogger(__name__)
 
@@ -24,6 +27,9 @@ FETCHERS: dict[str, Fetcher] = {
     "greenhouse": fetch_board_jobs,
     "lever": fetch_lever_jobs,
     "ashby": fetch_ashby_jobs,
+    "workday": fetch_workday_jobs,
+    "smartrecruiters": fetch_smartrecruiters_jobs,
+    "jsonld": fetch_jsonld_jobs,
 }
 
 

--- a/apps/job-api/app/services/smartrecruiters.py
+++ b/apps/job-api/app/services/smartrecruiters.py
@@ -1,0 +1,53 @@
+import httpx
+
+from app.services.standard_job import StandardJob
+
+SMARTRECRUITERS_BASE = "https://api.smartrecruiters.com/v1/companies"
+REQUEST_TIMEOUT = 10.0
+
+
+async def fetch_smartrecruiters_jobs(company_id: str) -> list[StandardJob]:
+    """Fetch jobs from SmartRecruiters' public Posting API."""
+    url = f"{SMARTRECRUITERS_BASE}/{company_id}/postings"
+
+    async with httpx.AsyncClient(timeout=REQUEST_TIMEOUT) as client:
+        try:
+            resp = await client.get(url)
+            if resp.status_code == 404:
+                return []
+            resp.raise_for_status()
+        except httpx.HTTPError:
+            return []
+
+    data = resp.json()
+    items = data.get("content", [])
+    if not isinstance(items, list):
+        return []
+
+    jobs: list[StandardJob] = []
+    for item in items:
+        location = item.get("location", {})
+        city = location.get("city", "")
+        country = location.get("country", "")
+        location_str = f"{city}, {country}".strip(", ") if city or country else None
+
+        department = item.get("department", {})
+
+        company = item.get("company", {})
+        job_url = item.get("ref", "")
+
+        jobs.append(
+            StandardJob(
+                external_id=str(item.get("id", "")),
+                title=item.get("name", ""),
+                location_name=location_str,
+                department=department.get("label") if department else None,
+                content=item.get("jobAd", {})
+                .get("sections", {})
+                .get("jobDescription", {})
+                .get("text", ""),
+                updated_at=item.get("releasedDate", ""),
+                absolute_url=company.get("website", job_url) if company else job_url,
+            )
+        )
+    return jobs

--- a/apps/job-api/app/services/workday.py
+++ b/apps/job-api/app/services/workday.py
@@ -1,0 +1,66 @@
+import httpx
+
+from app.services.standard_job import StandardJob
+
+REQUEST_TIMEOUT = 15.0
+MAX_JOBS = 200
+
+
+async def fetch_workday_jobs(board_token: str) -> list[StandardJob]:
+    """Fetch jobs from Workday's internal CXS API.
+
+    board_token format: "{base_url}|{tenant}|{site}"
+    e.g. "https://salesforce.wd12.myworkdayjobs.com|salesforce|External_Career_Site"
+    """
+    parts = board_token.split("|")
+    if len(parts) != 3:
+        return []
+
+    base_url, tenant, site = parts
+    url = f"{base_url}/wday/cxs/{tenant}/{site}/jobs"
+
+    async with httpx.AsyncClient(timeout=REQUEST_TIMEOUT) as client:
+        all_jobs: list[StandardJob] = []
+        offset = 0
+
+        while offset < MAX_JOBS:
+            try:
+                resp = await client.post(
+                    url,
+                    json={
+                        "appliedFacets": {},
+                        "limit": 20,
+                        "offset": offset,
+                        "searchText": "",
+                    },
+                )
+                if resp.status_code != 200:
+                    return all_jobs
+            except httpx.HTTPError:
+                return all_jobs
+
+            data = resp.json()
+            postings = data.get("jobPostings", [])
+            if not postings:
+                break
+
+            for item in postings:
+                external_path = item.get("externalPath", "")
+                all_jobs.append(
+                    StandardJob(
+                        external_id=external_path or str(item.get("bulletFields", [""])[0]),
+                        title=item.get("title", ""),
+                        location_name=item.get("locationsText"),
+                        department=None,
+                        content=item.get("descriptionTeaser", ""),
+                        updated_at=item.get("postedOn", ""),
+                        absolute_url=f"{base_url}/job/{external_path}" if external_path else "",
+                    )
+                )
+
+            total = data.get("total", 0)
+            offset += 20
+            if offset >= total:
+                break
+
+    return all_jobs

--- a/apps/job-api/tests/test_ats_detect.py
+++ b/apps/job-api/tests/test_ats_detect.py
@@ -57,6 +57,20 @@ class TestParseInput:
         assert provider == "lever"
         assert slug == "netlify"
 
+    def test_workday_url(self):
+        provider, slug = _parse_input(
+            "https://salesforce.wd12.myworkdayjobs.com/en-US/External"
+        )
+        assert provider == "workday"
+        assert slug == "salesforce"
+
+    def test_smartrecruiters_api_url(self):
+        provider, slug = _parse_input(
+            "https://api.smartrecruiters.com/v1/companies/VISA"
+        )
+        assert provider == "smartrecruiters"
+        assert slug == "visa"
+
 
 # --- detect_ats tests ---
 
@@ -191,3 +205,30 @@ async def test_detect_careers_page_url_probes_all():
     assert result is not None
     assert result.provider == "greenhouse"
     assert result.board_token == "notion"
+
+
+@pytest.mark.asyncio
+async def test_detect_smartrecruiters_from_api_url():
+    mock_client = AsyncMock()
+    mock_client.get.return_value = _make_http_response(
+        200,
+        {
+            "content": [{"id": "1", "name": "Engineer"}],
+            "totalFound": 42,
+        },
+    )
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch(
+        "app.services.ats_detect.httpx.AsyncClient",
+        return_value=mock_client,
+    ):
+        result = await detect_ats(
+            "https://api.smartrecruiters.com/v1/companies/VISA"
+        )
+
+    assert result is not None
+    assert result.provider == "smartrecruiters"
+    assert result.board_token == "visa"
+    assert result.job_count == 42

--- a/apps/job-api/tests/test_jsonld.py
+++ b/apps/job-api/tests/test_jsonld.py
@@ -1,0 +1,229 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from app.services.jsonld import _extract_job_postings, fetch_jsonld_jobs
+from app.services.standard_job import StandardJob
+
+_SINGLE_POSTING_HTML = """
+<html>
+<head>
+<script type="application/ld+json">
+{
+    "@context": "https://schema.org/",
+    "@type": "JobPosting",
+    "title": "Frontend Engineer",
+    "description": "Build UI components",
+    "datePosted": "2026-04-01",
+    "url": "https://example.com/jobs/fe",
+    "jobLocation": {
+        "@type": "Place",
+        "address": {
+            "addressLocality": "Austin",
+            "addressRegion": "TX"
+        }
+    },
+    "hiringOrganization": {
+        "@type": "Organization",
+        "name": "Acme Inc"
+    }
+}
+</script>
+</head>
+<body></body>
+</html>
+"""
+
+_GRAPH_HTML = """
+<html>
+<head>
+<script type="application/ld+json">
+{
+    "@context": "https://schema.org",
+    "@graph": [
+        {"@type": "Organization", "name": "Acme"},
+        {
+            "@type": "JobPosting",
+            "jobTitle": "Designer",
+            "description": "Design things",
+            "datePosted": "2026-04-02",
+            "sameAs": "https://example.com/jobs/des"
+        }
+    ]
+}
+</script>
+</head>
+<body></body>
+</html>
+"""
+
+_NO_JSONLD_HTML = """
+<html><body><h1>Careers</h1><p>No structured data here.</p></body></html>
+"""
+
+_HTML_DESCRIPTION = """
+<html>
+<head>
+<script type="application/ld+json">
+{
+    "@type": "JobPosting",
+    "title": "DevOps",
+    "description": "<p>Manage <b>infrastructure</b></p>",
+    "url": "https://example.com/jobs/devops"
+}
+</script>
+</head>
+<body></body>
+</html>
+"""
+
+_ARRAY_FORMAT_HTML = """
+<html>
+<head>
+<script type="application/ld+json">
+[
+    {
+        "@type": "JobPosting",
+        "title": "Job A",
+        "description": "desc a",
+        "url": "https://example.com/a"
+    },
+    {
+        "@type": "JobPosting",
+        "title": "Job B",
+        "description": "desc b",
+        "url": "https://example.com/b"
+    }
+]
+</script>
+</head>
+<body></body>
+</html>
+"""
+
+
+# --- _extract_job_postings unit tests ---
+
+
+class TestExtractJobPostings:
+    def test_single_posting(self):
+        postings = _extract_job_postings(_SINGLE_POSTING_HTML)
+        assert len(postings) == 1
+        assert postings[0]["title"] == "Frontend Engineer"
+
+    def test_graph_format(self):
+        postings = _extract_job_postings(_GRAPH_HTML)
+        assert len(postings) == 1
+        assert postings[0]["jobTitle"] == "Designer"
+
+    def test_no_jsonld(self):
+        postings = _extract_job_postings(_NO_JSONLD_HTML)
+        assert postings == []
+
+    def test_array_format(self):
+        postings = _extract_job_postings(_ARRAY_FORMAT_HTML)
+        assert len(postings) == 2
+
+    def test_invalid_json_skipped(self):
+        html = '<script type="application/ld+json">not valid json</script>'
+        postings = _extract_job_postings(html)
+        assert postings == []
+
+
+# --- fetch_jsonld_jobs integration tests ---
+
+
+def _mock_response(status_code: int, text: str) -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.text = text
+    return resp
+
+
+@pytest.mark.asyncio
+async def test_fetch_single_posting():
+    resp = _mock_response(200, _SINGLE_POSTING_HTML)
+    with patch("app.services.jsonld.httpx.AsyncClient") as cm:
+        client = cm.return_value.__aenter__.return_value
+        client.get = AsyncMock(return_value=resp)
+        result = await fetch_jsonld_jobs("https://example.com/careers")
+
+    assert len(result) == 1
+    job = result[0]
+    assert isinstance(job, StandardJob)
+    assert job.title == "Frontend Engineer"
+    assert job.location_name == "Austin, TX"
+    assert job.content == "Build UI components"
+    assert job.absolute_url == "https://example.com/jobs/fe"
+    assert len(job.external_id) == 16  # SHA256 truncated
+
+
+@pytest.mark.asyncio
+async def test_fetch_graph_format():
+    resp = _mock_response(200, _GRAPH_HTML)
+    with patch("app.services.jsonld.httpx.AsyncClient") as cm:
+        client = cm.return_value.__aenter__.return_value
+        client.get = AsyncMock(return_value=resp)
+        result = await fetch_jsonld_jobs("https://example.com/careers")
+
+    assert len(result) == 1
+    assert result[0].title == "Designer"
+    assert result[0].absolute_url == "https://example.com/jobs/des"
+
+
+@pytest.mark.asyncio
+async def test_fetch_strips_html_from_description():
+    resp = _mock_response(200, _HTML_DESCRIPTION)
+    with patch("app.services.jsonld.httpx.AsyncClient") as cm:
+        client = cm.return_value.__aenter__.return_value
+        client.get = AsyncMock(return_value=resp)
+        result = await fetch_jsonld_jobs("https://example.com/careers")
+
+    assert "<" not in result[0].content
+    assert "infrastructure" in result[0].content
+
+
+@pytest.mark.asyncio
+async def test_fetch_no_jsonld_returns_empty():
+    resp = _mock_response(200, _NO_JSONLD_HTML)
+    with patch("app.services.jsonld.httpx.AsyncClient") as cm:
+        client = cm.return_value.__aenter__.return_value
+        client.get = AsyncMock(return_value=resp)
+        result = await fetch_jsonld_jobs("https://example.com/careers")
+
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_fetch_404_returns_empty():
+    resp = _mock_response(404, "")
+    with patch("app.services.jsonld.httpx.AsyncClient") as cm:
+        client = cm.return_value.__aenter__.return_value
+        client.get = AsyncMock(return_value=resp)
+        result = await fetch_jsonld_jobs("https://example.com/careers")
+
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_fetch_network_error_returns_empty():
+    with patch("app.services.jsonld.httpx.AsyncClient") as cm:
+        client = cm.return_value.__aenter__.return_value
+        client.get = AsyncMock(side_effect=httpx.HTTPError("timeout"))
+        result = await fetch_jsonld_jobs("https://example.com/careers")
+
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_fetch_array_format():
+    resp = _mock_response(200, _ARRAY_FORMAT_HTML)
+    with patch("app.services.jsonld.httpx.AsyncClient") as cm:
+        client = cm.return_value.__aenter__.return_value
+        client.get = AsyncMock(return_value=resp)
+        result = await fetch_jsonld_jobs("https://example.com/careers")
+
+    assert len(result) == 2
+    assert result[0].title == "Job A"
+    assert result[1].title == "Job B"

--- a/apps/job-api/tests/test_schemas.py
+++ b/apps/job-api/tests/test_schemas.py
@@ -23,7 +23,7 @@ def test_source_action_bad_token_path_traversal():
 
 def test_source_action_token_too_long():
     with pytest.raises(ValidationError):
-        SourceAction(action="add", board_token="a" * 100, company_name="Foo")
+        SourceAction(action="add", board_token="a" * 260, company_name="Foo")
 
 
 def test_status_update_new_valid():

--- a/apps/job-api/tests/test_smartrecruiters.py
+++ b/apps/job-api/tests/test_smartrecruiters.py
@@ -1,0 +1,113 @@
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from app.services.smartrecruiters import fetch_smartrecruiters_jobs
+from app.services.standard_job import StandardJob
+
+
+def _mock_response(
+    status_code: int, json_data: dict[str, Any] | None = None
+) -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = json_data or {}
+    if status_code >= 400 and status_code != 404:
+        resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "error", request=MagicMock(), response=resp
+        )
+    else:
+        resp.raise_for_status.return_value = None
+    return resp
+
+
+@pytest.mark.asyncio
+async def test_fetch_404_returns_empty():
+    resp = _mock_response(404)
+    with patch("app.services.smartrecruiters.httpx.AsyncClient") as cm:
+        client = cm.return_value.__aenter__.return_value
+        client.get = AsyncMock(return_value=resp)
+        result = await fetch_smartrecruiters_jobs("missing-co")
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_fetch_http_error_returns_empty():
+    with patch("app.services.smartrecruiters.httpx.AsyncClient") as cm:
+        client = cm.return_value.__aenter__.return_value
+        client.get = AsyncMock(side_effect=httpx.HTTPError("boom"))
+        result = await fetch_smartrecruiters_jobs("bad")
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_fetch_valid_json_maps_jobs():
+    payload = {
+        "content": [
+            {
+                "id": "sr-001",
+                "name": "Backend Engineer",
+                "location": {"city": "Berlin", "country": "DE"},
+                "department": {"label": "Engineering"},
+                "company": {"website": "https://example.com"},
+                "ref": "https://api.smartrecruiters.com/v1/companies/ex/postings/sr-001",
+                "releasedDate": "2026-04-01T00:00:00Z",
+                "jobAd": {
+                    "sections": {
+                        "jobDescription": {"text": "Build APIs"},
+                    }
+                },
+            }
+        ]
+    }
+    resp = _mock_response(200, payload)
+    with patch("app.services.smartrecruiters.httpx.AsyncClient") as cm:
+        client = cm.return_value.__aenter__.return_value
+        client.get = AsyncMock(return_value=resp)
+        result = await fetch_smartrecruiters_jobs("example")
+
+    assert len(result) == 1
+    job = result[0]
+    assert isinstance(job, StandardJob)
+    assert job.external_id == "sr-001"
+    assert job.title == "Backend Engineer"
+    assert job.location_name == "Berlin, DE"
+    assert job.department == "Engineering"
+    assert job.content == "Build APIs"
+    assert job.absolute_url == "https://example.com"
+
+
+@pytest.mark.asyncio
+async def test_fetch_missing_optional_fields():
+    payload = {
+        "content": [
+            {
+                "id": "sr-002",
+                "name": "Designer",
+                "location": {},
+                "jobAd": {"sections": {}},
+            }
+        ]
+    }
+    resp = _mock_response(200, payload)
+    with patch("app.services.smartrecruiters.httpx.AsyncClient") as cm:
+        client = cm.return_value.__aenter__.return_value
+        client.get = AsyncMock(return_value=resp)
+        result = await fetch_smartrecruiters_jobs("co")
+
+    assert len(result) == 1
+    assert result[0].location_name is None
+    assert result[0].department is None
+    assert result[0].content == ""
+
+
+@pytest.mark.asyncio
+async def test_fetch_empty_content_returns_empty():
+    resp = _mock_response(200, {"content": []})
+    with patch("app.services.smartrecruiters.httpx.AsyncClient") as cm:
+        client = cm.return_value.__aenter__.return_value
+        client.get = AsyncMock(return_value=resp)
+        result = await fetch_smartrecruiters_jobs("empty")
+    assert result == []

--- a/apps/job-api/tests/test_workday.py
+++ b/apps/job-api/tests/test_workday.py
@@ -1,0 +1,97 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from app.services.workday import fetch_workday_jobs
+
+
+def _make_resp(status: int, json_data: object) -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = status
+    resp.json.return_value = json_data
+    return resp
+
+
+@pytest.mark.asyncio
+async def test_invalid_token_format():
+    result = await fetch_workday_jobs("bad-token")
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_valid_response():
+    mock_client = AsyncMock()
+    mock_client.post.return_value = _make_resp(
+        200,
+        {
+            "total": 2,
+            "jobPostings": [
+                {
+                    "externalPath": "job/abc123",
+                    "title": "Software Engineer",
+                    "locationsText": "San Francisco, CA",
+                    "descriptionTeaser": "Build things",
+                    "postedOn": "2026-04-01",
+                    "bulletFields": ["abc123"],
+                },
+                {
+                    "externalPath": "job/def456",
+                    "title": "Product Manager",
+                    "locationsText": "Remote",
+                    "descriptionTeaser": "Manage things",
+                    "postedOn": "2026-04-02",
+                    "bulletFields": ["def456"],
+                },
+            ],
+        },
+    )
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch(
+        "app.services.workday.httpx.AsyncClient",
+        return_value=mock_client,
+    ):
+        token = "https://salesforce.wd12.myworkdayjobs.com|salesforce|External"
+        jobs = await fetch_workday_jobs(token)
+
+    assert len(jobs) == 2
+    assert jobs[0].title == "Software Engineer"
+    assert jobs[0].external_id == "job/abc123"
+    assert jobs[0].location_name == "San Francisco, CA"
+    assert jobs[1].title == "Product Manager"
+
+
+@pytest.mark.asyncio
+async def test_404_returns_empty():
+    mock_client = AsyncMock()
+    mock_client.post.return_value = _make_resp(404, {})
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch(
+        "app.services.workday.httpx.AsyncClient",
+        return_value=mock_client,
+    ):
+        token = "https://example.wd5.myworkdayjobs.com|example|Site"
+        jobs = await fetch_workday_jobs(token)
+
+    assert jobs == []
+
+
+@pytest.mark.asyncio
+async def test_network_error():
+    mock_client = AsyncMock()
+    mock_client.post.side_effect = httpx.HTTPError("timeout")
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch(
+        "app.services.workday.httpx.AsyncClient",
+        return_value=mock_client,
+    ):
+        token = "https://example.wd5.myworkdayjobs.com|example|Site"
+        jobs = await fetch_workday_jobs(token)
+
+    assert jobs == []

--- a/apps/root/src/app/tools/admin/jobs/types.ts
+++ b/apps/root/src/app/tools/admin/jobs/types.ts
@@ -8,7 +8,14 @@ export const JOB_STATUSES = [
 
 export type JobStatus = (typeof JOB_STATUSES)[number];
 
-export const PROVIDERS = ['greenhouse', 'lever', 'ashby'] as const;
+export const PROVIDERS = [
+  'greenhouse',
+  'lever',
+  'ashby',
+  'workday',
+  'smartrecruiters',
+  'jsonld',
+] as const;
 
 export type Provider = (typeof PROVIDERS)[number];
 


### PR DESCRIPTION
## Summary

Adds three new ATS provider integrations (#415, #416, #417), all using free public APIs with zero new dependencies:

- **Workday** (#415): Pipe-delimited token format (`base_url|tenant|site`), fetches from Workday's `/wday/cxs/` internal JSON API with pagination
- **SmartRecruiters** (#416): Public Posting API v1 (`/v1/companies/{id}/postings`)
- **JSON-LD** (#417): Extracts `schema.org/JobPosting` structured data from any careers page using Python stdlib `html.parser` — handles single objects, arrays, and `@graph` format

Also includes:
- SmartRecruiters added to auto-detect probing (`ats_detect.py`)
- Workday URL pattern added to `_parse_input` (detect only, not probed — requires compound token)
- `board_token` pattern relaxed to support URLs and pipe-delimited tokens (`^[a-zA-Z0-9][a-zA-Z0-9_.:/|@-]{1,250}$`)
- Frontend `PROVIDERS` array updated with all three new providers

## Test plan

- [x] `uv run pytest` — 116 tests pass (includes 16 new tests across 3 test files)
- [x] `uv run ruff check .` — clean
- [x] `pnpm tsc --noEmit` — zero type errors
- [x] `pnpm nx test root` — 903 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)