### PR TITLE
fix(audit): derive Supabase image host from NEXT_PUBLIC_SUPABASE_URL

### DIFF
--- a/apps/root/next.config.mjs
+++ b/apps/root/next.config.mjs
@@ -16,6 +16,19 @@ const isCI = process.env.CI === 'true';
 const mockFonts = process.env.MOCK_FONTS === 'true';
 const isAnalyze = process.env.ANALYZE === 'true';
 
+// Derive the Supabase storage host from the env so screenshot URLs keep working
+// when the project is swapped. Falls back to undefined if the env is missing,
+// which leaves remotePatterns empty (safe — _next/image will reject unknown hosts).
+const supabaseHost = (() => {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  if (!url) return undefined;
+  try {
+    return new URL(url).hostname;
+  } catch {
+    return undefined;
+  }
+})();
+
 // Bundle analyzer
 const withBundleAnalyzer = bundleAnalyzer({
   enabled: isAnalyze,
@@ -103,12 +116,9 @@ const nextConfig = {
 
   // Image optimization
   images: {
-    remotePatterns: [
-      {
-        protocol: 'https',
-        hostname: 'grwmzluuqyczatkxorfa.supabase.co',
-      },
-    ],
+    remotePatterns: supabaseHost
+      ? [{ protocol: 'https', hostname: supabaseHost }]
+      : [],
     formats: ['image/webp', 'image/avif'],
     minimumCacheTTL: 60 * 60 * 24 * 30, // 30 days
     deviceSizes: [640, 768, 1024, 1280],


### PR DESCRIPTION
## Summary

- Production audit screenshots were returning 400 from `/_next/image` because the Supabase hostname in `images.remotePatterns` was hardcoded to a different project than the one `NEXT_PUBLIC_SUPABASE_URL` points at in prod.
- Parse the host from `NEXT_PUBLIC_SUPABASE_URL` at config-load time and inject it into `remotePatterns`, so whichever project the env targets is automatically allow-listed.
- If the env is missing or malformed, `remotePatterns` is left empty (safe default — `_next/image` rejects unknown hosts).

## Why this happened

`_next/image` returns **400 Bad Request** when asked to optimize a URL whose host isn't in `remotePatterns`. Both mobile and desktop screenshot previews broke in prod because they share the same Supabase bucket.

## Test plan

- [ ] Verify `NEXT_PUBLIC_SUPABASE_URL` is set in the Vercel production environment (if absent, `remotePatterns` will be empty and all remote images will 400).
- [ ] On preview deploy, open an audit report and confirm mobile + desktop screenshot previews render.
- [ ] Confirm the `_next/image` network request returns 200 instead of 400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)