### PR TITLE
feat(audit): Phase 5 — admin dashboard charts (#93)

### DIFF
--- a/apps/root/__mocks__/recharts.js
+++ b/apps/root/__mocks__/recharts.js
@@ -1,0 +1,39 @@
+// Jest mock for recharts.
+// Recharts' ResponsiveContainer relies on ResizeObserver / non-zero DOM
+// dimensions, neither of which jsdom provides. The mock replaces each
+// export with a pass-through component so specs can assert on surrounding
+// markup without Recharts failing to mount.
+
+const React = require('react');
+
+const passThrough = displayName => {
+  const Component = ({ children }) =>
+    React.createElement('div', { 'data-chart-mock': displayName }, children);
+  Component.displayName = displayName;
+  return Component;
+};
+
+const empty = displayName => {
+  const Component = () => null;
+  Component.displayName = displayName;
+  return Component;
+};
+
+module.exports = {
+  __esModule: true,
+  ResponsiveContainer: passThrough('ResponsiveContainer'),
+  AreaChart: passThrough('AreaChart'),
+  Area: empty('Area'),
+  BarChart: passThrough('BarChart'),
+  Bar: passThrough('Bar'),
+  LineChart: passThrough('LineChart'),
+  Line: empty('Line'),
+  PieChart: passThrough('PieChart'),
+  Pie: passThrough('Pie'),
+  Cell: empty('Cell'),
+  XAxis: empty('XAxis'),
+  YAxis: empty('YAxis'),
+  CartesianGrid: empty('CartesianGrid'),
+  Tooltip: empty('Tooltip'),
+  Legend: empty('Legend'),
+};

--- a/apps/root/src/app/api/audit/admin/leads/sources/route.test.ts
+++ b/apps/root/src/app/api/audit/admin/leads/sources/route.test.ts
@@ -1,0 +1,95 @@
+/**
+ * @jest-environment node
+ */
+import { readAdminSession } from '@/lib/adminSession';
+import { GET } from './route';
+
+const mockSelect = jest.fn();
+const mockFrom = jest.fn(() => ({ select: mockSelect }));
+
+jest.mock('@/lib/supabase/server', () => ({
+  createServerSupabaseClient: () => ({ from: mockFrom }),
+}));
+
+jest.mock('@/lib/errorTracking', () => ({
+  captureApiError: jest.fn(),
+}));
+
+jest.mock('@/lib/adminSession', () => ({
+  readAdminSession: jest.fn(),
+}));
+
+const mockedReadAdminSession = readAdminSession as jest.MockedFunction<
+  typeof readAdminSession
+>;
+
+describe('GET /api/audit/admin/leads/sources', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedReadAdminSession.mockResolvedValue({ sub: 'tools-admin' });
+  });
+
+  it('returns 401 without a valid session', async () => {
+    mockedReadAdminSession.mockResolvedValueOnce(null);
+    const res = await GET();
+    expect(res.status).toBe(401);
+  });
+
+  it('aggregates lead rows by source, descending', async () => {
+    mockSelect.mockResolvedValueOnce({
+      data: [
+        { source: 'organic' },
+        { source: 'organic' },
+        { source: 'full_report' },
+        { source: 'organic' },
+      ],
+      error: null,
+    });
+
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const json = await res.json();
+
+    expect(json.total).toBe(4);
+    expect(json.sources).toEqual([
+      { source: 'organic', count: 3 },
+      { source: 'full_report', count: 1 },
+    ]);
+  });
+
+  it("buckets null sources as 'unknown'", async () => {
+    mockSelect.mockResolvedValueOnce({
+      data: [{ source: null }, { source: null }, { source: 'organic' }],
+      error: null,
+    });
+
+    const res = await GET();
+    const json = await res.json();
+
+    expect(json.total).toBe(3);
+    expect(json.sources).toEqual([
+      { source: 'unknown', count: 2 },
+      { source: 'organic', count: 1 },
+    ]);
+  });
+
+  it('returns zero total with no rows', async () => {
+    mockSelect.mockResolvedValueOnce({ data: [], error: null });
+
+    const res = await GET();
+    const json = await res.json();
+
+    expect(json.total).toBe(0);
+    expect(json.sources).toEqual([]);
+  });
+
+  it('returns 500 when the query errors', async () => {
+    mockSelect.mockResolvedValueOnce({
+      data: null,
+      error: { message: 'boom' },
+    });
+
+    const res = await GET();
+    expect(res.status).toBe(500);
+  });
+});

