### PR TITLE
feat(jobs): concurrent polling and US-only location filter

### DIFF
--- a/apps/job-api/app/services/poller.py
+++ b/apps/job-api/app/services/poller.py
@@ -6,7 +6,6 @@ from typing import Any, cast
 
 from supabase import Client
 
-from app.config import settings
 from app.models.schemas import PollResult
 from app.seed.keyword_config import keyword_config
 from app.services.ashby import fetch_ashby_jobs
@@ -32,6 +31,101 @@ FETCHERS: dict[str, Fetcher] = {
     "jsonld": fetch_jsonld_jobs,
 }
 
+POLL_CONCURRENCY = 10
+
+# Substrings that flag a location as non-US. Case-insensitive, substring match.
+_NON_US_HINTS: tuple[str, ...] = (
+    "united kingdom",
+    "england",
+    "scotland",
+    "wales",
+    "ireland",
+    "dublin",
+    "germany",
+    "berlin",
+    "munich",
+    "france",
+    "paris",
+    "netherlands",
+    "amsterdam",
+    "spain",
+    "barcelona",
+    "madrid",
+    "italy",
+    "rome",
+    "milan",
+    "sweden",
+    "stockholm",
+    "denmark",
+    "copenhagen",
+    "norway",
+    "oslo",
+    "finland",
+    "helsinki",
+    "switzerland",
+    "zurich",
+    "geneva",
+    "austria",
+    "vienna",
+    "poland",
+    "warsaw",
+    "czech",
+    "prague",
+    "portugal",
+    "lisbon",
+    "greece",
+    "athens",
+    "turkey",
+    "istanbul",
+    "canada",
+    "toronto",
+    "vancouver",
+    "montreal",
+    "ottawa",
+    "mexico",
+    "brazil",
+    "são paulo",
+    "sao paulo",
+    "india",
+    "bangalore",
+    "bengaluru",
+    "hyderabad",
+    "mumbai",
+    "delhi",
+    "pune",
+    "china",
+    "beijing",
+    "shanghai",
+    "hong kong",
+    "singapore",
+    "japan",
+    "tokyo",
+    "korea",
+    "seoul",
+    "taiwan",
+    "australia",
+    "sydney",
+    "melbourne",
+    "new zealand",
+    "auckland",
+    "israel",
+    "tel aviv",
+    "south africa",
+    "johannesburg",
+    "argentina",
+    "buenos aires",
+    "chile",
+    "colombia",
+    "peru",
+    "uae",
+    "dubai",
+    "abu dhabi",
+    "emea",
+    "apac",
+    "latam",
+    "europe",
+)
+
 
 def _title_matches_any_role(title: str) -> bool:
     title_lower = title.lower()
@@ -43,98 +137,138 @@ def _title_matches_any_role(title: str) -> bool:
     return any(kw.lower() in title_lower for kw in all_titles)
 
 
