### PR TITLE
feat(audit-api): port /run-scan endpoint from Node service

### DIFF
--- a/apps/audit-api/Dockerfile
+++ b/apps/audit-api/Dockerfile
@@ -1,7 +1,27 @@
-FROM ghcr.io/astral-sh/uv:python3.11-bookworm-slim
+FROM ghcr.io/astral-sh/uv:python3.11-bookworm-slim AS base
 
 RUN groupadd --system --gid 1001 app \
     && useradd --system --uid 1001 --gid app --home-dir /app --shell /sbin/nologin app
+
+# System deps: Chromium (for Lighthouse + Playwright), Node (for Lighthouse CLI).
+# The Lighthouse CLI bundles puppeteer which expects Chrome/Chromium.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        chromium \
+        fonts-liberation \
+        curl \
+        gnupg \
+    && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Lighthouse CLI + axe-core globally
+RUN npm install -g lighthouse@12 \
+    && mkdir -p /app/vendor \
+    && npm pack axe-core@4 --pack-destination=/tmp \
+    && tar -xzf /tmp/axe-core-*.tgz -C /tmp \
+    && cp /tmp/package/axe.min.js /app/vendor/axe.min.js \
+    && rm -rf /tmp/package /tmp/axe-core-*.tgz
 
 WORKDIR /app
 
@@ -11,6 +31,10 @@ COPY apps/audit-api/pyproject.toml ./apps/audit-api/pyproject.toml
 
 RUN uv sync --frozen --no-dev --no-editable --package audit-api
 
+# Playwright Chromium install (used for axe injection + screenshots)
+ENV PLAYWRIGHT_BROWSERS_PATH=/app/.playwright
+RUN /app/.venv/bin/python -m playwright install chromium --with-deps
+
 COPY apps/audit-api/app ./apps/audit-api/app
 
 RUN chown -R app:app /app
@@ -19,7 +43,9 @@ USER app
 
 WORKDIR /app/apps/audit-api
 
-ENV PATH="/app/.venv/bin:$PATH"
+ENV PATH="/app/.venv/bin:$PATH" \
+    LIGHTHOUSE_BIN=lighthouse \
+    AXE_SCRIPT_PATH=/app/vendor/axe.min.js
 
 EXPOSE 8001
 

--- a/apps/audit-api/Dockerfile
+++ b/apps/audit-api/Dockerfile
@@ -11,14 +11,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         fonts-liberation \
         curl \
         gnupg \
-    && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+    && curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
     && apt-get install -y --no-install-recommends nodejs \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Lighthouse CLI + axe-core globally
-RUN npm install -g lighthouse@12 \
+RUN npm install -g lighthouse@12.8.0 \
     && mkdir -p /app/vendor \
-    && npm pack axe-core@4 --pack-destination=/tmp \
+    && npm pack axe-core@4.11.3 --pack-destination=/tmp \
     && tar -xzf /tmp/axe-core-*.tgz -C /tmp \
     && cp /tmp/package/axe.min.js /app/vendor/axe.min.js \
     && rm -rf /tmp/package /tmp/axe-core-*.tgz

--- a/apps/audit-api/app/main.py
+++ b/apps/audit-api/app/main.py
@@ -1,3 +1,6 @@
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+
 from fastapi import FastAPI
 from starlette.middleware.trustedhost import TrustedHostMiddleware
 
@@ -12,10 +15,22 @@ if not settings.allowed_hosts_list:
         "Use '*' only in local dev."
     )
 