--- a/apps/root/src/app/api/audit/admin/leads/sources/route.ts
+++ b/apps/root/src/app/api/audit/admin/leads/sources/route.ts
@@ -1,0 +1,72 @@
+import { NextResponse } from 'next/server';
+import { createServerSupabaseClient } from '@/lib/supabase/server';
+import { captureApiError } from '@/lib/errorTracking';
+import { verifyAdminAuth } from '../../auth';
+
+interface LeadRow {
+  source: string | null;
+}
+
+export interface LeadSourceEntry {
+  source: string;
+  count: number;
+}
+
+export interface LeadSourcesResponse {
+  total: number;
+  sources: LeadSourceEntry[];
+}
+
+export async function GET() {
+  try {
+    const authError = await verifyAdminAuth();
+    if (authError) return authError;
+
+    const supabase = createServerSupabaseClient();
+    if (!supabase) {
+      return NextResponse.json(
+        { error: 'Service unavailable' },
+        { status: 503 }
+      );
+    }
+
+    const { data, error } = await supabase.from('leads').select('source');
+
+    if (error) {
+      captureApiError(
+        new Error(error.message),
+        '/api/audit/admin/leads/sources',
+        'GET',
+        500
+      );
+      return NextResponse.json(
+        { error: 'Failed to aggregate lead sources' },
+        { status: 500 }
+      );
+    }
+
+    const rows = (data as LeadRow[] | null) ?? [];
+    const counts = new Map<string, number>();
+    for (const row of rows) {
+      const key = row.source ?? 'unknown';
+      counts.set(key, (counts.get(key) ?? 0) + 1);
+    }
+
+    const sources: LeadSourceEntry[] = Array.from(counts.entries())
+      .map(([source, count]) => ({ source, count }))
+      .sort((a, b) => b.count - a.count);
+
+    const body: LeadSourcesResponse = {
+      total: rows.length,
+      sources,
+    };
+
+    return NextResponse.json(body);
+  } catch (error) {
+    captureApiError(error, '/api/audit/admin/leads/sources', 'GET', 500);
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/root/src/app/tools/admin/audit/AdminDashboard.spec.tsx
+++ b/apps/root/src/app/tools/admin/audit/AdminDashboard.spec.tsx
@@ -44,6 +44,24 @@ describe('AdminDashboard', () => {
         page: 1,
         pageSize: 20,
       },
+      '/api/audit/insights/trends': {
+        interval: 'weekly',
+        period: '3m',
+        series: [],
+      },
+      '/api/audit/insights/scores': {
+        period: null,
+        averages: {
+          performance: null,
+          accessibility: null,
+          bestPractices: null,
+          seo: null,
+          overall: null,
+        },
+        gradeDistribution: { A: 0, B: 0, C: 0, D: 0, F: 0 },
+        total: 0,
+      },
+      '/api/audit/admin/leads/sources': { total: 0, sources: [] },
     });
 
     render(<AdminDashboard />);
@@ -56,6 +74,10 @@ describe('AdminDashboard', () => {
       expect(screen.getByText('10')).toBeInTheDocument();
       expect(screen.getByText('25%')).toBeInTheDocument();
     });
+
+    expect(screen.getByText('Scans Over Time')).toBeInTheDocument();
+    expect(screen.getByText('Score Distribution')).toBeInTheDocument();
+    expect(screen.getByText('Lead Sources')).toBeInTheDocument();
   });
 
   it('shows an error message when stats fail to load', async () => {

--- a/apps/root/src/app/tools/admin/audit/AdminDashboard.tsx
+++ b/apps/root/src/app/tools/admin/audit/AdminDashboard.tsx
@@ -1,6 +1,8 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import type { KeyboardEvent } from 'react';
+import dynamic from 'next/dynamic';
 import { Heading } from '@danieljoffe.com/shared-ui/Heading';
 import { Text } from '@danieljoffe.com/shared-ui/Text';
 import {
@@ -10,9 +12,12 @@ import {
 import StatsRow from './StatsRow';
 import ScansTable from './ScansTable';
 import LeadsTable from './LeadsTable';
-import ScansOverTimeCard from './charts/ScansOverTimeCard';
-import ScoreDistributionCard from './charts/ScoreDistributionCard';
-import LeadSourcesCard from './charts/LeadSourcesCard';
+
+const ScansOverTimeCard = dynamic(() => import('./charts/ScansOverTimeCard'));
+const ScoreDistributionCard = dynamic(
+  () => import('./charts/ScoreDistributionCard')
+);
+const LeadSourcesCard = dynamic(() => import('./charts/LeadSourcesCard'));
 
 interface Stats {
   totalScans: number;
@@ -21,10 +26,21 @@ interface Stats {
   conversionRate: number;
 }
 
+type TabId = 'scans' | 'leads';
+
+const TABS: { id: TabId; label: string }[] = [
+  { id: 'scans', label: 'Scans' },
+  { id: 'leads', label: 'Leads' },
+];
+
 export default function AdminDashboard() {
   const [stats, setStats] = useState<Stats | null>(null);
   const [statsError, setStatsError] = useState('');
-  const [activeTab, setActiveTab] = useState<'scans' | 'leads'>('scans');
+  const [activeTab, setActiveTab] = useState<TabId>('scans');
+  const tabRefs = useRef<Record<TabId, HTMLButtonElement | null>>({
+    scans: null,
+    leads: null,
+  });
 
   useEffect(() => {
     let cancelled = false;
@@ -46,10 +62,19 @@ export default function AdminDashboard() {
     };
   }, []);
 
-  const tabs = [
-    { id: 'scans' as const, label: 'Scans' },
-    { id: 'leads' as const, label: 'Leads' },
-  ];
+  const handleTabKeyDown = (
+    event: KeyboardEvent<HTMLButtonElement>,
+    index: number
+  ) => {
+    if (event.key !== 'ArrowRight' && event.key !== 'ArrowLeft') return;
+    event.preventDefault();
+    const delta = event.key === 'ArrowRight' ? 1 : -1;
+    const nextIndex = (index + delta + TABS.length) % TABS.length;
+    const nextTab = TABS[nextIndex];
+    if (!nextTab) return;
+    setActiveTab(nextTab.id);
+    tabRefs.current[nextTab.id]?.focus();
+  };
 
   return (
     <div className='max-w-6xl mx-auto w-full px-4 sm:px-6'>
@@ -59,7 +84,9 @@ export default function AdminDashboard() {
         </Heading>
 
         {statsError ? (
-          <Text variant='error'>{statsError}</Text>
+          <Text variant='error' role='alert'>
+            {statsError}
+          </Text>
         ) : stats ? (
           <StatsRow
             stats={[
@@ -74,7 +101,11 @@ export default function AdminDashboard() {
             ]}
           />
         ) : (
-          <div className='grid grid-cols-2 md:grid-cols-4 gap-4'>
+          <div
+            role='status'
+            aria-label='Loading stats'
+            className='grid grid-cols-2 md:grid-cols-4 gap-4'
+          >
             {Array.from({ length: 4 }).map((_, i) => (
               <div
                 key={i}
@@ -93,24 +124,40 @@ export default function AdminDashboard() {
         <div className='w-full'>
           <div className='border-b border-border'>
             <div role='tablist' className='flex gap-1 flex-wrap'>
-              {tabs.map(tab => (
-                <button
-                  key={tab.id}
-                  role='tab'
-                  aria-selected={activeTab === tab.id}
-                  className={`px-4 py-2.5 border-b-2 transition-colors ${FOCUS_RING} ${FOCUS_RING_OFFSET} ${
-                    activeTab === tab.id
-                      ? 'border-brand-500 text-brand-500'
-                      : 'border-transparent text-text-secondary hover:text-text-primary hover:border-border-secondary'
-                  }`}
-                  onClick={() => setActiveTab(tab.id)}
-                >
-                  {tab.label}
-                </button>
-              ))}
+              {TABS.map((tab, index) => {
+                const isActive = activeTab === tab.id;
+                return (
+                  <button
+                    key={tab.id}
+                    id={`admin-tab-${tab.id}`}
+                    role='tab'
+                    aria-selected={isActive}
+                    aria-controls={`admin-tabpanel-${tab.id}`}
+                    tabIndex={isActive ? 0 : -1}
+                    ref={el => {
+                      tabRefs.current[tab.id] = el;
+                    }}
+                    className={`px-4 py-2.5 border-b-2 transition-colors ${FOCUS_RING} ${FOCUS_RING_OFFSET} ${
+                      isActive
+                        ? 'border-brand-500 text-brand-500'
+                        : 'border-transparent text-text-secondary hover:text-text-primary hover:border-border-secondary'
+                    }`}
+                    onClick={() => setActiveTab(tab.id)}
+                    onKeyDown={event => handleTabKeyDown(event, index)}
+                  >
+                    {tab.label}
+                  </button>
+                );
+              })}
             </div>
           </div>
-          <div role='tabpanel' className='mt-4'>
+          <div
+            role='tabpanel'
+            id={`admin-tabpanel-${activeTab}`}
+            aria-labelledby={`admin-tab-${activeTab}`}
+            tabIndex={0}
+            className={`mt-4 ${FOCUS_RING} ${FOCUS_RING_OFFSET}`}
+          >
             {activeTab === 'scans' ? <ScansTable /> : <LeadsTable />}
           </div>
         </div>

--- a/apps/root/src/app/tools/admin/audit/AdminDashboard.tsx
+++ b/apps/root/src/app/tools/admin/audit/AdminDashboard.tsx
@@ -10,6 +10,9 @@ import {
 import StatsRow from './StatsRow';
 import ScansTable from './ScansTable';
 import LeadsTable from './LeadsTable';
+import ScansOverTimeCard from './charts/ScansOverTimeCard';
+import ScoreDistributionCard from './charts/ScoreDistributionCard';
+import LeadSourcesCard from './charts/LeadSourcesCard';
 
 interface Stats {
   totalScans: number;
@@ -49,7 +52,7 @@ export default function AdminDashboard() {
   ];
 
   return (
-    <div className='max-w-3xl mx-auto w-full px-4 sm:px-6'>
+    <div className='max-w-6xl mx-auto w-full px-4 sm:px-6'>
       <div className='flex flex-col gap-6 py-8'>
         <Heading variant='section' as='h1'>
           Audit Admin
@@ -80,6 +83,12 @@ export default function AdminDashboard() {
             ))}
           </div>
         )}
+
+        <div className='grid grid-cols-1 md:grid-cols-2 gap-4'>
+          <ScansOverTimeCard />
+          <ScoreDistributionCard />
+          <LeadSourcesCard />
+        </div>
 
         <div className='w-full'>
           <div className='border-b border-border'>

--- a/apps/root/src/app/tools/admin/audit/charts/LeadSourcesCard.spec.tsx
+++ b/apps/root/src/app/tools/admin/audit/charts/LeadSourcesCard.spec.tsx
@@ -1,0 +1,70 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import LeadSourcesCard from './LeadSourcesCard';
+
+const originalFetch = global.fetch;
+
+describe('LeadSourcesCard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.fetch = jest.fn();
+  });
+
+  afterAll(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('renders the empty state when no leads have been captured', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ total: 0, sources: [] }),
+    });
+
+    render(<LeadSourcesCard />);
+
+    expect(screen.getByText('Lead Sources')).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getByText(/no leads captured yet/i)).toBeInTheDocument();
+    });
+  });
+
+  it('shows an error when the fetch fails', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: false,
+      json: () => Promise.resolve({ error: 'Unauthorized' }),
+    });
+
+    render(<LeadSourcesCard />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/failed to load lead sources/i)
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('hides empty and error copy once sources load', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          total: 5,
+          sources: [
+            { source: 'organic', count: 3 },
+            { source: 'full_report', count: 2 },
+          ],
+        }),
+    });
+
+    render(<LeadSourcesCard />);
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText(/no leads captured yet/i)
+      ).not.toBeInTheDocument();
+    });
+    expect(
+      screen.queryByText(/failed to load lead sources/i)
+    ).not.toBeInTheDocument();
+  });
+});