+def _is_us_location(location: str | None) -> bool:
+    """Return True if the location looks like it's in the US (or is ambiguous).
+
+    Permissive by design: empty/None and generic 'Remote' pass through,
+    since many US companies list remote roles with no country. Rejects
+    only when a known non-US country or major city name is detected.
+    """
+    if not location:
+        return True
+    loc = location.lower()
+    return not any(hint in loc for hint in _NON_US_HINTS)
+
+
+async def _poll_one_source(
+    source: dict[str, Any], supabase: Client
+) -> dict[str, Any]:
+    """Poll a single job source. Returns a per-source summary dict."""
+    summary: dict[str, Any] = {
+        "polled": False,
+        "new": 0,
+        "updated": 0,
+        "archived": 0,
+        "error": None,
+    }
+    company_name: str = source.get("company_name", "?")
+
+    try:
+        board_token: str = source["board_token"]
+        source_id: str = source["id"]
+        provider: str = source.get("provider", "greenhouse")
+
+        fetcher = FETCHERS.get(provider)
+        if not fetcher:
+            summary["error"] = f"{company_name}: unknown provider '{provider}'"
+            return summary
+
+        jobs = await fetcher(board_token)
+        summary["polled"] = True
+
+        # Collect ALL external IDs from the API (before title/location filtering)
+        # so we don't archive jobs that exist on the board but don't match filters.
+        all_external_ids: set[str] = {job.external_id for job in jobs}
+
+        for job in jobs:
+            if not _title_matches_any_role(job.title):
+                continue
+            if not _is_us_location(job.location_name):
+                continue
+
+            score_result = score_job(job.title, job.content, keyword_config)
+
+            row: dict[str, Any] = {
+                "external_id": job.external_id,
+                "source_id": source_id,
+                "title": job.title,
+                "company_name": company_name,
+                "location": job.location_name,
+                "department": job.department,
+                "description_html": sanitize_html(job.content),
+                "absolute_url": job.absolute_url,
+                "score": score_result.score,
+                "score_breakdown": score_result.breakdown.model_dump(),
+                "greenhouse_updated_at": job.updated_at,
+            }
+
+            upsert_resp = (
+                supabase.table("job_postings")
+                .upsert(row, on_conflict="source_id,external_id")
+                .execute()
+            )
+
+            if upsert_resp.data:
+                data = cast(dict[str, Any], upsert_resp.data[0])
+                if data.get("created_at") == data.get("updated_at"):
+                    summary["new"] += 1
+                else:
+                    summary["updated"] += 1
+
+        # Archive stale jobs: postings in the DB for this source that are
+        # no longer returned by the ATS. Skip user-intent statuses.
+        existing_resp = (
+            supabase.table("job_postings")
+            .select("id, external_id")
+            .eq("source_id", source_id)
+            .not_.in_("status", ["saved", "applied", "archived"])
+            .execute()
+        )
+        now_iso = datetime.now(UTC).isoformat()
+        for existing_job in existing_resp.data or []:
+            row_data = cast(dict[str, Any], existing_job)
+            if row_data["external_id"] not in all_external_ids:
+                supabase.table("job_postings").update(
+                    {"status": "archived", "updated_at": now_iso}
+                ).eq("id", row_data["id"]).execute()
+                summary["archived"] += 1
+
+        supabase.table("job_sources").update(
+            {
+                "last_polled_at": datetime.now(UTC).isoformat(),
+                "job_count": len(jobs),
+            }
+        ).eq("id", source_id).execute()
+
+    except Exception:
+        logger.exception("Poll failed for %s", company_name)
+        summary["error"] = f"{company_name}: poll failed"
+
+    return summary
+
+
 async def poll_all_sources(supabase: Client) -> PollResult:
     sources_resp = supabase.table("job_sources").select("*").eq("enabled", True).execute()
     sources = sources_resp.data or []
 
+    semaphore = asyncio.Semaphore(POLL_CONCURRENCY)
+
+    async def _worker(raw_source: Any) -> dict[str, Any]:
+        async with semaphore:
+            return await _poll_one_source(cast(dict[str, Any], raw_source), supabase)
+
+    summaries = await asyncio.gather(*(_worker(s) for s in sources))
+
     result = PollResult(
         sources_polled=0, new_jobs=0, updated_jobs=0, archived_jobs=0, errors=[]
     )
-
-    for raw_source in sources:
-        source = cast(dict[str, Any], raw_source)
-        try:
-            board_token: str = source["board_token"]
-            company_name: str = source["company_name"]
-            source_id: str = source["id"]
-            provider: str = source.get("provider", "greenhouse")
-
-            fetcher = FETCHERS.get(provider)
-            if not fetcher:
-                result.errors.append(f"{company_name}: unknown provider '{provider}'")
-                continue
-
-            jobs = await fetcher(board_token)
+    for s in summaries:
+        if s["polled"]:
             result.sources_polled += 1
-
-            # Collect ALL external IDs from the API (before title filtering)
-            # so we don't archive jobs that exist on the board but don't match
-            # our role filter.
-            all_external_ids: set[str] = {job.external_id for job in jobs}
-
-            for job in jobs:
-                if not _title_matches_any_role(job.title):
-                    continue
-
-                score_result = score_job(job.title, job.content, keyword_config)
-
-                row: dict[str, Any] = {
-                    "external_id": job.external_id,
-                    "source_id": source_id,
-                    "title": job.title,
-                    "company_name": company_name,
-                    "location": job.location_name,
-                    "department": job.department,
-                    "description_html": sanitize_html(job.content),
-                    "absolute_url": job.absolute_url,
-                    "score": score_result.score,
-                    "score_breakdown": score_result.breakdown.model_dump(),
-                    "greenhouse_updated_at": job.updated_at,
-                }
-
-                upsert_resp = (
-                    supabase.table("job_postings")
-                    .upsert(row, on_conflict="source_id,external_id")
-                    .execute()
-                )
-
-                if upsert_resp.data:
-                    data = cast(dict[str, Any], upsert_resp.data[0])
-                    if data.get("created_at") == data.get("updated_at"):
-                        result.new_jobs += 1
-                    else:
-                        result.updated_jobs += 1
-
-            # Archive stale jobs: postings in the DB for this source that are
-            # no longer returned by the ATS. Skip user-intent statuses.
-            existing_resp = (
-                supabase.table("job_postings")
-                .select("id, external_id")
-                .eq("source_id", source_id)
-                .not_.in_("status", ["saved", "applied", "archived"])
-                .execute()
-            )
-            now_iso = datetime.now(UTC).isoformat()
-            for existing_job in existing_resp.data or []:
-                row_data = cast(dict[str, Any], existing_job)
-                if row_data["external_id"] not in all_external_ids:
-                    supabase.table("job_postings").update(
-                        {"status": "archived", "updated_at": now_iso}
-                    ).eq("id", row_data["id"]).execute()
-                    result.archived_jobs += 1
-
-            supabase.table("job_sources").update(
-                {
-                    "last_polled_at": datetime.now(UTC).isoformat(),
-                    "job_count": len(jobs),
-                }
-            ).eq("id", source_id).execute()
-
-            await asyncio.sleep(settings.greenhouse_delay_ms / 1000)
-
-        except Exception:
-            company = source.get("company_name", "?")
-            logger.exception("Poll failed for %s", company)
-            result.errors.append(f"{company}: poll failed")
+        result.new_jobs += s["new"]
+        result.updated_jobs += s["updated"]
+        result.archived_jobs += s["archived"]
+        if s["error"]:
+            result.errors.append(s["error"])
 
     return result

