### PR TITLE
fix(audit-api): redirect uv-managed Python under /app for venv perms

### DIFF
--- a/apps/audit-api/Dockerfile
+++ b/apps/audit-api/Dockerfile
@@ -33,6 +33,12 @@ COPY apps/audit-api/pyproject.toml ./apps/audit-api/pyproject.toml
 # Pin Python 3.11. Without this, uv picks the newest available (3.14 at time
 # of writing), which has no prebuilt wheels for supabase's pyiceberg dep and
 # would trigger a source build that requires a C toolchain we don't install.
+#
+# UV_PYTHON_INSTALL_DIR redirects the managed Python under /app so the later
+# `chown -R app:app /app` covers it. The default (/root/.local/share/uv/python)
+# is unreadable by the non-root `app` user, which makes the venv's uvicorn
+# shebang fail with "exec: Permission denied" at container start.
+ENV UV_PYTHON_INSTALL_DIR=/app/.uv-python
 RUN uv python install 3.11 \
     && uv sync --frozen --no-dev --no-editable --package audit-api --python 3.11
 


### PR DESCRIPTION
## Summary

- Container started crashing at boot with \`sh: exec: uvicorn: Permission denied\` after the Python 3.11 pin (#438) landed.
- Root cause: \`uv python install\` defaults to \`/root/.local/share/uv/python/\`; /root is mode 700, so the non-root \`app\` user can't read the interpreter that the venv's uvicorn shebang points at. Exec fails with EACCES.
- Fix: set \`UV_PYTHON_INSTALL_DIR=/app/.uv-python\` before the install step. The existing \`chown -R app:app /app\` then covers the interpreter along with the venv.

## Test plan

- [ ] Railway build still succeeds through \`uv sync\`
- [ ] Container boots; uvicorn starts without permission errors
- [ ] \`/health\` returns ok
- [ ] \`/run-scan\` smoke test completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)