### PR TITLE
fix(audit-api): stop Chromium SIGSEGV on Railway prod

### DIFF
--- a/apps/audit-api/Dockerfile
+++ b/apps/audit-api/Dockerfile
@@ -1,21 +1,15 @@
-FROM ghcr.io/astral-sh/uv:python3.11-bookworm-slim AS base
+# Official Playwright image ships Chromium + all required system libs, vetted
+# by the Playwright team. The previous uv+bookworm base with apt-installed
+# chromium was SIGSEGV-ing on Playwright's Chromium launch in Railway.
+FROM mcr.microsoft.com/playwright/python:v1.48.0-jammy AS base
+
+# uv for Python dependency management (not present in the Playwright image).
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
 
 RUN groupadd --system --gid 1001 app \
     && useradd --system --uid 1001 --gid app --home-dir /app --shell /sbin/nologin app
 
-# System deps: Chromium (for Lighthouse + Playwright), Node (for Lighthouse CLI).
-# The Lighthouse CLI bundles puppeteer which expects Chrome/Chromium.
-RUN apt-get update && apt-get install -y --no-install-recommends \
-        ca-certificates \
-        chromium \
-        fonts-liberation \
-        curl \
-        gnupg \
-    && curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
-    && apt-get install -y --no-install-recommends nodejs \
-    && rm -rf /var/lib/apt/lists/*
-
-# Install Lighthouse CLI + axe-core globally
+# Lighthouse CLI + axe-core. Node.js is already present in the Playwright image.
 RUN npm install -g lighthouse@12.8.0 \
     && mkdir -p /app/vendor \
     && npm pack axe-core@4.11.3 --pack-destination=/tmp \
@@ -25,15 +19,19 @@ RUN npm install -g lighthouse@12.8.0 \
 
 WORKDIR /app
 
-# Build context is the monorepo root so the workspace lockfile is available.
 COPY pyproject.toml uv.lock ./
 COPY apps/audit-api/pyproject.toml ./apps/audit-api/pyproject.toml
 
 RUN uv sync --frozen --no-dev --no-editable --package audit-api
 
-# Playwright Chromium install (used for axe injection + screenshots)
-ENV PLAYWRIGHT_BROWSERS_PATH=/app/.playwright
-RUN /app/.venv/bin/python -m playwright install chromium --with-deps
+# Playwright browsers are pre-installed at /ms-playwright. No re-download needed.
+ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
+
+# Lighthouse's chrome-launcher follows CHROME_PATH. Point it at Playwright's
+# Chromium so both scans use the same validated binary.
+RUN CHROME_BIN="$(ls -1d /ms-playwright/chromium-*/chrome-linux/chrome 2>/dev/null | head -1)" \
+    && test -n "$CHROME_BIN" \
+    && ln -sf "$CHROME_BIN" /usr/local/bin/chrome
 
 COPY apps/audit-api/app ./apps/audit-api/app
 
@@ -45,6 +43,7 @@ WORKDIR /app/apps/audit-api
 
 ENV PATH="/app/.venv/bin:$PATH" \
     LIGHTHOUSE_BIN=lighthouse \
+    CHROME_PATH=/usr/local/bin/chrome \
     AXE_SCRIPT_PATH=/app/vendor/axe.min.js \
     PORT=8001
 

--- a/apps/audit-api/app/services/scanner.py
+++ b/apps/audit-api/app/services/scanner.py
@@ -65,7 +65,13 @@ async def _run_axe_and_capture(
     cfg = config_for(device)
     async with async_playwright() as pw:
         browser = await pw.chromium.launch(
-            args=["--no-sandbox", "--disable-dev-shm-usage"]
+            args=[
+                "--no-sandbox",
+                "--disable-dev-shm-usage",
+                "--disable-gpu",
+                "--disable-software-rasterizer",
+                "--disable-setuid-sandbox",
+            ]
         )
         try:
             context = await browser.new_context(


### PR DESCRIPTION
## Summary

Railway prod was segfaulting on Playwright's Chromium launch after Lighthouse completed. Logs:

\`\`\`
[pid=180] Received signal 11 SI_KERNEL
playwright._impl._errors.TargetClosedError: BrowserType.launch:
  Target page, context or browser has been closed
File "app/services/scanner.py", line 67, in _run_axe_and_capture
\`\`\`

With 8GB RAM / 8 vCPU allocated to the Railway service, OOM is ruled out. The previous uv+bookworm base with an apt-installed \`chromium\` package brought a second Chromium binary and an older library set that conflicted with Playwright's own \`headless_shell\`.

## Fixes

1. **Dockerfile base image** → \`mcr.microsoft.com/playwright/python:v1.48.0-jammy\`. Ships Chromium plus every required system lib, vetted upstream. One Chromium, not two. Lighthouse's \`chrome-launcher\` picks up Playwright's binary via a \`CHROME_PATH\` symlink so both scan steps share the same validated Chrome.
2. **Playwright launch flags** → added \`--disable-gpu\`, \`--disable-software-rasterizer\`, \`--disable-setuid-sandbox\` to the flags in \`scanner.py\`. Defence in depth: any residual init path that probes a GPU device or setuid helper short-circuits cleanly instead of faulting.

## Why this over bumping RAM

RAM is already at the plan max (8GB). SIGSEGV on Chromium with ample memory is a binary/deps problem, not a capacity problem.

## Test plan

- [ ] Railway build succeeds on this branch
- [ ] \`/run-scan\` with a real UUID against \`https://danieljoffe.com/audit\` completes end-to-end
- [ ] Lighthouse score + axe violations surface in the report payload
- [ ] Screenshot uploads to Supabase
- [ ] No residual SIGSEGV / \`TargetClosedError\` in Railway logs for 24h

🤖 Generated with [Claude Code](https://claude.com/claude-code)