### PR TITLE
feat(audit-api): wire Sentry for prod error tracking

### DIFF
--- a/apps/audit-api/.env.example
+++ b/apps/audit-api/.env.example
@@ -13,3 +13,10 @@ ADMIN_SESSION_SECRET=
 # any private networking hostnames the Next.js proxy will call.
 # Example: audit-api.up.railway.app,audit-api.railway.internal
 ALLOWED_HOSTS=*
+
+# --- Sentry (optional locally, required in prod) ---
+# Empty DSN = no-op. Scan worker crashes and request exceptions only surface
+# in Railway logs when Sentry is off.
+SENTRY_DSN=
+SENTRY_ENVIRONMENT=development
+SENTRY_TRACES_SAMPLE_RATE=0.1

--- a/apps/audit-api/README.md
+++ b/apps/audit-api/README.md
@@ -36,6 +36,9 @@ The service builds from the monorepo root so the uv workspace lockfile is in sco
    - `AUDIT_API_KEY` — must match Vercel's `SCAN_SERVICE_API_KEY`
    - `ADMIN_SESSION_SECRET` — must match Vercel's
    - `ALLOWED_HOSTS` — set to the Railway public domain once known (use `*` temporarily during setup)
+   - `SENTRY_DSN` — project DSN from Sentry. Leave empty to disable (scan failures then only surface in Railway logs).
+   - `SENTRY_ENVIRONMENT` — `development` or `production`. Matches the Railway environment the service is deployed to.
+   - `SENTRY_TRACES_SAMPLE_RATE` — float 0..1. Start at `0.1` in prod; tune down if trace volume gets expensive.
 3. **Generate the public domain** (Settings → Networking → Generate Domain).
 4. **Smoke-test**: `curl https://<domain>/health` → `{"status":"ok",...}`.
 5. **Wire Vercel**: set `SCAN_SERVICE_URL=https://<domain>` after parity is confirmed (see below).
@@ -43,6 +46,17 @@ The service builds from the monorepo root so the uv workspace lockfile is in sco
 ### Resource tier
 
 Chromium needs headroom. Start at 1 GB RAM / 1 vCPU; bump to 2 GB if scans time out under real load.
+
+### Promoting to production
+
+The current Railway deployment is a `development` environment. To cut over to production:
+
+1. **Add a `production` environment** (Railway → Project → `+ New Environment` → duplicate `development`).
+2. **Scope the env vars per environment.** For each variable in step 2 above, use the environment dropdown so `production` gets its own `SUPABASE_*`, `AUDIT_API_KEY`, `ADMIN_SESSION_SECRET`, `ALLOWED_HOSTS`, and `SENTRY_ENVIRONMENT=production`. Share the Sentry DSN across environments; the `SENTRY_ENVIRONMENT` tag is how Sentry separates them.
+3. **Generate a production domain** (Networking → Generate Domain under the `production` environment). Set `ALLOWED_HOSTS` to that host.
+4. **Flip Vercel prod.** Set `SCAN_SERVICE_URL` in the Vercel production environment to the new domain. Trigger a redeploy of the Next.js app so the proxy picks it up.
+5. **Rotate `AUDIT_API_KEY`** on the new environment before flipping, so the prior shared secret can't be reused.
+6. **Watch Sentry + Railway logs for 24h** before retiring the `development` deployment.
 
 ## Parity test (before retiring the Node service)
 

--- a/apps/audit-api/app/config.py
+++ b/apps/audit-api/app/config.py
@@ -7,6 +7,9 @@ class Settings(BaseSettings):
     audit_api_key: str = ""
     admin_session_secret: str = ""
     allowed_hosts: str = ""
+    sentry_dsn: str = ""
+    sentry_environment: str = "development"
+    sentry_traces_sample_rate: float = 0.1
 
     model_config = {"env_file": ".env", "env_file_encoding": "utf-8"}
 

--- a/apps/audit-api/app/main.py
+++ b/apps/audit-api/app/main.py
@@ -5,6 +5,7 @@ from fastapi import FastAPI
 from starlette.middleware.trustedhost import TrustedHostMiddleware
 
 from app.config import settings
