### PR TITLE
perf(jobs): batch Supabase writes in poller, seed, and delete

### DIFF
--- a/apps/job-api/app/routers/jobs.py
+++ b/apps/job-api/app/routers/jobs.py
@@ -61,16 +61,13 @@ async def delete_job(
     posting_id: str,
     supabase: Client = Depends(get_supabase),
 ) -> dict[str, Any]:
-    current = (
+    resp = (
         supabase.table("job_postings")
-        .select("id")
+        .delete()
         .eq("id", posting_id)
-        .single()
         .execute()
     )
-    if not current.data:
+    if not resp.data:
         raise HTTPException(status_code=404, detail="Posting not found")
-
-    supabase.table("job_postings").delete().eq("id", posting_id).execute()
 
     return {"success": True, "deleted_id": posting_id}

--- a/apps/job-api/app/routers/sources.py
+++ b/apps/job-api/app/routers/sources.py
@@ -106,8 +106,7 @@ async def detect_provider(
 
 @router.post("/seed")
 async def seed_sources(supabase: Client = Depends(get_supabase)) -> dict[str, Any]:
-    inserted = 0
-    for company in COMPANY_SEED:
-        supabase.table("job_sources").upsert(company, on_conflict="board_token").execute()
-        inserted += 1
-    return {"success": True, "seeded": inserted}
+    supabase.table("job_sources").upsert(
+        list(COMPANY_SEED), on_conflict="board_token"
+    ).execute()
+    return {"success": True, "seeded": len(COMPANY_SEED)}

--- a/apps/job-api/app/services/poller.py
+++ b/apps/job-api/app/services/poller.py
@@ -180,6 +180,7 @@ async def _poll_one_source(
         # so we don't archive jobs that exist on the board but don't match filters.
         all_external_ids: set[str] = {job.external_id for job in jobs}
 
+        rows_to_upsert: list[dict[str, Any]] = []
         for job in jobs:
             if not _title_matches_any_role(job.title):
                 continue
@@ -188,28 +189,30 @@ async def _poll_one_source(
 
             score_result = score_job(job.title, job.content, keyword_config)
 
-            row: dict[str, Any] = {
-                "external_id": job.external_id,
-                "source_id": source_id,
-                "title": job.title,
-                "company_name": company_name,
-                "location": job.location_name,
-                "department": job.department,
-                "description_html": sanitize_html(job.content),
-                "absolute_url": job.absolute_url,
-                "score": score_result.score,
-                "score_breakdown": score_result.breakdown.model_dump(),
-                "greenhouse_updated_at": job.updated_at,
-            }
-
-            upsert_resp = (
-                supabase.table("job_postings")
-                .upsert(row, on_conflict="source_id,external_id")
-                .execute()
+            rows_to_upsert.append(
+                {
+                    "external_id": job.external_id,
+                    "source_id": source_id,
+                    "title": job.title,
+                    "company_name": company_name,
+                    "location": job.location_name,
+                    "department": job.department,
+                    "description_html": sanitize_html(job.content),
+                    "absolute_url": job.absolute_url,
+                    "score": score_result.score,
+                    "score_breakdown": score_result.breakdown.model_dump(),
+                    "greenhouse_updated_at": job.updated_at,
+                }
             )
 
-            if upsert_resp.data:
-                data = cast(dict[str, Any], upsert_resp.data[0])
+        if rows_to_upsert:
+            upsert_resp = (
+                supabase.table("job_postings")
+                .upsert(rows_to_upsert, on_conflict="source_id,external_id")
+                .execute()
+            )
+            for raw_row in upsert_resp.data or []:
+                data = cast(dict[str, Any], raw_row)
                 if data.get("created_at") == data.get("updated_at"):
                     summary["new"] += 1
                 else:
@@ -224,14 +227,17 @@ async def _poll_one_source(
             .not_.in_("status", ["saved", "applied", "archived"])
             .execute()
         )
-        now_iso = datetime.now(UTC).isoformat()
+        stale_ids: list[str] = []
         for existing_job in existing_resp.data or []:
             row_data = cast(dict[str, Any], existing_job)
             if row_data["external_id"] not in all_external_ids:
-                supabase.table("job_postings").update(
-                    {"status": "archived", "updated_at": now_iso}
-                ).eq("id", row_data["id"]).execute()
-                summary["archived"] += 1
+                stale_ids.append(row_data["id"])
+
+        if stale_ids:
+            supabase.table("job_postings").update(
+                {"status": "archived", "updated_at": datetime.now(UTC).isoformat()}
+            ).in_("id", stale_ids).execute()
+            summary["archived"] = len(stale_ids)
 
         supabase.table("job_sources").update(
             {

--- a/apps/job-api/tests/test_routers_sources.py
+++ b/apps/job-api/tests/test_routers_sources.py
@@ -86,7 +86,10 @@ def test_sources_seed_inserts_all(client_factory):
     body = r.json()
     assert body["success"] is True
     assert body["seeded"] == len(COMPANY_SEED)
-    assert sb.table.return_value.upsert.call_count == len(COMPANY_SEED)
+    assert sb.table.return_value.upsert.call_count == 1
+    call_args, call_kwargs = sb.table.return_value.upsert.call_args
+    assert len(call_args[0]) == len(COMPANY_SEED)
+    assert call_kwargs["on_conflict"] == "board_token"
 
 
 # --- GET /sources/verify ---

--- a/apps/job-api/tests/test_routers_status.py
+++ b/apps/job-api/tests/test_routers_status.py
@@ -21,7 +21,9 @@ def _build_supabase(posting_data: dict[str, Any] | None) -> MagicMock:
     # insert, update, and delete are chain-called; default MagicMock return is fine
     sb.table.return_value.insert.return_value.execute.return_value = _Resp(None)
     sb.table.return_value.update.return_value.eq.return_value.execute.return_value = _Resp(None)
-    sb.table.return_value.delete.return_value.eq.return_value.execute.return_value = _Resp(None)
+    delete_data = [posting_data] if posting_data else None
+    delete_chain = sb.table.return_value.delete.return_value.eq.return_value
+    delete_chain.execute.return_value = _Resp(delete_data)
     return sb
 
 


### PR DESCRIPTION
## Summary

Quick optimization audit of the `job-api` app surfaced three N+1 write patterns against Supabase. This PR collapses each into a single batched call.

- **`poller._poll_one_source`** — per-source polling now issues **one bulk upsert** of filtered jobs and **one `.in_()` archive update** instead of one round trip per job. For a source returning 300 jobs this drops ~300+ round trips to 2.
- **`sources.seed_sources`** — replaces the per-company upsert loop with a single bulk upsert of the whole `COMPANY_SEED` list (still uses `on_conflict="board_token"`).
- **`jobs.delete_job`** — drops the pre-SELECT round trip; the 404 check now reads `resp.data` from the delete itself.

Context: the scan endpoint was hanging ~48s even after the concurrent-poll + US filter change. `supabase-py` is sync under the hood, so `asyncio.gather` doesn't help — the real bottleneck was the ~760 sequential round trips per scan.

## Test plan

- [x] `uv run pytest` — 129 passed
- [x] `uv run ruff check .` — clean
- [ ] Manual: trigger a scan from `/tools/admin/jobs`, confirm runtime drops and row counts are unchanged
- [ ] Manual: delete a posting, confirm 200 and row disappears
- [ ] Manual: reseed sources, confirm count matches `COMPANY_SEED`

🤖 Generated with [Claude Code](https://claude.com/claude-code)