### PR TITLE
feat(job-api): experience foundation for resume tailor (#185 P1)

### DIFF
--- a/apps/job-api/app/main.py
+++ b/apps/job-api/app/main.py
@@ -7,7 +7,7 @@ from starlette.types import Receive, Scope, Send
 
 from app.config import settings
 from app.http_client import close_http_client
-from app.routers import jobs, poll, sources, status
+from app.routers import experience, jobs, poll, sources, status
 from app.supabase_pool import close_supabase, init_supabase
 
 if not settings.allowed_hosts_list:
@@ -49,6 +49,7 @@ app.add_middleware(
     allowed_hosts=settings.allowed_hosts_list,
 )
 
+app.include_router(experience.router)
 app.include_router(jobs.router)
 app.include_router(poll.router)
 app.include_router(sources.router)

--- a/apps/job-api/app/models/experience.py
+++ b/apps/job-api/app/models/experience.py
@@ -1,0 +1,142 @@
+"""Pydantic models for the experience module (#185 P1).
+
+Two-doc content model:
+- ProseDoc: user-owned narrative. Append-only from conversation turns.
+- OptimizedDoc: LLM-derived structured projection of the prose. User-editable.
+
+Chunks, turns, and preferences support retrieval, chat, and persistent style bias.
+"""
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+ConversationType = Literal["onboarding", "update"]
+TurnRole = Literal["user", "assistant", "system"]
+ChunkType = Literal["role", "skill", "outcome", "summary"]
+OptimizedDocSource = Literal["llm", "user_edit"]
+
+
+# ---------------------------------------------------------------------------
+# Optimized doc payload shape. The LLM produces this from the prose doc;
+# the tailor reads it. Every claim in a generated resume must trace back
+# to something in this structure.
+# ---------------------------------------------------------------------------
+
+class Outcome(BaseModel):
+    description: str
+    metric: str | None = None
+    value: str | None = None
+    role_ref: str | None = None
+
+
+class Role(BaseModel):
+    id: str
+    company: str
+    title: str
+    start: str
+    end: str | None = None
+    summary: str | None = None
+    skills: list[str] = Field(default_factory=list)
+    outcome_refs: list[str] = Field(default_factory=list)
+
+
+class Skill(BaseModel):
+    name: str
+    evidence_refs: list[str] = Field(default_factory=list)
+    years: float | None = None
+
+
+class OptimizedPayload(BaseModel):
+    summary: str | None = None
+    roles: list[Role] = Field(default_factory=list)
+    skills: list[Skill] = Field(default_factory=list)
+    outcomes: list[Outcome] = Field(default_factory=list)
+
+
+class PreferencesPayload(BaseModel):
+    rules: list[str] = Field(default_factory=list)
+    avoid: list[str] = Field(default_factory=list)
+    tone_notes: list[str] = Field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Row models (DB read shapes)
+# ---------------------------------------------------------------------------
+
+class ProseDoc(BaseModel):
+    id: str
+    user_id: str | None
+    version: int
+    content: str
+    created_at: datetime
+
+
+class OptimizedDoc(BaseModel):
+    id: str
+    user_id: str | None
+    prose_doc_id: str | None
+    version: int
+    payload: OptimizedPayload
+    markdown_view: str | None
+    source: OptimizedDocSource
+    created_at: datetime
+
+
+class Chunk(BaseModel):
+    id: str
+    optimized_doc_id: str
+    chunk_type: ChunkType
+    chunk_ref: str
+    content: str
+    metadata: dict[str, str | int | float | bool]
+    created_at: datetime
+
+
+class ConversationTurn(BaseModel):
+    id: str
+    user_id: str | None
+    conversation_type: ConversationType
+    turn_index: int
+    role: TurnRole
+    content: str
+    skipped: bool
+    prose_doc_id: str | None
+    metadata: dict[str, str | int | float | bool]
+    created_at: datetime
+
+
+class Preferences(BaseModel):
+    id: str
+    user_id: str | None
+    payload: PreferencesPayload
+    created_at: datetime
+    updated_at: datetime
+
+
+# ---------------------------------------------------------------------------
+# Request shapes (router inputs)
+# ---------------------------------------------------------------------------
+
+class ProseDocCreate(BaseModel):
+    content: str = Field(min_length=1, max_length=500_000)
+
+
+class OptimizedDocUpsert(BaseModel):
+    prose_doc_id: str | None = None
+    payload: OptimizedPayload
+    markdown_view: str | None = None
+    source: OptimizedDocSource = "llm"
+
+
+class PreferencesUpsert(BaseModel):
+    payload: PreferencesPayload
+
+
+class TurnAppend(BaseModel):
+    conversation_type: ConversationType
+    role: TurnRole
+    content: str = Field(min_length=1, max_length=50_000)
+    skipped: bool = False
+    prose_doc_id: str | None = None

--- a/apps/job-api/app/routers/experience.py
+++ b/apps/job-api/app/routers/experience.py
@@ -1,0 +1,145 @@
+"""Experience router (#185 P1).
+
+CRUD over prose docs, optimized docs, conversation turns, and preferences.
+No LLM involvement in this phase — that ships in P2. These endpoints exist
+so a client (CLI today, dashboard later) can exercise the data layer.
+"""
+
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from supabase import Client
+
+from app.dependencies import get_supabase, verify_api_key_or_session
+from app.models.experience import (
+    ConversationType,
+    OptimizedDoc,
+    OptimizedDocUpsert,
+    Preferences,
+    PreferencesUpsert,
+    ProseDoc,
+    ProseDocCreate,
+    TurnAppend,
+)
+from app.services.experience import optimized, preferences, prose, turns
+
+router = APIRouter(
+    prefix="/experience",
+    tags=["experience"],
+    dependencies=[Depends(verify_api_key_or_session)],
+)
+
+
+# ---- Prose doc ------------------------------------------------------------
+
+
+@router.get("/prose")
+async def get_prose(
+    supabase: Client = Depends(get_supabase),
+) -> ProseDoc | dict[str, None]:
+    doc = prose.get_latest(supabase, user_id=None)
+    if doc is None:
+        return {"prose": None}
+    return doc
+
+
+@router.post("/prose")
+async def create_prose(
+    body: ProseDocCreate,
+    supabase: Client = Depends(get_supabase),
+) -> ProseDoc:
+    return prose.create_version(supabase, user_id=None, content=body.content)
+
+
+# ---- Optimized doc --------------------------------------------------------
+
+
+@router.get("/optimized")
+async def get_optimized(
+    supabase: Client = Depends(get_supabase),
+) -> OptimizedDoc | dict[str, None]:
+    doc = optimized.get_latest(supabase, user_id=None)
+    if doc is None:
+        return {"optimized": None}
+    return doc
+
+
+@router.post("/optimized")
+async def create_optimized(
+    body: OptimizedDocUpsert,
+    supabase: Client = Depends(get_supabase),
+) -> OptimizedDoc:
+    return optimized.create_version(
+        supabase,
+        user_id=None,
+        payload=body.payload,
+        prose_doc_id=body.prose_doc_id,
+        source=body.source,
+        markdown_view=body.markdown_view,
+    )
+
+
+# ---- Preferences ----------------------------------------------------------
+
+
+@router.get("/preferences")
+async def get_preferences(
+    supabase: Client = Depends(get_supabase),
+) -> Preferences | dict[str, None]:
+    row = preferences.get(supabase, user_id=None)
+    if row is None:
+        return {"preferences": None}
+    return row
+
+
+@router.put("/preferences")
+async def upsert_preferences(
+    body: PreferencesUpsert,
+    supabase: Client = Depends(get_supabase),
+) -> Preferences:
+    return preferences.upsert(supabase, user_id=None, payload=body.payload)
+
+
+@router.delete("/preferences")
+async def reset_preferences(
+    supabase: Client = Depends(get_supabase),
+) -> dict[str, bool]:
+    preferences.reset(supabase, user_id=None)
+    return {"success": True}
+
+
+# ---- Conversation turns --------------------------------------------------
+
+
+@router.get("/turns")
+async def list_turns(
+    conversation_type: ConversationType | None = Query(default=None),
+    limit: int = Query(default=200, ge=1, le=1000),
+    supabase: Client = Depends(get_supabase),
+) -> dict[str, Any]:
+    rows = turns.list_turns(
+        supabase,
+        user_id=None,
+        conversation_type=conversation_type,
+        limit=limit,
+    )
+    return {"turns": [r.model_dump(mode="json") for r in rows]}
+
+
+@router.post("/turns")
+async def append_turn(
+    body: TurnAppend,
+    supabase: Client = Depends(get_supabase),
+) -> dict[str, Any]:
+    if body.skipped and body.role != "user":
+        raise HTTPException(status_code=400, detail="only user turns can be skipped")
+    turn = turns.append(
+        supabase,
+        user_id=None,
+        conversation_type=body.conversation_type,
+        role=body.role,
+        content=body.content,
+        skipped=body.skipped,
+        prose_doc_id=body.prose_doc_id,
+    )
+    return turn.model_dump(mode="json")

--- a/apps/job-api/app/services/experience/__init__.py
+++ b/apps/job-api/app/services/experience/__init__.py
@@ -1,0 +1,10 @@
+"""Experience module (#185 P1).
+
+Two-doc content model:
+- ProseDoc: user-owned narrative, append-only from chat turns.
+- OptimizedDoc: LLM-derived structured projection. User-editable.
+
+This module owns the data layer. Conversation orchestration, embedding/retrieval,
+and tailoring live in peer modules (added in later phases) that consume the
+optimized doc only.
+"""

--- a/apps/job-api/app/services/experience/optimized.py
+++ b/apps/job-api/app/services/experience/optimized.py
@@ -1,0 +1,66 @@
+"""Optimized doc CRUD. Versioned.
+
+LLM generates a new version from the current prose doc. User edits also create
+a new version with source='user_edit'. Version history preserves LLM drafts
+and manual edits alongside each other so nothing is silently clobbered.
+"""
+
+from typing import Any, cast
+
+from supabase import Client
+
+from app.models.experience import (
+    OptimizedDoc,
+    OptimizedDocSource,
+    OptimizedPayload,
+)
+
+TABLE = "experience_optimized_docs"
+
+
+def get_latest(supabase: Client, user_id: str | None) -> OptimizedDoc | None:
+    query = supabase.table(TABLE).select("*").order("version", desc=True).limit(1)
+    query = query.is_("user_id", "null") if user_id is None else query.eq("user_id", user_id)
+    resp = query.execute()
+    rows = cast(list[dict[str, Any]], resp.data or [])
+    if not rows:
+        return None
+    return OptimizedDoc.model_validate(rows[0])
+
+
+def list_versions(supabase: Client, user_id: str | None, limit: int = 50) -> list[OptimizedDoc]:
+    query = supabase.table(TABLE).select("*").order("version", desc=True).limit(limit)
+    query = query.is_("user_id", "null") if user_id is None else query.eq("user_id", user_id)
+    resp = query.execute()
+    rows = cast(list[dict[str, Any]], resp.data or [])
+    return [OptimizedDoc.model_validate(r) for r in rows]
+
+
+def create_version(
+    supabase: Client,
+    user_id: str | None,
+    payload: OptimizedPayload,
+    prose_doc_id: str | None,
+    source: OptimizedDocSource,
+    markdown_view: str | None = None,
+) -> OptimizedDoc:
+    latest = get_latest(supabase, user_id)
+    next_version = (latest.version + 1) if latest else 1
+    resp = (
+        supabase.table(TABLE)
+        .insert(
+            {
+                "user_id": user_id,
+                "prose_doc_id": prose_doc_id,
+                "version": next_version,
+                "payload": payload.model_dump(mode="json"),
+                "markdown_view": markdown_view,
+                "source": source,
+            }
+        )
+        .execute()
+    )
+    rows = cast(list[dict[str, Any]], resp.data or [])
+    if not rows:
+        raise RuntimeError("Failed to insert optimized doc version")
+    return OptimizedDoc.model_validate(rows[0])

--- a/apps/job-api/app/services/experience/preferences.py
+++ b/apps/job-api/app/services/experience/preferences.py
@@ -1,0 +1,52 @@
+"""Preferences CRUD. One row per user_id (unique).
+
+Persistent style bias the LLM reads on every tailoring.
+Reset by deleting the row — this is also what re-running onboarding does.
+"""
+
+from datetime import UTC, datetime
+from typing import Any, cast
+
+from supabase import Client
+
+from app.models.experience import Preferences, PreferencesPayload
+
+TABLE = "experience_preferences"
+
+
+def get(supabase: Client, user_id: str | None) -> Preferences | None:
+    query = supabase.table(TABLE).select("*").limit(1)
+    query = query.is_("user_id", "null") if user_id is None else query.eq("user_id", user_id)
+    resp = query.execute()
+    rows = cast(list[dict[str, Any]], resp.data or [])
+    if not rows:
+        return None
+    return Preferences.model_validate(rows[0])
+
+
+def upsert(
+    supabase: Client,
+    user_id: str | None,
+    payload: PreferencesPayload,
+) -> Preferences:
+    existing = get(supabase, user_id)
+    now_iso = datetime.now(UTC).isoformat()
+    row: dict[str, Any] = {
+        "payload": payload.model_dump(mode="json"),
+        "updated_at": now_iso,
+    }
+    if existing is None:
+        row["user_id"] = user_id
+        resp = supabase.table(TABLE).insert(row).execute()
+    else:
+        resp = supabase.table(TABLE).update(row).eq("id", existing.id).execute()
+    rows = cast(list[dict[str, Any]], resp.data or [])
+    if not rows:
+        raise RuntimeError("Failed to upsert preferences")
+    return Preferences.model_validate(rows[0])
+
+
+def reset(supabase: Client, user_id: str | None) -> None:
+    query = supabase.table(TABLE).delete()
+    query = query.is_("user_id", "null") if user_id is None else query.eq("user_id", user_id)
+    query.execute()

--- a/apps/job-api/app/services/experience/prose.py
+++ b/apps/job-api/app/services/experience/prose.py
@@ -1,0 +1,52 @@
+"""Prose doc CRUD. Versioned, append-only.
+
+The prose doc is the user's narrative source of truth. Every new version
+is a full snapshot — we do not diff. Callers that want to "append" should
+fetch the latest, concatenate, and create a new version.
+"""
+
+from typing import Any, cast
+
+from supabase import Client
+
+from app.models.experience import ProseDoc
+
+TABLE = "experience_prose_docs"
+
+
+def get_latest(supabase: Client, user_id: str | None) -> ProseDoc | None:
+    query = supabase.table(TABLE).select("*").order("version", desc=True).limit(1)
+    query = query.is_("user_id", "null") if user_id is None else query.eq("user_id", user_id)
+    resp = query.execute()
+    rows = cast(list[dict[str, Any]], resp.data or [])
+    if not rows:
+        return None
+    return ProseDoc.model_validate(rows[0])
+
+
+def list_versions(supabase: Client, user_id: str | None, limit: int = 50) -> list[ProseDoc]:
+    query = supabase.table(TABLE).select("*").order("version", desc=True).limit(limit)
+    query = query.is_("user_id", "null") if user_id is None else query.eq("user_id", user_id)
+    resp = query.execute()
+    rows = cast(list[dict[str, Any]], resp.data or [])
+    return [ProseDoc.model_validate(r) for r in rows]
+
+
+def create_version(supabase: Client, user_id: str | None, content: str) -> ProseDoc:
+    latest = get_latest(supabase, user_id)
+    next_version = (latest.version + 1) if latest else 1
+    resp = (
+        supabase.table(TABLE)
+        .insert(
+            {
+                "user_id": user_id,
+                "version": next_version,
+                "content": content,
+            }
+        )
+        .execute()
+    )
+    rows = cast(list[dict[str, Any]], resp.data or [])
+    if not rows:
+        raise RuntimeError("Failed to insert prose doc version")
+    return ProseDoc.model_validate(rows[0])

--- a/apps/job-api/app/services/experience/turns.py
+++ b/apps/job-api/app/services/experience/turns.py
@@ -1,0 +1,68 @@
+"""Conversation turns CRUD. Append-only.
+
+Stores both onboarding and update chat history. Skipped questions are stored
+as user turns with skipped=True so the LLM can see which prompts were declined.
+"""
+
+from typing import Any, cast
+
+from supabase import Client
+
+from app.models.experience import (
+    ConversationTurn,
+    ConversationType,
+    TurnRole,
+)
+
+TABLE = "experience_conversation_turns"
+
+
+def _scope_user(query: Any, user_id: str | None) -> Any:
+    return query.is_("user_id", "null") if user_id is None else query.eq("user_id", user_id)
+
+
+def list_turns(
+    supabase: Client,
+    user_id: str | None,
+    conversation_type: ConversationType | None = None,
+    limit: int = 200,
+) -> list[ConversationTurn]:
+    query = supabase.table(TABLE).select("*").order("created_at", desc=False).limit(limit)
+    query = _scope_user(query, user_id)
+    if conversation_type is not None:
+        query = query.eq("conversation_type", conversation_type)
+    resp = query.execute()
+    rows = cast(list[dict[str, Any]], resp.data or [])
+    return [ConversationTurn.model_validate(r) for r in rows]
+
+
+def append(
+    supabase: Client,
+    user_id: str | None,
+    conversation_type: ConversationType,
+    role: TurnRole,
+    content: str,
+    skipped: bool = False,
+    prose_doc_id: str | None = None,
+) -> ConversationTurn:
+    turns = list_turns(supabase, user_id, conversation_type=conversation_type, limit=1_000_000)
+    next_index = len(turns) + 1
+    resp = (
+        supabase.table(TABLE)
+        .insert(
+            {
+                "user_id": user_id,
+                "conversation_type": conversation_type,
+                "turn_index": next_index,
+                "role": role,
+                "content": content,
+                "skipped": skipped,
+                "prose_doc_id": prose_doc_id,
+            }
+        )
+        .execute()
+    )
+    rows = cast(list[dict[str, Any]], resp.data or [])
+    if not rows:
+        raise RuntimeError("Failed to append conversation turn")
+    return ConversationTurn.model_validate(rows[0])

--- a/supabase/migrations/20260422120000_create_experience_tables.sql
+++ b/supabase/migrations/20260422120000_create_experience_tables.sql
@@ -53,7 +53,7 @@ CREATE INDEX IF NOT EXISTS idx_experience_optimized_user_version
 -- Retrieval index over the optimized doc. One row per retrievable unit
 -- (role, skill, outcome, summary). Populated when an optimized doc is written.
 -- chunk_type tags what facet the chunk represents — useful for weighted retrieval.
--- embedding dim: 1536 (OpenAI text-embedding-3-small / Voyage via reduction).
+-- embedding dim: 1024 (Voyage voyage-3, Anthropic-aligned).
 -- If we switch embedding models later, we alter the column dim.
 -- ----------------------------------------------------------------------------
 CREATE TABLE IF NOT EXISTS experience_chunks (
@@ -64,7 +64,7 @@ CREATE TABLE IF NOT EXISTS experience_chunks (
   chunk_ref          TEXT NOT NULL,
   content            TEXT NOT NULL,
   metadata           JSONB NOT NULL DEFAULT '{}'::jsonb,
-  embedding          extensions.vector(1536),
+  embedding          extensions.vector(1024),
   created_at         TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 

--- a/supabase/migrations/20260422120000_create_experience_tables.sql
+++ b/supabase/migrations/20260422120000_create_experience_tables.sql
@@ -1,0 +1,126 @@
+-- ============================================
+-- MIGRATION: Create experience foundation tables (#185 P1)
+-- Two-doc model: prose (user-owned) + optimized (LLM-derived, user-editable),
+-- plus chunks for retrieval, conversation turns, and preferences.
+-- user_id is nullable today (single user). Non-nullable is a migration away.
+-- ============================================
+
+CREATE EXTENSION IF NOT EXISTS vector WITH SCHEMA extensions;
+
+-- ----------------------------------------------------------------------------
+-- Table: experience_prose_docs
+-- Versioned, append-only narrative. The user owns this. The LLM appends via
+-- conversation turns but never silently rewrites history.
+-- "Current" prose doc = MAX(version) per user_id.
+-- ----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS experience_prose_docs (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id     UUID,
+  version     INTEGER NOT NULL,
+  content     TEXT NOT NULL,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (user_id, version)
+);
+
+CREATE INDEX IF NOT EXISTS idx_experience_prose_user_version
+  ON experience_prose_docs(user_id, version DESC);
+
+-- ----------------------------------------------------------------------------
+-- Table: experience_optimized_docs
+-- LLM-derived structured projection of the prose doc. User-editable. Versioned
+-- so regeneration cannot clobber manual edits.
+-- payload shape: { roles: Role[], skills: Skill[], outcomes: Outcome[], summary }
+-- markdown_view is a rendered view of payload for human diffing.
+-- ----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS experience_optimized_docs (
+  id             UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id        UUID,
+  prose_doc_id   UUID REFERENCES experience_prose_docs(id) ON DELETE SET NULL,
+  version        INTEGER NOT NULL,
+  payload        JSONB NOT NULL,
+  markdown_view  TEXT,
+  source         TEXT NOT NULL DEFAULT 'llm'
+                 CHECK (source IN ('llm', 'user_edit')),
+  created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (user_id, version)
+);
+
+CREATE INDEX IF NOT EXISTS idx_experience_optimized_user_version
+  ON experience_optimized_docs(user_id, version DESC);
+
+-- ----------------------------------------------------------------------------
+-- Table: experience_chunks
+-- Retrieval index over the optimized doc. One row per retrievable unit
+-- (role, skill, outcome, summary). Populated when an optimized doc is written.
+-- chunk_type tags what facet the chunk represents — useful for weighted retrieval.
+-- embedding dim: 1536 (OpenAI text-embedding-3-small / Voyage via reduction).
+-- If we switch embedding models later, we alter the column dim.
+-- ----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS experience_chunks (
+  id                 UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  optimized_doc_id   UUID NOT NULL REFERENCES experience_optimized_docs(id) ON DELETE CASCADE,
+  chunk_type         TEXT NOT NULL
+                     CHECK (chunk_type IN ('role', 'skill', 'outcome', 'summary')),
+  chunk_ref          TEXT NOT NULL,
+  content            TEXT NOT NULL,
+  metadata           JSONB NOT NULL DEFAULT '{}'::jsonb,
+  embedding          extensions.vector(1536),
+  created_at         TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_experience_chunks_optimized_doc
+  ON experience_chunks(optimized_doc_id);
+CREATE INDEX IF NOT EXISTS idx_experience_chunks_type
+  ON experience_chunks(chunk_type);
+CREATE INDEX IF NOT EXISTS idx_experience_chunks_embedding
+  ON experience_chunks
+  USING hnsw (embedding extensions.vector_cosine_ops);
+
+-- ----------------------------------------------------------------------------
+-- Table: experience_conversation_turns
+-- Append-only chat log. conversation_type distinguishes onboarding from update.
+-- Skipped questions are recorded with role='user' and content='__SKIP__'
+-- so the LLM can see which prompts the user declined.
+-- ----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS experience_conversation_turns (
+  id                 UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id            UUID,
+  conversation_type  TEXT NOT NULL
+                     CHECK (conversation_type IN ('onboarding', 'update')),
+  turn_index         INTEGER NOT NULL,
+  role               TEXT NOT NULL
+                     CHECK (role IN ('user', 'assistant', 'system')),
+  content            TEXT NOT NULL,
+  skipped            BOOLEAN NOT NULL DEFAULT FALSE,
+  prose_doc_id       UUID REFERENCES experience_prose_docs(id) ON DELETE SET NULL,
+  metadata           JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at         TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_experience_turns_user_created
+  ON experience_conversation_turns(user_id, created_at);
+CREATE INDEX IF NOT EXISTS idx_experience_turns_type
+  ON experience_conversation_turns(conversation_type);
+
+-- ----------------------------------------------------------------------------
+-- Table: experience_preferences
+-- Persistent style bias applied to every tailoring. One row per user_id.
+-- payload shape: { rules: string[], avoid: string[], tone_notes: string[] }
+-- Reset by deleting the row (or re-running onboarding clears it).
+-- ----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS experience_preferences (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id     UUID UNIQUE,
+  payload     JSONB NOT NULL DEFAULT '{"rules": [], "avoid": [], "tone_notes": []}'::jsonb,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- ----------------------------------------------------------------------------
+-- RLS: service_role-only, matching the jobs tables pattern.
+-- ----------------------------------------------------------------------------
+ALTER TABLE experience_prose_docs ENABLE ROW LEVEL SECURITY;
+ALTER TABLE experience_optimized_docs ENABLE ROW LEVEL SECURITY;
+ALTER TABLE experience_chunks ENABLE ROW LEVEL SECURITY;
+ALTER TABLE experience_conversation_turns ENABLE ROW LEVEL SECURITY;
+ALTER TABLE experience_preferences ENABLE ROW LEVEL SECURITY;


### PR DESCRIPTION
## Summary

P1 of the canonical resume tailoring system (#185). Lands the data layer only — no LLM, no UI. Two-doc content model, retrieval table, conversation log, preferences.

**Note:** base retargeted to `feature/resume-tailor` — a long-lived integration branch for this feature. Subsequent phases (P2–P5) land on the same integration branch. The whole system merges into `develop` as a single tested unit, keeping `develop` free for unrelated work in the meantime.

Plan in #185: https://github.com/danieljoffe/danieljoffe.com/issues/185#issuecomment-4299270353

## What's in

**Migration** — `supabase/migrations/20260422120000_create_experience_tables.sql`
- Enables `pgvector`.
- `experience_prose_docs` — versioned, append-only narrative (user-owned).
- `experience_optimized_docs` — versioned LLM-derived structured projection. `source` distinguishes `'llm'` vs `'user_edit'` in history.
- `experience_chunks` — retrieval index over the optimized doc; `vector(1024)` for Voyage `voyage-3`; HNSW cosine index.
- `experience_conversation_turns` — append-only chat log; `conversation_type ∈ {onboarding, update}`; `skipped` flag for declined onboarding prompts.
- `experience_preferences` — singleton per user; persistent style bias; reset by delete.
- All user-authored tables get `user_id UUID NULL` (tenancy hedge — single user today, multi-user is a single ALTER away).
- RLS enabled on all tables (service-role-only, matching jobs tables pattern).

**Pydantic models** — `apps/job-api/app/models/experience.py`
- `ProseDoc`, `OptimizedDoc`, `Chunk`, `ConversationTurn`, `Preferences` (read shapes)
- `OptimizedPayload` with typed `Role`, `Skill`, `Outcome` shapes (the constraint surface for hallucination detection later)
- Request shapes: `ProseDocCreate`, `OptimizedDocUpsert`, `PreferencesUpsert`, `TurnAppend`

**Services** — `apps/job-api/app/services/experience/`
- `prose.py` — `get_latest`, `list_versions`, `create_version` (auto-bumps version)
- `optimized.py` — same shape, plus `source` and `prose_doc_id` linkage
- `preferences.py` — `get`, `upsert` (insert-or-update by `user_id`), `reset`
- `turns.py` — `list_turns` (filtered by `conversation_type`), `append` (auto-indexes)

**Router** — `apps/job-api/app/routers/experience.py`
- `GET/POST /experience/prose`
- `GET/POST /experience/optimized`
- `GET/PUT/DELETE /experience/preferences`
- `GET/POST /experience/turns`
- All behind `verify_api_key_or_session`.

## What's not in (intentional)

- No LLM code. `services/llm/`, `services/conversation/`, `services/tailor/`, `services/docx/`, `services/ats_lint/` ship in subsequent phases (P2–P5).
- No chunk-write path yet. The `experience_chunks` table is created but `services/experience/chunks.py` lands in P2b alongside the Voyage embedding client.
- No new tests. The new code is thin CRUD plumbing; substantive tests land alongside business logic in P2.

## Decisions worth flagging

- **Embeddings**: `vector(1024)` chosen for Voyage `voyage-3` (Anthropic-aligned).
- **Versioning**: full snapshots, not diffs. Storage is cheap; debuggability matters more.
- **`user_id NULL`**: kept nullable so single-user mode just doesn't populate it. Queries scope via `.is_("user_id", "null")`. Promoting to `NOT NULL` when auth lands is a one-line migration.

## Test plan

- [x] `uv run ruff check` — passes on new files
- [x] `uv run mypy --strict` — no issues found in 8 source files (including new experience module)
- [x] `uv run pytest` — 129/129 existing tests pass; no regressions
- [ ] Apply migration to a Supabase project (`pnpm db:push`) and verify table creation, RLS policies, and the HNSW index build
- [ ] Smoke-test the router endpoints via the API key flow

https://claude.ai/code/session_01GiZqgubpGXDBuQSEGNGsbp