### PR TITLE
ci(chromatic): enable TurboSnap via --only-changed

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "db:reset": "supabase db reset",
     "db:gen-types": "supabase gen types typescript --linked > libs/shared/audit/src/lib/database.types.ts",
     "build-storybook:ui": "nx build-storybook @danieljoffe.com/shared-ui",
-    "chromatic:ui": "chromatic --build-script-name=build-storybook:ui --storybook-base-dir=libs/shared/ui",
+    "chromatic:ui": "chromatic --build-script-name=build-storybook:ui --storybook-base-dir=libs/shared/ui --only-changed",
     "prebuild": "tsx scripts/generate-search-index.ts"
   },
   "private": true,


### PR DESCRIPTION
## Summary

Chromatic is a separate paid service with its own snapshot quota. The \`libs/shared/ui\` Storybook uses \`@storybook/react-vite\`, and Chromatic CLI v16 supports TurboSnap for Vite builders out of the box via \`--only-changed\`. Adds the flag to the \`chromatic:ui\` script.

TurboSnap diffs the Vite module graph against the last-accepted baseline and only snapshots stories whose dependency tree actually changed. Editing a single button no longer re-snapshots every component in the library.

Safety:
- First run on a branch is always full (no baseline yet) → no change in behavior
- If the dependency graph can't be parsed, Chromatic falls back to a full run automatically → worst case is identical to today
- Fully reversible with a one-line revert

## Test plan

- [ ] Merge, push a UI-only change to \`develop\`, check Chromatic build log for \"TurboSnap enabled\" and the \"Skipping X tests that weren't affected\" line
- [ ] Push a single-component change on a follow-up PR, confirm snapshot count is well below the component total
- [ ] If TurboSnap logs \"Couldn't retrieve stats\" or similar, revert this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)