### PR TITLE
fix(audit-api): resolve page.goto timeout on networkidle

### DIFF
--- a/apps/audit-api/app/services/scanner.py
+++ b/apps/audit-api/app/services/scanner.py
@@ -84,7 +84,11 @@ async def _run_axe_and_capture(
             )
             context.set_default_timeout(30_000)
             page = await context.new_page()
-            await page.goto(url, wait_until="networkidle", timeout=30_000)
+            await page.goto(url, wait_until="load", timeout=30_000)
+            try:
+                await page.wait_for_load_state("networkidle", timeout=10_000)
+            except Exception:
+                logger.info("networkidle not reached for %s; proceeding after load", url)
 
             page_title = await page.title()
             page_description = ""


### PR DESCRIPTION
## Summary

- Scans were failing with `TimeoutError: Page.goto: Timeout 30000ms exceeded` when target sites have persistent network activity (analytics, websockets, polling) that prevents `networkidle` from ever being reached.
- Changed `page.goto` to use `wait_until="load"` (reliable, fires when page resources finish), followed by a 10-second best-effort `networkidle` wait that logs and proceeds if not reached.

## Test plan

- [x] All 61 audit-api unit tests pass locally
- [ ] Deploy to dev and trigger scans against sites known to timeout (sites with heavy analytics/websockets)
- [ ] Verify scans complete successfully and produce valid axe results + screenshots

🤖 Generated with [Claude Code](https://claude.com/claude-code)