--- a/apps/job-api/tests/test_poller.py
+++ b/apps/job-api/tests/test_poller.py
@@ -1,4 +1,4 @@
-from app.services.poller import _title_matches_any_role
+from app.services.poller import _is_us_location, _title_matches_any_role
 
 
 def test_title_matches_senior_frontend_engineer():
@@ -9,7 +9,53 @@ def test_title_does_not_match_marketing():
     assert _title_matches_any_role("Marketing Specialist") is False
 
 
+class TestIsUsLocation:
+    def test_none_is_allowed(self):
+        assert _is_us_location(None) is True
+
+    def test_empty_string_is_allowed(self):
+        assert _is_us_location("") is True
+
+    def test_remote_is_allowed(self):
+        assert _is_us_location("Remote") is True
+
+    def test_us_city_state_is_allowed(self):
+        assert _is_us_location("San Francisco, CA") is True
+        assert _is_us_location("New York, NY") is True
+        assert _is_us_location("Austin, TX") is True
+
+    def test_us_remote_is_allowed(self):
+        assert _is_us_location("Remote - US") is True
+        assert _is_us_location("US (Remote)") is True
+
+    def test_uk_rejected(self):
+        assert _is_us_location("London, United Kingdom") is False
+
+    def test_germany_rejected(self):
+        assert _is_us_location("Berlin, Germany") is False
+
+    def test_canada_rejected(self):
+        assert _is_us_location("Toronto, Canada") is False
+        assert _is_us_location("Vancouver, BC") is False
+
+    def test_india_rejected(self):
+        assert _is_us_location("Bangalore, India") is False
+
+    def test_emea_rejected(self):
+        assert _is_us_location("Remote - EMEA") is False
+
+    def test_europe_rejected(self):
+        assert _is_us_location("Europe") is False
+
+    def test_apac_rejected(self):
+        assert _is_us_location("APAC") is False
+
+    def test_case_insensitive(self):
+        assert _is_us_location("BERLIN, GERMANY") is False
+        assert _is_us_location("berlin") is False
+
+
 # TODO: An integration test for `poll_all_sources` would require mocking the full
 # Supabase client chain (.table().select().eq().execute(), .upsert(...), .update(...))
-# plus `fetch_board_jobs`. The non-trivial chain is skipped here — scoring, sanitize,
-# and greenhouse are each covered individually and compose via simple sequential calls.
+# plus all fetchers. The non-trivial chain is skipped here — scoring, sanitize,
+# location/title filters, and each fetcher are covered individually.


### PR DESCRIPTION
## Summary

Two improvements to the job poller:

### Concurrent polling
- `poll_all_sources` now runs sources concurrently via `asyncio.gather` with a semaphore (`POLL_CONCURRENCY=10`).
- Extracted per-source logic into `_poll_one_source` for clarity and testability.
- Full poll of 49 sources drops from ~60-90s to ~5-10s, comfortably under Vercel's 60s function timeout.
- Dropped the `greenhouse_delay_ms` inter-source sleep — irrelevant under a semaphore-limited concurrent run.

### US-only location filter
- New `_is_us_location` helper rejects jobs whose `location_name` contains a known non-US country or major city name.
- Permissive by design: empty, `None`, and generic `Remote` locations pass through (many US companies list remote roles without a country).
- Filter applied in the per-source loop alongside `_title_matches_any_role`, before upsert.
- Stale-detection still uses pre-filter `all_external_ids` so non-US jobs aren't treated as archived.

## Test plan

- [x] 13 new unit tests for `_is_us_location` (US cities, remote, UK, Germany, Canada, India, EMEA, APAC, Europe, case-insensitivity)
- [x] `uv run pytest` — 129 tests pass
- [x] `uv run ruff check .` — clean
- [x] `pnpm tsc --noEmit` — zero type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)