+
+@asynccontextmanager
+async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
+    queue = get_queue()
+    queue.start()
+    try:
+        yield
+    finally:
+        await queue.stop()
+
+
 app = FastAPI(
     title="Audit Scan API",
     description="Runs Lighthouse + axe scans, grades results, serves reports",
     version="0.1.0",
+    lifespan=lifespan,
 )
 
 app.add_middleware(

--- a/apps/audit-api/app/main.py
+++ b/apps/audit-api/app/main.py
@@ -2,6 +2,9 @@ from fastapi import FastAPI
 from starlette.middleware.trustedhost import TrustedHostMiddleware
 
 from app.config import settings
+from app.routers import run_scan as run_scan_router
+from app.schemas import HealthResponse
+from app.services.scan_queue import get_queue
 
 if not settings.allowed_hosts_list:
     raise RuntimeError(
@@ -21,6 +24,10 @@ app.add_middleware(
 )
 
 
-@app.get("/health")
-async def health() -> dict[str, str]:
-    return {"status": "ok"}
+@app.get("/health", response_model=HealthResponse)
+async def health() -> HealthResponse:
+    queue = get_queue()
+    return HealthResponse(status="ok", queue=queue.size, running=queue.running)
+
+
+app.include_router(run_scan_router.router)

--- a/apps/audit-api/app/routers/run_scan.py
+++ b/apps/audit-api/app/routers/run_scan.py
@@ -1,0 +1,19 @@
+from fastapi import APIRouter, Depends
+
+from app.dependencies import verify_api_key
+from app.schemas import RunScanRequest, RunScanResponse
+from app.services.scan_queue import ScanJob, ScanQueue, get_queue
+
+router = APIRouter()
+
+
+@router.post("/run-scan", response_model=RunScanResponse)
+async def run_scan_endpoint(
+    body: RunScanRequest,
+    _: str = Depends(verify_api_key),
+    queue: ScanQueue = Depends(get_queue),
+) -> RunScanResponse:
+    await queue.enqueue(
+        ScanJob(scan_id=body.scan_id, url=body.url, device=body.device_mode)
+    )
+    return RunScanResponse(status="accepted", scan_id=body.scan_id)

--- a/apps/audit-api/app/schemas.py
+++ b/apps/audit-api/app/schemas.py
@@ -1,0 +1,20 @@
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+class RunScanRequest(BaseModel):
+    scan_id: str = Field(min_length=1)
+    url: str = Field(min_length=1)
+    device_mode: Literal["mobile", "desktop"] = "mobile"
+
+
+class RunScanResponse(BaseModel):
+    status: Literal["accepted"] = "accepted"
+    scan_id: str
+
+
+class HealthResponse(BaseModel):
+    status: Literal["ok"] = "ok"
+    queue: int
+    running: bool

--- a/apps/audit-api/app/schemas.py
+++ b/apps/audit-api/app/schemas.py
@@ -1,12 +1,47 @@
+from ipaddress import ip_address
 from typing import Literal
+from urllib.parse import urlparse
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
+
+_BLOCKED_HOSTNAMES = {
+    "localhost",
+    "metadata.google.internal",
+    "metadata.goog",
+}
 
 
 class RunScanRequest(BaseModel):
     scan_id: str = Field(min_length=1)
-    url: str = Field(min_length=1)
+    url: str = Field(min_length=1, max_length=2048)
     device_mode: Literal["mobile", "desktop"] = "mobile"
+
+    @field_validator("url")
+    @classmethod
+    def _validate_url(cls, value: str) -> str:
+        parsed = urlparse(value)
+        if parsed.scheme not in ("http", "https"):
+            raise ValueError("url must use http or https scheme")
+        host = (parsed.hostname or "").lower()
+        if not host:
+            raise ValueError("url must include a hostname")
+        if host in _BLOCKED_HOSTNAMES:
+            raise ValueError("url host is not allowed")
+        try:
+            ip = ip_address(host)
+        except ValueError:
+            pass
+        else:
+            if (
+                ip.is_private
+                or ip.is_loopback
+                or ip.is_link_local
+                or ip.is_reserved
+                or ip.is_multicast
+                or ip.is_unspecified
+            ):
+                raise ValueError("url host is not allowed")
+        return value
 
 
 class RunScanResponse(BaseModel):

--- a/apps/audit-api/app/services/grading.py
+++ b/apps/audit-api/app/services/grading.py
@@ -1,0 +1,37 @@
+from dataclasses import dataclass
+from typing import Literal
+
+Grade = Literal["A", "B", "C", "D", "F"]
+
+
+@dataclass(frozen=True)
+class CategoryScores:
+    performance: int
+    accessibility: int
+    seo: int
+    best_practices: int
+
+
+@dataclass(frozen=True)
+class GradeResult:
+    grade: Grade
+    label: str
+    color: str
+
+
+def calculate_grade(scores: CategoryScores) -> GradeResult:
+    weighted = (
+        scores.performance * 0.4
+        + scores.accessibility * 0.25
+        + scores.seo * 0.2
+        + scores.best_practices * 0.15
+    )
+    if weighted >= 90:
+        return GradeResult(grade="A", label="Excellent", color="#63CAA5")
+    if weighted >= 75:
+        return GradeResult(grade="B", label="Good", color="#8C8FFF")
+    if weighted >= 60:
+        return GradeResult(grade="C", label="Needs Work", color="#FFB46B")
+    if weighted >= 40:
+        return GradeResult(grade="D", label="Poor", color="#FF8CA0")
+    return GradeResult(grade="F", label="Critical", color="#FF6B6B")

--- a/apps/audit-api/app/services/issue_mappings.py
+++ b/apps/audit-api/app/services/issue_mappings.py
@@ -1,0 +1,318 @@
+from dataclasses import dataclass
+from typing import Literal
+
+Category = Literal["performance", "accessibility", "seo", "ux"]
+Severity = Literal["critical", "warning", "info"]
+FixDifficulty = Literal["easy", "moderate", "complex"]
+
+
+@dataclass(frozen=True)
+class IssueMapping:
+    title: str
+    description_template: str
+    impact_template: str
+    category: Category
+    fix_difficulty: FixDifficulty
+    severity: Severity
+
+
+LIGHTHOUSE_ISSUE_MAPPINGS: dict[str, IssueMapping] = {
+    "largest-contentful-paint": IssueMapping(
+        title="Main content takes too long to appear",
+        description_template=(
+            "Your page's primary content takes {value} to load. Users expect to see "
+            "meaningful content within 2.5 seconds on mobile."
+        ),
+        impact_template=(
+            "Pages with LCP over 4 seconds lose up to 25% of visitors before they see "
+            "your content."
+        ),
+        category="performance",
+        fix_difficulty="moderate",
+        severity="critical",
+    ),
+    "first-contentful-paint": IssueMapping(
+        title="Page is slow to show anything",
+        description_template=(
+            "It takes {value} before any content appears on screen. On slower mobile "
+            "connections, this feels even longer."
+        ),
+        impact_template=(
+            "Every second of delay in first paint increases bounce probability by 32%."
+        ),
+        category="performance",
+        fix_difficulty="moderate",
+        severity="critical",
+    ),
+    "total-blocking-time": IssueMapping(
+        title="Page freezes during load",
+        description_template=(
+            "Your page is unresponsive for {value} while loading. Users can't click, "
+            "scroll, or interact during this time."
+        ),
+        impact_template=(
+            "High blocking time makes your site feel broken, especially on mobile "
+            "devices."
+        ),
+        category="performance",
+        fix_difficulty="complex",
+        severity="critical",
+    ),
+    "cumulative-layout-shift": IssueMapping(
+        title="Content shifts around while loading",
+        description_template=(
+            "Elements on your page move unexpectedly as it loads (shift score: "
+            "{value}). Users may click the wrong thing or lose their place."
+        ),
+        impact_template=(
+            "Layout shifts frustrate users and directly hurt your Google search "
+            "ranking."
+        ),
+        category="performance",
+        fix_difficulty="easy",
+        severity="warning",
+    ),
+    "speed-index": IssueMapping(
+        title="Page feels slow to visually complete",
+        description_template=(
+            "Your page takes {value} to visually fill the screen. Content loads in "
+            "chunks rather than appearing smoothly."
+        ),
+        impact_template=(
+            "A slow speed index makes your site feel sluggish compared to competitors."
+        ),
+        category="performance",
+        fix_difficulty="moderate",
+        severity="warning",
+    ),
+    "render-blocking-resources": IssueMapping(
+        title="Files are blocking your page from loading",
+        description_template=(
+            "{value} resources are preventing your page from rendering. The browser "
+            "must download these before showing anything."
+        ),
+        impact_template=(
+            "Removing render-blocking resources can shave 1-3 seconds off perceived "
+            "load time."
+        ),
+        category="performance",
+        fix_difficulty="moderate",
+        severity="warning",
+    ),
+    "uses-optimized-images": IssueMapping(
+        title="Images aren't compressed",
+        description_template=(
+            "Your images could be {value} smaller without visible quality loss. "
+            "Uncompressed images are the #1 cause of slow pages."
+        ),
+        impact_template=(
+            "Compressed images typically reduce page weight by 30-50%, directly "
+            "improving load time."
+        ),
+        category="performance",
+        fix_difficulty="easy",
+        severity="warning",
+    ),
+    "uses-responsive-images": IssueMapping(
+        title="Mobile users are downloading desktop-sized images",
+        description_template=(
+            "{value} could serve appropriately-sized versions for each device. Phone "
+            "users are downloading images meant for large screens."
+        ),
+        impact_template=(
+            "Responsive images can reduce mobile data usage by 50%+ and speed up page "
+            "loads significantly."
+        ),
+        category="performance",
+        fix_difficulty="easy",
+        severity="warning",
+    ),
+    "offscreen-images": IssueMapping(
+        title="Images load before users scroll to them",
+        description_template=(
+            "{value} below the fold load immediately instead of waiting until the user "
+            "scrolls down. This wastes bandwidth and slows the initial page."
+        ),
+        impact_template=(
+            "Lazy-loading offscreen images can reduce initial page weight by 30-60%."
+        ),
+        category="performance",
+        fix_difficulty="easy",
+        severity="warning",
+    ),
+    "uses-text-compression": IssueMapping(
+        title="Text content isn't compressed",
+        description_template=(
+            "Your server isn't compressing text-based files. Enabling compression "
+            "could save {value} of transfer size."
+        ),
+        impact_template=(
+            "Text compression (gzip/brotli) typically reduces file sizes by 60-80% "
+            "with minimal server effort."
+        ),
+        category="performance",
+        fix_difficulty="easy",
+        severity="warning",
+    ),
+    "unminified-css": IssueMapping(
+        title="CSS files contain unnecessary whitespace",
+        description_template=(
+            "Your CSS files could be {value} smaller by removing comments and "
+            "whitespace. This is free performance."
+        ),
+        impact_template=(
+            "Minified CSS loads faster and costs nothing in development effort."
+        ),
+        category="performance",
+        fix_difficulty="easy",
+        severity="info",
+    ),
+    "unminified-javascript": IssueMapping(
+        title="JavaScript files aren't minified",
+        description_template=(
+            "Your JavaScript could be {value} smaller. Unminified code contains "
+            "developer comments and formatting that users don't need."
+        ),
+        impact_template=(
+            "Minified JavaScript loads and parses faster, improving time-to-interactive."
+        ),
+        category="performance",
+        fix_difficulty="easy",
+        severity="info",
+    ),
+    "color-contrast": IssueMapping(
+        title="Some text is hard to read",
+        description_template=(
+            "{value} text elements don't have enough contrast against their "
+            "background. This affects readability for all users, especially those with "
+            "visual impairments."
+        ),
+        impact_template=(
+            "Low contrast makes your site unusable for ~15% of the population and "
+            "violates accessibility standards."
+        ),
+        category="accessibility",
+        fix_difficulty="easy",
+        severity="critical",
+    ),
+    "image-alt": IssueMapping(
+        title="Images are missing descriptions",
+        description_template=(
+            "{value} images don't have alt text. Screen readers can't describe these "
+            "to visually impaired users, and search engines can't understand them."
+        ),
+        impact_template=(
+            "Missing alt text hurts both accessibility compliance and your SEO ranking."
+        ),
+        category="accessibility",
+        fix_difficulty="easy",
+        severity="critical",
+    ),
+    "label": IssueMapping(
+        title="Form fields are missing labels",
+        description_template=(
+            "{value} form inputs don't have associated labels. Users relying on screen "
+            "readers can't tell what information is being requested."
+        ),
+        impact_template=(
+            "Unlabeled forms are unusable for screen reader users and can confuse all "
+            "users."
+        ),
+        category="accessibility",
+        fix_difficulty="easy",
+        severity="critical",
+    ),
+    "heading-order": IssueMapping(
+        title="Heading levels are out of order",
+        description_template=(
+            "Your page skips heading levels (e.g., jumping from H1 to H3). This breaks "
+            "the logical outline that screen readers use to navigate."
+        ),
+        impact_template=(
+            "Proper heading hierarchy helps both accessibility and SEO content "
+            "structure."
+        ),
+        category="accessibility",
+        fix_difficulty="easy",
+        severity="warning",
+    ),
+    "link-name": IssueMapping(
+        title="Links don't describe where they go",
+        description_template=(
+            '{value} links lack descriptive text. "Click here" or empty links are '
+            "meaningless to screen reader users."
+        ),
+        impact_template=(
+            "Descriptive link text improves navigation for all users and helps SEO."
+        ),
+        category="accessibility",
+        fix_difficulty="easy",
+        severity="warning",
+    ),
+    "document-title": IssueMapping(
+        title="Page is missing a title",
+        description_template=(
+            "Your page doesn't have a <title> tag. This is what appears in browser "
+            "tabs, search results, and social shares."
+        ),
+        impact_template=(
+            "Missing titles significantly hurt SEO ranking and click-through rates "
+            "from search results."
+        ),
+        category="seo",
+        fix_difficulty="easy",
+        severity="critical",
+    ),
+    "meta-description": IssueMapping(
+        title="Page is missing a meta description",
+        description_template=(
+            "Your page doesn't have a meta description. Search engines display this as "
+            "the snippet below your page title in results."
+        ),
+        impact_template=(
+            "Pages with good meta descriptions get up to 5.8% higher click-through "
+            "rates from search."
+        ),
+        category="seo",
+        fix_difficulty="easy",
+        severity="warning",
+    ),
+    "viewport": IssueMapping(
+        title="Page isn't configured for mobile",
+        description_template=(
+            "Your page is missing a viewport meta tag. Mobile devices will render it "
+            "at desktop width, making it tiny and unusable."
+        ),
+        impact_template=(
+            "Without a viewport tag, your site is effectively broken on mobile — "
+            "where 60%+ of web traffic comes from."
+        ),
+        category="ux",
+        fix_difficulty="easy",
+        severity="critical",
+    ),
+    "http-status-code": IssueMapping(
+        title="Page returns an error",
+        description_template=(
+            "Your page returned an unsuccessful HTTP status code. Search engines may "
+            "not index this page."
+        ),
+        impact_template=(
+            "Error status codes prevent search engines from indexing your content."
+        ),
+        category="seo",
+        fix_difficulty="moderate",
+        severity="critical",
+    ),
+    "is-crawlable": IssueMapping(
+        title="Search engines can't find this page",
+        description_template=(
+            "Your page is blocked from search engine crawling. This means it won't "
+            "appear in Google or other search results."
+        ),
+        impact_template="A blocked page is invisible to organic search traffic.",
+        category="seo",
+        fix_difficulty="easy",
+        severity="critical",
+    ),
+}

--- a/apps/audit-api/app/services/issues.py
+++ b/apps/audit-api/app/services/issues.py
@@ -1,0 +1,116 @@
+from dataclasses import dataclass
+from typing import Any
+
+from app.services.issue_mappings import (
+    LIGHTHOUSE_ISSUE_MAPPINGS,
+    Category,
+    FixDifficulty,
+    Severity,
+)
+
+_SEVERITY_ORDER: dict[Severity, int] = {"critical": 0, "warning": 1, "info": 2}
+_CATEGORY_ORDER: dict[Category, int] = {
+    "performance": 0,
+    "accessibility": 1,
+    "seo": 2,
+    "ux": 3,
+}
+
+
+@dataclass(frozen=True)
+class ParsedIssue:
+    category: Category
+    severity: Severity
+    title: str
+    description: str
+    impact: str
+    fix_difficulty: FixDifficulty
+    technical_detail: dict[str, Any]
+
+
+def parse_issues(
+    lighthouse_result: dict[str, Any], axe_result: dict[str, Any]
+) -> list[ParsedIssue]:
+    issues: list[ParsedIssue] = []
+
+    audits = lighthouse_result.get("audits") or {}
+    for audit_id, mapping in LIGHTHOUSE_ISSUE_MAPPINGS.items():
+        audit = audits.get(audit_id)
+        if not audit:
+            continue
+
+        score = audit.get("score")
+        if score is None or score >= 0.9:
+            continue
+
+        display_value = audit.get("displayValue") or ""
+        numeric_value = audit.get("numericValue") or 0
+
+        description = mapping.description_template.replace("{value}", str(display_value))
+
+        issues.append(
+            ParsedIssue(
+                category=mapping.category,
+                severity=mapping.severity,
+                title=mapping.title,
+                description=description,
+                impact=mapping.impact_template,
+                fix_difficulty=mapping.fix_difficulty,
+                technical_detail={
+                    "auditId": audit_id,
+                    "score": score,
+                    "displayValue": display_value,
+                    "numericValue": numeric_value,
+                },
+            )
+        )
+
+    violations = axe_result.get("violations") or []
+    for violation in violations:
+        violation_id = violation.get("id", "")
+        spaced = violation_id.replace("-", " ").lower()
+        already_captured = any(spaced in i.title.lower() for i in issues)
+        if already_captured:
+            continue
+
+        nodes = violation.get("nodes") or []
+        node_count = len(nodes)
+        impact = violation.get("impact", "")
+
+        if impact in ("critical", "serious"):
+            severity: Severity = "critical"
+        elif impact == "moderate":
+            severity = "warning"
+        else:
+            severity = "info"
+
+        plural = "s" if node_count != 1 else ""
+        description = (
+            f"{violation.get('description', '')}. "
+            f"Found {node_count} instance{plural} on this page."
+        )
+
+        issues.append(
+            ParsedIssue(
+                category="accessibility",
+                severity=severity,
+                title=violation.get("help") or violation_id,
+                description=description,
+                impact=(
+                    "Fixing this improves usability for people using assistive "
+                    "technology and may improve your search ranking."
+                ),
+                fix_difficulty="easy",
+                technical_detail={
+                    "axeRuleId": violation_id,
+                    "impact": impact,
+                    "nodeCount": node_count,
+                    "helpUrl": violation.get("helpUrl", ""),
+                },
+            )
+        )
+
+    issues.sort(
+        key=lambda i: (_SEVERITY_ORDER[i.severity], _CATEGORY_ORDER[i.category])
+    )
+    return issues

--- a/apps/audit-api/app/services/lighthouse_config.py
+++ b/apps/audit-api/app/services/lighthouse_config.py
@@ -5,6 +5,10 @@ DeviceMode = Literal["mobile", "desktop"]
 
 LIGHTHOUSE_CATEGORIES = ["performance", "accessibility", "best-practices", "seo"]
 
+# Chromium sandbox is disabled because the service renders untrusted URLs
+# from inside an unprivileged container; the container itself is the sandbox
+# (non-root uid, no host mounts). Do not relax container isolation without
+# re-enabling --sandbox or introducing an out-of-process browser jail.
 CHROME_FLAGS = [
     "--headless=new",
     "--disable-gpu",

--- a/apps/audit-api/app/services/lighthouse_config.py
+++ b/apps/audit-api/app/services/lighthouse_config.py
@@ -1,0 +1,98 @@
+from dataclasses import dataclass
+from typing import Literal
+
+DeviceMode = Literal["mobile", "desktop"]
+
+LIGHTHOUSE_CATEGORIES = ["performance", "accessibility", "best-practices", "seo"]
+
+CHROME_FLAGS = [
+    "--headless=new",
+    "--disable-gpu",
+    "--no-sandbox",
+    "--disable-dev-shm-usage",
+    "--disable-extensions",
+    "--disable-background-networking",
+    "--disable-crash-reporter",
+    "--disable-breakpad",
+    "--disable-software-rasterizer",
+    "--single-process",
+    "--no-zygote",
+]
+
+
+@dataclass(frozen=True)
+class ScreenEmulation:
+    mobile: bool
+    width: int
+    height: int
+    device_scale_factor: float
+
+
+@dataclass(frozen=True)
+class Throttling:
+    cpu_slowdown_multiplier: int
+    download_throughput_kbps: int
+    upload_throughput_kbps: int
+    rtt_ms: int
+
+
+@dataclass(frozen=True)
+class LighthouseConfig:
+    form_factor: DeviceMode
+    throttling: Throttling
+    screen_emulation: ScreenEmulation
+
+
+MOBILE_CONFIG = LighthouseConfig(
+    form_factor="mobile",
+    throttling=Throttling(
+        cpu_slowdown_multiplier=1,
+        download_throughput_kbps=1600,
+        upload_throughput_kbps=750,
+        rtt_ms=150,
+    ),
+    screen_emulation=ScreenEmulation(
+        mobile=True, width=375, height=812, device_scale_factor=3
+    ),
+)
+
+DESKTOP_CONFIG = LighthouseConfig(
+    form_factor="desktop",
+    throttling=Throttling(
+        cpu_slowdown_multiplier=1,
+        download_throughput_kbps=10240,
+        upload_throughput_kbps=10240,
+        rtt_ms=40,
+    ),
+    screen_emulation=ScreenEmulation(
+        mobile=False, width=1350, height=940, device_scale_factor=1
+    ),
+)
+
+
+def config_for(device: DeviceMode) -> LighthouseConfig:
+    return DESKTOP_CONFIG if device == "desktop" else MOBILE_CONFIG
+
+
+def build_cli_args(url: str, device: DeviceMode, output_path: str) -> list[str]:
+    cfg = config_for(device)
+    chrome_flags = " ".join(CHROME_FLAGS)
+    return [
+        "lighthouse",
+        url,
+        f"--output-path={output_path}",
+        "--output=json",
+        "--quiet",
+        "--only-categories=" + ",".join(LIGHTHOUSE_CATEGORIES),
+        f"--form-factor={cfg.form_factor}",
+        "--throttling-method=simulate",
+        f"--throttling.cpuSlowdownMultiplier={cfg.throttling.cpu_slowdown_multiplier}",
+        f"--throttling.downloadThroughputKbps={cfg.throttling.download_throughput_kbps}",
+        f"--throttling.uploadThroughputKbps={cfg.throttling.upload_throughput_kbps}",
+        f"--throttling.rttMs={cfg.throttling.rtt_ms}",
+        f"--screen-emulation.mobile={'true' if cfg.screen_emulation.mobile else 'false'}",
+        f"--screen-emulation.width={cfg.screen_emulation.width}",
+        f"--screen-emulation.height={cfg.screen_emulation.height}",
+        f"--screen-emulation.deviceScaleFactor={cfg.screen_emulation.device_scale_factor}",
+        f"--chrome-flags={chrome_flags}",
+    ]

--- a/apps/audit-api/app/services/persistence.py
+++ b/apps/audit-api/app/services/persistence.py
@@ -1,0 +1,117 @@
+import asyncio
+import logging
+from datetime import UTC, datetime
+from typing import Any
+
+from app.services.grading import CategoryScores, calculate_grade
+from app.services.issues import ParsedIssue
+from app.services.scanner import ScanResults
+
+logger = logging.getLogger(__name__)
+
+
+def _extract_scores(lighthouse: dict[str, Any]) -> CategoryScores:
+    categories = lighthouse.get("categories") or {}
+
+    def _score(name: str) -> int:
+        raw = (categories.get(name) or {}).get("score")
+        return round((raw or 0) * 100)
+
+    return CategoryScores(
+        performance=_score("performance"),
+        accessibility=_score("accessibility"),
+        seo=_score("seo"),
+        best_practices=_score("best-practices"),
+    )
+
+
+def _extract_core_web_vitals(lighthouse: dict[str, Any]) -> dict[str, Any]:
+    audits = lighthouse.get("audits") or {}
+
+    def _numeric(key: str) -> Any:
+        value = (audits.get(key) or {}).get("numericValue")
+        return value if value is not None else None
+
+    return {
+        "fcp_ms": _numeric("first-contentful-paint"),
+        "lcp_ms": _numeric("largest-contentful-paint"),
+        "tbt_ms": _numeric("total-blocking-time"),
+        "cls": _numeric("cumulative-layout-shift"),
+        "si_ms": _numeric("speed-index"),
+    }
+
+
+async def mark_scan_running(supabase: Any, scan_id: str) -> None:
+    if supabase is None:
+        return
+    await asyncio.to_thread(
+        lambda: supabase.table("scans")
+        .update({"status": "running"})
+        .eq("id", scan_id)
+        .execute()
+    )
+
+
+async def persist_scan_completion(
+    supabase: Any,
+    scan_id: str,
+    results: ScanResults,
+    issues: list[ParsedIssue],
+) -> None:
+    scores = _extract_scores(results.lighthouse)
+    grade = calculate_grade(scores)
+    cwv = _extract_core_web_vitals(results.lighthouse)
+
+    payload: dict[str, Any] = {
+        "status": "completed",
+        "completed_at": datetime.now(UTC).isoformat(),
+        "score_performance": scores.performance,
+        "score_accessibility": scores.accessibility,
+        "score_best_practices": scores.best_practices,
+        "score_seo": scores.seo,
+        "grade_overall": grade.grade,
+        "page_title": results.page_title,
+        "page_description": results.page_description,
+        "page_screenshot_url": results.screenshot_url,
+        "lighthouse_raw": results.lighthouse,
+        "axe_raw": results.axe,
+        **cwv,
+    }
+
+    if supabase is None:
+        logger.info("Supabase not configured; skipping scan persistence for %s", scan_id)
+        return
+
+    await asyncio.to_thread(
+        lambda: supabase.table("scans").update(payload).eq("id", scan_id).execute()
+    )
+
+    if issues:
+        rows = [
+            {
+                "scan_id": scan_id,
+                "category": issue.category,
+                "severity": issue.severity,
+                "title": issue.title,
+                "description": issue.description,
+                "impact": issue.impact,
+                "fix_difficulty": issue.fix_difficulty,
+                "technical_detail": issue.technical_detail,
+                "sort_order": index,
+            }
+            for index, issue in enumerate(issues)
+        ]
+        await asyncio.to_thread(
+            lambda: supabase.table("scan_issues").insert(rows).execute()
+        )
+
+
+async def mark_scan_failed(supabase: Any, scan_id: str, error_message: str) -> None:
+    if supabase is None:
+        return
+    await asyncio.to_thread(
+        lambda: supabase.table("scans")
+        .update({"status": "failed", "error_message": error_message})
+        .eq("id", scan_id)
+        .execute()
+    )

--- a/apps/audit-api/app/services/scan_queue.py
+++ b/apps/audit-api/app/services/scan_queue.py
@@ -1,0 +1,100 @@
+import asyncio
+import logging
+from dataclasses import dataclass
+
+from app.services.issues import parse_issues
+from app.services.lighthouse_config import DeviceMode
+from app.services.persistence import (
+    mark_scan_failed,
+    mark_scan_running,
+    persist_scan_completion,
+)
+from app.services.scanner import ScanError, run_scan
+from app.services.supabase_client import get_supabase_client
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ScanJob:
+    scan_id: str
+    url: str
+    device: DeviceMode
+
+
+class ScanQueue:
+    """Serialized queue. Lighthouse uses global performance marks, so concurrent
+    runs in the same process collide. One job at a time."""
+
+    def __init__(self) -> None:
+        self._queue: asyncio.Queue[ScanJob] = asyncio.Queue()
+        self._worker: asyncio.Task[None] | None = None
+        self._running: bool = False
+
+    @property
+    def size(self) -> int:
+        return self._queue.qsize()
+
+    @property
+    def running(self) -> bool:
+        return self._running
+
+    def start(self) -> None:
+        if self._worker is None or self._worker.done():
+            self._worker = asyncio.create_task(self._run_loop())
+
+    async def stop(self) -> None:
+        if self._worker is not None:
+            self._worker.cancel()
+            try:
+                await self._worker
+            except (asyncio.CancelledError, Exception):
+                pass
+            self._worker = None
+
+    async def enqueue(self, job: ScanJob) -> None:
+        await self._queue.put(job)
+        self.start()
+
+    async def _run_loop(self) -> None:
+        while True:
+            job = await self._queue.get()
+            self._running = True
+            try:
+                await self._execute(job)
+            except Exception as exc:
+                logger.exception("Scan worker crashed on %s: %s", job.scan_id, exc)
+            finally:
+                self._running = False
+                self._queue.task_done()
+
+    async def _execute(self, job: ScanJob) -> None:
+        supabase = get_supabase_client()
+        try:
+            await mark_scan_running(supabase, job.scan_id)
+            results = await run_scan(job.url, job.device, supabase=supabase)
+            issues = parse_issues(results.lighthouse, results.axe)
+            await persist_scan_completion(supabase, job.scan_id, results, issues)
+            logger.info(
+                "Scan completed: %s | %s | issues=%d",
+                job.scan_id,
+                job.device,
+                len(issues),
+            )
+        except ScanError as exc:
+            await mark_scan_failed(supabase, job.scan_id, str(exc))
+            logger.warning("Scan failed: %s | %s", job.scan_id, exc)
+        except Exception as exc:
+            message = str(exc) or "Unknown scan error"
+            await mark_scan_failed(supabase, job.scan_id, message)
+            logger.exception("Scan errored: %s", job.scan_id)
+
+
+_queue: ScanQueue | None = None
+
+
+def get_queue() -> ScanQueue:
+    global _queue
+    if _queue is None:
+        _queue = ScanQueue()
+    return _queue

--- a/apps/audit-api/app/services/scan_queue.py
+++ b/apps/audit-api/app/services/scan_queue.py
@@ -48,8 +48,10 @@ class ScanQueue:
             self._worker.cancel()
             try:
                 await self._worker
-            except (asyncio.CancelledError, Exception):
+            except asyncio.CancelledError:
                 pass
+            except Exception:
+                logger.exception("Scan worker raised during shutdown")
             self._worker = None
 
     async def enqueue(self, job: ScanJob) -> None:

--- a/apps/audit-api/app/services/scanner.py
+++ b/apps/audit-api/app/services/scanner.py
@@ -15,6 +15,7 @@ logger = logging.getLogger(__name__)
 LIGHTHOUSE_BIN = os.environ.get("LIGHTHOUSE_BIN", "lighthouse")
 AXE_SCRIPT_PATH = os.environ.get("AXE_SCRIPT_PATH", "/app/vendor/axe.min.js")
 SCAN_TIMEOUT_SEC = int(os.environ.get("SCAN_TIMEOUT_SEC", "90"))
+AXE_TIMEOUT_SEC = int(os.environ.get("AXE_TIMEOUT_SEC", "30"))
 
 
 @dataclass(frozen=True)
@@ -75,6 +76,7 @@ async def _run_axe_and_capture(
                 device_scale_factor=cfg.screen_emulation.device_scale_factor,
                 is_mobile=cfg.screen_emulation.mobile,
             )
+            context.set_default_timeout(30_000)
             page = await context.new_page()
             await page.goto(url, wait_until="networkidle", timeout=30_000)
 
@@ -99,9 +101,17 @@ async def _run_axe_and_capture(
             axe_path = Path(AXE_SCRIPT_PATH)
             if axe_path.exists():
                 await page.add_script_tag(path=str(axe_path))
-                raw = await page.evaluate(
-                    "async () => await window.axe.run(document)"
-                )
+                try:
+                    raw = await asyncio.wait_for(
+                        page.evaluate("async () => await window.axe.run(document)"),
+                        timeout=AXE_TIMEOUT_SEC,
+                    )
+                except TimeoutError:
+                    logger.warning(
+                        "axe.run timed out after %ss; returning empty violations",
+                        AXE_TIMEOUT_SEC,
+                    )
+                    raw = None
                 if isinstance(raw, dict):
                     axe_result = raw
             else:

--- a/apps/audit-api/app/services/scanner.py
+++ b/apps/audit-api/app/services/scanner.py
@@ -1,0 +1,155 @@
+import asyncio
+import json
+import logging
+import os
+import tempfile
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from app.services.lighthouse_config import DeviceMode, build_cli_args, config_for
+
+logger = logging.getLogger(__name__)
+
+LIGHTHOUSE_BIN = os.environ.get("LIGHTHOUSE_BIN", "lighthouse")
+AXE_SCRIPT_PATH = os.environ.get("AXE_SCRIPT_PATH", "/app/vendor/axe.min.js")
+SCAN_TIMEOUT_SEC = int(os.environ.get("SCAN_TIMEOUT_SEC", "90"))
+
+
+@dataclass(frozen=True)
+class ScanResults:
+    lighthouse: dict[str, Any]
+    axe: dict[str, Any]
+    page_title: str
+    page_description: str
+    screenshot_url: str | None
+
+
+class ScanError(RuntimeError):
+    """Lighthouse run failed or returned unusable output."""
+
+
+async def _run_lighthouse(url: str, device: DeviceMode) -> dict[str, Any]:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        output_path = str(Path(tmpdir) / "report.json")
+        args = build_cli_args(url, device, output_path)
+        args[0] = LIGHTHOUSE_BIN
+
+        proc = await asyncio.create_subprocess_exec(
+            *args, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE
+        )
+        try:
+            _, stderr = await asyncio.wait_for(
+                proc.communicate(), timeout=SCAN_TIMEOUT_SEC
+            )
+        except TimeoutError as exc:
+            proc.kill()
+            await proc.wait()
+            raise ScanError(f"Lighthouse timed out after {SCAN_TIMEOUT_SEC}s") from exc
+
+        if not Path(output_path).exists():
+            detail = stderr.decode(errors="replace").strip() if stderr else ""
+            raise ScanError(f"Lighthouse produced no output. stderr: {detail[:500]}")
+
+        with open(output_path, encoding="utf-8") as f:
+            return dict(json.load(f))
+
+
+async def _run_axe_and_capture(
+    url: str, device: DeviceMode
+) -> tuple[dict[str, Any], str, str, bytes | None]:
+    from playwright.async_api import async_playwright
+
+    cfg = config_for(device)
+    async with async_playwright() as pw:
+        browser = await pw.chromium.launch(
+            args=["--no-sandbox", "--disable-dev-shm-usage"]
+        )
+        try:
+            context = await browser.new_context(
+                viewport={
+                    "width": cfg.screen_emulation.width,
+                    "height": cfg.screen_emulation.height,
+                },
+                device_scale_factor=cfg.screen_emulation.device_scale_factor,
+                is_mobile=cfg.screen_emulation.mobile,
+            )
+            page = await context.new_page()
+            await page.goto(url, wait_until="networkidle", timeout=30_000)
+
+            page_title = await page.title()
+            page_description = ""
+            try:
+                handle = await page.query_selector('meta[name="description"]')
+                if handle is not None:
+                    page_description = await handle.get_attribute("content") or ""
+            except Exception:
+                page_description = ""
+
+            screenshot_bytes: bytes | None = None
+            try:
+                screenshot_bytes = await page.screenshot(
+                    type="jpeg", quality=60, full_page=False
+                )
+            except Exception as exc:
+                logger.warning("Screenshot capture failed: %s", exc)
+
+            axe_result: dict[str, Any] = {"violations": []}
+            axe_path = Path(AXE_SCRIPT_PATH)
+            if axe_path.exists():
+                await page.add_script_tag(path=str(axe_path))
+                raw = await page.evaluate(
+                    "async () => await window.axe.run(document)"
+                )
+                if isinstance(raw, dict):
+                    axe_result = raw
+            else:
+                logger.warning("axe.min.js not found at %s; skipping axe", axe_path)
+
+            return axe_result, page_title, page_description, screenshot_bytes
+        finally:
+            await browser.close()
+
+
+async def _upload_screenshot(
+    supabase: Any, screenshot_bytes: bytes | None
+) -> str | None:
+    if not screenshot_bytes or supabase is None:
+        return None
+    try:
+        filename = f"{uuid.uuid4().hex}.jpg"
+        storage = supabase.storage.from_("screenshots")
+        await asyncio.to_thread(
+            storage.upload,
+            filename,
+            screenshot_bytes,
+            {"content-type": "image/jpeg", "cache-control": "31536000"},
+        )
+        public = await asyncio.to_thread(storage.get_public_url, filename)
+        if isinstance(public, dict):
+            return str(public.get("publicUrl") or "") or None
+        return str(public) if public else None
+    except Exception as exc:
+        logger.warning("Screenshot upload failed: %s", exc)
+        return None
+
+
+async def run_scan(
+    url: str,
+    device: DeviceMode = "mobile",
+    supabase: Any | None = None,
+) -> ScanResults:
+    lighthouse_result = await _run_lighthouse(url, device)
+    axe_result, page_title, page_description, screenshot_bytes = (
+        await _run_axe_and_capture(url, device)
+    )
+    screenshot_url = await _upload_screenshot(supabase, screenshot_bytes)
+
+    return ScanResults(
+        lighthouse=lighthouse_result,
+        axe=axe_result,
+        page_title=page_title,
+        page_description=page_description,
+        screenshot_url=screenshot_url,
+    )

--- a/apps/audit-api/app/services/supabase_client.py
+++ b/apps/audit-api/app/services/supabase_client.py
@@ -1,0 +1,13 @@
+from functools import lru_cache
+from typing import Any
+
+from app.config import settings
+
+
+@lru_cache(maxsize=1)
+def get_supabase_client() -> Any | None:
+    if not settings.supabase_url or not settings.supabase_service_role_key:
+        return None
+    from supabase import create_client
+
+    return create_client(settings.supabase_url, settings.supabase_service_role_key)

--- a/apps/audit-api/pyproject.toml
+++ b/apps/audit-api/pyproject.toml
@@ -10,6 +10,8 @@ dependencies = [
   "uvicorn[standard]>=0.34",
   "pydantic-settings>=2.7",
   "pyjwt>=2.10",
+  "playwright>=1.48",
+  "supabase>=2.9",
 ]
 
 [dependency-groups]

--- a/apps/audit-api/tests/test_grading.py
+++ b/apps/audit-api/tests/test_grading.py
@@ -1,0 +1,36 @@
+from app.services.grading import CategoryScores, calculate_grade
+
+
+def test_grade_a_for_high_weighted_score() -> None:
+    scores = CategoryScores(performance=95, accessibility=95, seo=95, best_practices=95)
+    result = calculate_grade(scores)
+    assert result.grade == "A"
+    assert result.label == "Excellent"
+
+
+def test_grade_f_for_failing_weighted_score() -> None:
+    scores = CategoryScores(performance=10, accessibility=20, seo=10, best_practices=20)
+    result = calculate_grade(scores)
+    assert result.grade == "F"
+
+
+def test_grade_weighting_favors_performance() -> None:
+    # performance has 0.4 weight; weighted = 90*0.4 + 90*0.25 + 90*0.2 + 90*0.15 = 90
+    scores = CategoryScores(performance=90, accessibility=90, seo=90, best_practices=90)
+    assert calculate_grade(scores).grade == "A"
+
+
+def test_grade_boundary_b() -> None:
+    # weighted = 75
+    scores = CategoryScores(performance=75, accessibility=75, seo=75, best_practices=75)
+    assert calculate_grade(scores).grade == "B"
+
+
+def test_grade_boundary_c() -> None:
+    scores = CategoryScores(performance=60, accessibility=60, seo=60, best_practices=60)
+    assert calculate_grade(scores).grade == "C"
+
+
+def test_grade_boundary_d() -> None:
+    scores = CategoryScores(performance=40, accessibility=40, seo=40, best_practices=40)
+    assert calculate_grade(scores).grade == "D"

--- a/apps/audit-api/tests/test_health.py
+++ b/apps/audit-api/tests/test_health.py
@@ -7,4 +7,7 @@ def test_health_returns_ok():
     client = TestClient(app)
     response = client.get("/health")
     assert response.status_code == 200
-    assert response.json() == {"status": "ok"}
+    body = response.json()
+    assert body["status"] == "ok"
+    assert body["queue"] == 0
+    assert body["running"] is False

--- a/apps/audit-api/tests/test_issues.py
+++ b/apps/audit-api/tests/test_issues.py
@@ -1,0 +1,117 @@
+from app.services.issues import parse_issues
+
+
+def _lh_audit(score: float, display_value: str = "", numeric_value: float = 0) -> dict:
+    return {
+        "score": score,
+        "displayValue": display_value,
+        "numericValue": numeric_value,
+    }
+
+
+def test_parse_ignores_audits_with_high_score() -> None:
+    lighthouse = {
+        "audits": {
+            "largest-contentful-paint": _lh_audit(score=0.95),
+            "color-contrast": _lh_audit(score=1.0),
+        }
+    }
+    assert parse_issues(lighthouse, {}) == []
+
+
+def test_parse_ignores_audits_with_null_score() -> None:
+    lighthouse = {"audits": {"largest-contentful-paint": _lh_audit(score=None)}}  # type: ignore[arg-type]
+    assert parse_issues(lighthouse, {}) == []
+
+
+def test_parse_lighthouse_issue_interpolates_display_value() -> None:
+    lighthouse = {
+        "audits": {
+            "largest-contentful-paint": _lh_audit(
+                score=0.3, display_value="4.2 s", numeric_value=4200
+            )
+        }
+    }
+    issues = parse_issues(lighthouse, {})
+    assert len(issues) == 1
+    assert "4.2 s" in issues[0].description
+    assert issues[0].category == "performance"
+    assert issues[0].severity == "critical"
+    assert issues[0].technical_detail["auditId"] == "largest-contentful-paint"
+
+
+def test_parse_axe_violation_severity_mapping() -> None:
+    axe = {
+        "violations": [
+            {
+                "id": "color-contrast-blue",
+                "impact": "critical",
+                "help": "Elements must have sufficient color contrast",
+                "description": "Fix color contrast",
+                "nodes": [{"html": "<p>"}, {"html": "<a>"}],
+                "helpUrl": "https://example.com",
+            }
+        ]
+    }
+    issues = parse_issues({}, axe)
+    assert len(issues) == 1
+    assert issues[0].severity == "critical"
+    assert issues[0].category == "accessibility"
+    assert "Found 2 instances" in issues[0].description
+
+
+def test_parse_keeps_axe_violation_when_not_deduped() -> None:
+    # Real-world case: Lighthouse color-contrast title doesn't contain the
+    # spaced violation id, so axe violation is preserved.
+    lighthouse = {
+        "audits": {
+            "color-contrast": _lh_audit(score=0.3, display_value="5"),
+        }
+    }
+    axe = {
+        "violations": [
+            {
+                "id": "color-contrast",
+                "impact": "serious",
+                "help": "Elements must have sufficient contrast",
+                "description": "Fix color contrast",
+                "nodes": [{}],
+                "helpUrl": "",
+            }
+        ]
+    }
+    issues = parse_issues(lighthouse, axe)
+    assert len(issues) == 2
+
+
+def test_parse_sorts_critical_before_warning_before_info() -> None:
+    lighthouse = {
+        "audits": {
+            # warning
+            "cumulative-layout-shift": _lh_audit(score=0.3, display_value="0.3"),
+            # info
+            "unminified-css": _lh_audit(score=0.3, display_value="10 KB"),
+            # critical
+            "largest-contentful-paint": _lh_audit(score=0.3, display_value="5 s"),
+        }
+    }
+    issues = parse_issues(lighthouse, {})
+    severities = [i.severity for i in issues]
+    assert severities == ["critical", "warning", "info"]
+
+
+def test_parse_singular_instance_label_for_one_violation_node() -> None:
+    axe = {
+        "violations": [
+            {
+                "id": "button-name",
+                "impact": "serious",
+                "help": "buttons need accessible names",
+                "description": "missing name",
+                "nodes": [{}],
+                "helpUrl": "",
+            }
+        ]
+    }
+    issues = parse_issues({}, axe)
+    assert "Found 1 instance on" in issues[0].description

--- a/apps/audit-api/tests/test_lighthouse_config.py
+++ b/apps/audit-api/tests/test_lighthouse_config.py
@@ -1,0 +1,44 @@
+from app.services.lighthouse_config import build_cli_args, config_for
+
+
+def test_mobile_config_defaults() -> None:
+    cfg = config_for("mobile")
+    assert cfg.form_factor == "mobile"
+    assert cfg.screen_emulation.mobile is True
+    assert cfg.screen_emulation.width == 375
+
+
+def test_desktop_config_overrides() -> None:
+    cfg = config_for("desktop")
+    assert cfg.form_factor == "desktop"
+    assert cfg.screen_emulation.mobile is False
+    assert cfg.screen_emulation.width == 1350
+    assert cfg.throttling.rtt_ms == 40
+
+
+def test_build_cli_args_includes_url_and_output_path() -> None:
+    args = build_cli_args("https://example.com", "mobile", "/tmp/out.json")
+    assert args[0] == "lighthouse"
+    assert "https://example.com" in args
+    assert "--output-path=/tmp/out.json" in args
+    assert "--output=json" in args
+
+
+def test_build_cli_args_passes_form_factor() -> None:
+    args = build_cli_args("https://x.com", "desktop", "/tmp/o.json")
+    assert "--form-factor=desktop" in args
+
+
+def test_build_cli_args_includes_only_categories() -> None:
+    args = build_cli_args("https://x.com", "mobile", "/tmp/o.json")
+    cats = next(a for a in args if a.startswith("--only-categories="))
+    assert "performance" in cats
+    assert "accessibility" in cats
+    assert "best-practices" in cats
+    assert "seo" in cats
+
+
+def test_build_cli_args_includes_throttling_overrides() -> None:
+    args = build_cli_args("https://x.com", "mobile", "/tmp/o.json")
+    assert "--throttling.cpuSlowdownMultiplier=1" in args
+    assert "--throttling.downloadThroughputKbps=1600" in args

--- a/apps/audit-api/tests/test_persistence.py
+++ b/apps/audit-api/tests/test_persistence.py
@@ -1,0 +1,163 @@
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from app.services.issues import ParsedIssue
+from app.services.persistence import (
+    mark_scan_failed,
+    mark_scan_running,
+    persist_scan_completion,
+)
+from app.services.scanner import ScanResults
+
+
+@dataclass
+class _FakeExecute:
+    called_with: dict[str, Any]
+
+    def execute(self) -> None:
+        return None
+
+
+class _FakeQuery:
+    def __init__(self, log: list[tuple[str, dict[str, Any]]]) -> None:
+        self._log = log
+        self._table = ""
+        self._op = ""
+        self._payload: Any = None
+
+    def update(self, payload: dict[str, Any]) -> "_FakeQuery":
+        self._op = "update"
+        self._payload = payload
+        return self
+
+    def insert(self, rows: list[dict[str, Any]]) -> "_FakeQuery":
+        self._op = "insert"
+        self._payload = rows
+        return self
+
+    def eq(self, column: str, value: Any) -> "_FakeQuery":
+        self._payload = {"filter_column": column, "filter_value": value, "payload": self._payload}
+        return self
+
+    def execute(self) -> None:
+        self._log.append((f"{self._table}.{self._op}", self._payload))
+
+
+class _FakeSupabase:
+    def __init__(self) -> None:
+        self.log: list[tuple[str, Any]] = []
+
+    def table(self, name: str) -> _FakeQuery:
+        q = _FakeQuery(self.log)
+        q._table = name
+        return q
+
+
+@pytest.fixture
+def fake_supabase() -> _FakeSupabase:
+    return _FakeSupabase()
+
+
+@pytest.fixture
+def scan_results() -> ScanResults:
+    return ScanResults(
+        lighthouse={
+            "categories": {
+                "performance": {"score": 0.82},
+                "accessibility": {"score": 0.95},
+                "seo": {"score": 0.90},
+                "best-practices": {"score": 0.70},
+            },
+            "audits": {
+                "first-contentful-paint": {"numericValue": 1500},
+                "largest-contentful-paint": {"numericValue": 2400},
+                "total-blocking-time": {"numericValue": 200},
+                "cumulative-layout-shift": {"numericValue": 0.05},
+                "speed-index": {"numericValue": 3200},
+            },
+        },
+        axe={"violations": []},
+        page_title="Example Page",
+        page_description="A description",
+        screenshot_url="https://supa.example/shots/abc.jpg",
+    )
+
+
+async def test_mark_scan_running_updates_status(fake_supabase: _FakeSupabase) -> None:
+    await mark_scan_running(fake_supabase, "scan-1")
+    assert fake_supabase.log == [
+        (
+            "scans.update",
+            {"filter_column": "id", "filter_value": "scan-1", "payload": {"status": "running"}},
+        )
+    ]
+
+
+async def test_mark_scan_running_noops_when_supabase_is_none() -> None:
+    await mark_scan_running(None, "scan-1")  # no error, no write
+
+
+async def test_persist_scan_completion_writes_scores_and_cwv(
+    fake_supabase: _FakeSupabase, scan_results: ScanResults
+) -> None:
+    await persist_scan_completion(fake_supabase, "scan-2", scan_results, [])
+    assert len(fake_supabase.log) == 1
+    op, payload = fake_supabase.log[0]
+    assert op == "scans.update"
+    scan_update = payload["payload"]
+    assert scan_update["score_performance"] == 82
+    assert scan_update["score_accessibility"] == 95
+    assert scan_update["score_best_practices"] == 70
+    assert scan_update["grade_overall"] in {"A", "B"}
+    assert scan_update["fcp_ms"] == 1500
+    assert scan_update["lcp_ms"] == 2400
+    assert scan_update["page_title"] == "Example Page"
+
+
+async def test_persist_scan_completion_inserts_issue_rows(
+    fake_supabase: _FakeSupabase, scan_results: ScanResults
+) -> None:
+    issues = [
+        ParsedIssue(
+            category="performance",
+            severity="critical",
+            title="slow",
+            description="desc",
+            impact="impact",
+            fix_difficulty="easy",
+            technical_detail={"auditId": "x"},
+        ),
+        ParsedIssue(
+            category="accessibility",
+            severity="warning",
+            title="alt",
+            description="desc",
+            impact="impact",
+            fix_difficulty="easy",
+            technical_detail={"auditId": "y"},
+        ),
+    ]
+    await persist_scan_completion(fake_supabase, "scan-3", scan_results, issues)
+    insert_entries = [e for e in fake_supabase.log if e[0] == "scan_issues.insert"]
+    assert len(insert_entries) == 1
+    rows = insert_entries[0][1]
+    assert len(rows) == 2
+    assert rows[0]["scan_id"] == "scan-3"
+    assert rows[0]["sort_order"] == 0
+    assert rows[1]["sort_order"] == 1
+
+
+async def test_mark_scan_failed_records_error(fake_supabase: _FakeSupabase) -> None:
+    await mark_scan_failed(fake_supabase, "scan-4", "boom")
+    assert fake_supabase.log == [
+        (
+            "scans.update",
+            {
+                "filter_column": "id",
+                "filter_value": "scan-4",
+                "payload": {"status": "failed", "error_message": "boom"},
+            },
+        )
+    ]

--- a/apps/audit-api/tests/test_run_scan_route.py
+++ b/apps/audit-api/tests/test_run_scan_route.py
@@ -1,0 +1,56 @@
+from unittest.mock import AsyncMock, patch
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.services.scan_queue import ScanJob, get_queue
+
+
+def test_run_scan_requires_api_key() -> None:
+    with TestClient(app) as client:
+        response = client.post(
+            "/run-scan",
+            json={"scan_id": "s1", "url": "https://example.com"},
+        )
+    assert response.status_code == 401
+
+
+def test_run_scan_rejects_invalid_device_mode() -> None:
+    with TestClient(app) as client:
+        response = client.post(
+            "/run-scan",
+            headers={"x-api-key": "testkey"},
+            json={"scan_id": "s1", "url": "https://example.com", "device_mode": "tv"},
+        )
+    assert response.status_code == 422
+
+
+def test_run_scan_enqueues_job_and_returns_accepted() -> None:
+    queue = get_queue()
+    with patch.object(queue, "enqueue", new_callable=AsyncMock) as mock_enqueue:
+        with TestClient(app) as client:
+            response = client.post(
+                "/run-scan",
+                headers={"x-api-key": "testkey"},
+                json={
+                    "scan_id": "s1",
+                    "url": "https://example.com",
+                    "device_mode": "desktop",
+                },
+            )
+        assert response.status_code == 200
+        assert response.json() == {"status": "accepted", "scan_id": "s1"}
+        mock_enqueue.assert_awaited_once()
+        enqueued: ScanJob = mock_enqueue.await_args.args[0]
+        assert enqueued.scan_id == "s1"
+        assert enqueued.device == "desktop"
+
+
+def test_health_reports_queue_state() -> None:
+    with TestClient(app) as client:
+        response = client.get("/health")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "ok"
+    assert "queue" in body
+    assert "running" in body

--- a/apps/audit-api/tests/test_run_scan_route.py
+++ b/apps/audit-api/tests/test_run_scan_route.py
@@ -1,5 +1,6 @@
 from unittest.mock import AsyncMock, patch
 
+import pytest
 from fastapi.testclient import TestClient
 
 from app.main import app
@@ -23,6 +24,33 @@ def test_run_scan_rejects_invalid_device_mode() -> None:
             json={"scan_id": "s1", "url": "https://example.com", "device_mode": "tv"},
         )
     assert response.status_code == 422
+
+
+@pytest.mark.parametrize(
+    "bad_url",
+    [
+        "file:///etc/passwd",
+        "chrome://net-internals",
+        "javascript:alert(1)",
+        "http://localhost:8000",
+        "http://127.0.0.1",
+        "https://10.0.0.5",
+        "http://169.254.169.254/latest/meta-data/",
+        "http://192.168.1.1",
+        "http://metadata.google.internal",
+        "http://[::1]",
+        "ftp://example.com",
+        "not-a-url",
+    ],
+)
+def test_run_scan_rejects_unsafe_url(bad_url: str) -> None:
+    with TestClient(app) as client:
+        response = client.post(
+            "/run-scan",
+            headers={"x-api-key": "testkey"},
+            json={"scan_id": "s1", "url": bad_url},
+        )
+    assert response.status_code == 422, bad_url
 
 
 def test_run_scan_enqueues_job_and_returns_accepted() -> None:

--- a/apps/audit-api/tests/test_scan_queue.py
+++ b/apps/audit-api/tests/test_scan_queue.py
@@ -1,0 +1,133 @@
+import asyncio
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from app.services.scan_queue import ScanJob, ScanQueue
+from app.services.scanner import ScanError, ScanResults
+
+
+async def _wait_until_idle(queue: ScanQueue, timeout: float = 2.0) -> None:
+    deadline = asyncio.get_event_loop().time() + timeout
+    while asyncio.get_event_loop().time() < deadline:
+        if queue.size == 0 and not queue.running:
+            return
+        await asyncio.sleep(0.01)
+    raise AssertionError("queue did not drain")
+
+
+@pytest.fixture
+def fake_results() -> ScanResults:
+    return ScanResults(
+        lighthouse={"categories": {}, "audits": {}},
+        axe={"violations": []},
+        page_title="t",
+        page_description="d",
+        screenshot_url=None,
+    )
+
+
+async def test_queue_executes_job_and_persists_completion(
+    fake_results: ScanResults,
+) -> None:
+    queue = ScanQueue()
+    calls: dict[str, Any] = {}
+
+    async def fake_run_scan(url: str, device: str, supabase: Any = None) -> ScanResults:
+        calls["run_scan"] = {"url": url, "device": device}
+        return fake_results
+
+    async def fake_mark_running(supabase: Any, scan_id: str) -> None:
+        calls.setdefault("running", []).append(scan_id)
+
+    async def fake_persist(
+        supabase: Any, scan_id: str, results: ScanResults, issues: list[Any]
+    ) -> None:
+        calls["persist"] = {"scan_id": scan_id, "issues_len": len(issues)}
+
+    async def fake_failed(supabase: Any, scan_id: str, message: str) -> None:
+        calls["failed"] = {"scan_id": scan_id, "message": message}
+
+    with (
+        patch("app.services.scan_queue.run_scan", fake_run_scan),
+        patch("app.services.scan_queue.mark_scan_running", fake_mark_running),
+        patch("app.services.scan_queue.persist_scan_completion", fake_persist),
+        patch("app.services.scan_queue.mark_scan_failed", fake_failed),
+        patch("app.services.scan_queue.get_supabase_client", return_value=None),
+    ):
+        await queue.enqueue(
+            ScanJob(scan_id="s1", url="https://x.com", device="mobile")
+        )
+        await _wait_until_idle(queue)
+        await queue.stop()
+
+    assert calls["run_scan"] == {"url": "https://x.com", "device": "mobile"}
+    assert calls["running"] == ["s1"]
+    assert calls["persist"]["scan_id"] == "s1"
+    assert "failed" not in calls
+
+
+async def test_queue_marks_failed_on_scan_error() -> None:
+    queue = ScanQueue()
+    calls: dict[str, Any] = {}
+
+    async def raising_run_scan(*args: Any, **kwargs: Any) -> ScanResults:
+        raise ScanError("lh exploded")
+
+    async def fake_failed(supabase: Any, scan_id: str, message: str) -> None:
+        calls["failed"] = {"scan_id": scan_id, "message": message}
+
+    async def noop_running(supabase: Any, scan_id: str) -> None:
+        return None
+
+    async def noop_persist(*args: Any, **kwargs: Any) -> None:
+        return None
+
+    with (
+        patch("app.services.scan_queue.run_scan", raising_run_scan),
+        patch("app.services.scan_queue.mark_scan_running", noop_running),
+        patch("app.services.scan_queue.persist_scan_completion", noop_persist),
+        patch("app.services.scan_queue.mark_scan_failed", fake_failed),
+        patch("app.services.scan_queue.get_supabase_client", return_value=None),
+    ):
+        await queue.enqueue(
+            ScanJob(scan_id="s2", url="https://x.com", device="mobile")
+        )
+        await _wait_until_idle(queue)
+        await queue.stop()
+
+    assert calls["failed"] == {"scan_id": "s2", "message": "lh exploded"}
+
+
+async def test_queue_serializes_concurrent_jobs(fake_results: ScanResults) -> None:
+    queue = ScanQueue()
+    running_now = 0
+    max_concurrent = 0
+
+    async def slow_run_scan(*args: Any, **kwargs: Any) -> ScanResults:
+        nonlocal running_now, max_concurrent
+        running_now += 1
+        max_concurrent = max(max_concurrent, running_now)
+        await asyncio.sleep(0.05)
+        running_now -= 1
+        return fake_results
+
+    async def noop(*args: Any, **kwargs: Any) -> None:
+        return None
+
+    with (
+        patch("app.services.scan_queue.run_scan", slow_run_scan),
+        patch("app.services.scan_queue.mark_scan_running", noop),
+        patch("app.services.scan_queue.persist_scan_completion", noop),
+        patch("app.services.scan_queue.mark_scan_failed", noop),
+        patch("app.services.scan_queue.get_supabase_client", return_value=None),
+    ):
+        for i in range(3):
+            await queue.enqueue(
+                ScanJob(scan_id=f"s{i}", url="https://x.com", device="mobile")
+            )
+        await _wait_until_idle(queue, timeout=3.0)
+        await queue.stop()
+
+    assert max_concurrent == 1

--- a/uv.lock
+++ b/uv.lock
@@ -46,8 +46,10 @@ version = "0.1.0"
 source = { virtual = "apps/audit-api" }
 dependencies = [
     { name = "fastapi" },
+    { name = "playwright" },
     { name = "pydantic-settings" },
     { name = "pyjwt" },
+    { name = "supabase" },
     { name = "uvicorn", extra = ["standard"] },
 ]
 
@@ -63,8 +65,10 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "fastapi", specifier = ">=0.115" },
+    { name = "playwright", specifier = ">=1.48" },
     { name = "pydantic-settings", specifier = ">=2.7" },
     { name = "pyjwt", specifier = ">=2.10" },
+    { name = "supabase", specifier = ">=2.9" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.34" },
 ]
 
@@ -399,6 +403,63 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e1/cf/b50ddf667c15276a9ab15a70ef5f257564de271957933ffea49d2cdbcdfb/fsspec-2026.3.0.tar.gz", hash = "sha256:1ee6a0e28677557f8c2f994e3eea77db6392b4de9cd1f5d7a9e87a0ae9d01b41", size = 313547, upload-time = "2026-03-27T19:11:14.892Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d5/1f/5f4a3cd9e4440e9d9bc78ad0a91a1c8d46b4d429d5239ebe6793c9fe5c41/fsspec-2026.3.0-py3-none-any.whl", hash = "sha256:d2ceafaad1b3457968ed14efa28798162f1638dbb5d2a6868a2db002a5ee39a4", size = 202595, upload-time = "2026-03-27T19:11:13.595Z" },
+]
+
+[[package]]
+name = "greenlet"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/86/94/a5935717b307d7c71fe877b52b884c6af707d2d2090db118a03fbd799369/greenlet-3.4.0.tar.gz", hash = "sha256:f50a96b64dafd6169e595a5c56c9146ef80333e67d4476a65a9c55f400fc22ff", size = 195913, upload-time = "2026-04-08T17:08:00.863Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/c6/dba32cab7e3a625b011aa5647486e2d28423a48845a2998c126dd69c85e1/greenlet-3.4.0-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:805bebb4945094acbab757d34d6e1098be6de8966009ab9ca54f06ff492def58", size = 285504, upload-time = "2026-04-08T15:52:14.071Z" },
+    { url = "https://files.pythonhosted.org/packages/54/f4/7cb5c2b1feb9a1f50e038be79980dfa969aa91979e5e3a18fdbcfad2c517/greenlet-3.4.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:439fc2f12b9b512d9dfa681c5afe5f6b3232c708d13e6f02c845e0d9f4c2d8c6", size = 605476, upload-time = "2026-04-08T16:24:37.064Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/af/b66ab0b2f9a4c5a867c136bf66d9599f34f21a1bcca26a2884a29c450bd9/greenlet-3.4.0-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a70ed1cb0295bee1df57b63bf7f46b4e56a5c93709eea769c1fec1bb23a95875", size = 618336, upload-time = "2026-04-08T16:30:56.59Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/31/56c43d2b5de476f77d36ceeec436328533bff960a4cba9a07616e93063ab/greenlet-3.4.0-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8c5696c42e6bb5cfb7c6ff4453789081c66b9b91f061e5e9367fa15792644e76", size = 625045, upload-time = "2026-04-08T16:40:37.111Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/5c/8c5633ece6ba611d64bf2770219a98dd439921d6424e4e8cf16b0ac74ea5/greenlet-3.4.0-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c660bce1940a1acae5f51f0a064f1bc785d07ea16efcb4bc708090afc4d69e83", size = 613515, upload-time = "2026-04-08T15:56:32.478Z" },
+    { url = "https://files.pythonhosted.org/packages/80/ca/704d4e2c90acb8bdf7ae593f5cbc95f58e82de95cc540fb75631c1054533/greenlet-3.4.0-cp311-cp311-manylinux_2_39_riscv64.whl", hash = "sha256:89995ce5ddcd2896d89615116dd39b9703bfa0c07b583b85b89bf1b5d6eddf81", size = 419745, upload-time = "2026-04-08T16:43:04.022Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/df/950d15bca0d90a0e7395eb777903060504cdb509b7b705631e8fb69ff415/greenlet-3.4.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:ee407d4d1ca9dc632265aee1c8732c4a2d60adff848057cdebfe5fe94eb2c8a2", size = 1574623, upload-time = "2026-04-08T16:26:18.596Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/e7/0839afab829fcb7333c9ff6d80c040949510055d2d4d63251f0d1c7c804e/greenlet-3.4.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:956215d5e355fffa7c021d168728321fd4d31fd730ac609b1653b450f6a4bc71", size = 1639579, upload-time = "2026-04-08T15:57:29.231Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/2b/b4482401e9bcaf9f5c97f67ead38db89c19520ff6d0d6699979c6efcc200/greenlet-3.4.0-cp311-cp311-win_amd64.whl", hash = "sha256:5cb614ace7c27571270354e9c9f696554d073f8aa9319079dcba466bbdead711", size = 238233, upload-time = "2026-04-08T17:02:54.286Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/4d/d8123a4e0bcd583d5cfc8ddae0bbe29c67aab96711be331a7cc935a35966/greenlet-3.4.0-cp311-cp311-win_arm64.whl", hash = "sha256:04403ac74fe295a361f650818de93be11b5038a78f49ccfb64d3b1be8fbf1267", size = 235045, upload-time = "2026-04-08T17:04:05.072Z" },
+    { url = "https://files.pythonhosted.org/packages/65/8b/3669ad3b3f247a791b2b4aceb3aa5a31f5f6817bf547e4e1ff712338145a/greenlet-3.4.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:1a54a921561dd9518d31d2d3db4d7f80e589083063ab4d3e2e950756ef809e1a", size = 286902, upload-time = "2026-04-08T15:52:12.138Z" },
+    { url = "https://files.pythonhosted.org/packages/38/3e/3c0e19b82900873e2d8469b590a6c4b3dfd2b316d0591f1c26b38a4879a5/greenlet-3.4.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:16dec271460a9a2b154e3b1c2fa1050ce6280878430320e85e08c166772e3f97", size = 606099, upload-time = "2026-04-08T16:24:38.408Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/33/99fef65e7754fc76a4ed14794074c38c9ed3394a5bd129d7f61b705f3168/greenlet-3.4.0-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:90036ce224ed6fe75508c1907a77e4540176dcf0744473627785dd519c6f9996", size = 618837, upload-time = "2026-04-08T16:30:58.298Z" },
+    { url = "https://files.pythonhosted.org/packages/44/57/eae2cac10421feae6c0987e3dc106c6d86262b1cb379e171b017aba893a6/greenlet-3.4.0-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6f0def07ec9a71d72315cf26c061aceee53b306c36ed38c35caba952ea1b319d", size = 624901, upload-time = "2026-04-08T16:40:38.981Z" },
+    { url = "https://files.pythonhosted.org/packages/36/f7/229f3aed6948faa20e0616a0b8568da22e365ede6a54d7d369058b128afd/greenlet-3.4.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a1c4f6b453006efb8310affb2d132832e9bbb4fc01ce6df6b70d810d38f1f6dc", size = 615062, upload-time = "2026-04-08T15:56:33.766Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/8a/0e73c9b94f31d1cc257fe79a0eff621674141cdae7d6d00f40de378a1e42/greenlet-3.4.0-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:0e1254cf0cbaa17b04320c3a78575f29f3c161ef38f59c977108f19ffddaf077", size = 423927, upload-time = "2026-04-08T16:43:05.293Z" },
+    { url = "https://files.pythonhosted.org/packages/08/97/d988180011aa40135c46cd0d0cf01dd97f7162bae14139b4a3ef54889ba5/greenlet-3.4.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:9b2d9a138ffa0e306d0e2b72976d2fb10b97e690d40ab36a472acaab0838e2de", size = 1573511, upload-time = "2026-04-08T16:26:20.058Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/0f/a5a26fe152fb3d12e6a474181f6e9848283504d0afd095f353d85726374b/greenlet-3.4.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8424683caf46eb0eb6f626cb95e008e8cc30d0cb675bdfa48200925c79b38a08", size = 1640396, upload-time = "2026-04-08T15:57:30.88Z" },
+    { url = "https://files.pythonhosted.org/packages/42/cf/bb2c32d9a100e36ee9f6e38fad6b1e082b8184010cb06259b49e1266ca01/greenlet-3.4.0-cp312-cp312-win_amd64.whl", hash = "sha256:a0a53fb071531d003b075c444014ff8f8b1a9898d36bb88abd9ac7b3524648a2", size = 238892, upload-time = "2026-04-08T17:03:10.094Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/47/6c41314bac56e71436ce551c7fbe3cc830ed857e6aa9708dbb9c65142eb6/greenlet-3.4.0-cp312-cp312-win_arm64.whl", hash = "sha256:f38b81880ba28f232f1f675893a39cf7b6db25b31cc0a09bb50787ecf957e85e", size = 235599, upload-time = "2026-04-08T15:52:54.3Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/75/7e9cd1126a1e1f0cd67b0eda02e5221b28488d352684704a78ed505bd719/greenlet-3.4.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:43748988b097f9c6f09364f260741aa73c80747f63389824435c7a50bfdfd5c1", size = 285856, upload-time = "2026-04-08T15:52:45.82Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/c4/3e2df392e5cb199527c4d9dbcaa75c14edcc394b45040f0189f649631e3c/greenlet-3.4.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5566e4e2cd7a880e8c27618e3eab20f3494452d12fd5129edef7b2f7aa9a36d1", size = 610208, upload-time = "2026-04-08T16:24:39.674Z" },
+    { url = "https://files.pythonhosted.org/packages/da/af/750cdfda1d1bd30a6c28080245be8d0346e669a98fdbae7f4102aa95fff3/greenlet-3.4.0-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1054c5a3c78e2ab599d452f23f7adafef55062a783a8e241d24f3b633ba6ff82", size = 621269, upload-time = "2026-04-08T16:30:59.767Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/93/c8c508d68ba93232784bbc1b5474d92371f2897dfc6bc281b419f2e0d492/greenlet-3.4.0-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:98eedd1803353daf1cd9ef23eef23eda5a4d22f99b1f998d273a8b78b70dd47f", size = 628455, upload-time = "2026-04-08T16:40:40.698Z" },
+    { url = "https://files.pythonhosted.org/packages/54/78/0cbc693622cd54ebe25207efbb3a0eb07c2639cb8594f6e3aaaa0bb077a8/greenlet-3.4.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f82cb6cddc27dd81c96b1506f4aa7def15070c3b2a67d4e46fd19016aacce6cf", size = 617549, upload-time = "2026-04-08T15:56:34.893Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/46/cfaaa0ade435a60550fd83d07dfd5c41f873a01da17ede5c4cade0b9bab8/greenlet-3.4.0-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:b7857e2202aae67bc5725e0c1f6403c20a8ff46094ece015e7d474f5f7020b55", size = 426238, upload-time = "2026-04-08T16:43:06.865Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/c0/8966767de01343c1ff47e8b855dc78e7d1a8ed2b7b9c83576a57e289f81d/greenlet-3.4.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:227a46251ecba4ff46ae742bc5ce95c91d5aceb4b02f885487aff269c127a729", size = 1575310, upload-time = "2026-04-08T16:26:21.671Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/38/bcdc71ba05e9a5fda87f63ffc2abcd1f15693b659346df994a48c968003d/greenlet-3.4.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5b99e87be7eba788dd5b75ba1cde5639edffdec5f91fe0d734a249535ec3408c", size = 1640435, upload-time = "2026-04-08T15:57:32.572Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/c2/19b664b7173b9e4ef5f77e8cef9f14c20ec7fce7920dc1ccd7afd955d093/greenlet-3.4.0-cp313-cp313-win_amd64.whl", hash = "sha256:849f8bc17acd6295fcb5de8e46d55cc0e52381c56eaf50a2afd258e97bc65940", size = 238760, upload-time = "2026-04-08T17:04:03.878Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/96/795619651d39c7fbd809a522f881aa6f0ead504cc8201c3a5b789dfaef99/greenlet-3.4.0-cp313-cp313-win_arm64.whl", hash = "sha256:9390ad88b652b1903814eaabd629ca184db15e0eeb6fe8a390bbf8b9106ae15a", size = 235498, upload-time = "2026-04-08T17:05:00.584Z" },
+    { url = "https://files.pythonhosted.org/packages/78/02/bde66806e8f169cf90b14d02c500c44cdbe02c8e224c9c67bafd1b8cadd1/greenlet-3.4.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:10a07aca6babdd18c16a3f4f8880acfffc2b88dfe431ad6aa5f5740759d7d75e", size = 286291, upload-time = "2026-04-08T17:09:34.307Z" },
+    { url = "https://files.pythonhosted.org/packages/05/1f/39da1c336a87d47c58352fb8a78541ce63d63ae57c5b9dae1fe02801bbc2/greenlet-3.4.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:076e21040b3a917d3ce4ad68fb5c3c6b32f1405616c4a57aa83120979649bd3d", size = 656749, upload-time = "2026-04-08T16:24:41.721Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/6c/90ee29a4ee27af7aa2e2ec408799eeb69ee3fcc5abcecac6ddd07a5cd0f2/greenlet-3.4.0-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e82689eea4a237e530bb5cb41b180ef81fa2160e1f89422a67be7d90da67f615", size = 669084, upload-time = "2026-04-08T16:31:01.372Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/4a/74078d3936712cff6d3c91a930016f476ce4198d84e224fe6d81d3e02880/greenlet-3.4.0-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:06c2d3b89e0c62ba50bd7adf491b14f39da9e7e701647cb7b9ff4c99bee04b19", size = 673405, upload-time = "2026-04-08T16:40:42.527Z" },
+    { url = "https://files.pythonhosted.org/packages/07/49/d4cad6e5381a50947bb973d2f6cf6592621451b09368b8c20d9b8af49c5b/greenlet-3.4.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4df3b0b2289ec686d3c821a5fee44259c05cfe824dd5e6e12c8e5f5df23085cf", size = 665621, upload-time = "2026-04-08T15:56:35.995Z" },
+    { url = "https://files.pythonhosted.org/packages/79/3e/df8a83ab894751bc31e1106fdfaa80ca9753222f106b04de93faaa55feb7/greenlet-3.4.0-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:070b8bac2ff3b4d9e0ff36a0d19e42103331d9737e8504747cd1e659f76297bd", size = 471670, upload-time = "2026-04-08T16:43:08.512Z" },
+    { url = "https://files.pythonhosted.org/packages/37/31/d1edd54f424761b5d47718822f506b435b6aab2f3f93b465441143ea5119/greenlet-3.4.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:8bff29d586ea415688f4cec96a591fcc3bf762d046a796cdadc1fdb6e7f2d5bf", size = 1622259, upload-time = "2026-04-08T16:26:23.201Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/c6/6d3f9cdcb21c4e12a79cb332579f1c6aa1af78eb68059c5a957c7812d95e/greenlet-3.4.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:8a569c2fb840c53c13a2b8967c63621fafbd1a0e015b9c82f408c33d626a2fda", size = 1686916, upload-time = "2026-04-08T15:57:34.282Z" },
+    { url = "https://files.pythonhosted.org/packages/63/45/c1ca4a1ad975de4727e52d3ffe641ae23e1d7a8ffaa8ff7a0477e1827b92/greenlet-3.4.0-cp314-cp314-win_amd64.whl", hash = "sha256:207ba5b97ea8b0b60eb43ffcacf26969dd83726095161d676aac03ff913ee50d", size = 239821, upload-time = "2026-04-08T17:03:48.423Z" },
+    { url = "https://files.pythonhosted.org/packages/71/c4/6f621023364d7e85a4769c014c8982f98053246d142420e0328980933ceb/greenlet-3.4.0-cp314-cp314-win_arm64.whl", hash = "sha256:f8296d4e2b92af34ebde81085a01690f26a51eb9ac09a0fcadb331eb36dbc802", size = 236932, upload-time = "2026-04-08T17:04:33.551Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/8f/18d72b629783f5e8d045a76f5325c1e938e659a9e4da79c7dcd10169a48d/greenlet-3.4.0-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:d70012e51df2dbbccfaf63a40aaf9b40c8bed37c3e3a38751c926301ce538ece", size = 294681, upload-time = "2026-04-08T15:52:35.778Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/ad/5fa86ec46769c4153820d58a04062285b3b9e10ba3d461ee257b68dcbf53/greenlet-3.4.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a58bec0751f43068cd40cff31bb3ca02ad6000b3a51ca81367af4eb5abc480c8", size = 658899, upload-time = "2026-04-08T16:24:43.32Z" },
+    { url = "https://files.pythonhosted.org/packages/43/f0/4e8174ca0e87ae748c409f055a1ba161038c43cc0a5a6f1433a26ac2e5bf/greenlet-3.4.0-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:05fa0803561028f4b2e3b490ee41216a842eaee11aed004cc343a996d9523aa2", size = 665284, upload-time = "2026-04-08T16:31:02.833Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/92/466b0d9afd44b8af623139a3599d651c7564fa4152f25f117e1ee5949ffb/greenlet-3.4.0-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c4cd56a9eb7a6444edbc19062f7b6fbc8f287c663b946e3171d899693b1c19fa", size = 665872, upload-time = "2026-04-08T16:40:43.912Z" },
+    { url = "https://files.pythonhosted.org/packages/19/da/991cf7cd33662e2df92a1274b7eb4d61769294d38a1bba8a45f31364845e/greenlet-3.4.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e60d38719cb80b3ab5e85f9f1aed4960acfde09868af6762ccb27b260d68f4ed", size = 661861, upload-time = "2026-04-08T15:56:37.269Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/14/3395a7ef3e260de0325152ddfe19dffb3e49fe10873b94654352b53ad48e/greenlet-3.4.0-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:1f85f204c4d54134ae850d401fa435c89cd667d5ce9dc567571776b45941af72", size = 489237, upload-time = "2026-04-08T16:43:09.993Z" },
+    { url = "https://files.pythonhosted.org/packages/36/c5/6c2c708e14db3d9caea4b459d8464f58c32047451142fe2cfd90e7458f41/greenlet-3.4.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7f50c804733b43eded05ae694691c9aa68bca7d0a867d67d4a3f514742a2d53f", size = 1622182, upload-time = "2026-04-08T16:26:24.777Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/4c/50c5fed19378e11a29fabab1f6be39ea95358f4a0a07e115a51ca93385d8/greenlet-3.4.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2d4f0635dc4aa638cda4b2f5a07ae9a2cff9280327b581a3fcb6f317b4fbc38a", size = 1685050, upload-time = "2026-04-08T15:57:36.453Z" },
+    { url = "https://files.pythonhosted.org/packages/db/72/85ae954d734703ab48e622c59d4ce35d77ce840c265814af9c078cacc7aa/greenlet-3.4.0-cp314-cp314t-win_amd64.whl", hash = "sha256:1a4a48f24681300c640f143ba7c404270e1ebbbcf34331d7104a4ff40f8ea705", size = 245554, upload-time = "2026-04-08T17:03:50.044Z" },
 ]
 
 [[package]]
