### PR TITLE
ci: path-gate ci-full jobs + log Playwright cache hits

### DIFF
--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -20,7 +20,52 @@ on:
         required: false
 
 jobs:
+  filter:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      e2e: ${{ steps.paths.outputs.e2e }}
+      lighthouse: ${{ steps.paths.outputs.lighthouse }}
+      storybook: ${{ steps.paths.outputs.storybook }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          filter: tree:0
+          fetch-depth: 0
+
+      - name: Classify changed paths
+        id: paths
+        run: |
+          CHANGED=$(git diff --name-only "${{ inputs.nx-base }}" "${{ inputs.nx-head }}")
+          E2E=false
+          LH=false
+          SB=false
+          while IFS= read -r file; do
+            [ -z "$file" ] && continue
+            case "$file" in
+              apps/root/*|apps/root-e2e/*|libs/*)
+                E2E=true
+                ;;
+            esac
+            case "$file" in
+              apps/root/*|libs/shared/*)
+                LH=true
+                ;;
+            esac
+            case "$file" in
+              libs/shared/ui/*|apps/root/.storybook/*|*.stories.ts|*.stories.tsx|*.stories.mdx|*.stories.js|*.stories.jsx)
+                SB=true
+                ;;
+            esac
+          done <<< "$CHANGED"
+          echo "e2e=$E2E" >> "$GITHUB_OUTPUT"
+          echo "lighthouse=$LH" >> "$GITHUB_OUTPUT"
+          echo "storybook=$SB" >> "$GITHUB_OUTPUT"
+          echo "Changed path flags: e2e=$E2E lighthouse=$LH storybook=$SB"
+
   e2e:
+    needs: filter
+    if: needs.filter.outputs.e2e == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -36,10 +81,19 @@ jobs:
         run: echo "version=$(node -e "console.log(require('@playwright/test/package.json').version)")" >> "$GITHUB_OUTPUT"
 
       - name: Cache Playwright browsers
+        id: playwright-cache
         uses: actions/cache@v5
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
+
+      - name: Log Playwright cache status
+        run: |
+          if [ "${{ steps.playwright-cache.outputs.cache-hit }}" = "true" ]; then
+            echo "::notice::Playwright cache HIT (version ${{ steps.playwright-version.outputs.version }})"
+          else
+            echo "::warning::Playwright cache MISS (version ${{ steps.playwright-version.outputs.version }}) — browsers will download"
+          fi
 
       - name: Install Playwright
         run: pnpm exec playwright install --with-deps chromium
@@ -53,6 +107,8 @@ jobs:
           NX_CLOUD_ID: ${{ secrets.NX_CLOUD_ID }}
 
   lighthouse:
+    needs: filter
+    if: needs.filter.outputs.lighthouse == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -75,6 +131,8 @@ jobs:
           LHCI_GITHUB_APP_TOKEN: ${{ github.token }}
 
   storybook-and-chromatic:
+    needs: filter
+    if: needs.filter.outputs.storybook == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
@@ -101,19 +159,31 @@ jobs:
 
   gate:
     if: always()
-    needs: [e2e, lighthouse, storybook-and-chromatic]
+    needs: [filter, e2e, lighthouse, storybook-and-chromatic]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - name: Check results
         run: |
-          if [ "${{ needs.e2e.result }}" = "failure" ] || \
-             [ "${{ needs.lighthouse.result }}" = "failure" ] || \
-             [ "${{ needs.storybook-and-chromatic.result }}" = "failure" ]; then
-            echo "CI full checks failed"
-            echo "  e2e: ${{ needs.e2e.result }}"
-            echo "  lighthouse: ${{ needs.lighthouse.result }}"
-            echo "  storybook-and-chromatic: ${{ needs.storybook-and-chromatic.result }}"
+          echo "  filter: ${{ needs.filter.result }}"
+          echo "  e2e: ${{ needs.e2e.result }}"
+          echo "  lighthouse: ${{ needs.lighthouse.result }}"
+          echo "  storybook-and-chromatic: ${{ needs.storybook-and-chromatic.result }}"
+
+          if [ "${{ needs.filter.result }}" = "failure" ] || [ "${{ needs.filter.result }}" = "cancelled" ]; then
+            echo "CI full filter failed"
             exit 1
           fi
-          echo "All CI full checks passed"
+          if [ "${{ needs.e2e.result }}" = "failure" ] || [ "${{ needs.e2e.result }}" = "cancelled" ]; then
+            echo "CI full e2e failed"
+            exit 1
+          fi
+          if [ "${{ needs.lighthouse.result }}" = "failure" ] || [ "${{ needs.lighthouse.result }}" = "cancelled" ]; then
+            echo "CI full lighthouse failed"
+            exit 1
+          fi
+          if [ "${{ needs.storybook-and-chromatic.result }}" = "failure" ] || [ "${{ needs.storybook-and-chromatic.result }}" = "cancelled" ]; then
+            echo "CI full storybook-and-chromatic failed"
+            exit 1
+          fi
+          echo "All CI full checks passed or were skipped"


### PR DESCRIPTION
## Summary

Follow-up to #432. Covers audit wins #3, #4, and #5.

- **Path-gate e2e / lighthouse / storybook** in ci-full.yml. Previously every push to \`develop\` ran all three jobs regardless of what changed. A new \`filter\` job classifies the diff between \`nx-base..nx-head\` and emits booleans; each downstream job gates on its flag.
- **Filter rules**:
  - \`e2e\` — apps/root, apps/root-e2e, libs
  - \`lighthouse\` — apps/root, libs/shared
  - \`storybook\` — libs/shared/ui, apps/root/.storybook, any \`*.stories.*\`
- **Playwright cache visibility**: the e2e job now logs a \`::notice::\` on cache hit and a \`::warning::\` on miss, so cold caches are obvious at a glance (audit win #5).

Expected impact: 20–30% fewer Nx Cloud transactions on non-UI pushes to develop, plus runner-minute savings (Playwright install + Lighthouse build are expensive). Preserves Chromatic quota on non-UI pushes.

## Test plan

- [ ] Push to develop touching only \`apps/root/src/app/**\` → all three full jobs run
- [ ] Push to develop touching only \`apps/audit-api/**\` → filter prints \`e2e=false lighthouse=false storybook=false\`; all three jobs skip; gate passes
- [ ] Push to develop touching a \`.stories.tsx\` in libs/shared/ui → storybook-and-chromatic runs, e2e and lighthouse skip
- [ ] Check Playwright cache annotation appears on e2e job summary (hit on second run, miss on first after Playwright version bump)
- [ ] Verify \`ci-status\` gate in ci.yml still passes when individual full jobs are skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)