+from app.observability import init_sentry
 from app.routers import run_scan as run_scan_router
 from app.schemas import HealthResponse
 from app.services.scan_queue import get_queue
@@ -14,6 +15,8 @@ if not settings.allowed_hosts_list:
         "ALLOWED_HOSTS must be set (comma-separated host allowlist). "
         "Use '*' only in local dev."
     )
+
+init_sentry()
 
 
 @asynccontextmanager

--- a/apps/audit-api/app/observability.py
+++ b/apps/audit-api/app/observability.py
@@ -1,0 +1,24 @@
+"""Sentry wiring. Must be imported before FastAPI is instantiated.
+
+Sentry's FastAPI integration patches Starlette middleware at init time, so
+`init_sentry()` has to run before `app = FastAPI(...)`. Callers with no DSN
+configured get a no-op (useful for local dev and tests without credentials).
+"""
+
+from __future__ import annotations
+
+import sentry_sdk
+
+from app.config import settings
+
+
+def init_sentry() -> None:
+    if not settings.sentry_dsn:
+        return
+
+    sentry_sdk.init(
+        dsn=settings.sentry_dsn,
+        environment=settings.sentry_environment,
+        traces_sample_rate=settings.sentry_traces_sample_rate,
+        send_default_pii=False,
+    )

--- a/apps/audit-api/app/services/scan_queue.py
+++ b/apps/audit-api/app/services/scan_queue.py
@@ -2,6 +2,8 @@ import asyncio
 import logging
 from dataclasses import dataclass
 