@@ -960,6 +1021,25 @@ wheels = [
 ]
 
 [[package]]
+name = "playwright"
+version = "1.58.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet" },
+    { name = "pyee" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/c9/9c6061d5703267f1baae6a4647bfd1862e386fbfdb97d889f6f6ae9e3f64/playwright-1.58.0-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:96e3204aac292ee639edbfdef6298b4be2ea0a55a16b7068df91adac077cc606", size = 42251098, upload-time = "2026-01-30T15:09:24.028Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/40/59d34a756e02f8c670f0fee987d46f7ee53d05447d43cd114ca015cb168c/playwright-1.58.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:70c763694739d28df71ed578b9c8202bb83e8fe8fb9268c04dd13afe36301f71", size = 41039625, upload-time = "2026-01-30T15:09:27.558Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/ee/3ce6209c9c74a650aac9028c621f357a34ea5cd4d950700f8e2c4b7fe2c4/playwright-1.58.0-py3-none-macosx_11_0_universal2.whl", hash = "sha256:185e0132578733d02802dfddfbbc35f42be23a45ff49ccae5081f25952238117", size = 42251098, upload-time = "2026-01-30T15:09:30.461Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/af/009958cbf23fac551a940d34e3206e6c7eed2b8c940d0c3afd1feb0b0589/playwright-1.58.0-py3-none-manylinux1_x86_64.whl", hash = "sha256:c95568ba1eda83812598c1dc9be60b4406dffd60b149bc1536180ad108723d6b", size = 46235268, upload-time = "2026-01-30T15:09:33.787Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/a6/0e66ad04b6d3440dae73efb39540c5685c5fc95b17c8b29340b62abbd952/playwright-1.58.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8f9999948f1ab541d98812de25e3a8c410776aa516d948807140aff797b4bffa", size = 45964214, upload-time = "2026-01-30T15:09:36.751Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/4b/236e60ab9f6d62ed0fd32150d61f1f494cefbf02304c0061e78ed80c1c32/playwright-1.58.0-py3-none-win32.whl", hash = "sha256:1e03be090e75a0fabbdaeab65ce17c308c425d879fa48bb1d7986f96bfad0b99", size = 36815998, upload-time = "2026-01-30T15:09:39.627Z" },
+    { url = "https://files.pythonhosted.org/packages/41/f8/5ec599c5e59d2f2f336a05b4f318e733077cd5044f24adb6f86900c3e6a7/playwright-1.58.0-py3-none-win_amd64.whl", hash = "sha256:a2bf639d0ce33b3ba38de777e08697b0d8f3dc07ab6802e4ac53fb65e3907af8", size = 36816005, upload-time = "2026-01-30T15:09:42.449Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/c4/cc0229fea55c87d6c9c67fe44a21e2cd28d1d558a5478ed4d617e9fb0c93/playwright-1.58.0-py3-none-win_arm64.whl", hash = "sha256:32ffe5c303901a13a0ecab91d1c3f74baf73b84f4bedbb6b935f5bc11cc98e1b", size = 33085919, upload-time = "2026-01-30T15:09:45.71Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1215,6 +1295,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/52/6d/fffca34caecc4a3f97bda81b2098da5e8ab7efc9a66e819074a11955d87e/pydantic_settings-2.13.1.tar.gz", hash = "sha256:b4c11847b15237fb0171e1462bf540e294affb9b86db4d9aa5c01730bdbe4025", size = 223826, upload-time = "2026-02-19T13:45:08.055Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/00/4b/ccc026168948fec4f7555b9164c724cf4125eac006e176541483d2c959be/pydantic_settings-2.13.1-py3-none-any.whl", hash = "sha256:d56fd801823dbeae7f0975e1f8c8e25c258eb75d278ea7abb5d9cebb01b56237", size = 58929, upload-time = "2026-02-19T13:45:06.034Z" },
+]
+
+[[package]]
+name = "pyee"
+version = "13.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/04/e7c1fe4dc78a6fdbfd6c337b1c3732ff543b8a397683ab38378447baa331/pyee-13.0.1.tar.gz", hash = "sha256:0b931f7c14535667ed4c7e0d531716368715e860b988770fc7eb8578d1f67fc8", size = 31655, upload-time = "2026-02-14T21:12:28.044Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/c4/b4d4827c93ef43c01f599ef31453ccc1c132b353284fc6c87d535c233129/pyee-13.0.1-py3-none-any.whl", hash = "sha256:af2f8fede4171ef667dfded53f96e2ed0d6e6bd7ee3bb46437f77e3b57689228", size = 15659, upload-time = "2026-02-14T21:12:26.263Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Part of #408 — completes Phase 1 Step 2 of the audit platform migration. Closes #183 (Python scan engine) once merged + verified in parallel with the Node service.

