### PR TITLE
fix(audit-api): layout-agnostic CHROME_PATH lookup for Playwright base image

### DIFF
--- a/apps/audit-api/Dockerfile
+++ b/apps/audit-api/Dockerfile
@@ -51,9 +51,12 @@ RUN uv python install 3.11 \
 # Playwright browsers are pre-installed at /ms-playwright. No re-download needed.
 ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
 
-# Lighthouse's chrome-launcher follows CHROME_PATH. Point it at Playwright's
-# Chromium so both scans use the same validated binary.
-RUN CHROME_BIN="$(ls -1d /ms-playwright/chromium-*/chrome-linux/chrome 2>/dev/null | head -1)" \
+# Lighthouse's chrome-launcher follows CHROME_PATH. Point it at whichever
+# Chromium launcher binary the Playwright base image ships. The layout shifts
+# across versions (chrome-linux → chrome-linux64; some images only bundle
+# chrome-headless-shell), so probe with find instead of pinning a glob.
+RUN CHROME_BIN="$(find /ms-playwright -path '*chromium*' -type f \
+      \( -name chrome -o -name chrome-headless-shell \) -executable 2>/dev/null | head -1)" \
     && test -n "$CHROME_BIN" \
     && ln -sf "$CHROME_BIN" /usr/local/bin/chrome
 


### PR DESCRIPTION
## Summary

- Build broke on v1.58.0-jammy at the CHROME_BIN symlink step. The previous glob (\`/ms-playwright/chromium-*/chrome-linux/chrome\`) no longer resolves — newer Playwright base images bundle \`chrome-headless-shell\` under \`chromium_headless_shell-*/chrome-headless-shell-linux64/\` instead.
- Replace the glob with a \`find\` over \`/ms-playwright\` that picks up any chromium launcher binary (\`chrome\` or \`chrome-headless-shell\`). Lighthouse's chrome-launcher only needs something that speaks CDP; \`chrome-headless-shell\` is the binary Google itself uses for headless audits.
- Benefit: survives the next Playwright base-image layout rename without another Dockerfile PR.

## Test plan

- [ ] Railway build succeeds past the CHROME_BIN step
- [ ] \`/health\` returns 200
- [ ] \`/run-scan\` completes: Playwright launches (via its own browsers path), Lighthouse launches via CHROME_PATH, axe produces violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)