### PR TITLE
fix(audit-api): drop Chrome flags that crash Chromium on Railway

### DIFF
--- a/apps/audit-api/app/services/lighthouse_config.py
+++ b/apps/audit-api/app/services/lighthouse_config.py
@@ -9,18 +9,19 @@ LIGHTHOUSE_CATEGORIES = ["performance", "accessibility", "best-practices", "seo"
 # from inside an unprivileged container; the container itself is the sandbox
 # (non-root uid, no host mounts). Do not relax container isolation without
 # re-enabling --sandbox or introducing an out-of-process browser jail.
+#
+# Flag set intentionally matches apps/audit-scan-service/src/config/lighthouse.ts
+# so Node and Python services produce comparable scan output during parity
+# testing. Notably absent: --single-process / --no-zygote (they crash modern
+# Chromium at launch when Lighthouse's CLI spawns Chrome), and --headless=new
+# (stick to --headless to match the Node service's flag set).
 CHROME_FLAGS = [
-    "--headless=new",
+    "--headless",
     "--disable-gpu",
     "--no-sandbox",
     "--disable-dev-shm-usage",
     "--disable-extensions",
     "--disable-background-networking",
-    "--disable-crash-reporter",
-    "--disable-breakpad",
-    "--disable-software-rasterizer",
-    "--single-process",
-    "--no-zygote",
 ]
 
 


### PR DESCRIPTION
## Summary

- Lighthouse on the deployed Python service was failing with \`Failed to fetch browser webSocket URL from http://127.0.0.1:NNNNN/json/version\`.
- Root cause: \`--single-process\` + \`--no-zygote\` cause Chrome to exit before DevTools opens when launched via Lighthouse's CLI (which spawns its own Chrome, not Puppeteer-managed like the Node service does).
- Also dropped \`--headless=new\` in favor of \`--headless\` and removed the \`--disable-crash-reporter\` / \`--disable-breakpad\` / \`--disable-software-rasterizer\` flags so the set exactly matches \`apps/audit-scan-service/src/config/lighthouse.ts\`. That way the Python service reproduces Node behavior during parity testing.

## Test plan

- [x] \`pnpm nx test audit-api\` — 59 tests pass
- [ ] Redeploy on Railway and smoke-test \`POST /run-scan\` — expect \`Scan completed\` in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)