## Summary

Ports the Lighthouse scan engine from `apps/audit-scan-service` (Node/Express/Puppeteer) to `apps/audit-api` (Python/FastAPI). Same API contract — Next.js proxy route at `/api/audit/scan` keeps working after swapping `SCAN_SERVICE_URL`.

## What changed

### Services (`app/services/`)
- **`lighthouse_config.py`** — Mobile/desktop configs + `build_cli_args()` that produce flags matching the Node config exactly (`cpuSlowdownMultiplier=1`, throttling, screen emulation).
- **`scanner.py`** — Async `run_scan()`: shells out to Lighthouse CLI via `asyncio.create_subprocess_exec` → writes JSON → re-reads; Playwright Chromium for page title/meta/screenshot and axe-core injection from bundled `axe.min.js`.
- **`issues.py`** — Line-for-line port of `parseIssues`: Lighthouse audits with `score < 0.9` via `LIGHTHOUSE_ISSUE_MAPPINGS`, then axe violations with severity mapping, then stable sort (critical → warning → info, then perf → a11y → seo → ux).
- **`issue_mappings.py`** — Full port of `LIGHTHOUSE_ISSUE_MAPPINGS` (22 mappings).
- **`grading.py`** — Weighted A-F grade (0.4/0.25/0.2/0.15 for perf/a11y/seo/bp).
- **`persistence.py`** — `mark_scan_running`, `persist_scan_completion` (writes scores, CWV, raw payloads, inserts `scan_issues` rows), `mark_scan_failed`.
- **`scan_queue.py`** — Asyncio single-worker queue. Lighthouse uses global performance marks so concurrent runs collide; one job at a time.
- **`supabase_client.py`** — Cached factory; returns `None` if env vars are unset (local dev).

