### PR TITLE
fix(audit-api): pin uv to Python 3.11 in Dockerfile

### DIFF
--- a/apps/audit-api/Dockerfile
+++ b/apps/audit-api/Dockerfile
@@ -30,7 +30,11 @@ WORKDIR /app
 COPY pyproject.toml uv.lock ./
 COPY apps/audit-api/pyproject.toml ./apps/audit-api/pyproject.toml
 
-RUN uv sync --frozen --no-dev --no-editable --package audit-api
+# Pin Python 3.11. Without this, uv picks the newest available (3.14 at time
+# of writing), which has no prebuilt wheels for supabase's pyiceberg dep and
+# would trigger a source build that requires a C toolchain we don't install.
+RUN uv python install 3.11 \
+    && uv sync --frozen --no-dev --no-editable --package audit-api --python 3.11
 
 # Playwright browsers are pre-installed at /ms-playwright. No re-download needed.
 ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright


### PR DESCRIPTION
## Summary

- Railway build was failing because uv picked cpython-3.14.4 when syncing the audit-api environment.
- 3.14 has no prebuilt wheels for supabase's pyiceberg transitive dep, so uv fell back to a source build and the Playwright base image has no C toolchain.
- Pin uv to 3.11 (the project's declared minimum) so wheels resolve cleanly.

## Test plan

- [ ] Railway build of \`audit-api\` succeeds past the \`uv sync\` step
- [ ] Container boots, \`/health\` returns ok
- [ ] \`/run-scan\` smoke test completes (confirms Chromium still launches on the new base image)

🤖 Generated with [Claude Code](https://claude.com/claude-code)