### PR TITLE
Release: fix audit botid false positive, CSP cleanup, CI review tooling

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -27,7 +27,9 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          claude_args: '--max-turns 20'
+          claude_args: >-
+            --max-turns 40
+            --allowed-tools "Read,Grep,Glob,Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git status:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr comment:*),mcp__github_inline_comment__create_inline_comment"
           prompt: |
             Review this PR and post a single summary comment. Do NOT make any code changes.
 

--- a/apps/root/src/app/api/audit/compare/route.ts
+++ b/apps/root/src/app/api/audit/compare/route.ts
@@ -1,5 +1,4 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { checkBotId } from 'botid/server';
 import { isValidUuid, type ScanIssue } from '@danieljoffe.com/shared-audit';
 import { createServerSupabaseClient } from '@/lib/supabase/server';
 import { captureApiError } from '@/lib/errorTracking';
@@ -16,13 +15,6 @@ const CACHE_HEADERS = {
 
 export async function GET(request: NextRequest) {
   try {
-    if (process.env['VERCEL']) {
-      const botCheck = await checkBotId();
-      if (botCheck.isBot) {
-        return NextResponse.json({ error: 'Access denied' }, { status: 403 });
-      }
-    }
-
     const { searchParams } = new URL(request.url);
     const auditA = searchParams.get('auditA');
     const auditB = searchParams.get('auditB');

--- a/apps/root/src/app/api/audit/previous/[id]/route.ts
+++ b/apps/root/src/app/api/audit/previous/[id]/route.ts
@@ -1,5 +1,4 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { checkBotId } from 'botid/server';
 import { isValidUuid } from '@danieljoffe.com/shared-audit';
 import { createServerSupabaseClient } from '@/lib/supabase/server';
 import { captureApiError } from '@/lib/errorTracking';
@@ -23,13 +22,6 @@ export async function GET(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
-    if (process.env['VERCEL']) {
-      const botCheck = await checkBotId();
-      if (botCheck.isBot) {
-        return NextResponse.json({ error: 'Access denied' }, { status: 403 });
-      }
-    }
-
     const { id } = await params;
 
     if (!isValidUuid(id)) {

--- a/apps/root/src/app/home/Head.tsx
+++ b/apps/root/src/app/home/Head.tsx
@@ -26,8 +26,6 @@ export default async function Head() {
       <link rel='dns-prefetch' href='https://www.google-analytics.com' />
       <link rel='dns-prefetch' href='https://hcaptcha.com' />
       <link rel='dns-prefetch' href='https://api.hcaptcha.com' />
-      <link rel='prefetch' href='https://images.unsplash.com' />
-      <link rel='prefetch' href='https://unsplash.com' />
     </head>
   );
 }

--- a/apps/root/src/utils/constants.ts
+++ b/apps/root/src/utils/constants.ts
@@ -9,6 +9,7 @@ export const EXAMPLE_URL = 'https://example.com';
 export const GOOGLE_ANALYTICS_URL = 'https://www.google-analytics.com';
 export const GOOGLE_TAG_MANAGER_URL = 'https://www.googletagmanager.com';
 const SENTRY_URL = 'https://www.sentry.io';
+const SENTRY_INGEST_URL = 'https://*.ingest.us.sentry.io';
 const SCHEMA_ORG_URL = 'https://schema.org';
 export const HCAPTCHA_URL = 'https://www.hcaptcha.com';
 const SUPABASE_STORAGE_URL = 'https://grwmzluuqyczatkxorfa.supabase.co';
@@ -43,6 +44,7 @@ export const allowedOrigins = [
   ...allowedImageOrigins,
   DOMAIN_URL,
   SENTRY_URL,
+  SENTRY_INGEST_URL,
   SCHEMA_ORG_URL,
   HCAPTCHA_URL,
 ];


### PR DESCRIPTION
## Summary

- `fix(audit)`: remove botid check from read-only audit routes (`compare`, `previous/[id]`) to stop false-positive blocks
- `fix(csp)`: drop dead Unsplash prefetches from home head and add Sentry ingest origin to CSP
- `fix(ci)`: raise `claude-review` max-turns and allowlist review tools

## Test plan

- [ ] CI green on `develop` → `main` (release validation pipeline)
- [ ] Audit compare/previous endpoints reachable from production clients (no botid 403)
- [ ] Sentry events reach ingest in production (no CSP violations)
- [ ] Claude review workflow completes without hitting turn cap

https://claude.ai/code/session_01SzeUka3845ioNhKntHSq3r