### Routes
- **`routers/run_scan.py`** — `POST /run-scan` with `x-api-key` auth. Fire-and-forget: enqueues and returns `{status: \"accepted\", scan_id}`.
- **`main.py`** — Registers router; `/health` now reports `queue` size + `running` flag.

### Infrastructure
- **`pyproject.toml`** — Adds `playwright>=1.48`, `supabase>=2.9`.
- **`Dockerfile`** — Installs Chromium, Node 20, Lighthouse CLI 12, axe-core, and Playwright Chromium browser. `LIGHTHOUSE_BIN` and `AXE_SCRIPT_PATH` env vars for path overrides.

## Tests

47 passing pytest cases:
- `test_grading.py` (6) — weighted boundaries A/B/C/D/F.
- `test_issues.py` (7) — null score ignore, 0.9 threshold, severity mapping, singular/plural, dedup edge case.
- `test_lighthouse_config.py` (6) — CLI arg generation.
- `test_persistence.py` (5) — update/insert payloads via fake Supabase client.
- `test_run_scan_route.py` (4) — auth, validation, enqueue, health.
- `test_scan_queue.py` (3) — completion, failure path, serialization (concurrent jobs produce `max_concurrent == 1`).

## Not in this PR (follow-up)

- **Railway deploy** — needs `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`, `AUDIT_API_KEY`, `ADMIN_SESSION_SECRET`, `ALLOWED_HOSTS` set.
- **Env-var swap** — change Next.js `SCAN_SERVICE_URL` to point at the FastAPI service.
- **Parity run** — scan the same URL against both services; compare scores + issues.
- **Retire Node service** — delete `apps/audit-scan-service/` after parity is confirmed.

## Note on branches

`develop` is behind `main` by merge commit 9208729 (PR #414 cut). Not blocking this PR, but flagging per CLAUDE.md.

## Test plan

- [x] `uv run --package audit-api pytest` — 47 passed
- [x] `uv run --package audit-api ruff check .` — clean
- [x] `uv run --package audit-api mypy app/` — clean
- [x] `pnpm tsc --noEmit` — zero errors
- [ ] Manual: `docker build` on this Dockerfile + smoke scan locally
- [ ] Parity: run Node and Python services against the same URL, diff scores

🤖 Generated with [Claude Code](https://claude.com/claude-code)