+import sentry_sdk
+
 from app.services.issues import parse_issues
 from app.services.lighthouse_config import DeviceMode
 from app.services.persistence import (
@@ -66,6 +68,7 @@ class ScanQueue:
                 await self._execute(job)
             except Exception as exc:
                 logger.exception("Scan worker crashed on %s: %s", job.scan_id, exc)
+                sentry_sdk.capture_exception(exc)
             finally:
                 self._running = False
                 self._queue.task_done()
@@ -90,6 +93,7 @@ class ScanQueue:
             message = str(exc) or "Unknown scan error"
             await mark_scan_failed(supabase, job.scan_id, message)
             logger.exception("Scan errored: %s", job.scan_id)
+            sentry_sdk.capture_exception(exc)
 
 
 _queue: ScanQueue | None = None

--- a/apps/audit-api/pyproject.toml
+++ b/apps/audit-api/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
   "pyjwt>=2.10",
   "playwright>=1.48",
   "supabase>=2.9",
+  "sentry-sdk[fastapi]>=2.19",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -49,6 +49,7 @@ dependencies = [
     { name = "playwright" },
     { name = "pydantic-settings" },
     { name = "pyjwt" },
+    { name = "sentry-sdk", extra = ["fastapi"] },
     { name = "supabase" },
     { name = "uvicorn", extra = ["standard"] },
 ]
@@ -68,6 +69,7 @@ requires-dist = [
     { name = "playwright", specifier = ">=1.48" },
     { name = "pydantic-settings", specifier = ">=2.7" },
     { name = "pyjwt", specifier = ">=2.10" },
+    { name = "sentry-sdk", extras = ["fastapi"], specifier = ">=2.19" },
     { name = "supabase", specifier = ">=2.9" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.34" },
 ]
@@ -1622,6 +1624,24 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/88/3d/1364fcde8656962782aa9ea93c92d98682b1ecec2f184e625a965ad3b4a6/ruff-0.15.9-py3-none-win32.whl", hash = "sha256:bde6ff36eaf72b700f32b7196088970bf8fdb2b917b7accd8c371bfc0fd573ec", size = 10583382, upload-time = "2026-04-02T18:17:04.261Z" },
     { url = "https://files.pythonhosted.org/packages/4c/56/5c7084299bd2cacaa07ae63a91c6f4ba66edc08bf28f356b24f6b717c799/ruff-0.15.9-py3-none-win_amd64.whl", hash = "sha256:45a70921b80e1c10cf0b734ef09421f71b5aa11d27404edc89d7e8a69505e43d", size = 11744969, upload-time = "2026-04-02T18:16:59.611Z" },
     { url = "https://files.pythonhosted.org/packages/03/36/76704c4f312257d6dbaae3c959add2a622f63fcca9d864659ce6d8d97d3d/ruff-0.15.9-py3-none-win_arm64.whl", hash = "sha256:0694e601c028fd97dc5c6ee244675bc241aeefced7ef80cd9c6935a871078f53", size = 11005870, upload-time = "2026-04-02T18:17:15.773Z" },
+]
+
+[[package]]
+name = "sentry-sdk"
+version = "2.58.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/26/b3/fb8291170d0e844173164709fc0fa0c221ed75a5da740c8746f2a83b4eb1/sentry_sdk-2.58.0.tar.gz", hash = "sha256:c1144d947352d54e5b7daa63596d9f848adf684989c06c4f5a659f0c85a18f6f", size = 438764, upload-time = "2026-04-13T17:23:26.265Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/eb/d875669993b762556ae8b2efd86219943b4c0864d22204d622a9aee3052b/sentry_sdk-2.58.0-py2.py3-none-any.whl", hash = "sha256:688d1c704ddecf382ea3326f21a67453d4caa95592d722b7c780a36a9d23109e", size = 460919, upload-time = "2026-04-13T17:23:24.675Z" },
+]
+
+[package.optional-dependencies]
+fastapi = [
+    { name = "fastapi" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Scan failures in `apps/audit-api` currently only surface in Railway logs. Wire Sentry so the scan worker's unexpected errors page us through the same Sentry project the Next.js app uses.
- Leaves `ScanError` alone — those are expected per-URL failures (bad URL, timeout, site 5xx) and belong in the scan's `error_message` column, not in Sentry. Only genuinely unexpected exceptions (worker crash or unknown exception in `_execute`) get captured.
- Init pattern: `init_sentry()` runs at module-top in \`main.py\` **before** \`FastAPI(...)\` is instantiated, because Sentry's Starlette middleware patches have to attach in time.
- Empty \`SENTRY_DSN\` = no-op. Local dev and unit tests need no extra config.

## Changes

- \`pyproject.toml\` — \`sentry-sdk[fastapi]>=2.19\`
- \`app/config.py\` — three new Settings fields: \`sentry_dsn\`, \`sentry_environment\`, \`sentry_traces_sample_rate\`
- \`app/observability.py\` (new, 24 lines) — \`init_sentry()\`
- \`app/main.py\` — calls \`init_sentry()\` before FastAPI instantiation
- \`app/services/scan_queue.py\` — \`sentry_sdk.capture_exception\` in the two unexpected-error paths
- \`README.md\` — three new env vars documented + new **Promoting to production** section (duplicate the Railway \`development\` env, scope vars per env, rotate the API key before Vercel flips)
- \`.env.example\` — Sentry block appended

## Manual follow-ups (not in this PR)

- [ ] Create a Sentry project (or reuse the Next.js one with a separate DSN) and set \`SENTRY_DSN\` in Railway → Variables.
- [ ] Set \`SENTRY_ENVIRONMENT=development\` on the existing Railway env; later set \`=production\` on the prod env when the README walkthrough is followed.

## Test plan

- [x] \`pnpm nx typecheck audit-api\` — mypy strict, 17 source files, 0 errors
- [x] \`pnpm nx test audit-api\` — 59 tests pass
- [x] \`uv sync --package audit-api\` — sentry-sdk 2.58.0 resolved
- [x] Existing tests exercise the no-op path (empty DSN) at import time, so \`init_sentry()\` is proved safe without a DSN configured
- [ ] After merge + Railway DSN set, verify a captured event lands in the Sentry project (intentional \`raise\` in a scan to prove the wiring)

## Why not capture \`ScanError\`?

\`ScanError\` means Lighthouse or axe ran but the scan didn't produce usable output (bad URL, target site returned 500, timeout). Those are expected per-URL outcomes, shown to the user via the scan report's \`error_message\`. Sending them to Sentry turns every broken customer URL into a Sentry notification — that's noise, not signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)