### PR TITLE
fix(job-api): healthcheck 400s from TrustedHostMiddleware

### DIFF
--- a/apps/job-api/app/main.py
+++ b/apps/job-api/app/main.py
@@ -3,6 +3,7 @@ from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
 from starlette.middleware.trustedhost import TrustedHostMiddleware
+from starlette.types import Receive, Scope, Send
 
 from app.config import settings
 from app.http_client import close_http_client
@@ -33,8 +34,18 @@ app = FastAPI(
     lifespan=lifespan,
 )
 
+class _HealthBypassTrustedHost(TrustedHostMiddleware):
+    """Skip host validation for infrastructure health probes."""
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] == "http" and scope["path"] == "/health":
+            await self.app(scope, receive, send)
+            return
+        await super().__call__(scope, receive, send)
+
+
 app.add_middleware(
-    TrustedHostMiddleware,
+    _HealthBypassTrustedHost,
     allowed_hosts=settings.allowed_hosts_list,
 )
 

--- a/apps/job-api/railway.toml
+++ b/apps/job-api/railway.toml
@@ -3,7 +3,7 @@ builder = "DOCKERFILE"
 dockerfilePath = "apps/job-api/Dockerfile"
 
 [deploy]
-startCommand = "uv run --package job-api uvicorn app.main:app --host 0.0.0.0 --port 8080"
+startCommand = "uv run --package job-api uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8000}"
 healthcheckPath = "/health"
 healthcheckTimeout = 30
 restartPolicyType = "ON_FAILURE"


### PR DESCRIPTION
## Summary
- Railway's internal healthcheck probes send a `Host` header that doesn't match `ALLOWED_HOSTS`, causing `TrustedHostMiddleware` to return 400 Bad Request on every `/health` probe
- Subclass `TrustedHostMiddleware` to bypass host validation for `/health` — infrastructure probes shouldn't be subject to host allowlisting
- Replace hardcoded `--port 8080` in `railway.toml` with `${PORT:-8000}` to respect Railway's injected `PORT` env var

## Test plan
- [ ] Deploy to Railway dev and verify healthcheck passes
- [ ] Confirm `/health` returns 200 from Railway's internal probe
- [ ] Confirm other endpoints still enforce `ALLOWED_HOSTS`

🤖 Generated with [Claude Code](https://claude.com/claude-code)