### PR TITLE
ci: drop redundant warmup in update-snapshots workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,19 +194,6 @@ jobs:
 
       - uses: ./.github/actions/setup-workspace
 
-      - uses: nrwl/nx-set-shas@v5
-        id: shas
-        with:
-          main-branch-name: develop
-
-      - name: Run affected tasks
-        run: pnpm nx affected -t lint test build typecheck build-storybook --nxBail
-        env:
-          NX_BASE: ${{ steps.shas.outputs.base }}
-          NX_HEAD: ${{ steps.shas.outputs.head }}
-          NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
-          NX_CLOUD_ID: ${{ secrets.NX_CLOUD_ID }}
-
       - name: Get Playwright version
         id: playwright-version
         run: echo "version=$(node -e "console.log(require('@playwright/test/package.json').version)")" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

Small cleanup from the CI cost audit. \`update-snapshots\` is a manual \`workflow_dispatch\` for regenerating visual-regression baselines. It pre-ran \`lint test build typecheck build-storybook\` via \`nx affected\` before the snapshot regen, but that's already covered by regular CI on the same branch — duplicating the work on manual dispatch burns runner minutes and Nx Cloud credits for no added safety.

Removes the warmup step and the \`nx-set-shas\` step that only existed to feed it. The explicit \`nx build root\` before snapshot regen stays (Playwright needs that build).

Saves ~3 min wall-clock and 1 Nx Cloud transaction per manual dispatch (rare, but free is free).

## Test plan

- [ ] Trigger \`update-snapshots\` workflow manually with \`update-snapshots: true\`
- [ ] Confirm it builds the app, installs Playwright, regenerates snapshots, and commits them as before
- [ ] No \"Run affected tasks\" step appears in the run

🤖 Generated with [Claude Code](https://claude.com/claude-code)