### PR TITLE
ci: split Python per-package and collapse ci-full to one job

### DIFF
--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -11,6 +11,18 @@ on:
         description: NX_HEAD SHA for affected detection
         type: string
         required: true
+      e2e-changed:
+        description: Whether paths affecting e2e tests changed
+        type: string
+        required: true
+      lighthouse-changed:
+        description: Whether paths affecting Lighthouse CI changed
+        type: string
+        required: true
+      storybook-changed:
+        description: Whether paths affecting Storybook/Chromatic changed
+        type: string
+        required: true
     secrets:
       NX_CLOUD_ACCESS_TOKEN:
         required: false
@@ -24,121 +36,16 @@ env:
   NX_NO_CLOUD: 'true'
 
 jobs:
-  filter:
+  # Single consolidated job. Previously three parallel jobs (e2e, lighthouse,
+  # storybook-and-chromatic) each did their own checkout + pnpm install +
+  # Nx cache restore (~60s × 3). Collapsing into one job shares that setup,
+  # trading parallelism for credits. Only runs when at least one flag is set;
+  # individual step blocks are gated by their respective changed flags so we
+  # still skip the expensive work when it isn't needed.
+  full:
+    if: ${{ inputs.e2e-changed == 'true' || inputs.lighthouse-changed == 'true' || inputs.storybook-changed == 'true' }}
     runs-on: ubuntu-latest
