### PR TITLE
ci: add Claude Code workflows for auto-fix and PR review

### DIFF
--- a/.github/workflows/claude-auto-fix.yml
+++ b/.github/workflows/claude-auto-fix.yml
@@ -1,0 +1,112 @@
+name: Claude Auto-Fix
+
+on:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+
+permissions:
+  contents: write
+  pull-requests: write
+  actions: read
+
+jobs:
+  auto-fix:
+    # Only run when CI failed on a PR (not push to develop)
+    if: |
+      github.event.workflow_run.conclusion == 'failure' &&
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.head_branch != 'develop' &&
+      github.event.workflow_run.head_branch != 'main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Check for prior auto-fix attempt
+        id: check
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const commits = await github.rest.pulls.listCommits({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.workflow_run.pull_requests[0]?.number,
+              per_page: 5
+            });
+            const hasAutoFix = commits.data.some(c =>
+              c.commit.message.startsWith('fix(ci):') &&
+              c.commit.author?.name === 'github-actions[bot]'
+            );
+            core.setOutput('skip', hasAutoFix ? 'true' : 'false');
+
+      - name: Skip if already attempted
+        if: steps.check.outputs.skip == 'true'
+        run: |
+          echo "::notice::Auto-fix already attempted on this PR. Skipping to prevent loops."
+          exit 0
+
+      - uses: actions/checkout@v5
+        if: steps.check.outputs.skip != 'true'
+        with:
+          ref: ${{ github.event.workflow_run.head_branch }}
+          fetch-depth: 0
+          token: ${{ secrets.PAT_TOKEN }}
+
+      - uses: ./.github/actions/setup-workspace
+        if: steps.check.outputs.skip != 'true'
+
+      - name: Identify and fix failures
+        if: steps.check.outputs.skip != 'true'
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          max_turns: 10
+          timeout_minutes: 15
+          direct_prompt: |
+            CI failed on this branch. Diagnose and fix ONLY mechanical failures.
+
+            Run these commands in order and fix what fails:
+
+            1. `pnpm lint:fix` — if lint errors remain after auto-fix, fix them manually
+            2. `pnpm format` — format all files
+            3. `pnpm tsc --noEmit` — if typecheck fails with simple errors (missing imports, type mismatches from renames), fix them
+            4. `pnpm nx test root` — if snapshot tests fail, run `pnpm nx test root -- -u` to update snapshots
+
+            After fixing, stage and commit changes with:
+            ```
+            git add -A
+            git commit -m "fix(ci): auto-fix lint/format/typecheck/snapshots"
+            git push
+            ```
+
+            RULES:
+            - Do NOT refactor code or change behavior
+            - Do NOT fix failing unit tests by changing test expectations (only snapshot updates are allowed)
+            - Do NOT modify business logic
+            - If the failure requires judgment (test logic wrong, architectural issue), stop and leave a PR comment explaining what you found
+            - Only commit if you actually fixed something
+
+      - name: Update snapshot baselines (if e2e failed)
+        if: steps.check.outputs.skip != 'true'
+        run: |
+          # Check if e2e visual regression was the failure
+          if git log --oneline -1 | grep -q "fix(ci):"; then
+            echo "Already fixed in previous step"
+            exit 0
+          fi
+
+          # Attempt snapshot update
+          pnpm exec playwright install --with-deps chromium
+          pnpm nx build root
+          cd apps/root-e2e
+          if pnpm exec playwright test src/visual-regression.spec.ts --update-snapshots --project=chromium 2>/dev/null; then
+            cd ../..
+            git add apps/root-e2e/src/visual-regression.spec.ts-snapshots/
+            if ! git diff --cached --quiet; then
+              git config user.name "github-actions[bot]"
+              git config user.email "github-actions[bot]@users.noreply.github.com"
+              git commit -m "fix(ci): update visual regression snapshots"
+              git push
+            fi
+          fi
+        env:
+          NX_NO_CLOUD: 'true'

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,92 @@
+name: Claude PR Review
+
+on:
+  pull_request:
+    types: [ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  review:
+    # Skip PRs from bots (renovate, dependabot) and PRs targeting main
+    if: |
+      github.event.pull_request.user.login != 'renovate[bot]' &&
+      github.event.pull_request.user.login != 'dependabot[bot]' &&
+      github.event.pull_request.base.ref != 'main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          max_turns: 20
+          timeout_minutes: 8
+          direct_prompt: |
+            Review this PR and post a single summary comment. Do NOT make any code changes.
+
+            ## Context
+
+            This is a Next.js 16 / React 19 / TypeScript Nx monorepo. Key conventions:
+            - `exactOptionalPropertyTypes` is enabled (use `prop: T | undefined`, not `prop?: T`)
+            - Custom ESLint rules: `require-button-name`, `no-raw-headings`
+            - Import order: builtin > external > @danieljoffe.com/* > @/* > local
+            - Shared UI (`libs/shared/ui`) must not depend on Next.js APIs
+            - First-person singular voice in content ("I", never "we")
+
+            ## Review checklist
+
+            Run `git diff origin/develop...HEAD` to see all changes, then evaluate:
+
+            **Accessibility:**
+            - ARIA attributes on interactive elements
+            - Keyboard navigation support
+            - Form inputs have `aria-describedby` for errors
+            - Images have meaningful alt text
+
+            **Performance:**
+            - No unnecessary client components ('use client' only when needed)
+            - Large dependencies not added to client bundles
+            - Images use next/image with proper sizing
+
+            **Architecture:**
+            - Module boundaries respected (shared-ui has no Next.js imports)
+            - No circular imports
+            - Content changes follow the MDX metadata schema
+
+            **Security:**
+            - No secrets or PII in code
+            - API routes validate input
+            - `data-sentry-mask` on PII form fields
+
+            **TypeScript:**
+            - No `any` types without justification
+            - `exactOptionalPropertyTypes` respected
+
+            ## Output format
+
+            Post a SINGLE comment on the PR with this structure:
+
+            ```
+            ## 🤖 Claude Review
+
+            **Files reviewed**: <count>
+            **Verdict**: ✅ Ready to merge | ⚠️ Changes suggested | 🚫 Blocking issues
+
+            ### Critical (must fix before merge)
+            - file:line — description
+
+            ### Suggestions (non-blocking)
+            - file:line — description
+
+            ### Looks good
+            - Brief note on what's well done
+            ```
+
+            If everything looks clean, keep it short — just the verdict and a one-liner.

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,32 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  claude:
+    # Only trigger on @claude mentions in PR comments
+    if: |
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.pull_request.head.ref || github.head_ref }}
+          fetch-depth: 0
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          max_turns: 15
+          timeout_minutes: 12


### PR DESCRIPTION
## Summary

- **`claude.yml`**: `@claude` mentions in PR comments trigger Claude to read the comment and push changes
- **`claude-auto-fix.yml`**: When CI fails on a PR, attempts mechanical fixes (lint, format, typecheck, snapshot updates). One attempt max — checks commit history to prevent loops.
- **`claude-review.yml`**: When a PR moves from draft → ready, posts a single review summary comment covering a11y, performance, architecture, security, and TypeScript conventions.

## Cost guardrails

- `max_turns` caps tool calls (10 auto-fix, 15 on-demand, 20 review)
- `timeout_minutes` hard-kills each run
- Auto-fix skips if a prior `fix(ci):` bot commit exists
- Bot PRs (Renovate, Dependabot) skip review
- Auto-fix only fires on PR branches, never `develop` or `main`

## Setup

Requires `ANTHROPIC_API_KEY` repo secret (done).

## Test plan

- [ ] Trigger `@claude fix the lint error` in a PR comment → verify it responds
- [ ] Introduce a lint failure on a PR → verify auto-fix pushes a commit
- [ ] Mark a draft PR as ready → verify review comment appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)