### PR TITLE
feat(job-api): mocked embeddings + chunk write path (#185 P2b)

### DIFF
--- a/apps/job-api/app/dependencies.py
+++ b/apps/job-api/app/dependencies.py
@@ -1,4 +1,5 @@
 import hmac
+from typing import TYPE_CHECKING
 
 import jwt
 from fastapi import Depends, HTTPException, Request, Security
@@ -6,6 +7,9 @@ from fastapi.security import APIKeyHeader
 from supabase import Client
 
 from app.config import Settings, settings
+
+if TYPE_CHECKING:
+    from app.services.embeddings.client import EmbeddingsClient
 
 api_key_header = APIKeyHeader(name="x-api-key", auto_error=False)
 
@@ -21,6 +25,15 @@ def get_supabase() -> Client:
     if client is None:
         raise HTTPException(status_code=503, detail="Supabase not configured")
     return client
+
+
+def get_embeddings_client() -> "EmbeddingsClient":
+    """Embeddings client factory. Returns the default (mock today,
+    Voyage when the real implementation lands).
+    """
+    from app.services.embeddings import get_default_client
+
+    return get_default_client()
 
 
 def _api_key_matches(presented: str | None, expected: str) -> bool:

--- a/apps/job-api/app/models/embeddings.py
+++ b/apps/job-api/app/models/embeddings.py
@@ -1,0 +1,28 @@
+"""Pydantic models for the embeddings layer (#185 P2b).
+
+Embeddings are conceptually different from LLM completions but share
+the same cost-tracking surface (llm_cost_log). The model column there
+holds either a Claude ID or a Voyage ID — disambiguated at the call
+site, opaque at the read layer.
+"""
+
+from typing import Literal
+
+from pydantic import BaseModel
+
+EmbeddingModelId = Literal["voyage-3", "voyage-3-lite"]
+"""Voyage models we target. Extend as new ones land."""
+
+
+class EmbeddingUsage(BaseModel):
+    input_tokens: int = 0
+
+
+class EmbeddingResult(BaseModel):
+    embeddings: list[list[float]]
+    """One vector per input string, in the same order."""
+
+    model: EmbeddingModelId
+    usage: EmbeddingUsage
+    cost_usd: float
+    latency_ms: int

--- a/apps/job-api/app/models/llm.py
+++ b/apps/job-api/app/models/llm.py
@@ -41,9 +41,16 @@ class LLMResult(BaseModel):
 
 
 class LLMCallRecord(BaseModel):
+    """Read shape for llm_cost_log rows.
+
+    Covers both LLM completions and embedding calls. The `model` column
+    holds either a Claude ID (ModelId) or a Voyage ID (EmbeddingModelId);
+    typed as `str` here since at read time we don't disambiguate.
+    """
+
     id: str
     user_id: str | None
-    model: ModelId
+    model: str
     purpose: str
     input_tokens: int
     output_tokens: int

--- a/apps/job-api/app/routers/experience.py
+++ b/apps/job-api/app/routers/experience.py
@@ -1,8 +1,7 @@
-"""Experience router (#185 P1).
+"""Experience router.
 
 CRUD over prose docs, optimized docs, conversation turns, and preferences.
-No LLM involvement in this phase — that ships in P2. These endpoints exist
-so a client (CLI today, dashboard later) can exercise the data layer.
+Creating a new optimized doc also embeds + writes its chunks (P2b).
 """
 
 from typing import Any
@@ -10,7 +9,7 @@ from typing import Any
 from fastapi import APIRouter, Depends, HTTPException, Query
 from supabase import Client
 
-from app.dependencies import get_supabase, verify_api_key_or_session
+from app.dependencies import get_embeddings_client, get_supabase, verify_api_key_or_session
 from app.models.experience import (
     ConversationType,
     OptimizedDoc,
@@ -21,7 +20,8 @@ from app.models.experience import (
     ProseDocCreate,
     TurnAppend,
 )
-from app.services.experience import optimized, preferences, prose, turns
+from app.services.embeddings.client import EmbeddingsClient
+from app.services.experience import chunks, optimized, preferences, prose, turns
 
 router = APIRouter(
     prefix="/experience",
@@ -68,8 +68,9 @@ async def get_optimized(
 async def create_optimized(
     body: OptimizedDocUpsert,
     supabase: Client = Depends(get_supabase),
+    embeddings: EmbeddingsClient = Depends(get_embeddings_client),
 ) -> OptimizedDoc:
-    return optimized.create_version(
+    doc = optimized.create_version(
         supabase,
         user_id=None,
         payload=body.payload,
@@ -77,6 +78,13 @@ async def create_optimized(
         source=body.source,
         markdown_view=body.markdown_view,
     )
+    await chunks.upsert_for_optimized(
+        supabase,
+        embeddings,
+        doc,
+        user_id=None,
+    )
+    return doc
 
 
 # ---- Preferences ----------------------------------------------------------

--- a/apps/job-api/app/services/embeddings/__init__.py
+++ b/apps/job-api/app/services/embeddings/__init__.py
@@ -1,0 +1,17 @@
+"""Embeddings module (#185 P2b).
+
+Mock-only for now. Real Voyage-backed client is a later phase — the
+Protocol interface makes that swap a constructor change at the call site.
+"""
+
+from app.services.embeddings.client import EmbeddingsClient
+from app.services.embeddings.mock import MockEmbeddingsClient
+
+__all__ = ["EmbeddingsClient", "MockEmbeddingsClient", "get_default_client"]
+
+
+def get_default_client() -> EmbeddingsClient:
+    """Default factory. Returns a MockEmbeddingsClient today; will read
+    an EMBEDDING_PROVIDER env var when the real Voyage client lands.
+    """
+    return MockEmbeddingsClient()

--- a/apps/job-api/app/services/embeddings/client.py
+++ b/apps/job-api/app/services/embeddings/client.py
@@ -1,0 +1,31 @@
+"""Embeddings client Protocol.
+
+Single method: embed a batch of strings. Real and mock implementations
+both satisfy it. Batching is the API's natural unit — Voyage charges
+per-token regardless of how many inputs you bundle, and one batch is
+one HTTP roundtrip.
+"""
+
+from typing import Protocol
+
+from app.models.embeddings import EmbeddingModelId, EmbeddingResult
+
+
+class EmbeddingsClient(Protocol):
+    async def embed(
+        self,
+        *,
+        model: EmbeddingModelId,
+        inputs: list[str],
+        purpose: str,
+    ) -> EmbeddingResult:
+        """Embed a batch of strings.
+
+        Args:
+            model: Voyage model ID.
+            inputs: Strings to embed. Empty list returns an EmbeddingResult
+                with empty embeddings and zero cost.
+            purpose: Cost-log grouping label (e.g. "experience.chunks",
+                "tailor.retrieval"). Required so spend can be sliced by feature.
+        """
+        ...

--- a/apps/job-api/app/services/embeddings/mock.py
+++ b/apps/job-api/app/services/embeddings/mock.py
@@ -1,0 +1,73 @@
+"""MockEmbeddingsClient — deterministic fake.
+
+Returns vectors derived from a sha256 hash of each input, projected into
+the target dimension as floats in [-1, 1]. Same input always yields the
+same vector — useful for snapshot tests of retrieval.
+
+Token estimation: char-count / 4 (matches the LLM mock heuristic).
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+from app.models.embeddings import EmbeddingModelId, EmbeddingResult, EmbeddingUsage
+from app.services.embeddings.pricing import calculate_cost
+
+DIMENSIONS: dict[EmbeddingModelId, int] = {
+    "voyage-3": 1024,
+    "voyage-3-lite": 512,
+}
+
+
+def _approx_tokens(text: str) -> int:
+    return max(1, len(text) // 4)
+
+
+def _deterministic_vector(text: str, dim: int) -> list[float]:
+    """Generate a stable pseudo-random vector for a given text + dim."""
+    out: list[float] = []
+    counter = 0
+    while len(out) < dim:
+        seed = f"{text}::{counter}".encode()
+        digest = hashlib.sha256(seed).digest()
+        for i in range(0, len(digest), 2):
+            if len(out) >= dim:
+                break
+            sample = int.from_bytes(digest[i : i + 2], "big")
+            out.append((sample / 65535.0) * 2 - 1)
+        counter += 1
+    return out
+
+
+class MockEmbeddingsClient:
+    def __init__(self, *, default_latency_ms: int = 30) -> None:
+        self._default_latency_ms = default_latency_ms
+        self.calls: list[dict[str, object]] = []
+
+    async def embed(
+        self,
+        *,
+        model: EmbeddingModelId,
+        inputs: list[str],
+        purpose: str,
+    ) -> EmbeddingResult:
+        dim = DIMENSIONS[model]
+        embeddings = [_deterministic_vector(text, dim) for text in inputs]
+        usage = EmbeddingUsage(input_tokens=sum(_approx_tokens(t) for t in inputs))
+
+        self.calls.append(
+            {
+                "model": model,
+                "purpose": purpose,
+                "input_count": len(inputs),
+            }
+        )
+
+        return EmbeddingResult(
+            embeddings=embeddings,
+            model=model,
+            usage=usage,
+            cost_usd=calculate_cost(model, usage),
+            latency_ms=self._default_latency_ms,
+        )

--- a/apps/job-api/app/services/embeddings/pricing.py
+++ b/apps/job-api/app/services/embeddings/pricing.py
@@ -1,0 +1,18 @@
+"""Voyage embedding pricing.
+
+USD per million input tokens. No output dimension — embeddings only
+charge for input. Source: voyage.ai pricing page as of 2026-04.
+Revisit quarterly.
+"""
+
+from app.models.embeddings import EmbeddingModelId, EmbeddingUsage
+
+PRICING: dict[EmbeddingModelId, float] = {
+    "voyage-3": 0.06,
+    "voyage-3-lite": 0.02,
+}
+
+
+def calculate_cost(model: EmbeddingModelId, usage: EmbeddingUsage) -> float:
+    """USD cost of a single embedding call, rounded to 6 decimals."""
+    return round(PRICING[model] * usage.input_tokens / 1_000_000, 6)

--- a/apps/job-api/app/services/experience/chunks.py
+++ b/apps/job-api/app/services/experience/chunks.py
@@ -1,0 +1,155 @@
+"""Chunking + chunk-write path for the optimized doc.
+
+Decomposes an OptimizedPayload into retrievable units (one per role,
+skill, outcome, plus a summary chunk), embeds them in a single batch
+call, and writes them to experience_chunks. Old chunks for the same
+optimized_doc_id are deleted first so the function is idempotent.
+
+Pure decomposition lives in `chunks_for_optimized()` so it can be
+unit-tested without a DB or embedding client.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Any, cast
+
+from pydantic import BaseModel, Field
+from supabase import Client
+
+from app.models.embeddings import EmbeddingModelId
+from app.models.experience import Chunk, ChunkType, OptimizedDoc, OptimizedPayload
+from app.services.embeddings.client import EmbeddingsClient
+from app.services.llm import cost_log
+
+TABLE = "experience_chunks"
+DEFAULT_PURPOSE = "experience.chunks"
+
+
+class ChunkInput(BaseModel):
+    """Pre-embed shape: what we want to insert, minus the vector."""
+
+    chunk_type: ChunkType
+    chunk_ref: str
+    content: str
+    metadata: dict[str, str | int | float | bool] = Field(default_factory=dict)
+
+
+def _outcome_ref(description: str) -> str:
+    return hashlib.sha256(description.encode("utf-8")).hexdigest()[:16]
+
+
+def chunks_for_optimized(payload: OptimizedPayload) -> list[ChunkInput]:
+    """Decompose an OptimizedPayload into retrievable chunks.
+
+    One chunk per role, skill, outcome, plus an optional summary chunk.
+    Order is stable (summary, roles in declared order, skills, outcomes)
+    so embeddings line up with inputs by index.
+    """
+    out: list[ChunkInput] = []
+
+    if payload.summary:
+        out.append(
+            ChunkInput(
+                chunk_type="summary",
+                chunk_ref="summary",
+                content=payload.summary,
+            )
+        )
+
+    for role in payload.roles:
+        end = role.end or "present"
+        text = f"{role.title} at {role.company} ({role.start} to {end})"
+        if role.summary:
+            text += f"\n{role.summary}"
+        if role.skills:
+            text += f"\nSkills: {', '.join(role.skills)}"
+        out.append(
+            ChunkInput(
+                chunk_type="role",
+                chunk_ref=role.id,
+                content=text,
+                metadata={"company": role.company, "title": role.title},
+            )
+        )
+
+    for skill in payload.skills:
+        text = skill.name
+        if skill.years is not None:
+            text += f" ({skill.years} years)"
+        out.append(
+            ChunkInput(
+                chunk_type="skill",
+                chunk_ref=skill.name.lower(),
+                content=text,
+                metadata={"name": skill.name},
+            )
+        )
+
+    for outcome in payload.outcomes:
+        text = outcome.description
+        if outcome.metric and outcome.value:
+            text += f" — {outcome.metric}: {outcome.value}"
+        out.append(
+            ChunkInput(
+                chunk_type="outcome",
+                chunk_ref=_outcome_ref(outcome.description),
+                content=text,
+                metadata={"role_ref": outcome.role_ref or ""},
+            )
+        )
+
+    return out
+
+
+def _delete_existing(supabase: Client, optimized_doc_id: str) -> None:
+    supabase.table(TABLE).delete().eq("optimized_doc_id", optimized_doc_id).execute()
+
+
+async def upsert_for_optimized(
+    supabase: Client,
+    embeddings: EmbeddingsClient,
+    optimized: OptimizedDoc,
+    *,
+    user_id: str | None,
+    model: EmbeddingModelId = "voyage-3",
+    purpose: str = DEFAULT_PURPOSE,
+) -> list[Chunk]:
+    """Generate, embed, and persist chunks for an optimized doc.
+
+    Idempotent: deletes any existing chunks for this doc_id before insert.
+    Records embedding cost in llm_cost_log under `purpose`.
+    """
+    inputs = chunks_for_optimized(optimized.payload)
+    _delete_existing(supabase, optimized.id)
+
+    if not inputs:
+        return []
+
+    result = await embeddings.embed(
+        model=model,
+        inputs=[c.content for c in inputs],
+        purpose=purpose,
+    )
+    cost_log.record_embedding(
+        supabase,
+        user_id=user_id,
+        purpose=purpose,
+        result=result,
+        metadata={"optimized_doc_id": optimized.id, "chunk_count": len(inputs)},
+    )
+
+    rows: list[dict[str, Any]] = [
+        {
+            "optimized_doc_id": optimized.id,
+            "chunk_type": c.chunk_type,
+            "chunk_ref": c.chunk_ref,
+            "content": c.content,
+            "metadata": c.metadata,
+            "embedding": vector,
+        }
+        for c, vector in zip(inputs, result.embeddings, strict=True)
+    ]
+    resp = supabase.table(TABLE).insert(rows).execute()
+    inserted = cast(list[dict[str, Any]], resp.data or [])
+    return [Chunk.model_validate(r) for r in inserted]

--- a/apps/job-api/app/services/llm/cost_log.py
+++ b/apps/job-api/app/services/llm/cost_log.py
@@ -1,8 +1,12 @@
-"""Cost-log CRUD. Every LLM call writes one row here.
+"""Cost-log CRUD. Every LLM completion or embedding call writes one row here.
 
-Consumers call `record(...)` right after `client.complete(...)` with the
-resulting `LLMResult` + a `purpose` label. Spend queries (`total_spend`,
-`spend_by_purpose`) power the dashboard and any future budget guards.
+Consumers call `record(...)` right after `client.complete(...)` (LLM) or
+`record_embedding(...)` after `embed_client.embed(...)` with the result
++ a `purpose` label. Spend queries (`total_spend`, `spend_by_purpose`)
+power the dashboard and any future budget guards.
+
+The model column holds either a Claude ID or a Voyage ID — disambiguated
+by the caller, opaque at the read layer.
 """
 
 from datetime import datetime
@@ -10,9 +14,18 @@ from typing import Any, cast
 
 from supabase import Client
 
+from app.models.embeddings import EmbeddingResult
 from app.models.llm import LLMCallRecord, LLMResult
 
 TABLE = "llm_cost_log"
+
+
+def _insert_row(supabase: Client, row: dict[str, Any]) -> LLMCallRecord:
+    resp = supabase.table(TABLE).insert(row).execute()
+    rows = cast(list[dict[str, Any]], resp.data or [])
+    if not rows:
+        raise RuntimeError("Failed to insert llm_cost_log row")
+    return LLMCallRecord.model_validate(rows[0])
 
 
 def record(
@@ -22,23 +35,45 @@ def record(
     result: LLMResult,
     metadata: dict[str, str | int | float | bool] | None = None,
 ) -> LLMCallRecord:
-    row = {
-        "user_id": user_id,
-        "model": result.model,
-        "purpose": purpose,
-        "input_tokens": result.usage.input_tokens,
-        "output_tokens": result.usage.output_tokens,
-        "cache_read_input_tokens": result.usage.cache_read_input_tokens,
-        "cache_creation_input_tokens": result.usage.cache_creation_input_tokens,
-        "cost_usd": result.cost_usd,
-        "latency_ms": result.latency_ms,
-        "metadata": metadata or {},
-    }
-    resp = supabase.table(TABLE).insert(row).execute()
-    rows = cast(list[dict[str, Any]], resp.data or [])
-    if not rows:
-        raise RuntimeError("Failed to insert llm_cost_log row")
-    return LLMCallRecord.model_validate(rows[0])
+    return _insert_row(
+        supabase,
+        {
+            "user_id": user_id,
+            "model": result.model,
+            "purpose": purpose,
+            "input_tokens": result.usage.input_tokens,
+            "output_tokens": result.usage.output_tokens,
+            "cache_read_input_tokens": result.usage.cache_read_input_tokens,
+            "cache_creation_input_tokens": result.usage.cache_creation_input_tokens,
+            "cost_usd": result.cost_usd,
+            "latency_ms": result.latency_ms,
+            "metadata": metadata or {},
+        },
+    )
+
+
+def record_embedding(
+    supabase: Client,
+    user_id: str | None,
+    purpose: str,
+    result: EmbeddingResult,
+    metadata: dict[str, str | int | float | bool] | None = None,
+) -> LLMCallRecord:
+    return _insert_row(
+        supabase,
+        {
+            "user_id": user_id,
+            "model": result.model,
+            "purpose": purpose,
+            "input_tokens": result.usage.input_tokens,
+            "output_tokens": 0,
+            "cache_read_input_tokens": 0,
+            "cache_creation_input_tokens": 0,
+            "cost_usd": result.cost_usd,
+            "latency_ms": result.latency_ms,
+            "metadata": metadata or {},
+        },
+    )
 
 
 def list_recent(

--- a/apps/job-api/tests/test_chunks.py
+++ b/apps/job-api/tests/test_chunks.py
@@ -1,0 +1,122 @@
+"""Pure-function tests for chunks_for_optimized.
+
+The DB-write path (`upsert_for_optimized`) needs Supabase mocking and is
+left for an integration test alongside the rest of the experience layer.
+"""
+
+from app.models.experience import OptimizedPayload, Outcome, Role, Skill
+from app.services.experience.chunks import chunks_for_optimized
+
+
+def _payload(**overrides: object) -> OptimizedPayload:
+    base: dict[str, object] = {
+        "summary": "Senior frontend with a focus on performance and a11y.",
+        "roles": [
+            Role(
+                id="fightcamp",
+                company="FightCamp",
+                title="Senior Frontend Engineer",
+                start="2021-11",
+                end="2024-04",
+                summary="Cut mobile load times from 10s to 2s.",
+                skills=["React", "Next.js"],
+                outcome_refs=[],
+            )
+        ],
+        "skills": [Skill(name="React", years=8.0)],
+        "outcomes": [
+            Outcome(
+                description="Cut mobile load times from 10s to 2s",
+                metric="LCP",
+                value="2s",
+                role_ref="fightcamp",
+            )
+        ],
+    }
+    base.update(overrides)
+    return OptimizedPayload.model_validate(base)
+
+
+def test_summary_chunk_first() -> None:
+    chunks = chunks_for_optimized(_payload())
+    assert chunks[0].chunk_type == "summary"
+    assert chunks[0].chunk_ref == "summary"
+
+
+def test_one_chunk_per_role_skill_outcome() -> None:
+    chunks = chunks_for_optimized(_payload())
+    by_type = {c.chunk_type: 0 for c in chunks}
+    for c in chunks:
+        by_type[c.chunk_type] += 1
+    assert by_type == {"summary": 1, "role": 1, "skill": 1, "outcome": 1}
+
+
+def test_role_chunk_includes_company_and_dates() -> None:
+    chunks = chunks_for_optimized(_payload())
+    role_chunk = next(c for c in chunks if c.chunk_type == "role")
+    assert "FightCamp" in role_chunk.content
+    assert "2021-11" in role_chunk.content
+    assert "2024-04" in role_chunk.content
+
+
+def test_role_with_no_end_uses_present() -> None:
+    chunks = chunks_for_optimized(
+        _payload(
+            roles=[
+                Role(
+                    id="current",
+                    company="Acme",
+                    title="Engineer",
+                    start="2024-05",
+                    end=None,
+                    summary=None,
+                    skills=[],
+                    outcome_refs=[],
+                )
+            ]
+        )
+    )
+    role_chunk = next(c for c in chunks if c.chunk_type == "role")
+    assert "present" in role_chunk.content
+
+
+def test_outcome_with_metric_appends_metric_value() -> None:
+    chunks = chunks_for_optimized(_payload())
+    outcome_chunk = next(c for c in chunks if c.chunk_type == "outcome")
+    assert "LCP" in outcome_chunk.content
+    assert "2s" in outcome_chunk.content
+
+
+def test_outcome_ref_is_stable_for_same_description() -> None:
+    p = _payload()
+    a = chunks_for_optimized(p)
+    b = chunks_for_optimized(p)
+    a_outcome = next(c for c in a if c.chunk_type == "outcome")
+    b_outcome = next(c for c in b if c.chunk_type == "outcome")
+    assert a_outcome.chunk_ref == b_outcome.chunk_ref
+
+
+def test_skill_with_no_years_omits_paren() -> None:
+    chunks = chunks_for_optimized(
+        _payload(skills=[Skill(name="TypeScript", years=None)])
+    )
+    skill_chunk = next(c for c in chunks if c.chunk_type == "skill")
+    assert "(" not in skill_chunk.content
+
+
+def test_skill_chunk_ref_is_lowercased() -> None:
+    chunks = chunks_for_optimized(
+        _payload(skills=[Skill(name="GraphQL", years=None)])
+    )
+    skill_chunk = next(c for c in chunks if c.chunk_type == "skill")
+    assert skill_chunk.chunk_ref == "graphql"
+
+
+def test_empty_payload_yields_no_chunks() -> None:
+    payload = OptimizedPayload(summary=None, roles=[], skills=[], outcomes=[])
+    assert chunks_for_optimized(payload) == []
+
+
+def test_no_summary_omits_summary_chunk() -> None:
+    chunks = chunks_for_optimized(_payload(summary=None))
+    assert all(c.chunk_type != "summary" for c in chunks)

--- a/apps/job-api/tests/test_embeddings_mock.py
+++ b/apps/job-api/tests/test_embeddings_mock.py
@@ -1,0 +1,65 @@
+"""MockEmbeddingsClient behavior."""
+
+from app.services.embeddings.mock import DIMENSIONS, MockEmbeddingsClient
+
+
+async def test_returns_one_vector_per_input() -> None:
+    client = MockEmbeddingsClient()
+    result = await client.embed(
+        model="voyage-3",
+        inputs=["a", "b", "c"],
+        purpose="t",
+    )
+    assert len(result.embeddings) == 3
+
+
+async def test_vector_dimension_matches_model() -> None:
+    client = MockEmbeddingsClient()
+    for model in ("voyage-3", "voyage-3-lite"):
+        result = await client.embed(model=model, inputs=["hello"], purpose="t")
+        assert len(result.embeddings[0]) == DIMENSIONS[model]
+
+
+async def test_vectors_are_in_range() -> None:
+    client = MockEmbeddingsClient()
+    result = await client.embed(model="voyage-3", inputs=["abc"], purpose="t")
+    assert all(-1 <= v <= 1 for v in result.embeddings[0])
+
+
+async def test_same_input_yields_same_vector() -> None:
+    client = MockEmbeddingsClient()
+    a = await client.embed(model="voyage-3", inputs=["fixed"], purpose="t")
+    b = await client.embed(model="voyage-3", inputs=["fixed"], purpose="t")
+    assert a.embeddings == b.embeddings
+
+
+async def test_different_inputs_yield_different_vectors() -> None:
+    client = MockEmbeddingsClient()
+    result = await client.embed(model="voyage-3", inputs=["x", "y"], purpose="t")
+    assert result.embeddings[0] != result.embeddings[1]
+
+
+async def test_empty_inputs_returns_empty_embeddings_and_zero_cost() -> None:
+    client = MockEmbeddingsClient()
+    result = await client.embed(model="voyage-3", inputs=[], purpose="t")
+    assert result.embeddings == []
+    assert result.usage.input_tokens == 0
+    assert result.cost_usd == 0.0
+
+
+async def test_usage_and_cost_are_nonzero_for_real_input() -> None:
+    # Voyage-3 is $0.06/MTok — need a few hundred tokens to round above zero
+    # at six decimals. Use a payload representative of a real chunk.
+    client = MockEmbeddingsClient()
+    long_input = "Senior frontend engineer. " * 200
+    result = await client.embed(model="voyage-3", inputs=[long_input], purpose="t")
+    assert result.usage.input_tokens > 0
+    assert result.cost_usd > 0
+
+
+async def test_call_is_tracked() -> None:
+    client = MockEmbeddingsClient()
+    await client.embed(model="voyage-3", inputs=["a", "b"], purpose="tracked")
+    assert client.calls == [
+        {"model": "voyage-3", "purpose": "tracked", "input_count": 2},
+    ]

--- a/apps/job-api/tests/test_embeddings_pricing.py
+++ b/apps/job-api/tests/test_embeddings_pricing.py
@@ -1,0 +1,30 @@
+"""Voyage embedding pricing."""
+
+import pytest
+
+from app.models.embeddings import EmbeddingUsage
+from app.services.embeddings.pricing import PRICING, calculate_cost
+
+
+def test_pricing_defined_for_targeted_models() -> None:
+    for model in ("voyage-3", "voyage-3-lite"):
+        assert model in PRICING
+
+
+def test_voyage_3_input_cost() -> None:
+    cost = calculate_cost("voyage-3", EmbeddingUsage(input_tokens=1_000_000))
+    assert cost == pytest.approx(0.06, rel=1e-6)
+
+
+def test_voyage_3_lite_cheaper_than_voyage_3() -> None:
+    usage = EmbeddingUsage(input_tokens=10_000)
+    assert calculate_cost("voyage-3-lite", usage) < calculate_cost("voyage-3", usage)
+
+
+def test_zero_tokens_costs_nothing() -> None:
+    assert calculate_cost("voyage-3", EmbeddingUsage(input_tokens=0)) == 0.0
+
+
+def test_result_rounded_to_six_decimals() -> None:
+    cost = calculate_cost("voyage-3", EmbeddingUsage(input_tokens=37))
+    assert cost == round(cost, 6)


### PR DESCRIPTION
## Summary

P2b of the canonical resume tailoring system (#185). Closes the retrieval-side loop: every optimized doc is now decomposed into typed chunks, embedded in a single batch call, and persisted with vectors. **Voyage client is mocked** with deterministic vectors so retrieval tests can be written today; real Voyage swap-in is a constructor change at `get_default_client()`.

Builds on P1 (#481) and P2a (#483). Targets the `feature/resume-tailor` integration branch.

## What's in

**Embeddings layer (mocked)**
- `apps/job-api/app/models/embeddings.py` — `EmbeddingResult`, `EmbeddingUsage`, `EmbeddingModelId` Literal (`voyage-3 | voyage-3-lite`).
- `apps/job-api/app/services/embeddings/client.py` — `EmbeddingsClient` Protocol, single `embed(model, inputs[], purpose)` method.
- `apps/job-api/app/services/embeddings/mock.py` — `MockEmbeddingsClient`. Vectors derived from sha256(text); same input always yields the same vector. Empty input list returns empty result + zero cost.
- `apps/job-api/app/services/embeddings/pricing.py` — Voyage USD/MTok constants. `voyage-3` = $0.06, `voyage-3-lite` = $0.02.
- `app/services/embeddings/__init__.py` — `get_default_client()` factory (mock today, env-driven swap later).

**Chunking + write path**
- `apps/job-api/app/services/experience/chunks.py` —
  - `chunks_for_optimized(payload)`: pure decomposition. Yields one chunk per role/skill/outcome plus an optional summary. Stable ordering. Outcome refs are content-hash IDs.
  - `upsert_for_optimized(supabase, embeddings, doc, ...)`: idempotent — deletes existing chunks for the doc id, embeds in one batch, inserts rows with vectors. Records embedding cost in `llm_cost_log` under `experience.chunks`.

**Cost-log extension**
- `services/llm/cost_log.py` — factored shared `_insert_row` helper; added `record_embedding(...)` sibling to `record(...)`. Both write to the same table (`llm_cost_log`); the model column disambiguates.
- `models/llm.py` — widened `LLMCallRecord.model` from `ModelId` to `str`. The read shape now covers Voyage IDs too. Justified inline.

**Wiring**
- `dependencies.py` — `get_embeddings_client()` factory dependency.
- `routers/experience.py` — `POST /experience/optimized` now embeds + writes chunks via the injected client. New endpoint signature is backwards-compatible at the wire level.

## What's not in (intentional)

- **No real Voyage HTTP client.** Per the same "mock first" pattern from P2a. The interface and the chunk write path are stable; swapping in the real client is a single-file addition with no consumer changes.
- **No retrieval API.** Searching chunks (e.g. `vector_search(query_text, top_k)`) ships in P3 alongside the tailor — it's the first consumer.
- **No re-chunk on user_edit.** When a user edits the optimized doc directly via `OptimizedDocUpsert(source="user_edit")`, the new version triggers a new chunk batch automatically. That's intentional.

## Design notes

- **Idempotent upsert.** `upsert_for_optimized` deletes existing chunks for the doc id before insert. Re-running on the same doc is safe.
- **One batch per doc.** All chunks for an optimized doc are embedded in one `embed()` call — single roundtrip, single cost-log row. Voyage charges per-token regardless of batch size.
- **Stable chunk_refs.** Roles use `role.id`. Skills use `skill.name.lower()`. Outcomes use `sha256(description)[:16]`. Summary is just `"summary"`. Lets the tailor reference specific chunks by name later.
- **`llm_cost_log` covers both.** Embedding rows have `output_tokens=0` and zero cache columns. Spend-by-purpose queries naturally separate them by `purpose` label.

## Test plan

- [x] `uv run ruff check app/ tests/` — passes
- [x] `uv run mypy` strict on touched files — no issues
- [x] `uv run pytest` — **170/170** (was 147 before P2b; +23 new)
  - 5 pricing tests (per-model, ratios, rounding, zero-tokens)
  - 8 mock-client tests (vector dim, range, determinism, distinctness, empty-input, call tracking)
  - 10 chunking tests (summary first, one-per-type, role formatting, present-when-no-end, outcome metric, stable refs, lowercased skill ref, empty payload, no-summary case)
- [ ] Apply P1 + P2a + P2b migrations to Supabase and verify HNSW index works on inserted vectors
- [ ] Smoke-test `POST /experience/optimized` end-to-end: hits embeddings, writes chunks, logs cost

## Up next (P2c)

- `services/experience/derive.py` — prose → `OptimizedPayload` via the mocked LLM client. Triggered when `OptimizedDocUpsert(source="llm")` is posted with no payload (or via a new endpoint).
- Closes the first true end-to-end loop: write prose → derive optimized → chunks become retrievable.

https://claude.ai/code/session_01GiZqgubpGXDBuQSEGNGsbp

---
_Generated by [Claude Code](https://claude.ai/code/session_01GiZqgubpGXDBuQSEGNGsbp)_