### PR TITLE
fix(audit-api): match Playwright base image to pypi package version

### DIFF
--- a/apps/audit-api/Dockerfile
+++ b/apps/audit-api/Dockerfile
@@ -1,7 +1,13 @@
 # Official Playwright image ships Chromium + all required system libs, vetted
 # by the Playwright team. The previous uv+bookworm base with apt-installed
 # chromium was SIGSEGV-ing on Playwright's Chromium launch in Railway.
-FROM mcr.microsoft.com/playwright/python:v1.48.0-jammy AS base
+#
+# IMPORTANT: this tag MUST match the `playwright` version resolved in uv.lock.
+# Playwright pre-installs browsers at version-specific paths
+# (/ms-playwright/chromium_headless_shell-<build>), and the pypi package
+# refuses to launch a mismatched build. When bumping the playwright pypi dep,
+# bump this tag in the same commit.
+FROM mcr.microsoft.com/playwright/python:v1.58.0-jammy AS base
 
 # uv for Python dependency management (not present in the Playwright image).
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/

--- a/apps/audit-api/pyproject.toml
+++ b/apps/audit-api/pyproject.toml
@@ -10,7 +10,9 @@ dependencies = [
   "uvicorn[standard]>=0.34",
   "pydantic-settings>=2.7",
   "pyjwt>=2.10",
-  "playwright>=1.48",
+  # Must match the Playwright base image tag in apps/audit-api/Dockerfile —
+  # browser binaries ship at version-specific paths in the base image.
+  "playwright==1.58.0",
   "supabase>=2.9",
   "sentry-sdk[fastapi]>=2.19",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -66,7 +66,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "fastapi", specifier = ">=0.115" },
-    { name = "playwright", specifier = ">=1.48" },
+    { name = "playwright", specifier = "==1.58.0" },
     { name = "pydantic-settings", specifier = ">=2.7" },
     { name = "pyjwt", specifier = ">=2.10" },
     { name = "sentry-sdk", extras = ["fastapi"], specifier = ">=2.19" },


### PR DESCRIPTION
## Summary

- Runtime scans were failing with \`BrowserType.launch: Executable doesn't exist at /ms-playwright/chromium_headless_shell-1208/...\`.
- Root cause: \`uv sync\` resolved \`playwright>=1.48\` to 1.58.0, but the Docker base image was still \`v1.48.0-jammy\`. The image pre-installs browsers at version-specific paths and the pypi package refuses to launch a mismatched build.
- Fix:
  - Bump base image to \`mcr.microsoft.com/playwright/python:v1.58.0-jammy\`.
  - Pin pypi \`playwright==1.58.0\` with a comment pointing at the Dockerfile, so a future re-lock can't silently drift the pypi package ahead of the image again.

## Test plan

- [ ] Railway build succeeds with the v1.58.0-jammy base
- [ ] \`/health\` responds 200
- [ ] \`/run-scan\` with a real UUID completes end-to-end (Chromium launches, Lighthouse + axe produce results)

🤖 Generated with [Claude Code](https://claude.com/claude-code)