### PR TITLE
ci: disable Nx Cloud until May 1 credit reset (hotfix)

### DIFF
--- a/.github/workflows/ci-fast.yml
+++ b/.github/workflows/ci-fast.yml
@@ -17,6 +17,10 @@ on:
       NX_CLOUD_ID:
         required: false
 
+env:
+  # Nx Cloud org is disabled until the May 1 credit reset; skip the cloud handshake entirely.
+  NX_NO_CLOUD: 'true'
+
 jobs:
   checks:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -19,6 +19,10 @@ on:
       CHROMATIC_PROJECT_TOKEN:
         required: false
 
+env:
+  # Nx Cloud org is disabled until the May 1 credit reset; skip the cloud handshake entirely.
+  NX_NO_CLOUD: 'true'
+
 jobs:
   filter:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,10 @@ permissions:
   contents: read
   statuses: write
 
+env:
+  # Nx Cloud org is disabled until the May 1 credit reset; skip the cloud handshake entirely.
+  NX_NO_CLOUD: 'true'
+
 jobs:
   preflight:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

CI is currently failing on every run with:

\`\`\`
NX   Nx Cloud: Workspace is unable to be authorized. Exiting run.
This Nx Cloud organization has been disabled due to exceeding the FREE plan.
\`\`\`

The Hobby-plan org was hard-disabled after exceeding credits — not just cache-disabled. Nx Cloud rejects the auth handshake, which causes \`nx\` itself to exit before running any task.

Sets \`NX_NO_CLOUD: 'true'\` at the workflow level in \`ci.yml\`, \`ci-fast.yml\`, and \`ci-full.yml\` so Nx skips the cloud handshake entirely and runs locally on the GitHub runner.

The \`NX_CLOUD_ACCESS_TOKEN\` and \`NX_CLOUD_ID\` secrets stay in place. When billing resets on May 1 (or when upgrading to the Team plan), revert this by deleting the three \`env:\` blocks.

## Test plan

- [ ] Merge this PR, watch the \`fast\` job on develop: should run \`nx affected\` without the "unable to be authorized" error
- [ ] Confirm \`update-snapshots\` workflow dispatch still runs
- [ ] Note in calendar: re-enable Nx Cloud on May 1 (revert this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)