--- a/apps/root/src/app/tools/admin/audit/charts/LeadSourcesCard.tsx
+++ b/apps/root/src/app/tools/admin/audit/charts/LeadSourcesCard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import {
   BarChart,
   Bar,
@@ -45,13 +45,22 @@ export default function LeadSourcesCard() {
     };
   }, []);
 
-  const chartData =
-    data?.sources.map(entry => ({
-      source: formatSourceLabel(entry.source),
-      count: entry.count,
-    })) ?? [];
+  const chartData = useMemo(
+    () =>
+      data?.sources.map(entry => ({
+        source: formatSourceLabel(entry.source),
+        count: entry.count,
+      })) ?? [],
+    [data]
+  );
 
   const hasData = (data?.total ?? 0) > 0 && chartData.length > 0;
+
+  const chartLabel = useMemo(() => {
+    if (!hasData) return '';
+    const parts = chartData.map(({ source, count }) => `${source}: ${count}`);
+    return `Lead counts by source. ${parts.join(', ')}.`;
+  }, [chartData, hasData]);
 
   return (
     <section
@@ -68,19 +77,21 @@ export default function LeadSourcesCard() {
       </Text>
 
       {error ? (
-        <Text variant='error'>{error}</Text>
+        <Text variant='error' role='alert'>
+          {error}
+        </Text>
       ) : !data ? (
-        <div className='h-48 w-full rounded bg-surface animate-pulse' />
+        <div
+          role='status'
+          aria-label='Loading lead sources'
+          className='h-48 w-full rounded bg-surface animate-pulse'
+        />
       ) : !hasData ? (
         <Text variant='body' className='text-text-secondary'>
           No leads captured yet.
         </Text>
       ) : (
-        <div
-          className='h-48 w-full'
-          role='img'
-          aria-label='Horizontal bar chart showing lead counts grouped by source'
-        >
+        <div className='h-48 w-full' role='img' aria-label={chartLabel}>
           <ResponsiveContainer width='100%' height='100%'>
             <BarChart data={chartData} layout='vertical'>
               <CartesianGrid strokeDasharray='3 3' className='stroke-border' />

--- a/apps/root/src/app/tools/admin/audit/charts/LeadSourcesCard.tsx
+++ b/apps/root/src/app/tools/admin/audit/charts/LeadSourcesCard.tsx
@@ -1,0 +1,116 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from 'recharts';
+import { Heading } from '@danieljoffe.com/shared-ui/Heading';
+import { Text } from '@danieljoffe.com/shared-ui/Text';
+import type { LeadSourcesResponse } from '@/app/api/audit/admin/leads/sources/route';
+
+function formatSourceLabel(source: string): string {
+  return source
+    .split('_')
+    .map(part => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+}
+
+export default function LeadSourcesCard() {
+  const [data, setData] = useState<LeadSourcesResponse | null>(null);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch('/api/audit/admin/leads/sources');
+        if (!res.ok) {
+          if (!cancelled) setError('Failed to load lead sources');
+          return;
+        }
+        const json = (await res.json()) as LeadSourcesResponse;
+        if (!cancelled) setData(json);
+      } catch {
+        if (!cancelled) setError('Failed to load lead sources');
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const chartData =
+    data?.sources.map(entry => ({
+      source: formatSourceLabel(entry.source),
+      count: entry.count,
+    })) ?? [];
+
+  const hasData = (data?.total ?? 0) > 0 && chartData.length > 0;
+
+  return (
+    <section
+      aria-labelledby='admin-lead-sources-heading'
+      className='rounded-lg border border-border bg-surface-elevated p-4'
+    >
+      <Heading variant='cardTitle' as='h2' id='admin-lead-sources-heading'>
+        Lead Sources
+      </Heading>
+      <Text variant='detail' className='mt-1 mb-4'>
+        {hasData
+          ? `Where ${data!.total.toLocaleString()} captured leads came from`
+          : 'Where captured leads come from'}
+      </Text>
+
+      {error ? (
+        <Text variant='error'>{error}</Text>
+      ) : !data ? (
+        <div className='h-48 w-full rounded bg-surface animate-pulse' />
+      ) : !hasData ? (
+        <Text variant='body' className='text-text-secondary'>
+          No leads captured yet.
+        </Text>
+      ) : (
+        <div
+          className='h-48 w-full'
+          role='img'
+          aria-label='Horizontal bar chart showing lead counts grouped by source'
+        >
+          <ResponsiveContainer width='100%' height='100%'>
+            <BarChart data={chartData} layout='vertical'>
+              <CartesianGrid strokeDasharray='3 3' className='stroke-border' />
+              <XAxis
+                type='number'
+                className='fill-muted'
+                fontSize={12}
+                allowDecimals={false}
+              />
+              <YAxis
+                type='category'
+                dataKey='source'
+                className='fill-muted'
+                fontSize={12}
+                width={100}
+              />
+              <Tooltip
+                contentStyle={{
+                  backgroundColor: 'var(--color-surface-elevated)',
+                  borderColor: 'var(--color-border)',
+                  borderRadius: '0.5rem',
+                }}
+                labelStyle={{ color: 'var(--color-foreground)' }}
+                formatter={value => [String(value), 'Leads']}
+              />
+              <Bar dataKey='count' fill='#63CAA5' radius={[0, 4, 4, 0]} />
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/root/src/app/tools/admin/audit/charts/LeadSourcesCard.tsx
+++ b/apps/root/src/app/tools/admin/audit/charts/LeadSourcesCard.tsx
@@ -63,7 +63,7 @@ export default function LeadSourcesCard() {
       </Heading>
       <Text variant='detail' className='mt-1 mb-4'>
         {hasData
-          ? `Where ${data!.total.toLocaleString()} captured leads came from`
+          ? `Where ${(data?.total ?? 0).toLocaleString()} captured leads came from`
           : 'Where captured leads come from'}
       </Text>
 

--- a/apps/root/src/app/tools/admin/audit/charts/ScansOverTimeCard.spec.tsx
+++ b/apps/root/src/app/tools/admin/audit/charts/ScansOverTimeCard.spec.tsx
@@ -1,0 +1,90 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import ScansOverTimeCard from './ScansOverTimeCard';
+
+const originalFetch = global.fetch;
+
+describe('ScansOverTimeCard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.fetch = jest.fn();
+  });
+
+  afterAll(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('renders the empty state when the series has no scans', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          interval: 'weekly',
+          period: '3m',
+          series: [
+            {
+              bucketStart: '2026-03-01T00:00:00Z',
+              avgOverall: null,
+              scanCount: 0,
+            },
+          ],
+        }),
+    });
+
+    render(<ScansOverTimeCard />);
+
+    expect(screen.getByText('Scans Over Time')).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getByText(/not enough data yet/i)).toBeInTheDocument();
+    });
+  });
+
+  it('shows an error when the fetch fails', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: false,
+      json: () => Promise.resolve({ error: 'Boom' }),
+    });
+
+    render(<ScansOverTimeCard />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/failed to load trend data/i)
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('hides empty and error copy once scans are loaded', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          interval: 'weekly',
+          period: '3m',
+          series: [
+            {
+              bucketStart: '2026-03-01T00:00:00Z',
+              avgOverall: 72,
+              scanCount: 12,
+            },
+            {
+              bucketStart: '2026-03-08T00:00:00Z',
+              avgOverall: 68,
+              scanCount: 9,
+            },
+          ],
+        }),
+    });
+
+    render(<ScansOverTimeCard />);
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText(/not enough data yet/i)
+      ).not.toBeInTheDocument();
+    });
+    expect(
+      screen.queryByText(/failed to load trend data/i)
+    ).not.toBeInTheDocument();
+  });
+});

