### PR TITLE
ci: skip fast job on draft PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches-ignore:
       - main # PRs to main are handled by ci-preview.yml
+    # ready_for_review re-triggers CI when a draft is marked ready, so the
+    # draft-gated jobs (fast, ci-python) run before merge.
+    types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
     inputs:
       update-snapshots:
@@ -93,7 +96,7 @@ jobs:
 
   fast:
     needs: preflight
-    if: ${{ needs.preflight.outputs.docs-only != 'true' && !inputs.update-snapshots }}
+    if: ${{ needs.preflight.outputs.docs-only != 'true' && !inputs.update-snapshots && github.event.pull_request.draft != true }}
     uses: ./.github/workflows/ci-fast.yml
     with:
       nx-base: ${{ needs.preflight.outputs.nx-base }}


### PR DESCRIPTION
## Summary

- Gate the `fast` job on `github.event.pull_request.draft != true` so draft pushes skip the biggest Nx Cloud credit consumer
- Add `ready_for_review` to `pull_request` trigger types so promoting a draft re-runs CI and surfaces a real `fast` result before the required `ci-status` gate
- `ci-python` was already draft-gated (line 114); this brings `fast` in line

## Credit impact

`fast` runs Lint + typecheck + test + build across affected projects on every PR synchronize. Most draft iteration pushes don't need the full affected run — the dev can opt in by marking the PR ready. Expected cut: ~30–60% fewer `fast` runs on multi-push PRs.

## Safety

- `ci-status` already treats `skipped` as pass (only `failure`/`cancelled` trip the gate)
- `full` only runs on push to develop, so this change doesn't affect release CI
- Branch protection requires `ci-status`, not `fast` directly — docs-only PRs already exercise the same skip path
- `ready_for_review` trigger makes sure `fast` actually runs before merge

## Test plan

- [ ] Open a new draft PR with code changes → confirm `fast` is skipped, `ci-status` still passes
- [ ] Mark the draft ready → confirm CI re-triggers and `fast` runs
- [ ] Verify merge is blocked if `fast` fails after ready-for-review

🤖 Generated with [Claude Code](https://claude.com/claude-code)