### PR TITLE
fix: remove botid false positives and clean up CSP violations

### DIFF
--- a/apps/root/src/app/api/audit/compare/route.ts
+++ b/apps/root/src/app/api/audit/compare/route.ts
@@ -1,5 +1,4 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { checkBotId } from 'botid/server';
 import { isValidUuid, type ScanIssue } from '@danieljoffe.com/shared-audit';
 import { createServerSupabaseClient } from '@/lib/supabase/server';
 import { captureApiError } from '@/lib/errorTracking';
@@ -16,13 +15,6 @@ const CACHE_HEADERS = {
 
 export async function GET(request: NextRequest) {
   try {
-    if (process.env['VERCEL']) {
-      const botCheck = await checkBotId();
-      if (botCheck.isBot) {
-        return NextResponse.json({ error: 'Access denied' }, { status: 403 });
-      }
-    }
-
     const { searchParams } = new URL(request.url);
     const auditA = searchParams.get('auditA');
     const auditB = searchParams.get('auditB');

--- a/apps/root/src/app/api/audit/previous/[id]/route.ts
+++ b/apps/root/src/app/api/audit/previous/[id]/route.ts
@@ -1,5 +1,4 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { checkBotId } from 'botid/server';
 import { isValidUuid } from '@danieljoffe.com/shared-audit';
 import { createServerSupabaseClient } from '@/lib/supabase/server';
 import { captureApiError } from '@/lib/errorTracking';
@@ -23,13 +22,6 @@ export async function GET(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
-    if (process.env['VERCEL']) {
-      const botCheck = await checkBotId();
-      if (botCheck.isBot) {
-        return NextResponse.json({ error: 'Access denied' }, { status: 403 });
-      }
-    }
-
     const { id } = await params;
 
     if (!isValidUuid(id)) {

--- a/apps/root/src/app/home/Head.tsx
+++ b/apps/root/src/app/home/Head.tsx
@@ -26,8 +26,6 @@ export default async function Head() {
       <link rel='dns-prefetch' href='https://www.google-analytics.com' />
       <link rel='dns-prefetch' href='https://hcaptcha.com' />
       <link rel='dns-prefetch' href='https://api.hcaptcha.com' />
-      <link rel='prefetch' href='https://images.unsplash.com' />
-      <link rel='prefetch' href='https://unsplash.com' />
     </head>
   );
 }

--- a/apps/root/src/utils/constants.ts
+++ b/apps/root/src/utils/constants.ts
@@ -9,6 +9,7 @@ export const EXAMPLE_URL = 'https://example.com';
 export const GOOGLE_ANALYTICS_URL = 'https://www.google-analytics.com';
 export const GOOGLE_TAG_MANAGER_URL = 'https://www.googletagmanager.com';
 const SENTRY_URL = 'https://www.sentry.io';
+const SENTRY_INGEST_URL = 'https://*.ingest.us.sentry.io';
 const SCHEMA_ORG_URL = 'https://schema.org';
 export const HCAPTCHA_URL = 'https://www.hcaptcha.com';
 const SUPABASE_STORAGE_URL = 'https://grwmzluuqyczatkxorfa.supabase.co';
@@ -43,6 +44,7 @@ export const allowedOrigins = [
   ...allowedImageOrigins,
   DOMAIN_URL,
   SENTRY_URL,
+  SENTRY_INGEST_URL,
   SCHEMA_ORG_URL,
   HCAPTCHA_URL,
 ];


### PR DESCRIPTION
## Summary

- **botid false positives**: Remove `checkBotId()` from `/api/audit/previous/[id]` and `/api/audit/compare` — these read-only GET routes were never in the client-side `protect` list, so every request was flagged as a bot (403). The three routes that need bot protection (contact, leads, scan) remain unchanged.
- **CSP: dead Unsplash prefetches**: Remove `<link rel='prefetch'>` for `images.unsplash.com` and `unsplash.com` in `Head.tsx`. Thumbnails use local `/images/covers/*` now; the prefetches just triggered `default-src` violations.
- **CSP: Sentry ingest origin**: Add `https://*.ingest.us.sentry.io` to `connect-src`. The `tunnelRoute` handles most Sentry traffic but some SDK requests still hit the ingest URL directly.

## Test plan

- [ ] Load audit report page — no more 403 on previous scan fetch
- [ ] Load `/audit/compare` — no more 403
- [ ] Check console for CSP violations on homepage and about page
- [ ] Verify Sentry error reporting still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)