### PR TITLE
release: audit scan polling timeout + worker config hardening

### DIFF
--- a/apps/root/src/app/(public)/audit/r/[id]/ScanPending.spec.tsx
+++ b/apps/root/src/app/(public)/audit/r/[id]/ScanPending.spec.tsx
@@ -99,6 +99,42 @@ describe('ScanPending', () => {
     );
   });
 
+  it('shows a timeout error after the max poll attempts', async () => {
+    jest.useFakeTimers();
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ status: 'pending' }),
+    });
+
+    await act(async () => {
+      render(
+        <ScanPending
+          scanId='scan-1'
+          url='https://example.com'
+          deviceMode='mobile'
+          isPaired={false}
+        />
+      );
+    });
+
+    // Advance through 90 polling intervals (3 minutes at 2s each).
+    for (let i = 0; i < 90; i += 1) {
+      await act(async () => {
+        jest.advanceTimersByTime(2000);
+      });
+    }
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('heading', { name: /scan failed/i })
+      ).toBeInTheDocument();
+    });
+    expect(
+      screen.getByText(/taking longer than expected/i)
+    ).toBeInTheDocument();
+    jest.useRealTimers();
+  });
+
   it('shows a failed state when the poll request errors', async () => {
     (global.fetch as jest.Mock).mockResolvedValue({
       ok: false,

--- a/apps/root/src/app/(public)/audit/r/[id]/ScanPending.tsx
+++ b/apps/root/src/app/(public)/audit/r/[id]/ScanPending.tsx
@@ -12,6 +12,9 @@ import ScanProgress from '../../ScanProgress';
 import { friendlyErrorMessage } from './friendlyErrorMessage';
 
 const POLL_INTERVAL_MS = 2000;
+const MAX_POLL_ATTEMPTS = 90;
+const TIMEOUT_MESSAGE =
+  'This scan is taking longer than expected. The worker may be unavailable. Please try again in a few minutes.';
 
 interface ScanPendingProps {
   scanId: string;
@@ -29,6 +32,7 @@ export default function ScanPending({
   const router = useRouter();
   const [error, setError] = useState<string | null>(null);
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const attemptsRef = useRef(0);
 
   const clearPoll = useCallback(() => {
     if (pollRef.current) {
@@ -39,6 +43,7 @@ export default function ScanPending({
 
   useEffect(() => {
     const poll = async () => {
+      attemptsRef.current += 1;
       try {
         const res = await fetch(`/api/audit/status/${scanId}`);
         if (!res.ok) {
@@ -50,9 +55,16 @@ export default function ScanPending({
         if (data.status === 'completed') {
           clearPoll();
           router.refresh();
-        } else if (data.status === 'failed') {
+          return;
+        }
+        if (data.status === 'failed') {
           clearPoll();
           setError(friendlyErrorMessage(data.error_message));
+          return;
+        }
+        if (attemptsRef.current >= MAX_POLL_ATTEMPTS) {
+          clearPoll();
+          setError(TIMEOUT_MESSAGE);
         }
       } catch {
         clearPoll();

--- a/apps/root/src/app/api/audit/scan/route.test.ts
+++ b/apps/root/src/app/api/audit/scan/route.test.ts
@@ -244,6 +244,109 @@ describe('POST /api/audit/scan', () => {
     expect(json.device).toBe('both');
   });
 
+  it('returns 503 when SCAN_SERVICE_URL is missing', async () => {
+    delete process.env['SCAN_SERVICE_URL'];
+
+    // Rate limit check: under limit
+    const rateLimitChain = {
+      eq: jest.fn().mockReturnThis(),
+      gte: jest.fn().mockReturnThis(),
+    };
+    mockSelect.mockReturnValueOnce(rateLimitChain);
+    rateLimitChain.gte.mockResolvedValueOnce({ count: 0 });
+
+    // Cache check: no cached result
+    const cacheChain = {
+      eq: jest.fn().mockReturnThis(),
+      gte: jest.fn().mockReturnThis(),
+      order: jest.fn().mockReturnThis(),
+      limit: jest.fn().mockReturnThis(),
+      maybeSingle: jest.fn().mockResolvedValue({ data: null, error: null }),
+    };
+    mockSelect.mockReturnValueOnce(cacheChain);
+
+    const req = createRequest({ url: 'https://example.com' });
+    const res = await POST(req);
+    expect(res.status).toBe(503);
+    const json = await res.json();
+    expect(json.error).toContain('not configured');
+    // Crucially: no scan row was inserted
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it('returns 503 when SCAN_SERVICE_API_KEY is missing', async () => {
+    delete process.env['SCAN_SERVICE_API_KEY'];
+
+    const rateLimitChain = {
+      eq: jest.fn().mockReturnThis(),
+      gte: jest.fn().mockReturnThis(),
+    };
+    mockSelect.mockReturnValueOnce(rateLimitChain);
+    rateLimitChain.gte.mockResolvedValueOnce({ count: 0 });
+
+    const cacheChain = {
+      eq: jest.fn().mockReturnThis(),
+      gte: jest.fn().mockReturnThis(),
+      order: jest.fn().mockReturnThis(),
+      limit: jest.fn().mockReturnThis(),
+      maybeSingle: jest.fn().mockResolvedValue({ data: null, error: null }),
+    };
+    mockSelect.mockReturnValueOnce(cacheChain);
+
+    const req = createRequest({ url: 'https://example.com' });
+    const res = await POST(req);
+    expect(res.status).toBe(503);
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it('marks scan failed when scan service returns non-2xx', async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValue(new Response('boom', { status: 500 }));
+
+    const rateLimitChain = {
+      eq: jest.fn().mockReturnThis(),
+      gte: jest.fn().mockReturnThis(),
+    };
+    mockSelect.mockReturnValueOnce(rateLimitChain);
+    rateLimitChain.gte.mockResolvedValueOnce({ count: 0 });
+
+    const cacheChain = {
+      eq: jest.fn().mockReturnThis(),
+      gte: jest.fn().mockReturnThis(),
+      order: jest.fn().mockReturnThis(),
+      limit: jest.fn().mockReturnThis(),
+      maybeSingle: jest.fn().mockResolvedValue({ data: null, error: null }),
+    };
+    mockSelect.mockReturnValueOnce(cacheChain);
+
+    const insertChain = {
+      select: jest.fn().mockReturnThis(),
+      single: jest.fn().mockResolvedValue({
+        data: { id: 'scan-500' },
+        error: null,
+      }),
+    };
+    mockInsert.mockReturnValueOnce(insertChain);
+
+    const updateChain = { eq: jest.fn().mockResolvedValue({ error: null }) };
+    mockUpdate.mockReturnValue(updateChain);
+
+    const req = createRequest({ url: 'https://example.com' });
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+
+    // Wait for fire-and-forget fetch().then() to settle
+    await new Promise(resolve => setImmediate(resolve));
+
+    expect(mockUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'failed',
+        error_message: expect.stringContaining('HTTP 500'),
+      })
+    );
+  });
+
   it('returns 500 on unexpected error', async () => {
     // Make Supabase throw
     mockSelect.mockImplementationOnce(() => {

--- a/apps/root/src/app/api/audit/scan/route.ts
+++ b/apps/root/src/app/api/audit/scan/route.ts
@@ -20,6 +20,17 @@ function parseDevice(raw: unknown): DeviceSelection {
   return 'mobile';
 }
 
+async function markScanFailed(
+  supabase: any,
+  scanId: string,
+  errorMessage: string
+) {
+  await supabase
+    .from('scans')
+    .update({ status: 'failed', error_message: errorMessage })
+    .eq('id', scanId);
+}
+
 function fireScan(
   serviceUrl: string,
   apiKey: string,
@@ -33,25 +44,36 @@ function fireScan(
       'x-api-key': apiKey,
     },
     body: JSON.stringify(payload),
-  }).catch(async (fetchError: unknown) => {
-    await supabase
-      .from('scans')
-      .update({
-        status: 'failed',
-        error_message: 'Failed to reach scan service',
-      })
-      .eq('id', payload.scan_id);
+  })
+    .then(async res => {
+      if (res.ok) return;
+      const message = `Scan service returned HTTP ${res.status}`;
+      await markScanFailed(supabase, payload.scan_id, message);
+      captureApiError(
+        new Error(message),
+        '/api/audit/scan',
+        'POST',
+        res.status,
+        { scanId: payload.scan_id }
+      );
+    })
+    .catch(async (fetchError: unknown) => {
+      await markScanFailed(
+        supabase,
+        payload.scan_id,
+        'Failed to reach scan service'
+      );
 
-    captureApiError(
-      fetchError instanceof Error
-        ? fetchError
-        : new Error('Scan service fetch failed'),
-      '/api/audit/scan',
-      'POST',
-      500,
-      { scanId: payload.scan_id }
-    );
-  });
+      captureApiError(
+        fetchError instanceof Error
+          ? fetchError
+          : new Error('Scan service fetch failed'),
+        '/api/audit/scan',
+        'POST',
+        500,
+        { scanId: payload.scan_id }
+      );
+    });
 }
 
 export async function POST(request: NextRequest) {
@@ -152,6 +174,18 @@ export async function POST(request: NextRequest) {
 
     const scanServiceUrl = process.env['SCAN_SERVICE_URL'];
     const scanServiceApiKey = process.env['SCAN_SERVICE_API_KEY'];
+    if (!scanServiceUrl || !scanServiceApiKey) {
+      captureApiError(
+        new Error('SCAN_SERVICE_URL or SCAN_SERVICE_API_KEY is not set'),
+        '/api/audit/scan',
+        'POST',
+        503
+      );
+      return NextResponse.json(
+        { error: 'Scan service is not configured. Please try again later.' },
+        { status: 503 }
+      );
+    }
     const sourceValue = source || 'organic';
 
     // --- "both" mode: create two scans, link them ---
@@ -200,25 +234,22 @@ export async function POST(request: NextRequest) {
         .update({ paired_scan_id: mobileScan.id })
         .eq('id', desktopScan.id);
 
-      // Fire both scans
-      if (scanServiceUrl && scanServiceApiKey) {
-        fireScan(
-          scanServiceUrl,
-          scanServiceApiKey,
-          { scan_id: mobileScan.id, url: normalized, device_mode: 'mobile' },
-          supabase
-        );
-        fireScan(
-          scanServiceUrl,
-          scanServiceApiKey,
-          {
-            scan_id: desktopScan.id,
-            url: normalized,
-            device_mode: 'desktop',
-          },
-          supabase
-        );
-      }
+      fireScan(
+        scanServiceUrl,
+        scanServiceApiKey,
+        { scan_id: mobileScan.id, url: normalized, device_mode: 'mobile' },
+        supabase
+      );
+      fireScan(
+        scanServiceUrl,
+        scanServiceApiKey,
+        {
+          scan_id: desktopScan.id,
+          url: normalized,
+          device_mode: 'desktop',
+        },
+        supabase
+      );
 
       return NextResponse.json({
         scan_id: mobileScan.id,
@@ -246,15 +277,12 @@ export async function POST(request: NextRequest) {
       throw new Error(insertError?.message || 'Failed to create scan');
     }
 
-    // Fire-and-forget scan trigger
-    if (scanServiceUrl && scanServiceApiKey) {
-      fireScan(
-        scanServiceUrl,
-        scanServiceApiKey,
-        { scan_id: newScan.id, url: normalized, device_mode: device },
-        supabase
-      );
-    }
+    fireScan(
+      scanServiceUrl,
+      scanServiceApiKey,
+      { scan_id: newScan.id, url: normalized, device_mode: device },
+      supabase
+    );
 
     return NextResponse.json({
       scan_id: newScan.id,


### PR DESCRIPTION
## Summary

Promotes #451 to production. Three layered defenses against the prod incident where audit scans hung indefinitely in `pending`:

- **UI**: cap scan-status polling at ~3 min with a clear timeout error
- **API**: return 503 if `SCAN_SERVICE_URL` / `SCAN_SERVICE_API_KEY` are missing (no orphaned pending rows)
- **API**: `fireScan` now checks `res.ok` so non-2xx Railway responses mark the scan failed

## Post-merge checklist

- [ ] Set `SCAN_SERVICE_URL` (Railway public URL) in Vercel prod
- [ ] Set `SCAN_SERVICE_API_KEY` (random secret) in Vercel prod
- [ ] Set `AUDIT_API_KEY` (matching value) on Railway
- [ ] Push an empty commit to `main` to trigger a fresh build (env vars bake in at build time)
- [ ] Verify a scan completes end-to-end on prod

## Test plan

- [x] Already gated by #451 CI (typecheck, 17/17 unit tests, lint)