--- a/apps/root/src/app/tools/admin/audit/charts/ScansOverTimeCard.tsx
+++ b/apps/root/src/app/tools/admin/audit/charts/ScansOverTimeCard.tsx
@@ -1,0 +1,107 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from 'recharts';
+import { Heading } from '@danieljoffe.com/shared-ui/Heading';
+import { Text } from '@danieljoffe.com/shared-ui/Text';
+import type { TrendsData } from '@/app/(public)/audit/insights/types';
+
+function formatBucket(iso: string): string {
+  const date = new Date(iso);
+  return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+}
+
+export default function ScansOverTimeCard() {
+  const [data, setData] = useState<TrendsData | null>(null);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch(
+          '/api/audit/insights/trends?interval=weekly&period=3m'
+        );
+        if (!res.ok) {
+          if (!cancelled) setError('Failed to load trend data');
+          return;
+        }
+        const json = (await res.json()) as TrendsData;
+        if (!cancelled) setData(json);
+      } catch {
+        if (!cancelled) setError('Failed to load trend data');
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const chartData =
+    data?.series.map(point => ({
+      date: formatBucket(point.bucketStart),
+      scans: point.scanCount,
+    })) ?? [];
+
+  const hasData = chartData.some(point => point.scans > 0);
+
+  return (
+    <section
+      aria-labelledby='admin-scans-over-time-heading'
+      className='rounded-lg border border-border bg-surface-elevated p-4'
+    >
+      <Heading variant='cardTitle' as='h2' id='admin-scans-over-time-heading'>
+        Scans Over Time
+      </Heading>
+      <Text variant='detail' className='mt-1 mb-4'>
+        Weekly scan volume, last 3 months
+      </Text>
+
+      {error ? (
+        <Text variant='error'>{error}</Text>
+      ) : !data ? (
+        <div className='h-48 w-full rounded bg-surface animate-pulse' />
+      ) : !hasData ? (
+        <Text variant='body' className='text-text-secondary'>
+          Not enough data yet. Scans will appear here as they accumulate.
+        </Text>
+      ) : (
+        <div
+          className='h-48 w-full'
+          role='img'
+          aria-label='Bar chart showing weekly scan counts over the last three months'
+        >
+          <ResponsiveContainer width='100%' height='100%'>
+            <BarChart data={chartData}>
+              <CartesianGrid strokeDasharray='3 3' className='stroke-border' />
+              <XAxis dataKey='date' className='fill-muted' fontSize={12} />
+              <YAxis
+                className='fill-muted'
+                fontSize={12}
+                allowDecimals={false}
+              />
+              <Tooltip
+                contentStyle={{
+                  backgroundColor: 'var(--color-surface-elevated)',
+                  borderColor: 'var(--color-border)',
+                  borderRadius: '0.5rem',
+                }}
+                labelStyle={{ color: 'var(--color-foreground)' }}
+                formatter={value => [String(value), 'Scans']}
+              />
+              <Bar dataKey='scans' fill='#8C8FFF' radius={[4, 4, 0, 0]} />
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/root/src/app/tools/admin/audit/charts/ScansOverTimeCard.tsx
+++ b/apps/root/src/app/tools/admin/audit/charts/ScansOverTimeCard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import {
   BarChart,
   Bar,
@@ -45,13 +45,26 @@ export default function ScansOverTimeCard() {
     };
   }, []);
 
-  const chartData =
-    data?.series.map(point => ({
-      date: formatBucket(point.bucketStart),
-      scans: point.scanCount,
-    })) ?? [];
+  const chartData = useMemo(
+    () =>
+      data?.series.map(point => ({
+        date: formatBucket(point.bucketStart),
+        scans: point.scanCount,
+      })) ?? [],
+    [data]
+  );
 
   const hasData = chartData.some(point => point.scans > 0);
+
+  const chartLabel = useMemo(() => {
+    if (!hasData) return '';
+    const total = chartData.reduce((sum, point) => sum + point.scans, 0);
+    const peak = chartData.reduce(
+      (max, point) => (point.scans > max.scans ? point : max),
+      chartData[0] ?? { date: '', scans: 0 }
+    );
+    return `Weekly scan counts, last 3 months. Total ${total} scans across ${chartData.length} weeks. Peak ${peak.scans} in week of ${peak.date}.`;
+  }, [chartData, hasData]);
 
   return (
     <section
@@ -66,19 +79,21 @@ export default function ScansOverTimeCard() {
       </Text>
 
       {error ? (
-        <Text variant='error'>{error}</Text>
+        <Text variant='error' role='alert'>
+          {error}
+        </Text>
       ) : !data ? (
-        <div className='h-48 w-full rounded bg-surface animate-pulse' />
+        <div
+          role='status'
+          aria-label='Loading scan trend'
+          className='h-48 w-full rounded bg-surface animate-pulse'
+        />
       ) : !hasData ? (
         <Text variant='body' className='text-text-secondary'>
           Not enough data yet. Scans will appear here as they accumulate.
         </Text>
       ) : (
-        <div
-          className='h-48 w-full'
-          role='img'
-          aria-label='Bar chart showing weekly scan counts over the last three months'
-        >
+        <div className='h-48 w-full' role='img' aria-label={chartLabel}>
           <ResponsiveContainer width='100%' height='100%'>
             <BarChart data={chartData}>
               <CartesianGrid strokeDasharray='3 3' className='stroke-border' />

--- a/apps/root/src/app/tools/admin/audit/charts/ScoreDistributionCard.spec.tsx
+++ b/apps/root/src/app/tools/admin/audit/charts/ScoreDistributionCard.spec.tsx
@@ -1,0 +1,87 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import ScoreDistributionCard from './ScoreDistributionCard';
+
+const originalFetch = global.fetch;
+
+describe('ScoreDistributionCard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.fetch = jest.fn();
+  });
+
+  afterAll(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('renders the empty state when no scans have completed', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          period: null,
+          averages: {
+            performance: null,
+            accessibility: null,
+            bestPractices: null,
+            seo: null,
+            overall: null,
+          },
+          gradeDistribution: { A: 0, B: 0, C: 0, D: 0, F: 0 },
+          total: 0,
+        }),
+    });
+
+    render(<ScoreDistributionCard />);
+
+    expect(screen.getByText('Score Distribution')).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getByText(/not enough data yet/i)).toBeInTheDocument();
+    });
+  });
+
+  it('shows an error when the fetch fails', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: false,
+      json: () => Promise.resolve({ error: 'Boom' }),
+    });
+
+    render(<ScoreDistributionCard />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/failed to load score data/i)
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('hides empty copy once grade data loads', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          period: null,
+          averages: {
+            performance: 72,
+            accessibility: 84,
+            bestPractices: 79,
+            seo: 88,
+            overall: 81,
+          },
+          gradeDistribution: { A: 4, B: 6, C: 3, D: 1, F: 0 },
+          total: 14,
+        }),
+    });
+
+    render(<ScoreDistributionCard />);
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText(/not enough data yet/i)
+      ).not.toBeInTheDocument();
+    });
+    expect(
+      screen.queryByText(/failed to load score data/i)
+    ).not.toBeInTheDocument();
+  });
+});

