### PR TITLE
ci: drop size-limit bootstrap fallback, cache uv downloads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,6 +160,9 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
 
       - name: Install Python dependencies
         run: uv sync --frozen

--- a/.github/workflows/size-limit.yml
+++ b/.github/workflows/size-limit.yml
@@ -36,16 +36,3 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           skip_step: build
           build_script: 'size:noop'
-        # Note: The first PR adding size-limit will fail the base branch
-        # comparison because develop doesn't have the size:noop script yet.
-        # After this PR merges, all subsequent PRs will work correctly.
-        continue-on-error: true
-
-      # The action leaves the working tree on develop after comparison.
-      # Checkout the PR branch before running the standalone fallback.
-      - uses: actions/checkout@v5
-
-      - run: pnpm install --frozen-lockfile
-
-      - name: Size check (standalone)
-        run: pnpm run size


### PR DESCRIPTION
## Summary

Two small CI cleanups that save time per run.

### 1. Drop the size-limit bootstrap fallback

`size-limit.yml` previously ran `andresz1/size-limit-action` with `continue-on-error: true`, then did a second checkout + `pnpm install` + `pnpm run size` as a standalone fallback. The comment explained why:

> The first PR adding size-limit will fail the base branch comparison because develop doesn't have the \`size:noop\` script yet. After this PR merges, all subsequent PRs will work correctly.

That bootstrap condition hasn't applied in a while — \`size:noop\` has been on \`develop\` for months. The action works as the real gate now, so the fallback is pure overhead: ~90s of duplicate checkout + install every PR.

### 2. Cache uv downloads in ci-python

\`astral-sh/setup-uv@v6\` supports \`enable-cache: true\` keyed on \`uv.lock\`. Cold \`uv sync --frozen\` was ~30s per run; warm cache drops it to a few seconds.

## Test plan

- [ ] Verify size-limit runs and posts a PR comment with before/after sizes (the action is now the enforcement gate)
- [ ] Verify ci-python still passes on this PR and subsequent Python-touching PRs
- [ ] Confirm uv cache hit on second run (check job log for cache restore)

🤖 Generated with [Claude Code](https://claude.com/claude-code)