### PR TITLE
fix(audit-api, job-api): Chrome orphan cleanup and duplicate seed entry

### DIFF
--- a/apps/audit-api/app/services/scanner.py
+++ b/apps/audit-api/app/services/scanner.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 import logging
 import os
+import signal
 import tempfile
 import uuid
 from dataclasses import dataclass
@@ -38,6 +39,23 @@ class ScanError(RuntimeError):
     """Lighthouse run failed or returned unusable output."""
 
 
+def _kill_process_group(proc: asyncio.subprocess.Process) -> None:
+    """Kill the entire process group that *proc* leads.
+
+    Lighthouse's Node process spawns Chrome as a child via chrome-launcher.
+    A bare proc.kill() only SIGKILLs the Node process; Chrome survives as
+    an orphan, consuming memory and blocking subsequent scans with "Unable
+    to connect to Chrome." start_new_session=True on the subprocess puts
+    the tree in its own process group so killpg reaches Chrome too.
+    """
+    if proc.pid is None:
+        return
+    try:
+        os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+    except (ProcessLookupError, OSError):
+        pass
+
+
 async def _run_lighthouse(url: str, device: DeviceMode) -> dict[str, Any]:
     with tempfile.TemporaryDirectory() as tmpdir:
         output_path = str(Path(tmpdir) / "report.json")
@@ -45,14 +63,20 @@ async def _run_lighthouse(url: str, device: DeviceMode) -> dict[str, Any]:
         args[0] = LIGHTHOUSE_BIN
 
         proc = await asyncio.create_subprocess_exec(
-            *args, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE
+            *args,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            start_new_session=True,
         )
         try:
             _, stderr = await asyncio.wait_for(
                 proc.communicate(), timeout=SCAN_TIMEOUT_SEC
             )
         except TimeoutError as exc:
-            proc.kill()
+            # Kill the entire process group — not just the Node process.
+            # Without this, Chrome is orphaned and causes the next scan to
+            # fail with "Unable to connect to Chrome."
+            _kill_process_group(proc)
             await proc.wait()
             raise ScanError(f"Lighthouse timed out after {SCAN_TIMEOUT_SEC}s") from exc
 

--- a/apps/job-api/app/seed/company_seed.py
+++ b/apps/job-api/app/seed/company_seed.py
@@ -22,7 +22,6 @@ COMPANY_SEED: list[dict[str, str]] = [
     {"board_token": "dbtlabs", "company_name": "dbt Labs"},
     {"board_token": "loom", "company_name": "Loom"},
     {"board_token": "mux", "company_name": "Mux"},
-    {"board_token": "vercel", "company_name": "Vercel"},
     {"board_token": "planetscale", "company_name": "PlanetScale"},
     {"board_token": "supabase", "company_name": "Supabase"},
     {"board_token": "clerk", "company_name": "Clerk"},


### PR DESCRIPTION
## Summary

- **audit-api**: When Lighthouse times out, `proc.kill()` only kills the Node process — Chrome (spawned by `chrome-launcher` as a child) survives as an orphan consuming memory and ports. The next queued scan fails with "Unable to connect to Chrome." Fix: launch Lighthouse subprocess with `start_new_session=True` and use `os.killpg()` on timeout to kill the entire process tree.
- **job-api**: `COMPANY_SEED` had a duplicate `vercel` board_token entry. PostgreSQL rejects a single `upsert` when two rows share the same `ON CONFLICT` key, causing `POST /sources/seed` to 500 (surfaced as 502 through the Vercel proxy).

## Test plan

- [ ] Deploy job-api to Railway and verify `POST /sources/seed` succeeds
- [ ] Deploy audit-api to Railway and trigger two sequential scans against a slow site
- [ ] Verify timed-out scan doesn't orphan Chrome and the next scan succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)