--- a/apps/root/src/app/tools/admin/audit/charts/ScoreDistributionCard.tsx
+++ b/apps/root/src/app/tools/admin/audit/charts/ScoreDistributionCard.tsx
@@ -1,0 +1,116 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  Cell,
+} from 'recharts';
+import { Heading } from '@danieljoffe.com/shared-ui/Heading';
+import { Text } from '@danieljoffe.com/shared-ui/Text';
+import type { ScoresData } from '@/app/(public)/audit/insights/types';
+
+const GRADE_COLORS: Record<string, string> = {
+  A: '#63CAA5',
+  B: '#8C8FFF',
+  C: '#FFB46B',
+  D: '#FF8CA0',
+  F: '#FF6B6B',
+};
+
+export default function ScoreDistributionCard() {
+  const [data, setData] = useState<ScoresData | null>(null);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch('/api/audit/insights/scores');
+        if (!res.ok) {
+          if (!cancelled) setError('Failed to load score data');
+          return;
+        }
+        const json = (await res.json()) as ScoresData;
+        if (!cancelled) setData(json);
+      } catch {
+        if (!cancelled) setError('Failed to load score data');
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const chartData = data
+    ? Object.entries(data.gradeDistribution).map(([grade, count]) => ({
+        grade,
+        count,
+      }))
+    : [];
+
+  const hasData = (data?.total ?? 0) > 0;
+
+  return (
+    <section
+      aria-labelledby='admin-score-dist-heading'
+      className='rounded-lg border border-border bg-surface-elevated p-4'
+    >
+      <Heading variant='cardTitle' as='h2' id='admin-score-dist-heading'>
+        Score Distribution
+      </Heading>
+      <Text variant='detail' className='mt-1 mb-4'>
+        {hasData
+          ? `Grades across ${data!.total.toLocaleString()} completed scans`
+          : 'Grades across completed scans'}
+      </Text>
+
+      {error ? (
+        <Text variant='error'>{error}</Text>
+      ) : !data ? (
+        <div className='h-48 w-full rounded bg-surface animate-pulse' />
+      ) : !hasData ? (
+        <Text variant='body' className='text-text-secondary'>
+          Not enough data yet. Grades will appear as scans complete.
+        </Text>
+      ) : (
+        <div
+          className='h-48 w-full'
+          role='img'
+          aria-label='Bar chart showing grade distribution A through F across all completed scans'
+        >
+          <ResponsiveContainer width='100%' height='100%'>
+            <BarChart data={chartData}>
+              <CartesianGrid strokeDasharray='3 3' className='stroke-border' />
+              <XAxis dataKey='grade' className='fill-muted' fontSize={12} />
+              <YAxis
+                className='fill-muted'
+                fontSize={12}
+                allowDecimals={false}
+              />
+              <Tooltip
+                contentStyle={{
+                  backgroundColor: 'var(--color-surface-elevated)',
+                  borderColor: 'var(--color-border)',
+                  borderRadius: '0.5rem',
+                }}
+                labelStyle={{ color: 'var(--color-foreground)' }}
+                formatter={value => [String(value), 'Sites']}
+              />
+              <Bar dataKey='count' radius={[4, 4, 0, 0]}>
+                {chartData.map(entry => (
+                  <Cell key={entry.grade} fill={GRADE_COLORS[entry.grade]} />
+                ))}
+              </Bar>
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/root/src/app/tools/admin/audit/charts/ScoreDistributionCard.tsx
+++ b/apps/root/src/app/tools/admin/audit/charts/ScoreDistributionCard.tsx
@@ -66,7 +66,7 @@ export default function ScoreDistributionCard() {
       </Heading>
       <Text variant='detail' className='mt-1 mb-4'>
         {hasData
-          ? `Grades across ${data!.total.toLocaleString()} completed scans`
+          ? `Grades across ${(data?.total ?? 0).toLocaleString()} completed scans`
           : 'Grades across completed scans'}
       </Text>
 

--- a/apps/root/src/app/tools/admin/audit/charts/ScoreDistributionCard.tsx
+++ b/apps/root/src/app/tools/admin/audit/charts/ScoreDistributionCard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import {
   BarChart,
   Bar,
@@ -47,14 +47,24 @@ export default function ScoreDistributionCard() {
     };
   }, []);
 
-  const chartData = data
-    ? Object.entries(data.gradeDistribution).map(([grade, count]) => ({
-        grade,
-        count,
-      }))
-    : [];
+  const chartData = useMemo(
+    () =>
+      data
+        ? Object.entries(data.gradeDistribution).map(([grade, count]) => ({
+            grade,
+            count,
+          }))
+        : [],
+    [data]
+  );
 
   const hasData = (data?.total ?? 0) > 0;
+
+  const chartLabel = useMemo(() => {
+    if (!hasData) return '';
+    const parts = chartData.map(({ grade, count }) => `${grade}: ${count}`);
+    return `Grade distribution across ${(data?.total ?? 0).toLocaleString()} completed scans. ${parts.join(', ')}.`;
+  }, [chartData, hasData, data]);
 
   return (
     <section
@@ -71,19 +81,21 @@ export default function ScoreDistributionCard() {
       </Text>
 
       {error ? (
-        <Text variant='error'>{error}</Text>
+        <Text variant='error' role='alert'>
+          {error}
+        </Text>
       ) : !data ? (
-        <div className='h-48 w-full rounded bg-surface animate-pulse' />
+        <div
+          role='status'
+          aria-label='Loading score distribution'
+          className='h-48 w-full rounded bg-surface animate-pulse'
+        />
       ) : !hasData ? (
         <Text variant='body' className='text-text-secondary'>
           Not enough data yet. Grades will appear as scans complete.
         </Text>
       ) : (
-        <div
-          className='h-48 w-full'
-          role='img'
-          aria-label='Bar chart showing grade distribution A through F across all completed scans'
-        >
+        <div className='h-48 w-full' role='img' aria-label={chartLabel}>
           <ResponsiveContainer width='100%' height='100%'>
             <BarChart data={chartData}>
               <CartesianGrid strokeDasharray='3 3' className='stroke-border' />
@@ -100,6 +112,7 @@ export default function ScoreDistributionCard() {
                   borderRadius: '0.5rem',
                 }}
                 labelStyle={{ color: 'var(--color-foreground)' }}
+                labelFormatter={label => `Grade ${label}`}
                 formatter={value => [String(value), 'Sites']}
               />
               <Bar dataKey='count' radius={[4, 4, 0, 0]}>


### PR DESCRIPTION
## Summary

Phase 5 of the audit platform roadmap (#408). Adds analytics charts to the internal admin dashboard at `/tools/admin/audit` so scan activity, score trends, and lead sources are visible at a glance without running SQL.

**Closes:** #93 (Admin dashboard charts)
**Parent tracker:** #408 (Audit platform roadmap)
**Depends on:** #455 / #104 (Phase 3: insights aggregation API — merged ✓), #456 / #105 (Phase 4: public insights page — merged ✓)

## What shipped

### 1. Three chart cards on the admin dashboard

| Component | Data source | Chart type | Description |
|-----------|-------------|------------|-------------|
| `ScansOverTimeCard` | `/api/audit/insights/trends?interval=weekly&period=3m` | Bar chart | Weekly scan counts for the last 3 months. X-axis shows "Mar 12", "Mar 19" etc. |
| `ScoreDistributionCard` | `/api/audit/insights/scores` | Colored bar chart | A/B/C/D/F grade distribution with per-grade brand colors. |
| `LeadSourcesCard` | `/api/audit/admin/leads/sources` (new) | Horizontal bar chart | Lead counts per source (`organic`, `full_report`, `unknown`). |

All three cards are lazy-loaded via `next/dynamic` to avoid bundling Recharts into the initial admin page load. Each card handles loading, empty, and error states independently.

### 2. New admin-only API endpoint

`GET /api/audit/admin/leads/sources` — Aggregates the `leads.source` column into `{ total, sources: [{ source, count }] }`. Gated by `verifyAdminAuth()` (JWT-cookie). Nulls bucket as `'unknown'`.

### 3. Admin dashboard layout + a11y improvements

- Container widened from `max-w-3xl` to `max-w-6xl` to fit the chart grid alongside existing tables.
- Charts render in a responsive `grid-cols-1 md:grid-cols-2` grid between the stats row and the scans/leads tabs.
- Tabs upgraded to full ARIA tablist pattern: `aria-controls`, `aria-labelledby`, `tabIndex` roving, and arrow-key navigation between tabs.
- Loading skeleton gets `role="status"` + `aria-label`.
- Error text gets `role="alert"`.

### 4. Jest mock for Recharts

`apps/root/__mocks__/recharts.js` — jsdom has no layout engine or `ResizeObserver`, so `ResponsiveContainer` fails to mount under Jest. The mock replaces every Recharts export with a pass-through `<div data-chart-mock={name}>{children}</div>`. Tests assert the data-loaded branch rendered (absence of empty-state text) without touching chart internals.

## Scope decision: conversion funnel deferred

The original Phase 5 brief included a conversion-funnel chart (scan → email capture → calendar book). Dropped from this PR: the site needs traffic before funnel data is meaningful, and a signup wall or funnel-focused surface could dampen the current LinkedIn-driven traffic push. Will revisit once volume justifies it.

## Files

**New (7):**
- `apps/root/__mocks__/recharts.js` — Jest mock
- `apps/root/src/app/api/audit/admin/leads/sources/route.ts` — API endpoint
- `apps/root/src/app/api/audit/admin/leads/sources/route.test.ts` — endpoint tests
- `apps/root/src/app/tools/admin/audit/charts/ScansOverTimeCard.tsx`
- `apps/root/src/app/tools/admin/audit/charts/ScansOverTimeCard.spec.tsx`
- `apps/root/src/app/tools/admin/audit/charts/ScoreDistributionCard.tsx`
- `apps/root/src/app/tools/admin/audit/charts/ScoreDistributionCard.spec.tsx`
- `apps/root/src/app/tools/admin/audit/charts/LeadSourcesCard.tsx`
- `apps/root/src/app/tools/admin/audit/charts/LeadSourcesCard.spec.tsx`

**Modified (2):**
- `apps/root/src/app/tools/admin/audit/AdminDashboard.tsx` — layout, chart grid, ARIA tabs
- `apps/root/src/app/tools/admin/audit/AdminDashboard.spec.tsx` — updated test assertions

## Test plan

- [x] `pnpm tsc --noEmit` passes
- [x] `pnpm nx test root --testPathPattern="admin/audit"` passes
- [ ] Manual smoke: log into `/tools/admin/audit`, confirm all three chart cards render with data
- [ ] Verify loading skeletons appear while data fetches
- [ ] Verify empty states display when no data exists ("Not enough data yet" / "No leads recorded yet")
- [ ] Responsive: chart grid stacks to single column below `md` breakpoint
- [ ] Auth: `GET /api/audit/admin/leads/sources` returns 401 when unauthenticated
- [ ] Tab keyboard navigation: arrow keys move focus between Scans/Leads tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)