### PR TITLE
feat(job-api): mocked LLM plumbing + cost-log (#185 P2a)

### DIFF
--- a/apps/job-api/app/models/llm.py
+++ b/apps/job-api/app/models/llm.py
@@ -1,0 +1,55 @@
+"""Pydantic models for the LLM plumbing layer (#185 P2a).
+
+Interface-only. The real Anthropic client ships in a later phase;
+P2a uses MockLLMClient so the rest of the system can be wired up and
+tested without external API calls.
+"""
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+ModelId = Literal[
+    "claude-opus-4-7",
+    "claude-sonnet-4-6",
+    "claude-haiku-4-5",
+]
+"""Models this workspace targets. Extend as new models land."""
+
+TurnRole = Literal["user", "assistant"]
+
+
+class Message(BaseModel):
+    role: TurnRole
+    content: str
+
+
+class LLMUsage(BaseModel):
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cache_read_input_tokens: int = 0
+    cache_creation_input_tokens: int = 0
+
+
+class LLMResult(BaseModel):
+    content: str
+    model: ModelId
+    usage: LLMUsage
+    cost_usd: float
+    latency_ms: int
+
+
+class LLMCallRecord(BaseModel):
+    id: str
+    user_id: str | None
+    model: ModelId
+    purpose: str
+    input_tokens: int
+    output_tokens: int
+    cache_read_input_tokens: int
+    cache_creation_input_tokens: int
+    cost_usd: float
+    latency_ms: int
+    metadata: dict[str, str | int | float | bool] = Field(default_factory=dict)
+    created_at: datetime

--- a/apps/job-api/app/services/llm/__init__.py
+++ b/apps/job-api/app/services/llm/__init__.py
@@ -1,0 +1,13 @@
+"""LLM plumbing module (#185 P2a).
+
+Mock-only for now. A real Anthropic-backed client is a later phase —
+the Protocol interface makes that swap a constructor change.
+
+Every consumer (derive, tailor, conversation) tags calls with a `purpose`
+string so cost-log rows can be grouped by feature for spend analysis.
+"""
+
+from app.services.llm.client import LLMClient
+from app.services.llm.mock import MockLLMClient
+
+__all__ = ["LLMClient", "MockLLMClient"]

--- a/apps/job-api/app/services/llm/client.py
+++ b/apps/job-api/app/services/llm/client.py
@@ -1,0 +1,78 @@
+"""LLM client Protocol.
+
+The interface every consumer codes against. Real and mock implementations
+both satisfy it. Keeping the surface small: a single `complete` method that
+takes system + user messages and returns structured usage + content.
+
+JSON-mode (structured output via Pydantic schema) is a thin helper layered
+on top — see `complete_json` below. Consumers that need a typed object
+use that; everyone else uses `complete`.
+"""
+
+from typing import Protocol, TypeVar
+
+from pydantic import BaseModel
+
+from app.models.llm import LLMResult, Message, ModelId
+
+T = TypeVar("T", bound=BaseModel)
+
+
+class LLMClient(Protocol):
+    """Protocol satisfied by both MockLLMClient and (later) AnthropicLLMClient."""
+
+    async def complete(
+        self,
+        *,
+        model: ModelId,
+        system: str,
+        messages: list[Message],
+        purpose: str,
+        max_tokens: int = 4096,
+        cache_system: bool = False,
+    ) -> LLMResult:
+        """Run a completion.
+
+        Args:
+            model: Which Claude model to use.
+            system: System prompt. If `cache_system=True`, the real client
+                will set `cache_control` on this block.
+            messages: User/assistant history. At least one user message required.
+            purpose: Short label for cost-log grouping (e.g. "derive", "tailor",
+                "conversation.onboarding", "conversation.update", "gap_probe").
+            max_tokens: Hard cap on output.
+            cache_system: Hint to the real client to apply prompt caching on
+                the system block. Ignored by the mock.
+        """
+        ...
+
+
+async def complete_json(
+    client: LLMClient,
+    *,
+    model: ModelId,
+    system: str,
+    messages: list[Message],
+    schema: type[T],
+    purpose: str,
+    max_tokens: int = 4096,
+    cache_system: bool = False,
+) -> tuple[T, LLMResult]:
+    """Call `complete` and validate the response against `schema`.
+
+    Returns both the parsed object and the underlying LLMResult so callers
+    can log cost. The real implementation may use tool_use / structured_output
+    primitives; this helper just parses the content string as JSON. That's
+    fine for the mock (which returns JSON) and will be upgraded in the real
+    client without changing the consumer API.
+    """
+    result = await client.complete(
+        model=model,
+        system=system,
+        messages=messages,
+        purpose=purpose,
+        max_tokens=max_tokens,
+        cache_system=cache_system,
+    )
+    parsed = schema.model_validate_json(result.content)
+    return parsed, result

--- a/apps/job-api/app/services/llm/cost_log.py
+++ b/apps/job-api/app/services/llm/cost_log.py
@@ -1,0 +1,84 @@
+"""Cost-log CRUD. Every LLM call writes one row here.
+
+Consumers call `record(...)` right after `client.complete(...)` with the
+resulting `LLMResult` + a `purpose` label. Spend queries (`total_spend`,
+`spend_by_purpose`) power the dashboard and any future budget guards.
+"""
+
+from datetime import datetime
+from typing import Any, cast
+
+from supabase import Client
+
+from app.models.llm import LLMCallRecord, LLMResult
+
+TABLE = "llm_cost_log"
+
+
+def record(
+    supabase: Client,
+    user_id: str | None,
+    purpose: str,
+    result: LLMResult,
+    metadata: dict[str, str | int | float | bool] | None = None,
+) -> LLMCallRecord:
+    row = {
+        "user_id": user_id,
+        "model": result.model,
+        "purpose": purpose,
+        "input_tokens": result.usage.input_tokens,
+        "output_tokens": result.usage.output_tokens,
+        "cache_read_input_tokens": result.usage.cache_read_input_tokens,
+        "cache_creation_input_tokens": result.usage.cache_creation_input_tokens,
+        "cost_usd": result.cost_usd,
+        "latency_ms": result.latency_ms,
+        "metadata": metadata or {},
+    }
+    resp = supabase.table(TABLE).insert(row).execute()
+    rows = cast(list[dict[str, Any]], resp.data or [])
+    if not rows:
+        raise RuntimeError("Failed to insert llm_cost_log row")
+    return LLMCallRecord.model_validate(rows[0])
+
+
+def list_recent(
+    supabase: Client,
+    user_id: str | None,
+    limit: int = 100,
+) -> list[LLMCallRecord]:
+    query = supabase.table(TABLE).select("*").order("created_at", desc=True).limit(limit)
+    query = query.is_("user_id", "null") if user_id is None else query.eq("user_id", user_id)
+    resp = query.execute()
+    rows = cast(list[dict[str, Any]], resp.data or [])
+    return [LLMCallRecord.model_validate(r) for r in rows]
+
+
+def total_spend(
+    supabase: Client,
+    user_id: str | None,
+    since: datetime | None = None,
+) -> float:
+    query = supabase.table(TABLE).select("cost_usd")
+    query = query.is_("user_id", "null") if user_id is None else query.eq("user_id", user_id)
+    if since is not None:
+        query = query.gte("created_at", since.isoformat())
+    resp = query.execute()
+    rows = cast(list[dict[str, Any]], resp.data or [])
+    return round(sum(float(r["cost_usd"]) for r in rows), 6)
+
+
+def spend_by_purpose(
+    supabase: Client,
+    user_id: str | None,
+    since: datetime | None = None,
+) -> dict[str, float]:
+    query = supabase.table(TABLE).select("purpose, cost_usd")
+    query = query.is_("user_id", "null") if user_id is None else query.eq("user_id", user_id)
+    if since is not None:
+        query = query.gte("created_at", since.isoformat())
+    resp = query.execute()
+    rows = cast(list[dict[str, Any]], resp.data or [])
+    totals: dict[str, float] = {}
+    for r in rows:
+        totals[r["purpose"]] = totals.get(r["purpose"], 0.0) + float(r["cost_usd"])
+    return {k: round(v, 6) for k, v in totals.items()}

--- a/apps/job-api/app/services/llm/mock.py
+++ b/apps/job-api/app/services/llm/mock.py
@@ -1,0 +1,105 @@
+"""MockLLMClient — deterministic fake for tests and local dev.
+
+Two modes:
+1. Scripted responses: register `(purpose, response_text)` pairs; calls with
+   a matching purpose return that text. Good for unit tests where the exact
+   response matters.
+2. Echo mode (default): the client synthesizes a predictable response from
+   the latest user message. Useful for integration tests where we care about
+   the pipeline, not the content.
+
+Both modes compute realistic-ish token counts (roughly 4 chars/token) and
+apply real pricing so cost-log rows look sensible when inspected.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+
+from app.models.llm import LLMResult, LLMUsage, Message, ModelId
+from app.services.llm.pricing import calculate_cost
+
+
+def _approx_tokens(text: str) -> int:
+    """Rough char-to-token heuristic. Good enough for a mock."""
+    return max(1, len(text) // 4)
+
+
+ResponseSource = str | Callable[[str, list[Message]], str]
+
+
+class MockLLMClient:
+    """Implements the LLMClient Protocol. Not used in production."""
+
+    def __init__(
+        self,
+        *,
+        scripted: dict[str, ResponseSource] | None = None,
+        default_latency_ms: int = 50,
+    ) -> None:
+        self._scripted: dict[str, ResponseSource] = scripted or {}
+        self._default_latency_ms = default_latency_ms
+        self.calls: list[dict[str, object]] = []
+
+    def register(self, purpose: str, response: ResponseSource) -> None:
+        """Register a scripted response for a given purpose label."""
+        self._scripted[purpose] = response
+
+    async def complete(
+        self,
+        *,
+        model: ModelId,
+        system: str,
+        messages: list[Message],
+        purpose: str,
+        max_tokens: int = 4096,
+        cache_system: bool = False,
+    ) -> LLMResult:
+        if not messages:
+            raise ValueError("MockLLMClient.complete requires at least one message")
+
+        latest_user = next(
+            (m.content for m in reversed(messages) if m.role == "user"),
+            messages[-1].content,
+        )
+
+        response_text = self._render_response(purpose, latest_user, messages)
+
+        usage = LLMUsage(
+            input_tokens=_approx_tokens(system) + sum(_approx_tokens(m.content) for m in messages),
+            output_tokens=_approx_tokens(response_text),
+            cache_read_input_tokens=0,
+            cache_creation_input_tokens=_approx_tokens(system) if cache_system else 0,
+        )
+
+        cost = calculate_cost(model, usage)
+
+        self.calls.append(
+            {
+                "model": model,
+                "purpose": purpose,
+                "system_len": len(system),
+                "messages_count": len(messages),
+                "cache_system": cache_system,
+                "max_tokens": max_tokens,
+            }
+        )
+
+        return LLMResult(
+            content=response_text,
+            model=model,
+            usage=usage,
+            cost_usd=cost,
+            latency_ms=self._default_latency_ms,
+        )
+
+    def _render_response(
+        self, purpose: str, latest_user: str, messages: list[Message]
+    ) -> str:
+        source = self._scripted.get(purpose)
+        if source is None:
+            return json.dumps({"mock": True, "purpose": purpose, "echo": latest_user})
+        if callable(source):
+            return source(latest_user, messages)
+        return source

--- a/apps/job-api/app/services/llm/pricing.py
+++ b/apps/job-api/app/services/llm/pricing.py
@@ -1,0 +1,50 @@
+"""Model pricing and cost calculation.
+
+Prices are USD per million tokens. Kept here as static constants rather
+than fetching from an API — the values change rarely, and a wrong value
+is visible the next time we review spend.
+
+Prompt caching rates follow Anthropic's standard: cache writes cost 1.25x
+the base input rate, cache reads cost 0.1x. If this ratio changes, update
+the multipliers in `ModelPricing`.
+
+Source: Anthropic pricing page as of 2026-04. Revisit quarterly.
+"""
+
+from pydantic import BaseModel
+
+from app.models.llm import LLMUsage, ModelId
+
+
+class ModelPricing(BaseModel):
+    """USD per million tokens."""
+
+    input: float
+    output: float
+
+    @property
+    def cache_read(self) -> float:
+        return self.input * 0.1
+
+    @property
+    def cache_write(self) -> float:
+        return self.input * 1.25
+
+
+PRICING: dict[ModelId, ModelPricing] = {
+    "claude-opus-4-7": ModelPricing(input=15.00, output=75.00),
+    "claude-sonnet-4-6": ModelPricing(input=3.00, output=15.00),
+    "claude-haiku-4-5": ModelPricing(input=0.80, output=4.00),
+}
+
+
+def calculate_cost(model: ModelId, usage: LLMUsage) -> float:
+    """Total USD cost of a single call, rounded to 6 decimals."""
+    p = PRICING[model]
+    total_per_mtok = (
+        p.input * usage.input_tokens
+        + p.output * usage.output_tokens
+        + p.cache_read * usage.cache_read_input_tokens
+        + p.cache_write * usage.cache_creation_input_tokens
+    )
+    return round(total_per_mtok / 1_000_000, 6)

--- a/apps/job-api/tests/test_llm_mock.py
+++ b/apps/job-api/tests/test_llm_mock.py
@@ -1,0 +1,146 @@
+"""MockLLMClient behavior."""
+
+import json
+
+import pytest
+
+from app.models.llm import Message
+from app.services.llm.client import complete_json
+from app.services.llm.mock import MockLLMClient
+
+
+async def test_echo_mode_returns_json_with_latest_user_content() -> None:
+    client = MockLLMClient()
+    result = await client.complete(
+        model="claude-haiku-4-5",
+        system="sys",
+        messages=[Message(role="user", content="hello world")],
+        purpose="test.echo",
+    )
+    parsed = json.loads(result.content)
+    assert parsed["echo"] == "hello world"
+    assert parsed["purpose"] == "test.echo"
+    assert result.model == "claude-haiku-4-5"
+
+
+async def test_scripted_string_response() -> None:
+    client = MockLLMClient(scripted={"derive": '{"ok": true}'})
+    result = await client.complete(
+        model="claude-sonnet-4-6",
+        system="",
+        messages=[Message(role="user", content="irrelevant")],
+        purpose="derive",
+    )
+    assert result.content == '{"ok": true}'
+
+
+async def test_scripted_callable_sees_latest_user_content() -> None:
+    seen: dict[str, str] = {}
+
+    def responder(latest_user: str, _messages: list[Message]) -> str:
+        seen["latest"] = latest_user
+        return f"got:{latest_user}"
+
+    client = MockLLMClient(scripted={"p": responder})
+    result = await client.complete(
+        model="claude-haiku-4-5",
+        system="",
+        messages=[
+            Message(role="user", content="first"),
+            Message(role="assistant", content="mid"),
+            Message(role="user", content="second"),
+        ],
+        purpose="p",
+    )
+    assert seen["latest"] == "second"
+    assert result.content == "got:second"
+
+
+async def test_register_adds_scripted_response() -> None:
+    client = MockLLMClient()
+    client.register("late", "OK")
+    result = await client.complete(
+        model="claude-haiku-4-5",
+        system="",
+        messages=[Message(role="user", content="anything")],
+        purpose="late",
+    )
+    assert result.content == "OK"
+
+
+async def test_call_is_tracked() -> None:
+    client = MockLLMClient()
+    await client.complete(
+        model="claude-haiku-4-5",
+        system="sys",
+        messages=[Message(role="user", content="hi")],
+        purpose="tracked",
+    )
+    assert len(client.calls) == 1
+    assert client.calls[0]["purpose"] == "tracked"
+    assert client.calls[0]["model"] == "claude-haiku-4-5"
+
+
+async def test_usage_and_cost_are_nonzero() -> None:
+    client = MockLLMClient()
+    result = await client.complete(
+        model="claude-sonnet-4-6",
+        system="some system prompt",
+        messages=[Message(role="user", content="some reasonably long input string")],
+        purpose="u",
+    )
+    assert result.usage.input_tokens > 0
+    assert result.usage.output_tokens > 0
+    assert result.cost_usd > 0
+
+
+async def test_cache_system_hint_bumps_cache_creation_tokens() -> None:
+    client = MockLLMClient()
+    without = await client.complete(
+        model="claude-sonnet-4-6",
+        system="cached",
+        messages=[Message(role="user", content="x")],
+        purpose="nocache",
+        cache_system=False,
+    )
+    with_cache = await client.complete(
+        model="claude-sonnet-4-6",
+        system="cached",
+        messages=[Message(role="user", content="x")],
+        purpose="cache",
+        cache_system=True,
+    )
+    assert without.usage.cache_creation_input_tokens == 0
+    assert with_cache.usage.cache_creation_input_tokens > 0
+
+
+async def test_empty_messages_raises() -> None:
+    client = MockLLMClient()
+    with pytest.raises(ValueError):
+        await client.complete(
+            model="claude-haiku-4-5",
+            system="",
+            messages=[],
+            purpose="empty",
+        )
+
+
+async def test_complete_json_parses_against_schema() -> None:
+    from pydantic import BaseModel
+
+    class Shape(BaseModel):
+        name: str
+        value: int
+
+    client = MockLLMClient(scripted={"parsed": '{"name": "x", "value": 42}'})
+    parsed, result = await complete_json(
+        client,
+        model="claude-sonnet-4-6",
+        system="",
+        messages=[Message(role="user", content="go")],
+        schema=Shape,
+        purpose="parsed",
+    )
+    assert parsed.name == "x"
+    assert parsed.value == 42
+    assert result.cost_usd > 0

--- a/apps/job-api/tests/test_llm_pricing.py
+++ b/apps/job-api/tests/test_llm_pricing.py
@@ -1,0 +1,68 @@
+"""Cost calculation for the LLM pricing table."""
+
+import pytest
+
+from app.models.llm import LLMUsage
+from app.services.llm.pricing import PRICING, calculate_cost
+
+
+def test_pricing_defined_for_every_model() -> None:
+    for model in ("claude-opus-4-7", "claude-sonnet-4-6", "claude-haiku-4-5"):
+        assert model in PRICING
+
+
+def test_sonnet_input_only() -> None:
+    cost = calculate_cost(
+        "claude-sonnet-4-6",
+        LLMUsage(input_tokens=1_000_000, output_tokens=0),
+    )
+    assert cost == pytest.approx(3.0, rel=1e-6)
+
+
+def test_sonnet_output_only() -> None:
+    cost = calculate_cost(
+        "claude-sonnet-4-6",
+        LLMUsage(input_tokens=0, output_tokens=1_000_000),
+    )
+    assert cost == pytest.approx(15.0, rel=1e-6)
+
+
+def test_sonnet_mixed() -> None:
+    cost = calculate_cost(
+        "claude-sonnet-4-6",
+        LLMUsage(input_tokens=2000, output_tokens=500),
+    )
+    expected = (3.0 * 2000 + 15.0 * 500) / 1_000_000
+    assert cost == pytest.approx(expected, rel=1e-6)
+
+
+def test_haiku_cheaper_than_sonnet_on_identical_usage() -> None:
+    usage = LLMUsage(input_tokens=10_000, output_tokens=1_000)
+    assert calculate_cost("claude-haiku-4-5", usage) < calculate_cost(
+        "claude-sonnet-4-6", usage
+    )
+
+
+def test_cache_read_is_one_tenth_of_input() -> None:
+    full_input = calculate_cost("claude-sonnet-4-6", LLMUsage(input_tokens=1_000_000))
+    cache_read = calculate_cost(
+        "claude-sonnet-4-6", LLMUsage(cache_read_input_tokens=1_000_000)
+    )
+    assert cache_read == pytest.approx(full_input * 0.1, rel=1e-6)
+
+
+def test_cache_write_is_1_25x_of_input() -> None:
+    full_input = calculate_cost("claude-sonnet-4-6", LLMUsage(input_tokens=1_000_000))
+    cache_write = calculate_cost(
+        "claude-sonnet-4-6", LLMUsage(cache_creation_input_tokens=1_000_000)
+    )
+    assert cache_write == pytest.approx(full_input * 1.25, rel=1e-6)
+
+
+def test_zero_usage_costs_nothing() -> None:
+    assert calculate_cost("claude-opus-4-7", LLMUsage()) == 0.0
+
+
+def test_result_rounded_to_six_decimals() -> None:
+    cost = calculate_cost("claude-haiku-4-5", LLMUsage(input_tokens=37))
+    assert cost == round(cost, 6)

--- a/supabase/migrations/20260422130000_create_llm_cost_log.sql
+++ b/supabase/migrations/20260422130000_create_llm_cost_log.sql
@@ -1,0 +1,28 @@
+-- ============================================
+-- MIGRATION: Create llm_cost_log (#185 P2a)
+-- One row per LLM call. Powers cost tracking, debugging, and per-feature
+-- spend analysis (purpose column groups calls by feature — onboarding,
+-- derive, tailor, score_breakdown, etc.)
+-- ============================================
+
+CREATE TABLE IF NOT EXISTS llm_cost_log (
+  id                              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id                         UUID,
+  model                           TEXT NOT NULL,
+  purpose                         TEXT NOT NULL,
+  input_tokens                    INTEGER NOT NULL DEFAULT 0,
+  output_tokens                   INTEGER NOT NULL DEFAULT 0,
+  cache_read_input_tokens         INTEGER NOT NULL DEFAULT 0,
+  cache_creation_input_tokens     INTEGER NOT NULL DEFAULT 0,
+  cost_usd                        NUMERIC(10, 6) NOT NULL DEFAULT 0,
+  latency_ms                      INTEGER NOT NULL DEFAULT 0,
+  metadata                        JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at                      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_llm_cost_log_created_at
+  ON llm_cost_log(created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_llm_cost_log_user_purpose
+  ON llm_cost_log(user_id, purpose, created_at DESC);
+
+ALTER TABLE llm_cost_log ENABLE ROW LEVEL SECURITY;


### PR DESCRIPTION
## Summary

P2a of the canonical resume tailoring system (#185). Lands the LLM plumbing layer — **mocked only**. No real Anthropic SDK yet. Consumers in P2b/P2c/P2d code against the `LLMClient` Protocol today; swapping to `AnthropicLLMClient` later is a constructor change at the call site, no interface rewrite.

Builds on P1 (#481). Targets the `feature/resume-tailor` integration branch.

## What's in

**Migration** — `supabase/migrations/20260422130000_create_llm_cost_log.sql`
- `llm_cost_log` — one row per call. Columns for input/output/cache-read/cache-creation tokens, `cost_usd` (numeric 10,6), `latency_ms`, `purpose` (feature label for grouping), `metadata` (jsonb escape hatch).
- Indexed on `(user_id, purpose, created_at DESC)` for spend-by-feature queries and `created_at DESC` for recent calls.
- RLS enabled, service-role-only (matches the existing `jobs_*` / `experience_*` pattern).

**Models** — `apps/job-api/app/models/llm.py`
- `ModelId` Literal covering `claude-opus-4-7 | claude-sonnet-4-6 | claude-haiku-4-5`.
- `Message`, `LLMUsage`, `LLMResult`, `LLMCallRecord`.

**Pricing** — `apps/job-api/app/services/llm/pricing.py`
- USD per 1M tokens, hardcoded. Source: Anthropic pricing page 2026-04.
- Cache read = 0.1× input; cache write = 1.25× input (Anthropic standard). Expressed as `ModelPricing` properties so changing the ratio is one line.
- `calculate_cost(model, usage) -> float` rounded to 6 decimals.

**Client Protocol** — `apps/job-api/app/services/llm/client.py`
- `LLMClient` Protocol with a single `complete(...)` method. Args: `model`, `system`, `messages`, `purpose` (required, for cost-log grouping), `max_tokens`, `cache_system` (prompt caching hint).
- `complete_json(client, ..., schema=SomePydanticModel)` helper wraps `complete` and validates the content against a Pydantic schema; returns `(parsed, LLMResult)` so the caller can still log cost.

**Mock** — `apps/job-api/app/services/llm/mock.py`
- Two modes: scripted (`{purpose: response_str | callable}`) or echo (default, returns JSON describing the call).
- Records every call on `client.calls` for test assertions.
- Uses real pricing + an approximate char-to-token heuristic so `cost_usd` and `usage` look realistic in the cost-log during integration tests.

**Cost-log CRUD** — `apps/job-api/app/services/llm/cost_log.py`
- `record(client, user_id, purpose, result, metadata?)` — writes a row given an `LLMResult`.
- `list_recent(...)`, `total_spend(...)`, `spend_by_purpose(...)` — query helpers. `spend_by_purpose` returns a dict, which the dashboard will eventually render.

## What's not in (intentional)

- **No Anthropic SDK.** Per discussion: mock first, add the real client in P2c or later when there's a consumer that actually needs it. Keeps this PR dependency-free.
- **No Voyage embedding client.** Ships in P2b alongside the chunk-write path.
- **No retry/backoff logic.** Belongs on the real client implementation, not the interface.
- **No cost-log router endpoint.** Adding `/llm/cost` makes sense once the dashboard exists (P4).

## Design notes

- **`purpose` is required.** Every call gets tagged. Examples of intended values: `"derive"`, `"tailor.resume"`, `"tailor.cover_letter"`, `"conversation.onboarding"`, `"conversation.update"`, `"score.breakdown"`, `"gap_probe"`. Prevents a future "where is this cost coming from?" mystery.
- **`complete_json` is a helper, not a Protocol method.** Real clients can override it with tool-use / structured-output primitives; the default implementation works for any Protocol-compliant client.
- **Mock applies real pricing.** So when P2c/P2d tests land cost-log rows via the mock, the dashboards aren't full of zeroes.

## Test plan

- [x] `uv run ruff check app/ tests/` — all checks pass
- [x] `uv run mypy` strict on new files — no issues
- [x] `uv run pytest` — **147/147** (was 129 before P2a; +18 new tests)
  - 9 pricing tests (per-model, cache multipliers, rounding, zero-usage)
  - 9 mock tests (echo, scripted string/callable, call tracking, cache hint, empty-messages guard, `complete_json` schema parsing)
- [ ] Apply migration to Supabase and verify `llm_cost_log` RLS + indexes
- [ ] Wire MockLLMClient into a P2c derive flow and confirm cost-log rows look sensible

## Up next (P2b)

- Voyage embedding client (mocked too, per the same pattern).
- `services/experience/chunks.py` — write path that triggers when an optimized doc is created.
- Wires the existing `experience_chunks` table (`vector(1024)` + HNSW cosine) into actual retrieval.

https://claude.ai/code/session_01GiZqgubpGXDBuQSEGNGsbp

---
_Generated by [Claude Code](https://claude.ai/code/session_01GiZqgubpGXDBuQSEGNGsbp)_