-    timeout-minutes: 5
-    outputs:
-      e2e: ${{ steps.paths.outputs.e2e }}
-      lighthouse: ${{ steps.paths.outputs.lighthouse }}
-      storybook: ${{ steps.paths.outputs.storybook }}
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          filter: tree:0
-          fetch-depth: 0
-
-      - name: Classify changed paths
-        id: paths
-        run: |
-          CHANGED=$(git diff --name-only "${{ inputs.nx-base }}" "${{ inputs.nx-head }}")
-          E2E=false
-          LH=false
-          SB=false
-          while IFS= read -r file; do
-            [ -z "$file" ] && continue
-            case "$file" in
-              apps/root/*|apps/root-e2e/*|libs/*)
-                E2E=true
-                ;;
-            esac
-            case "$file" in
-              apps/root/*|libs/shared/*)
-                LH=true
-                ;;
-            esac
-            case "$file" in
-              libs/shared/ui/*|apps/root/.storybook/*|*.stories.ts|*.stories.tsx|*.stories.mdx|*.stories.js|*.stories.jsx)
-                SB=true
-                ;;
-            esac
-          done <<< "$CHANGED"
-          echo "e2e=$E2E" >> "$GITHUB_OUTPUT"
-          echo "lighthouse=$LH" >> "$GITHUB_OUTPUT"
-          echo "storybook=$SB" >> "$GITHUB_OUTPUT"
-          echo "Changed path flags: e2e=$E2E lighthouse=$LH storybook=$SB"
-
-  e2e:
-    needs: filter
-    if: needs.filter.outputs.e2e == 'true'
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          filter: tree:0
-          fetch-depth: 0
-
-      - uses: ./.github/actions/setup-workspace
-
-      - name: Get Playwright version
-        id: playwright-version
-        run: echo "version=$(node -e "console.log(require('@playwright/test/package.json').version)")" >> "$GITHUB_OUTPUT"
-
-      - name: Cache Playwright browsers
-        id: playwright-cache
-        uses: actions/cache@v5
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
-
-      - name: Log Playwright cache status
-        run: |
-          if [ "${{ steps.playwright-cache.outputs.cache-hit }}" = "true" ]; then
-            echo "::notice::Playwright cache HIT (version ${{ steps.playwright-version.outputs.version }})"
-          else
-            echo "::warning::Playwright cache MISS (version ${{ steps.playwright-version.outputs.version }}) — browsers will download"
-          fi
-
-      - name: Install Playwright
-        run: pnpm exec playwright install --with-deps chromium
-
-      - name: Run e2e tests
-        run: pnpm nx affected -t e2e --nxBail
-        env:
-          NX_BASE: ${{ inputs.nx-base }}
-          NX_HEAD: ${{ inputs.nx-head }}
-          NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
-          NX_CLOUD_ID: ${{ secrets.NX_CLOUD_ID }}
-
-  lighthouse:
-    needs: filter
-    if: needs.filter.outputs.lighthouse == 'true'
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          filter: tree:0
-          fetch-depth: 0
-
-      - uses: ./.github/actions/setup-workspace
-
-      - name: Build app (remote cache hit from ci-fast)
-        run: pnpm nx build root
-        env:
-          NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
-          NX_CLOUD_ID: ${{ secrets.NX_CLOUD_ID }}
-
-      - name: Run Lighthouse CI
-        run: pnpm test:lighthouse
-        env:
-          LHCI_GITHUB_APP_TOKEN: ${{ github.token }}
-
-  storybook-and-chromatic:
-    needs: filter
-    if: needs.filter.outputs.storybook == 'true'
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 45
     env:
       CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
     steps:
@@ -149,7 +56,59 @@ jobs:
 
       - uses: ./.github/actions/setup-workspace
 
+      # --- e2e ---
+      - name: Get Playwright version
+        if: inputs.e2e-changed == 'true'
+        id: playwright-version
+        run: echo "version=$(node -e "console.log(require('@playwright/test/package.json').version)")" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        if: inputs.e2e-changed == 'true'
+        id: playwright-cache
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
+
+      - name: Log Playwright cache status
+        if: inputs.e2e-changed == 'true'
+        run: |
+          if [ "${{ steps.playwright-cache.outputs.cache-hit }}" = "true" ]; then
+            echo "::notice::Playwright cache HIT (version ${{ steps.playwright-version.outputs.version }})"
+          else
+            echo "::warning::Playwright cache MISS (version ${{ steps.playwright-version.outputs.version }}) — browsers will download"
+          fi
+
+      - name: Install Playwright
+        if: inputs.e2e-changed == 'true'
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Run e2e tests
+        if: inputs.e2e-changed == 'true'
+        run: pnpm nx affected -t e2e --nxBail
+        env:
+          NX_BASE: ${{ inputs.nx-base }}
+          NX_HEAD: ${{ inputs.nx-head }}
+          NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
+          NX_CLOUD_ID: ${{ secrets.NX_CLOUD_ID }}
+
+      # --- lighthouse ---
+      - name: Build app for Lighthouse
+        if: inputs.lighthouse-changed == 'true'
+        run: pnpm nx build root
+        env:
+          NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
+          NX_CLOUD_ID: ${{ secrets.NX_CLOUD_ID }}
+
+      - name: Run Lighthouse CI
+        if: inputs.lighthouse-changed == 'true'
+        run: pnpm test:lighthouse
+        env:
+          LHCI_GITHUB_APP_TOKEN: ${{ github.token }}
+
+      # --- storybook + chromatic ---
       - name: Build Storybook affected
+        if: inputs.storybook-changed == 'true'
         run: pnpm nx affected -t build-storybook --nxBail
         env:
           NX_BASE: ${{ inputs.nx-base }}
@@ -158,36 +117,5 @@ jobs:
           NX_CLOUD_ID: ${{ secrets.NX_CLOUD_ID }}
 
       - name: Run Chromatic visual tests
-        if: env.CHROMATIC_PROJECT_TOKEN != ''
+        if: inputs.storybook-changed == 'true' && env.CHROMATIC_PROJECT_TOKEN != ''
         run: pnpm chromatic:ui --exit-zero-on-changes --exit-once-sent
-
-  gate:
-    if: always()
-    needs: [filter, e2e, lighthouse, storybook-and-chromatic]
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - name: Check results
-        run: |
-          echo "  filter: ${{ needs.filter.result }}"
-          echo "  e2e: ${{ needs.e2e.result }}"
-          echo "  lighthouse: ${{ needs.lighthouse.result }}"
-          echo "  storybook-and-chromatic: ${{ needs.storybook-and-chromatic.result }}"
-
-          if [ "${{ needs.filter.result }}" = "failure" ] || [ "${{ needs.filter.result }}" = "cancelled" ]; then
-            echo "CI full filter failed"
-            exit 1
-          fi
-          if [ "${{ needs.e2e.result }}" = "failure" ] || [ "${{ needs.e2e.result }}" = "cancelled" ]; then
-            echo "CI full e2e failed"
-            exit 1
-          fi
-          if [ "${{ needs.lighthouse.result }}" = "failure" ] || [ "${{ needs.lighthouse.result }}" = "cancelled" ]; then
-            echo "CI full lighthouse failed"
-            exit 1
-          fi
-          if [ "${{ needs.storybook-and-chromatic.result }}" = "failure" ] || [ "${{ needs.storybook-and-chromatic.result }}" = "cancelled" ]; then
-            echo "CI full storybook-and-chromatic failed"
-            exit 1
-          fi
-          echo "All CI full checks passed or were skipped"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
-      docs-only: ${{ steps.check.outputs.docs-only }}
-      python-changed: ${{ steps.check.outputs.python-changed }}
+      docs-only: ${{ steps.classify.outputs.docs-only }}
+      python-changed: ${{ steps.classify.outputs.python-changed }}
+      job-api-changed: ${{ steps.classify.outputs.job-api-changed }}
+      audit-api-changed: ${{ steps.classify.outputs.audit-api-changed }}
+      e2e-changed: ${{ steps.classify.outputs.e2e-changed }}
+      lighthouse-changed: ${{ steps.classify.outputs.lighthouse-changed }}
+      storybook-changed: ${{ steps.classify.outputs.storybook-changed }}
       nx-base: ${{ steps.shas.outputs.base }}
       nx-head: ${{ steps.shas.outputs.head }}
     steps:
@@ -49,22 +54,28 @@ jobs:
           filter: tree:0
           fetch-depth: 0
 
-      - name: Check for docs-only and Python changes
-        id: check
+      - uses: nrwl/nx-set-shas@v5
+        id: shas
+        with:
+          main-branch-name: ${{ github.base_ref || 'main' }}
+
+      - name: Classify changed paths
+        id: classify
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             CHANGED=$(gh pr view ${{ github.event.pull_request.number }} --json files --jq '.files[].path')
           else
-            # Push to develop — always run full CI including Python
-            echo "docs-only=false" >> "$GITHUB_OUTPUT"
-            echo "python-changed=true" >> "$GITHUB_OUTPUT"
-            exit 0
+            CHANGED=$(git diff --name-only "${{ steps.shas.outputs.base }}" "${{ steps.shas.outputs.head }}")
           fi
 
           DOCS_ONLY=true
-          PYTHON_CHANGED=false
+          JOB_API=false
+          AUDIT_API=false
+          E2E=false
+          LH=false
+          SB=false
           while IFS= read -r file; do
             [ -z "$file" ] && continue
             case "$file" in
@@ -79,20 +90,41 @@ jobs:
               *) DOCS_ONLY=false ;;
             esac
             case "$file" in
-              apps/job-api/*|apps/audit-api/*|pyproject.toml|uv.lock|.python-version)
-                PYTHON_CHANGED=true
+              apps/job-api/*) JOB_API=true ;;
+            esac
+            case "$file" in
+              apps/audit-api/*) AUDIT_API=true ;;
+            esac
+            case "$file" in
+              pyproject.toml|uv.lock|.python-version)
+                JOB_API=true
+                AUDIT_API=true
                 ;;
+            esac
+            case "$file" in
+              apps/root/*|apps/root-e2e/*|libs/*) E2E=true ;;
+            esac
+            case "$file" in
+              apps/root/*|libs/shared/*) LH=true ;;
+            esac
+            case "$file" in
+              libs/shared/ui/*|apps/root/.storybook/*|*.stories.ts|*.stories.tsx|*.stories.mdx|*.stories.js|*.stories.jsx) SB=true ;;
             esac
           done <<< "$CHANGED"
 
+          PYTHON_CHANGED=false
+          if [ "$JOB_API" = "true" ] || [ "$AUDIT_API" = "true" ]; then
+            PYTHON_CHANGED=true
+          fi
+
           echo "docs-only=$DOCS_ONLY" >> "$GITHUB_OUTPUT"
           echo "python-changed=$PYTHON_CHANGED" >> "$GITHUB_OUTPUT"
-
-      - uses: nrwl/nx-set-shas@v5
-        id: shas
-        if: steps.check.outputs.docs-only != 'true'
-        with:
-          main-branch-name: ${{ github.base_ref || 'main' }}
+          echo "job-api-changed=$JOB_API" >> "$GITHUB_OUTPUT"
+          echo "audit-api-changed=$AUDIT_API" >> "$GITHUB_OUTPUT"
+          echo "e2e-changed=$E2E" >> "$GITHUB_OUTPUT"
+          echo "lighthouse-changed=$LH" >> "$GITHUB_OUTPUT"
+          echo "storybook-changed=$SB" >> "$GITHUB_OUTPUT"
+          echo "Flags: docs-only=$DOCS_ONLY job-api=$JOB_API audit-api=$AUDIT_API e2e=$E2E lighthouse=$LH storybook=$SB"
 
   fast:
     needs: preflight
@@ -110,6 +142,9 @@ jobs:
     with:
       nx-base: ${{ needs.preflight.outputs.nx-base }}
       nx-head: ${{ needs.preflight.outputs.nx-head }}
+      e2e-changed: ${{ needs.preflight.outputs.e2e-changed }}
+      lighthouse-changed: ${{ needs.preflight.outputs.lighthouse-changed }}
+      storybook-changed: ${{ needs.preflight.outputs.storybook-changed }}
     secrets: inherit
 
   ci-python:
@@ -134,6 +169,7 @@ jobs:
         run: uv sync --frozen
 
       - name: job-api — lint, typecheck, test
+        if: needs.preflight.outputs.job-api-changed == 'true'
         working-directory: apps/job-api
         run: |
           uv run --package job-api ruff check .
@@ -141,6 +177,7 @@ jobs:
           uv run --package job-api pytest -v
 
       - name: audit-api — lint, typecheck, test
+        if: needs.preflight.outputs.audit-api-changed == 'true'
         working-directory: apps/audit-api
         run: |
           uv run --package audit-api ruff check .


### PR DESCRIPTION
## Summary

Three CI changes to cut Nx Cloud credit burn further:

1. **Split Python CI per package.** `preflight` now emits `job-api-changed` and `audit-api-changed` separately, and each `uv run` block in `ci-python` is gated on its own flag. A PR touching only `audit-api` no longer runs the `job-api` suite (and vice versa). Shared triggers (`pyproject.toml`, `uv.lock`, `.python-version`) still fire both.

2. **Move path classification into `preflight`.** `ci-full.yml` previously had a dedicated `filter` job doing a `fetch-depth=0` checkout purely to run a `git diff`. That work now happens in `preflight` alongside the existing docs-only / Python classifier, so the filter job is gone. Push events also get granular diffs (previously always ran the full suite).

3. **Collapse `ci-full` to a single job.** Three parallel jobs (`e2e`, `lighthouse`, `storybook-and-chromatic`) each did their own checkout + pnpm install + Nx cache restore (~60s × 3). One consolidated job shares that setup.

## Trade-off on #3

Wall time on push to develop goes up when multiple flags are set — work runs sequentially instead of in parallel. Credits down, latency up. Right call while Nx Cloud is disabled and we're optimizing for cost over release cadence.

## Credit impact estimate

- Python split: saves ~30–60s per PR when only one package changes (common — \`audit-api\` changes often, \`job-api\` rarely).
- Drop filter job: ~60–90s per push to develop (one fewer runner, checkout, and path diff).
- ci-full collapse: ~2–3 min per push to develop (2× setup overhead eliminated) at the cost of serialized test time.

## Safety

- \`ci-status\` gate in \`ci.yml\` still checks \`needs.full.result\` — unchanged. Skipped is treated as pass.
- Per-step \`if:\` gates in the consolidated \`full\` job preserve skip behavior for docs-only and filtered-out changes.
- Chromatic token check preserved (\`env.CHROMATIC_PROJECT_TOKEN != ''\`).
- No changes to update-snapshots workflow or e2e/lighthouse/storybook script behavior.

## Test plan

- [ ] Verify CI runs on this PR and flags populate correctly in preflight logs
- [ ] After merge, push to develop → confirm consolidated \`full\` job runs the expected step blocks based on actual change flags
- [ ] Test audit-api-only PR → confirm job-api step is skipped in ci-python
- [ ] Test docs-only PR → confirm everything downstream skips as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)