### PR TITLE
feat(job-api): prose-to-optimized derivation + end-to-end loop (#185 P2c)

### DIFF
--- a/apps/job-api/app/dependencies.py
+++ b/apps/job-api/app/dependencies.py
@@ -10,6 +10,7 @@ from app.config import Settings, settings
 
 if TYPE_CHECKING:
     from app.services.embeddings.client import EmbeddingsClient
+    from app.services.llm.client import LLMClient
 
 api_key_header = APIKeyHeader(name="x-api-key", auto_error=False)
 
@@ -32,6 +33,15 @@ def get_embeddings_client() -> "EmbeddingsClient":
     Voyage when the real implementation lands).
     """
     from app.services.embeddings import get_default_client
+
+    return get_default_client()
+
+
+def get_llm_client() -> "LLMClient":
+    """LLM client factory. Returns the default (mock today, Anthropic
+    when the real implementation lands).
+    """
+    from app.services.llm import get_default_client
 
     return get_default_client()
 

--- a/apps/job-api/app/routers/experience.py
+++ b/apps/job-api/app/routers/experience.py
@@ -1,7 +1,9 @@
 """Experience router.
 
 CRUD over prose docs, optimized docs, conversation turns, and preferences.
-Creating a new optimized doc also embeds + writes its chunks (P2b).
+Creating a new optimized doc also embeds + writes its chunks.
+POST /experience/derive runs the end-to-end loop: prose -> LLM -> optimized
+doc -> chunks, all cost-logged.
 """
 
 from typing import Any
@@ -9,7 +11,12 @@ from typing import Any
 from fastapi import APIRouter, Depends, HTTPException, Query
 from supabase import Client
 
-from app.dependencies import get_embeddings_client, get_supabase, verify_api_key_or_session
+from app.dependencies import (
+    get_embeddings_client,
+    get_llm_client,
+    get_supabase,
+    verify_api_key_or_session,
+)
 from app.models.experience import (
     ConversationType,
     OptimizedDoc,
@@ -21,7 +28,9 @@ from app.models.experience import (
     TurnAppend,
 )
 from app.services.embeddings.client import EmbeddingsClient
-from app.services.experience import chunks, optimized, preferences, prose, turns
+from app.services.experience import chunks, derive, optimized, preferences, prose, turns
+from app.services.llm import cost_log
+from app.services.llm.client import LLMClient
 
 router = APIRouter(
     prefix="/experience",
@@ -77,6 +86,47 @@ async def create_optimized(
         prose_doc_id=body.prose_doc_id,
         source=body.source,
         markdown_view=body.markdown_view,
+    )
+    await chunks.upsert_for_optimized(
+        supabase,
+        embeddings,
+        doc,
+        user_id=None,
+    )
+    return doc
+
+
+@router.post("/derive")
+async def derive_optimized(
+    supabase: Client = Depends(get_supabase),
+    llm: LLMClient = Depends(get_llm_client),
+    embeddings: EmbeddingsClient = Depends(get_embeddings_client),
+) -> OptimizedDoc:
+    """Read the latest prose doc, derive an OptimizedPayload via LLM,
+    persist it as a new optimized version, embed its chunks, and log cost.
+    """
+    prose_doc = prose.get_latest(supabase, user_id=None)
+    if prose_doc is None:
+        raise HTTPException(status_code=404, detail="no prose doc to derive from")
+
+    payload, result = await derive.derive_from_prose(
+        llm,
+        prose_text=prose_doc.content,
+    )
+    cost_log.record(
+        supabase,
+        user_id=None,
+        purpose=derive.DEFAULT_PURPOSE,
+        result=result,
+        metadata={"prose_doc_id": prose_doc.id, "prose_version": prose_doc.version},
+    )
+
+    doc = optimized.create_version(
+        supabase,
+        user_id=None,
+        payload=payload,
+        prose_doc_id=prose_doc.id,
+        source="llm",
     )
     await chunks.upsert_for_optimized(
         supabase,

--- a/apps/job-api/app/services/experience/derive.py
+++ b/apps/job-api/app/services/experience/derive.py
@@ -1,0 +1,78 @@
+"""Derive an OptimizedPayload from a prose doc via LLM.
+
+The prose doc is free-form narrative — what the user wrote during
+onboarding + update turns. The optimized doc is typed structure:
+roles, skills, outcomes, summary. This module bridges the two.
+
+Keeping the prompt static and cacheable. The prose text is the only
+variable content, which is ideal for Anthropic's prompt caching
+(90% discount on cache reads). When the real client lands, cache_system=True
+becomes a genuine cost-saver.
+"""
+
+from app.models.experience import OptimizedPayload
+from app.models.llm import LLMResult, Message, ModelId
+from app.services.llm.client import LLMClient, complete_json
+
+DEFAULT_MODEL: ModelId = "claude-sonnet-4-6"
+DEFAULT_PURPOSE = "experience.derive"
+
+SYSTEM_PROMPT = """You are an extraction engine. Given a first-person career \
+narrative, produce a strictly structured JSON projection.
+
+Output must match this schema:
+
+{
+  "summary": "string — one-sentence positioning statement, or null",
+  "roles": [
+    {
+      "id": "stable slug, e.g. 'fightcamp-senior-fe'",
+      "company": "string",
+      "title": "string",
+      "start": "YYYY-MM",
+      "end": "YYYY-MM or null if current",
+      "summary": "string or null — 1-2 sentences on scope and impact",
+      "skills": ["string", ...],
+      "outcome_refs": ["outcome description strings this role owned", ...]
+    }
+  ],
+  "skills": [
+    { "name": "canonical name", "years": number or null, "evidence_refs": [] }
+  ],
+  "outcomes": [
+    {
+      "description": "past-tense impact statement",
+      "metric": "what was measured, or null",
+      "value": "the measurement, or null",
+      "role_ref": "role.id this outcome belongs to"
+    }
+  ]
+}
+
+Rules:
+- Extract only what the prose supports. Do not invent outcomes, metrics, or roles.
+- Prefer canonical skill names (React, TypeScript, Next.js) over variants (reactjs, TS).
+- Quantified outcomes (with metric + value) are higher-signal than unquantified ones.
+- If a detail is ambiguous or missing, leave the field null rather than guessing.
+- Role ids should be stable slugs the user can reference later.
+
+Return ONLY the JSON object. No prose, no code fences."""
+
+
+async def derive_from_prose(
+    llm: LLMClient,
+    *,
+    prose_text: str,
+    model: ModelId = DEFAULT_MODEL,
+    purpose: str = DEFAULT_PURPOSE,
+) -> tuple[OptimizedPayload, LLMResult]:
+    """Run the derivation. Returns (payload, result) so callers can cost-log."""
+    return await complete_json(
+        llm,
+        model=model,
+        system=SYSTEM_PROMPT,
+        messages=[Message(role="user", content=prose_text)],
+        schema=OptimizedPayload,
+        purpose=purpose,
+        cache_system=True,
+    )

--- a/apps/job-api/app/services/llm/__init__.py
+++ b/apps/job-api/app/services/llm/__init__.py
@@ -1,7 +1,7 @@
-"""LLM plumbing module (#185 P2a).
+"""LLM plumbing module.
 
-Mock-only for now. A real Anthropic-backed client is a later phase —
-the Protocol interface makes that swap a constructor change.
+Mock-only today. A real Anthropic-backed client is a later phase —
+the Protocol interface makes that swap a single-file addition.
 
 Every consumer (derive, tailor, conversation) tags calls with a `purpose`
 string so cost-log rows can be grouped by feature for spend analysis.
@@ -10,4 +10,11 @@ string so cost-log rows can be grouped by feature for spend analysis.
 from app.services.llm.client import LLMClient
 from app.services.llm.mock import MockLLMClient
 
-__all__ = ["LLMClient", "MockLLMClient"]
+__all__ = ["LLMClient", "MockLLMClient", "get_default_client"]
+
+
+def get_default_client() -> LLMClient:
+    """Default factory. Returns a MockLLMClient today; will read an
+    LLM_PROVIDER env var when the real Anthropic client lands.
+    """
+    return MockLLMClient()

--- a/apps/job-api/tests/test_derive.py
+++ b/apps/job-api/tests/test_derive.py
@@ -1,0 +1,114 @@
+"""Derivation of OptimizedPayload from prose via a mocked LLM."""
+
+import json
+
+import pytest
+
+from app.models.experience import OptimizedPayload
+from app.services.experience.derive import (
+    DEFAULT_MODEL,
+    DEFAULT_PURPOSE,
+    SYSTEM_PROMPT,
+    derive_from_prose,
+)
+from app.services.llm.mock import MockLLMClient
+
+
+def _sample_payload_json() -> str:
+    return json.dumps(
+        {
+            "summary": "Senior frontend with a decade of shipped work.",
+            "roles": [
+                {
+                    "id": "fightcamp-senior-fe",
+                    "company": "FightCamp",
+                    "title": "Senior Frontend Engineer",
+                    "start": "2021-11",
+                    "end": "2024-04",
+                    "summary": "Cut mobile load times and drove the PDP rebuild.",
+                    "skills": ["React", "Next.js", "TypeScript"],
+                    "outcome_refs": ["Cut mobile load times from 10s to 2s"],
+                }
+            ],
+            "skills": [
+                {"name": "React", "evidence_refs": [], "years": 8.0},
+                {"name": "Next.js", "evidence_refs": [], "years": 5.0},
+            ],
+            "outcomes": [
+                {
+                    "description": "Cut mobile load times from 10s to 2s",
+                    "metric": "LCP",
+                    "value": "2s",
+                    "role_ref": "fightcamp-senior-fe",
+                }
+            ],
+        }
+    )
+
+
+async def test_returns_parsed_optimized_payload() -> None:
+    client = MockLLMClient(scripted={DEFAULT_PURPOSE: _sample_payload_json()})
+    payload, _ = await derive_from_prose(client, prose_text="some prose")
+    assert isinstance(payload, OptimizedPayload)
+    assert payload.summary is not None
+    assert len(payload.roles) == 1
+    assert payload.roles[0].company == "FightCamp"
+    assert len(payload.skills) == 2
+    assert len(payload.outcomes) == 1
+
+
+async def test_passes_default_model_and_purpose() -> None:
+    client = MockLLMClient(scripted={DEFAULT_PURPOSE: _sample_payload_json()})
+    await derive_from_prose(client, prose_text="prose")
+    assert len(client.calls) == 1
+    call = client.calls[0]
+    assert call["model"] == DEFAULT_MODEL
+    assert call["purpose"] == DEFAULT_PURPOSE
+
+
+async def test_enables_system_cache() -> None:
+    client = MockLLMClient(scripted={DEFAULT_PURPOSE: _sample_payload_json()})
+    await derive_from_prose(client, prose_text="prose")
+    assert client.calls[0]["cache_system"] is True
+
+
+async def test_returns_result_with_positive_cost() -> None:
+    client = MockLLMClient(scripted={DEFAULT_PURPOSE: _sample_payload_json()})
+    _, result = await derive_from_prose(
+        client, prose_text="some reasonably long narrative " * 50
+    )
+    assert result.cost_usd > 0
+    assert result.usage.input_tokens > 0
+    assert result.usage.output_tokens > 0
+
+
+async def test_sends_prose_as_user_message() -> None:
+    seen: dict[str, str] = {}
+
+    def responder(latest_user: str, _messages: object) -> str:
+        seen["latest"] = latest_user
+        return _sample_payload_json()
+
+    client = MockLLMClient(scripted={DEFAULT_PURPOSE: responder})
+    await derive_from_prose(client, prose_text="the prose goes here")
+    assert seen["latest"] == "the prose goes here"
+
+
+async def test_model_override_is_respected() -> None:
+    client = MockLLMClient(scripted={DEFAULT_PURPOSE: _sample_payload_json()})
+    await derive_from_prose(
+        client, prose_text="prose", model="claude-haiku-4-5"
+    )
+    assert client.calls[0]["model"] == "claude-haiku-4-5"
+
+
+async def test_invalid_json_response_raises() -> None:
+    client = MockLLMClient(scripted={DEFAULT_PURPOSE: "not valid json"})
+    with pytest.raises(Exception):  # noqa: B017
+        await derive_from_prose(client, prose_text="prose")
+
+
+def test_system_prompt_mentions_schema_rules() -> None:
+    assert "null" in SYSTEM_PROMPT
+    assert "Do not invent" in SYSTEM_PROMPT
+    assert "Return ONLY the JSON" in SYSTEM_PROMPT


### PR DESCRIPTION
## Summary

P2c of the canonical resume tailoring system (#185). **Closes the first end-to-end loop**: posting to `/experience/derive` now reads the latest prose doc, runs it through a (mocked) LLM to produce a typed `OptimizedPayload`, cost-logs the call, persists a new optimized doc version, and embeds + writes chunks via the P2b path.

Builds on P1 (#481), P2a (#483), P2b (#484). Targets `feature/resume-tailor`.

## What's in

**Derivation service** — `apps/job-api/app/services/experience/derive.py`
- `derive_from_prose(llm, prose_text, ...)` wraps `complete_json` with a strict JSON-schema system prompt. Returns `(OptimizedPayload, LLMResult)` so callers can cost-log.
- Default model: `claude-sonnet-4-6` (per earlier discussion — Sonnet for quality-sensitive sync work).
- `cache_system=True` so the real Anthropic client will get prompt-caching on the static extraction instructions (90% discount on cache reads).
- `DEFAULT_PURPOSE = "experience.derive"` — the cost-log grouping label.

**System prompt rules (load-bearing):**
- Output must match the `OptimizedPayload` schema exactly.
- "Do not invent outcomes, metrics, or roles." — hallucination constraint.
- Prefer canonical skill names (React, TypeScript, Next.js) over variants.
- Ambiguous fields are `null`, not guessed.
- Return ONLY the JSON object (no prose, no code fences).

**LLM client factory**
- `services/llm/__init__.py` — `get_default_client()` parallel to the embeddings factory. Returns a `MockLLMClient` today.
- `dependencies.py` — `get_llm_client` FastAPI dependency.

**Router endpoint** — `POST /experience/derive`
- No body. Reads latest prose doc.
- Calls `derive_from_prose` → records LLM cost → creates a new optimized version with `source="llm"` linked to the prose doc id + version → upserts chunks.
- Returns the new `OptimizedDoc`.
- Returns `404` if there is no prose doc yet.

## Flow

```
POST /experience/derive
    ↓
prose.get_latest(user)         ← prose_doc (or 404)
    ↓
derive_from_prose(llm, prose.content, cache_system=True)
    ↓                              ← (OptimizedPayload, LLMResult)
cost_log.record(purpose="experience.derive", metadata={prose_doc_id, prose_version})
    ↓
optimized.create_version(payload, source="llm", prose_doc_id=prose.id)
    ↓                              ← new OptimizedDoc (versioned)
chunks.upsert_for_optimized(supabase, embeddings, doc)
    ↓                              ← writes vectors, cost-logs embedding call
return OptimizedDoc
```

Two cost-log rows per successful derive: one `experience.derive` (LLM) + one `experience.chunks` (embedding).

## What's not in (intentional)

- **No real Anthropic client.** Mock returns scripted JSON. Swap-in is a single-file `AnthropicLLMClient` + env toggle on `get_default_client()`. No consumer changes.
- **No streaming.** Derivation is a single synthesis call; streaming adds complexity without user-visible benefit.
- **No partial-update / merge logic.** Each derive run produces a fresh `OptimizedPayload`. User edits happen via `POST /experience/optimized` with `source="user_edit"` (existing P1 behavior). Versioning preserves both.
- **No validation that the derived payload references the prose faithfully.** That's the hallucination-detection pass — lands in P3 alongside the tailor (or earlier as a standalone guard if it proves necessary).

## Design notes

- **Two cost-log rows per derive.** Intentional: they have different `purpose` labels (`experience.derive` vs `experience.chunks`) and different models (Sonnet vs Voyage). Spend-by-purpose queries can slice them.
- **prose_doc_id + prose_version in metadata.** Lets the dashboard answer "which prose version produced this optimized doc?" without extra joins.
- **Derive is idempotent-ish.** Running it twice on the same prose produces two optimized versions. The chunks for the *latest* version win for retrieval; older chunks survive until the optimized doc they belong to is deleted.

## Test plan

- [x] `uv run ruff check` — passes
- [x] `uv run mypy` strict on new files — no issues
- [x] `uv run pytest` — **178/178** (was 170; +8 new)
  - 8 derive tests (schema parse, default model/purpose, `cache_system=True`, positive cost, prose goes into user message, model override, invalid-JSON raises, system-prompt sanity checks)
- [ ] Apply migrations, POST prose, POST /experience/derive, inspect `llm_cost_log` + `experience_chunks`
- [ ] Register a realistic scripted payload on the mock and walk the full flow from CLI

## Up next (P2d)

- `services/conversation/` — onboarding interview + update-mode chat, gap tracker, skip handling, reset-via-re-onboarding.
- Biggest slice of P2. Depends on derive (P2c) because each conversation turn eventually triggers re-derivation.

https://claude.ai/code/session_01GiZqgubpGXDBuQSEGNGsbp

---
_Generated by [Claude Code](https://claude.ai/code/session_01GiZqgubpGXDBuQSEGNGsbp)_