### PR TITLE
fix(docker): honor $PORT env var in audit-api and job-api CMDs

### DIFF
--- a/apps/audit-api/Dockerfile
+++ b/apps/audit-api/Dockerfile
@@ -45,11 +45,12 @@ WORKDIR /app/apps/audit-api
 
 ENV PATH="/app/.venv/bin:$PATH" \
     LIGHTHOUSE_BIN=lighthouse \
-    AXE_SCRIPT_PATH=/app/vendor/axe.min.js
+    AXE_SCRIPT_PATH=/app/vendor/axe.min.js \
+    PORT=8001
 
 EXPOSE 8001
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-    CMD python -c "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://127.0.0.1:8001/health', timeout=3).status == 200 else 1)"
+    CMD python -c "import os,urllib.request,sys; sys.exit(0 if urllib.request.urlopen(f'http://127.0.0.1:{os.environ.get(\"PORT\", \"8001\")}/health', timeout=3).status == 200 else 1)"
 
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8001", "--proxy-headers", "--forwarded-allow-ips=*"]
+CMD ["sh", "-c", "exec uvicorn app.main:app --host 0.0.0.0 --port ${PORT} --proxy-headers --forwarded-allow-ips=*"]

--- a/apps/job-api/Dockerfile
+++ b/apps/job-api/Dockerfile
@@ -14,6 +14,8 @@ COPY apps/job-api/app ./apps/job-api/app
 
 WORKDIR /app/apps/job-api
 
+ENV PORT=8000
+
 EXPOSE 8000
 
-CMD ["uv", "run", "--package", "job-api", "uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["sh", "-c", "exec uv run --package job-api uvicorn app.main:app --host 0.0.0.0 --port ${PORT}"]


### PR DESCRIPTION
## Summary

- Railway (and most PaaS runtimes) inject `$PORT` at runtime and expect the container to bind to it.
- Both `apps/audit-api/Dockerfile` and `apps/job-api/Dockerfile` were using exec-form `CMD` arrays with hardcoded ports (8001 / 8000). Exec-form does not expand env vars, so when Railway's Config-as-code path was not wired up, the container fell back to the Dockerfile `CMD` and bound to the wrong port — causing a 502 on the public domain.
- Switch both `CMD`s to sh-form with `exec` so:
  - `${PORT}` expands (Railway, Fly, Cloud Run)
  - signals still reach uvicorn directly (the `exec` replaces the shell, preserving graceful shutdown)
  - `ENV PORT=<default>` preserves local `docker run` behavior

The audit-api `HEALTHCHECK` now also reads `PORT` from the environment.

## Test plan

- [x] `pnpm nx test audit-api` / `pnpm nx test job-api` still pass (no code change)
- [ ] Redeploy `audit-api` on Railway — `/health` should return 200 on the public domain without needing Config-as-code override
- [ ] Redeploy `job-api` on Railway — `/health` should still return 200 (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)