### PR TITLE
fix(audit-api): fail fast when the scans row is missing

### DIFF
--- a/apps/audit-api/app/services/persistence.py
+++ b/apps/audit-api/app/services/persistence.py
@@ -10,6 +10,12 @@ from app.services.scanner import ScanResults
 logger = logging.getLogger(__name__)
 
 
+class ScanRowMissingError(RuntimeError):
+    """The `scans` row referenced by a job is not in this database. Usually
+    signals a config mismatch (e.g. SUPABASE_URL pointing at a different
+    project than the caller that enqueued the scan)."""
+
+
 def _extract_scores(lighthouse: dict[str, Any]) -> CategoryScores:
     categories = lighthouse.get("categories") or {}
 
@@ -44,12 +50,19 @@ def _extract_core_web_vitals(lighthouse: dict[str, Any]) -> dict[str, Any]:
 async def mark_scan_running(supabase: Any, scan_id: str) -> None:
     if supabase is None:
         return
-    await asyncio.to_thread(
+    response = await asyncio.to_thread(
         lambda: supabase.table("scans")
         .update({"status": "running"})
         .eq("id", scan_id)
         .execute()
     )
+    # postgrest UPDATEs silently affect 0 rows when the id isn't found.
+    # Without this check, the scan runs ~20s before failing at the
+    # scan_issues FK constraint with a confusing error.
+    if not getattr(response, "data", None):
+        raise ScanRowMissingError(
+            f"scans row {scan_id} not found — check SUPABASE_URL matches caller"
+        )
 
 
 async def persist_scan_completion(

--- a/apps/audit-api/app/services/scan_queue.py
+++ b/apps/audit-api/app/services/scan_queue.py
@@ -7,6 +7,7 @@ import sentry_sdk
 from app.services.issues import parse_issues
 from app.services.lighthouse_config import DeviceMode
 from app.services.persistence import (
+    ScanRowMissingError,
     mark_scan_failed,
     mark_scan_running,
     persist_scan_completion,
@@ -86,6 +87,12 @@ class ScanQueue:
                 job.device,
                 len(issues),
             )
+        except ScanRowMissingError as exc:
+            # No row to mark_scan_failed against. Surface loudly — this is
+            # almost always a DB/env config mismatch between the caller and
+            # this service, and the scan never ran.
+            logger.error("Scan aborted, row missing: %s | %s", job.scan_id, exc)
+            sentry_sdk.capture_exception(exc)
         except ScanError as exc:
             await mark_scan_failed(supabase, job.scan_id, str(exc))
             logger.warning("Scan failed: %s | %s", job.scan_id, exc)

--- a/apps/audit-api/tests/test_persistence.py
+++ b/apps/audit-api/tests/test_persistence.py
@@ -1,23 +1,16 @@
-from dataclasses import dataclass
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
 
 from app.services.issues import ParsedIssue
 from app.services.persistence import (
+    ScanRowMissingError,
     mark_scan_failed,
     mark_scan_running,
     persist_scan_completion,
 )
 from app.services.scanner import ScanResults
-
-
-@dataclass
-class _FakeExecute:
-    called_with: dict[str, Any]
-
-    def execute(self) -> None:
-        return None
 
 
 class _FakeQuery:
@@ -41,8 +34,9 @@ class _FakeQuery:
         self._payload = {"filter_column": column, "filter_value": value, "payload": self._payload}
         return self
 
-    def execute(self) -> None:
+    def execute(self) -> SimpleNamespace:
         self._log.append((f"{self._table}.{self._op}", self._payload))
+        return SimpleNamespace(data=[{"ok": True}])
 
 
 class _FakeSupabase:
@@ -97,6 +91,24 @@ async def test_mark_scan_running_updates_status(fake_supabase: _FakeSupabase) ->
 
 async def test_mark_scan_running_noops_when_supabase_is_none() -> None:
     await mark_scan_running(None, "scan-1")  # no error, no write
+
+
+async def test_mark_scan_running_raises_when_row_missing() -> None:
+    class _EmptySupabase:
+        def table(self, _name: str) -> "_EmptySupabase":
+            return self
+
+        def update(self, _payload: dict[str, Any]) -> "_EmptySupabase":
+            return self
+
+        def eq(self, _col: str, _val: Any) -> "_EmptySupabase":
+            return self
+
+        def execute(self) -> SimpleNamespace:
+            return SimpleNamespace(data=[])
+
+    with pytest.raises(ScanRowMissingError):
+        await mark_scan_running(_EmptySupabase(), "scan-missing")
 
 
 async def test_persist_scan_completion_writes_scores_and_cwv(

--- a/apps/audit-api/tests/test_scan_queue.py
+++ b/apps/audit-api/tests/test_scan_queue.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 import pytest
 
+from app.services.persistence import ScanRowMissingError
 from app.services.scan_queue import ScanJob, ScanQueue
 from app.services.scanner import ScanError, ScanResults
 
@@ -98,6 +99,40 @@ async def test_queue_marks_failed_on_scan_error() -> None:
         await queue.stop()
 
     assert calls["failed"] == {"scan_id": "s2", "message": "lh exploded"}
+
+
+async def test_queue_skips_mark_failed_when_row_is_missing() -> None:
+    queue = ScanQueue()
+    calls: dict[str, Any] = {}
+
+    async def raising_running(supabase: Any, scan_id: str) -> None:
+        raise ScanRowMissingError(f"scans row {scan_id} not found")
+
+    async def fake_failed(supabase: Any, scan_id: str, message: str) -> None:
+        calls["failed"] = {"scan_id": scan_id, "message": message}
+
+    async def noop_run_scan(*args: Any, **kwargs: Any) -> ScanResults:
+        calls["ran_scan"] = True
+        raise AssertionError("run_scan should not be reached")
+
+    async def noop_persist(*args: Any, **kwargs: Any) -> None:
+        return None
+
+    with (
+        patch("app.services.scan_queue.mark_scan_running", raising_running),
+        patch("app.services.scan_queue.run_scan", noop_run_scan),
+        patch("app.services.scan_queue.persist_scan_completion", noop_persist),
+        patch("app.services.scan_queue.mark_scan_failed", fake_failed),
+        patch("app.services.scan_queue.get_supabase_client", return_value=None),
+    ):
+        await queue.enqueue(
+            ScanJob(scan_id="s-missing", url="https://x.com", device="mobile")
+        )
+        await _wait_until_idle(queue)
+        await queue.stop()
+
+    assert "failed" not in calls
+    assert "ran_scan" not in calls
 
 
 async def test_queue_serializes_concurrent_jobs(fake_results: ScanResults) -> None:


### PR DESCRIPTION
## Summary

- \`mark_scan_running\` silently no-ops on a 0-row UPDATE, so when the caller and audit-api point at different Supabase projects, the symptom surfaces ~20 seconds later as a \`scan_issues_scan_id_fkey\` violation — long after Lighthouse + axe have already run.
- Inspect \`response.data\`. If empty, raise \`ScanRowMissingError\` immediately.
- Queue treats the new error as a distinct branch: no \`mark_scan_failed\` round trip (there's no row to mark), just a loud log + Sentry capture so config drift is obvious.

## Context

Caught this after Railway's audit-api started scanning cleanly (all browser/build blockers resolved) but every scan failed the final FK insert. Not a bug in this service — the caller's row genuinely isn't in the database this service is talking to — but the previous failure mode hid it behind a wall of scan output.

## Test plan

- [x] \`uv run pytest\` — 61 passed, including new \`test_mark_scan_running_raises_when_row_missing\` and \`test_queue_skips_mark_failed_when_row_is_missing\`
- [x] \`ruff check\` and \`mypy\` clean
- [ ] On next deploy: if the Supabase env mismatch is still present, logs will show \`Scan aborted, row missing: <id>\` and a Sentry event within seconds of the POST /run-scan

🤖 Generated with [Claude Code](https://claude.com/claude-code)