### PR TITLE
fix(audit-api): add User-Agent and friendly scan error messages

### DIFF
--- a/apps/audit-api/app/services/scan_queue.py
+++ b/apps/audit-api/app/services/scan_queue.py
@@ -17,6 +17,49 @@ from app.services.supabase_client import get_supabase_client
 
 logger = logging.getLogger(__name__)
 
+_ERROR_PATTERNS: list[tuple[str, str]] = [
+    (
+        "ERR_HTTP2_PROTOCOL_ERROR",
+        "This site blocked our scanner. It uses bot detection that prevents automated audits.",
+    ),
+    (
+        "ERR_CONNECTION_REFUSED",
+        "Could not connect to this site. The server refused the connection.",
+    ),
+    (
+        "ERR_NAME_NOT_RESOLVED",
+        "This domain could not be found. Check the URL for typos.",
+    ),
+    (
+        "ERR_CONNECTION_TIMED_OUT",
+        "The site took too long to respond. It may be down or unreachable.",
+    ),
+    (
+        "ERR_SSL_PROTOCOL_ERROR",
+        "This site has an SSL/TLS configuration issue that prevents secure connections.",
+    ),
+    (
+        "ERR_CERT_",
+        "This site has an invalid or expired SSL certificate.",
+    ),
+    (
+        "ERR_TOO_MANY_REDIRECTS",
+        "This site has a redirect loop. Check the URL.",
+    ),
+    (
+        "Timeout 30000ms exceeded",
+        "This site took too long to load. It may be very slow or blocking automated browsers.",
+    ),
+]
+
+
+def _friendly_error(raw: str) -> str:
+    """Map raw Playwright/network errors to user-friendly messages."""
+    for pattern, message in _ERROR_PATTERNS:
+        if pattern in raw:
+            return message
+    return raw or "Unknown scan error"
+
 
 @dataclass(frozen=True)
 class ScanJob:
@@ -97,7 +140,7 @@ class ScanQueue:
             await mark_scan_failed(supabase, job.scan_id, str(exc))
             logger.warning("Scan failed: %s | %s", job.scan_id, exc)
         except Exception as exc:
-            message = str(exc) or "Unknown scan error"
+            message = _friendly_error(str(exc))
             await mark_scan_failed(supabase, job.scan_id, message)
             logger.exception("Scan errored: %s", job.scan_id)
             sentry_sdk.capture_exception(exc)

--- a/apps/audit-api/app/services/scanner.py
+++ b/apps/audit-api/app/services/scanner.py
@@ -81,6 +81,11 @@ async def _run_axe_and_capture(
                 },
                 device_scale_factor=cfg.screen_emulation.device_scale_factor,
                 is_mobile=cfg.screen_emulation.mobile,
+                user_agent=(
+                    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+                    "AppleWebKit/537.36 (KHTML, like Gecko) "
+                    "Chrome/125.0.0.0 Safari/537.36"
+                ),
             )
             context.set_default_timeout(30_000)
             page = await context.new_page()


### PR DESCRIPTION
## Summary

- Add a realistic Chrome User-Agent to the Playwright browser context to reduce bot-detection blocking from sites like Washington Post
- Map common network errors (`ERR_HTTP2_PROTOCOL_ERROR`, `ERR_CONNECTION_REFUSED`, `ERR_NAME_NOT_RESOLVED`, etc.) to user-friendly messages displayed on the scan result page

## Context

After deploying the `networkidle` → `load` fix (#462), scans still failed on washingtonpost.com with `net::ERR_HTTP2_PROTOCOL_ERROR`. The site's CDN fingerprints the headless browser and rejects the connection. The User-Agent alone may not bypass WaPo-level detection, but it helps with less aggressive sites. Either way, the user now sees "This site blocked our scanner" instead of a raw protocol error.

## Test plan

- [x] All 61 audit-api tests pass
- [ ] Deploy and scan washingtonpost.com — expect friendly "blocked" message instead of raw error
- [ ] Scan a normal site — confirm scans still complete successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)