### PR TITLE
feat(job-api): conversation orchestrator + gap tracker (#185 P2d)

### DIFF
--- a/apps/job-api/app/models/conversation.py
+++ b/apps/job-api/app/models/conversation.py
@@ -1,0 +1,74 @@
+"""Pydantic models for the conversation orchestrator (#185 P2d)."""
+
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+from app.models.experience import ConversationType
+
+GapKind = Literal[
+    "role.missing_outcomes",
+    "role.missing_summary",
+    "role.missing_end_date",
+    "outcome.missing_metric",
+    "skill.missing_evidence",
+    "content.empty",
+]
+
+
+class Gap(BaseModel):
+    """A missing slot in the optimized doc worth probing for."""
+
+    kind: GapKind
+    ref: str
+    priority: int
+    context: str
+
+
+class TurnRequest(BaseModel):
+    """Client payload for POST /experience/conversation/turn."""
+
+    conversation_type: ConversationType
+    content: str = Field(min_length=1, max_length=50_000)
+    skipped: bool = False
+
+
+class LLMTurnResponse(BaseModel):
+    """The structured shape the LLM must return.
+
+    - `assistant_message`: the question or acknowledgement shown to the user.
+    - `prose_append`: optional chunk of narrative to append to the prose doc.
+      The LLM can only *append*, never rewrite existing prose.
+    - `done`: true when the orchestrator should stop probing for this phase.
+    """
+
+    assistant_message: str = Field(min_length=1, max_length=10_000)
+    prose_append: str | None = None
+    done: bool = False
+
+
+class TurnResult(BaseModel):
+    """What POST /experience/conversation/turn returns to the client."""
+
+    assistant_message: str
+    prose_updated: bool
+    prose_version: int | None
+    done: bool
+
+
+class ProbeResult(BaseModel):
+    """What GET /experience/conversation/next-probe returns.
+
+    `gap` is None when there are no gaps worth probing.
+    """
+
+    question: str
+    gap: Gap | None
+
+
+class ResetResult(BaseModel):
+    """What POST /experience/conversation/reset returns."""
+
+    prose_versions_deleted: int
+    optimized_versions_deleted: int
+    turns_deleted: int

--- a/apps/job-api/app/routers/experience.py
+++ b/apps/job-api/app/routers/experience.py
@@ -17,6 +17,12 @@ from app.dependencies import (
     get_supabase,
     verify_api_key_or_session,
 )
+from app.models.conversation import (
+    ProbeResult,
+    ResetResult,
+    TurnRequest,
+    TurnResult,
+)
 from app.models.experience import (
     ConversationType,
     OptimizedDoc,
@@ -27,6 +33,7 @@ from app.models.experience import (
     ProseDocCreate,
     TurnAppend,
 )
+from app.services.conversation import orchestrator
 from app.services.embeddings.client import EmbeddingsClient
 from app.services.experience import chunks, derive, optimized, preferences, prose, turns
 from app.services.llm import cost_log
@@ -201,3 +208,44 @@ async def append_turn(
         prose_doc_id=body.prose_doc_id,
     )
     return turn.model_dump(mode="json")
+
+
+# ---- Conversation orchestrator (P2d) -------------------------------------
+
+
+@router.post("/conversation/turn")
+async def conversation_turn(
+    body: TurnRequest,
+    supabase: Client = Depends(get_supabase),
+    llm: LLMClient = Depends(get_llm_client),
+) -> TurnResult:
+    """Run one orchestrated turn. Persists user + assistant turns,
+    appends to prose doc if the LLM determined fresh content was shared.
+    """
+    return await orchestrator.handle_turn(
+        supabase,
+        llm,
+        user_id=None,
+        conversation_type=body.conversation_type,
+        user_content=body.content,
+        skipped=body.skipped,
+    )
+
+
+@router.post("/conversation/reset")
+async def conversation_reset(
+    supabase: Client = Depends(get_supabase),
+) -> ResetResult:
+    """Wipe prose, optimized (chunks cascade), and turns. Preferences are
+    preserved — delete them via DELETE /experience/preferences if wanted.
+    """
+    return orchestrator.reset_content(supabase, user_id=None)
+
+
+@router.get("/conversation/next-probe")
+async def conversation_next_probe(
+    supabase: Client = Depends(get_supabase),
+    llm: LLMClient = Depends(get_llm_client),
+) -> ProbeResult:
+    """Top-priority gap phrased as a user-facing question by the LLM."""
+    return await orchestrator.next_probe(supabase, llm, user_id=None)

--- a/apps/job-api/app/services/conversation/__init__.py
+++ b/apps/job-api/app/services/conversation/__init__.py
@@ -1,0 +1,13 @@
+"""Conversation orchestration module (#185 P2d).
+
+Three entry points: `handle_turn`, `reset_content`, `next_probe`.
+See `orchestrator.py` for details.
+"""
+
+from app.services.conversation.orchestrator import (
+    handle_turn,
+    next_probe,
+    reset_content,
+)
+
+__all__ = ["handle_turn", "next_probe", "reset_content"]

--- a/apps/job-api/app/services/conversation/orchestrator.py
+++ b/apps/job-api/app/services/conversation/orchestrator.py
@@ -1,0 +1,244 @@
+"""Conversation orchestrator.
+
+Three entry points:
+- `handle_turn(...)` — processes one user turn in onboarding or update mode,
+  persists the assistant's reply, and appends to the prose doc if the LLM
+  determined fresh career content was shared.
+- `reset_content(...)` — destructive wipe of prose/optimized/chunks/turns.
+  Preferences survive (they have their own DELETE endpoint).
+- `next_probe(...)` — pure orchestration over the gap tracker + LLM: find
+  the top-priority gap, ask the LLM to phrase it as a question.
+
+Auto-derivation is NOT triggered on every turn — that would add LLM cost
+to every conversation tick. The user calls POST /experience/derive when
+they want the optimized doc regenerated from accumulated prose.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, cast
+
+from supabase import Client
+
+from app.models.conversation import (
+    LLMTurnResponse,
+    ProbeResult,
+    ResetResult,
+    TurnResult,
+)
+from app.models.experience import ConversationType
+from app.models.llm import Message, ModelId
+from app.services.conversation.prompts import (
+    ONBOARDING_SYSTEM,
+    PROBE_SYSTEM,
+    UPDATE_SYSTEM,
+)
+from app.services.experience import gap_tracker, optimized, prose, turns
+from app.services.llm import cost_log
+from app.services.llm.client import LLMClient, complete_json
+
+PURPOSE_TURN_ONBOARDING = "conversation.onboarding"
+PURPOSE_TURN_UPDATE = "conversation.update"
+PURPOSE_PROBE = "conversation.probe"
+
+DEFAULT_TURN_MODEL: ModelId = "claude-haiku-4-5"
+"""Haiku for interactive turns — latency matters, reasoning demands are modest."""
+
+DEFAULT_PROBE_MODEL: ModelId = "claude-haiku-4-5"
+"""Haiku for phrasing a probe — one-sentence output from structured input."""
+
+
+def _system_for(conv_type: ConversationType) -> str:
+    return ONBOARDING_SYSTEM if conv_type == "onboarding" else UPDATE_SYSTEM
+
+
+def _purpose_for(conv_type: ConversationType) -> str:
+    return (
+        PURPOSE_TURN_ONBOARDING
+        if conv_type == "onboarding"
+        else PURPOSE_TURN_UPDATE
+    )
+
+
+def _history_as_messages(
+    history: list[Any],
+    latest_user_content: str,
+) -> list[Message]:
+    """Convert persisted turns + the current user content into LLM messages.
+
+    Assistant and user turns become the conversation history. `system`
+    turns are skipped — they're metadata, not chat content.
+    Skipped user turns are annotated inline so the LLM knows the user declined.
+    """
+    out: list[Message] = []
+    for t in history:
+        if t.role == "system":
+            continue
+        if t.role == "user" and t.skipped:
+            out.append(Message(role="user", content="[skipped question]"))
+        else:
+            out.append(Message(role=t.role, content=t.content))
+    out.append(Message(role="user", content=latest_user_content))
+    return out
+
+
+async def handle_turn(
+    supabase: Client,
+    llm: LLMClient,
+    *,
+    user_id: str | None,
+    conversation_type: ConversationType,
+    user_content: str,
+    skipped: bool,
+) -> TurnResult:
+    """Persist the user turn, run the LLM, persist the assistant reply,
+    and optionally append to the prose doc."""
+    history = turns.list_turns(
+        supabase,
+        user_id=user_id,
+        conversation_type=conversation_type,
+        limit=1_000_000,
+    )
+    current_prose = prose.get_latest(supabase, user_id=user_id)
+
+    turns.append(
+        supabase,
+        user_id=user_id,
+        conversation_type=conversation_type,
+        role="user",
+        content=user_content,
+        skipped=skipped,
+        prose_doc_id=current_prose.id if current_prose else None,
+    )
+
+    messages = _history_as_messages(history, user_content)
+    if current_prose and current_prose.content.strip():
+        messages.insert(
+            0,
+            Message(
+                role="user",
+                content=(
+                    "[context: current prose doc]\n" + current_prose.content
+                ),
+            ),
+        )
+
+    purpose = _purpose_for(conversation_type)
+    parsed, result = await complete_json(
+        llm,
+        model=DEFAULT_TURN_MODEL,
+        system=_system_for(conversation_type),
+        messages=messages,
+        schema=LLMTurnResponse,
+        purpose=purpose,
+        cache_system=True,
+    )
+    cost_log.record(
+        supabase,
+        user_id=user_id,
+        purpose=purpose,
+        result=result,
+        metadata={"conversation_type": conversation_type},
+    )
+
+    new_prose_version: int | None = None
+    prose_updated = False
+    if parsed.prose_append and parsed.prose_append.strip():
+        existing = current_prose.content if current_prose else ""
+        new_content = (
+            (existing + "\n\n" + parsed.prose_append.strip()).strip()
+            if existing
+            else parsed.prose_append.strip()
+        )
+        new_doc = prose.create_version(
+            supabase, user_id=user_id, content=new_content
+        )
+        new_prose_version = new_doc.version
+        prose_updated = True
+
+    turns.append(
+        supabase,
+        user_id=user_id,
+        conversation_type=conversation_type,
+        role="assistant",
+        content=parsed.assistant_message,
+        skipped=False,
+        prose_doc_id=None,
+    )
+
+    return TurnResult(
+        assistant_message=parsed.assistant_message,
+        prose_updated=prose_updated,
+        prose_version=new_prose_version,
+        done=parsed.done,
+    )
+
+
+def reset_content(
+    supabase: Client,
+    *,
+    user_id: str | None,
+) -> ResetResult:
+    """Wipe prose, optimized (chunks cascade), and turns. Preserve preferences."""
+
+    def _scoped(table: str) -> Any:
+        q = supabase.table(table).delete()
+        return q.is_("user_id", "null") if user_id is None else q.eq("user_id", user_id)
+
+    prose_resp = _scoped("experience_prose_docs").execute()
+    optimized_resp = _scoped("experience_optimized_docs").execute()
+    turns_resp = _scoped("experience_conversation_turns").execute()
+
+    prose_deleted = len(cast(list[Any], prose_resp.data or []))
+    optimized_deleted = len(cast(list[Any], optimized_resp.data or []))
+    turns_deleted = len(cast(list[Any], turns_resp.data or []))
+
+    return ResetResult(
+        prose_versions_deleted=prose_deleted,
+        optimized_versions_deleted=optimized_deleted,
+        turns_deleted=turns_deleted,
+    )
+
+
+async def next_probe(
+    supabase: Client,
+    llm: LLMClient,
+    *,
+    user_id: str | None,
+) -> ProbeResult:
+    """Find the top-priority gap and phrase it as a user-facing question."""
+    current = optimized.get_latest(supabase, user_id=user_id)
+    if current is None:
+        return ProbeResult(
+            question=(
+                "Tell me about your most recent role — company, title, and one "
+                "win you'd lead with."
+            ),
+            gap=None,
+        )
+
+    gap = gap_tracker.top_gap(current.payload)
+    if gap is None:
+        return ProbeResult(
+            question="Your optimized doc looks complete. Share what you shipped this week.",
+            gap=None,
+        )
+
+    result = await llm.complete(
+        model=DEFAULT_PROBE_MODEL,
+        system=PROBE_SYSTEM,
+        messages=[Message(role="user", content=json.dumps(gap.model_dump()))],
+        purpose=PURPOSE_PROBE,
+        cache_system=True,
+    )
+    cost_log.record(
+        supabase,
+        user_id=user_id,
+        purpose=PURPOSE_PROBE,
+        result=result,
+        metadata={"gap_kind": gap.kind, "gap_ref": gap.ref},
+    )
+
+    question = result.content.strip().strip('"').strip()
+    return ProbeResult(question=question, gap=gap)

--- a/apps/job-api/app/services/conversation/prompts.py
+++ b/apps/job-api/app/services/conversation/prompts.py
@@ -1,0 +1,80 @@
+"""System prompts for the conversation orchestrator.
+
+All three are static and cache-friendly: the only variable content is
+the conversation history + current prose, which live in user messages.
+With cache_system=True, the real Anthropic client gets prompt caching
+on every turn.
+"""
+
+_SHARED_OUTPUT_CONTRACT = """Return a strict JSON object matching this schema \
+— no prose around it, no code fences:
+
+{
+  "assistant_message": "string — what to show the user next (1-3 sentences)",
+  "prose_append": "string or null — new text to append to the prose doc, if \
+the user just gave you fresh career content. Must be the user's claim restated \
+in third-person-neutral or first-person-singular. Never a summary. Never \
+invention.",
+  "done": boolean — true when the current phase has enough content to stop probing
+}
+
+Rules:
+- Never invent outcomes, metrics, companies, dates, or skills the user did \
+not say.
+- Never rewrite existing prose; prose_append is strictly additive.
+- If the user's latest turn did not carry new career content, prose_append is null.
+- If the user skipped a question (skipped=true in the turn metadata), \
+acknowledge gracefully and ask the next question.
+- Keep assistant_message short and direct — one concrete question at a time.
+"""
+
+
+ONBOARDING_SYSTEM = f"""You are the onboarding interviewer for Daniel's \
+personal resume tailoring tool. Your job is to draw out a complete career \
+narrative through a structured 20–30 question interview.
+
+Strategy:
+- Start with the most recent role and work backwards.
+- Per role, probe for: scope, team size, technical stack, one or two \
+quantified outcomes (metric + value), and one hard decision or trade-off.
+- Prefer specifics over generalities: "what did LCP drop from and to?" \
+not "did you improve performance?"
+- Avoid yes/no questions. Prefer "what" and "how" phrasings.
+- Move on when the user skips or says "I don't remember."
+- Set done=true when you have roles + outcomes for the last 3 positions.
+
+{_SHARED_OUTPUT_CONTRACT}"""
+
+
+UPDATE_SYSTEM = f"""You are a career-log assistant for Daniel's resume \
+tailoring tool. The user visits periodically to log wins, shipped work, and \
+lessons learned.
+
+Strategy:
+- Treat each turn as a free-form update. Acknowledge briefly.
+- Ask at most ONE clarifying follow-up if a quantified outcome or technical \
+detail is obviously missing. Otherwise, end the turn.
+- If the user just dropped a win, mirror it back in one line and ask for the \
+metric + value if they're missing.
+- Keep the tone direct, peer-level. No cheerleading, no filler.
+- Set done=true after you've asked your one follow-up (or if none was needed).
+
+{_SHARED_OUTPUT_CONTRACT}"""
+
+
+PROBE_SYSTEM = """You phrase deterministic gap-tracker findings as a single \
+probing question the user can answer in one sentence.
+
+Input: a JSON object describing one gap in the career record.
+Output: ONE sentence ending with a question mark. No preamble. No closing. \
+No quoting the gap back verbatim.
+
+Examples:
+Input: {"kind": "role.missing_outcomes", "ref": "fightcamp-senior-fe", \
+"context": "Senior Frontend Engineer at FightCamp has no outcomes."}
+Output: What's the single number you'd lead with from your time at FightCamp?
+
+Input: {"kind": "outcome.missing_metric", "ref": "Cut mobile load times", \
+"context": "Outcome lacks a quantified metric: 'Cut mobile load times'"}
+Output: What did the mobile load time drop from and to, and in what units?
+"""

--- a/apps/job-api/app/services/experience/gap_tracker.py
+++ b/apps/job-api/app/services/experience/gap_tracker.py
@@ -1,0 +1,118 @@
+"""Deterministic gap detection over an optimized doc.
+
+Pure function. No LLM. Scans the typed payload for missing slots that
+matter for resume tailoring: roles without quantified outcomes, outcomes
+without metrics, roles without end dates, etc.
+
+The conversation orchestrator calls `next_probe()` to turn the top-priority
+gap into a user-facing probing question (LLM phrases it; priorities here
+are deterministic).
+
+Priority scale: lower = more urgent. Tailored so a missing outcome on the
+most recent role beats a missing end-date on an older role.
+"""
+
+from app.models.conversation import Gap
+from app.models.experience import OptimizedPayload
+
+
+def _role_priority_boost(index: int, total: int) -> int:
+    """Earlier roles (by declared order) get higher priority boost since
+    `roles[0]` is usually the most recent. Translates index to an additive
+    adjustment; 0 for newest, grows with age.
+    """
+    if total <= 0:
+        return 0
+    return min(index * 2, 20)
+
+
+def detect_gaps(payload: OptimizedPayload) -> list[Gap]:
+    """Return all gaps, sorted by priority ascending (most urgent first)."""
+    gaps: list[Gap] = []
+
+    if (
+        not payload.roles
+        and not payload.skills
+        and not payload.outcomes
+        and not payload.summary
+    ):
+        gaps.append(
+            Gap(
+                kind="content.empty",
+                ref="",
+                priority=0,
+                context="No content yet. Start with an onboarding turn.",
+            )
+        )
+        return gaps
+
+    outcome_refs_by_role: dict[str, list[str]] = {}
+    for o in payload.outcomes:
+        if o.role_ref:
+            outcome_refs_by_role.setdefault(o.role_ref, []).append(o.description)
+
+    for idx, role in enumerate(payload.roles):
+        boost = _role_priority_boost(idx, len(payload.roles))
+        role_outcomes = outcome_refs_by_role.get(role.id, [])
+        if not role_outcomes and not role.outcome_refs:
+            gaps.append(
+                Gap(
+                    kind="role.missing_outcomes",
+                    ref=role.id,
+                    priority=10 + boost,
+                    context=f"{role.title} at {role.company} has no outcomes.",
+                )
+            )
+        if not role.summary:
+            gaps.append(
+                Gap(
+                    kind="role.missing_summary",
+                    ref=role.id,
+                    priority=30 + boost,
+                    context=f"{role.title} at {role.company} has no summary sentence.",
+                )
+            )
+        if role.end is None and idx > 0:
+            gaps.append(
+                Gap(
+                    kind="role.missing_end_date",
+                    ref=role.id,
+                    priority=40 + boost,
+                    context=(
+                        f"{role.title} at {role.company} has no end date but "
+                        "isn't the most recent role."
+                    ),
+                )
+            )
+
+    for outcome in payload.outcomes:
+        if outcome.metric is None or outcome.value is None:
+            gaps.append(
+                Gap(
+                    kind="outcome.missing_metric",
+                    ref=outcome.description[:80],
+                    priority=20,
+                    context=(
+                        f"Outcome lacks a quantified metric: "
+                        f"'{outcome.description[:80]}'"
+                    ),
+                )
+            )
+
+    for skill in payload.skills:
+        if not skill.evidence_refs:
+            gaps.append(
+                Gap(
+                    kind="skill.missing_evidence",
+                    ref=skill.name,
+                    priority=50,
+                    context=f"Skill '{skill.name}' has no evidence references.",
+                )
+            )
+
+    return sorted(gaps, key=lambda g: g.priority)
+
+
+def top_gap(payload: OptimizedPayload) -> Gap | None:
+    gaps = detect_gaps(payload)
+    return gaps[0] if gaps else None

--- a/apps/job-api/tests/test_conversation_orchestrator.py
+++ b/apps/job-api/tests/test_conversation_orchestrator.py
@@ -1,0 +1,297 @@
+"""Orchestrator behavior tests with patched service dependencies.
+
+The orchestrator touches 5 service modules + Supabase. We patch the
+service module functions (the natural seam) rather than building a full
+fake Supabase. LLM interactions use the real MockLLMClient with scripted
+responses so the JSON contract is exercised end-to-end.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.models.conversation import LLMTurnResponse
+from app.models.experience import (
+    ConversationTurn,
+    OptimizedDoc,
+    OptimizedPayload,
+    ProseDoc,
+    Role,
+)
+from app.services.conversation import orchestrator
+from app.services.experience import optimized as optimized_mod
+from app.services.experience import prose as prose_mod
+from app.services.experience import turns as turns_mod
+from app.services.llm import cost_log as cost_log_mod
+from app.services.llm.mock import MockLLMClient
+
+
+def _prose(content: str, version: int = 1) -> ProseDoc:
+    return ProseDoc(
+        id=f"prose-{version}",
+        user_id=None,
+        version=version,
+        content=content,
+        created_at=datetime.now(UTC),
+    )
+
+
+def _turn(role: str, content: str, skipped: bool = False, idx: int = 1) -> ConversationTurn:
+    return ConversationTurn(
+        id=f"turn-{idx}",
+        user_id=None,
+        conversation_type="onboarding",
+        turn_index=idx,
+        role=role,  # type: ignore[arg-type]
+        content=content,
+        skipped=skipped,
+        prose_doc_id=None,
+        metadata={},
+        created_at=datetime.now(UTC),
+    )
+
+
+def _llm_response(
+    assistant_message: str = "Next question?",
+    prose_append: str | None = None,
+    done: bool = False,
+) -> str:
+    return LLMTurnResponse(
+        assistant_message=assistant_message,
+        prose_append=prose_append,
+        done=done,
+    ).model_dump_json()
+
+
+@pytest.fixture
+def mock_service_layer(monkeypatch: pytest.MonkeyPatch) -> dict[str, MagicMock]:
+    """Patch the service-module attributes the orchestrator imports.
+
+    Return a dict of mocks so each test can tune return values and assert
+    on call args.
+    """
+    appended: list[dict[str, Any]] = []
+
+    def fake_append(*_args: Any, **kwargs: Any) -> ConversationTurn:
+        appended.append(kwargs)
+        return _turn(kwargs["role"], kwargs["content"], kwargs.get("skipped", False))
+
+    mocks: dict[str, MagicMock] = {
+        "turns_list": MagicMock(return_value=[]),
+        "turns_append": MagicMock(side_effect=fake_append),
+        "prose_get_latest": MagicMock(return_value=None),
+        "prose_create_version": MagicMock(
+            side_effect=lambda _s, user_id, content: _prose(content, version=2)
+        ),
+        "cost_log_record": MagicMock(return_value=None),
+        "_appended_turns": appended,  # type: ignore[dict-item]
+    }
+
+    monkeypatch.setattr(turns_mod, "list_turns", mocks["turns_list"])
+    monkeypatch.setattr(turns_mod, "append", mocks["turns_append"])
+    monkeypatch.setattr(prose_mod, "get_latest", mocks["prose_get_latest"])
+    monkeypatch.setattr(prose_mod, "create_version", mocks["prose_create_version"])
+    monkeypatch.setattr(cost_log_mod, "record", mocks["cost_log_record"])
+    return mocks
+
+
+async def test_handle_turn_persists_user_then_assistant(
+    mock_service_layer: dict[str, Any],
+) -> None:
+    llm = MockLLMClient(
+        scripted={orchestrator.PURPOSE_TURN_ONBOARDING: _llm_response()}
+    )
+    await orchestrator.handle_turn(
+        MagicMock(),
+        llm,
+        user_id=None,
+        conversation_type="onboarding",
+        user_content="I worked at FightCamp",
+        skipped=False,
+    )
+    appended = mock_service_layer["_appended_turns"]
+    assert len(appended) == 2
+    assert appended[0]["role"] == "user"
+    assert appended[0]["content"] == "I worked at FightCamp"
+    assert appended[1]["role"] == "assistant"
+
+
+async def test_handle_turn_appends_prose_when_llm_requests(
+    mock_service_layer: dict[str, Any],
+) -> None:
+    llm = MockLLMClient(
+        scripted={
+            orchestrator.PURPOSE_TURN_ONBOARDING: _llm_response(
+                prose_append="Worked at FightCamp 2021-11 to 2024-04."
+            )
+        }
+    )
+    mock_service_layer["prose_get_latest"].return_value = _prose("existing prose.")
+
+    result = await orchestrator.handle_turn(
+        MagicMock(),
+        llm,
+        user_id=None,
+        conversation_type="onboarding",
+        user_content="...",
+        skipped=False,
+    )
+
+    assert result.prose_updated is True
+    assert result.prose_version == 2
+    create_call = mock_service_layer["prose_create_version"].call_args
+    assert "existing prose." in create_call.kwargs["content"]
+    assert "FightCamp" in create_call.kwargs["content"]
+
+
+async def test_handle_turn_does_not_append_when_no_prose_content(
+    mock_service_layer: dict[str, Any],
+) -> None:
+    llm = MockLLMClient(
+        scripted={
+            orchestrator.PURPOSE_TURN_ONBOARDING: _llm_response(prose_append=None)
+        }
+    )
+    result = await orchestrator.handle_turn(
+        MagicMock(),
+        llm,
+        user_id=None,
+        conversation_type="onboarding",
+        user_content="skip",
+        skipped=False,
+    )
+    assert result.prose_updated is False
+    mock_service_layer["prose_create_version"].assert_not_called()
+
+
+async def test_handle_turn_cost_logs_with_correct_purpose_for_update_mode(
+    mock_service_layer: dict[str, Any],
+) -> None:
+    llm = MockLLMClient(
+        scripted={orchestrator.PURPOSE_TURN_UPDATE: _llm_response()}
+    )
+    await orchestrator.handle_turn(
+        MagicMock(),
+        llm,
+        user_id=None,
+        conversation_type="update",
+        user_content="shipped the audit tool",
+        skipped=False,
+    )
+    call = mock_service_layer["cost_log_record"].call_args
+    assert call.kwargs["purpose"] == orchestrator.PURPOSE_TURN_UPDATE
+
+
+async def test_handle_turn_annotates_skipped_history(
+    mock_service_layer: dict[str, Any],
+) -> None:
+    mock_service_layer["turns_list"].return_value = [
+        _turn("assistant", "what was the team size?"),
+        _turn("user", "should-not-appear", skipped=True, idx=2),
+    ]
+
+    seen: dict[str, list[Any]] = {}
+
+    def responder(_latest: str, messages: list[Any]) -> str:
+        seen["messages"] = messages
+        return _llm_response()
+
+    llm = MockLLMClient(
+        scripted={orchestrator.PURPOSE_TURN_ONBOARDING: responder}
+    )
+    await orchestrator.handle_turn(
+        MagicMock(),
+        llm,
+        user_id=None,
+        conversation_type="onboarding",
+        user_content="next",
+        skipped=False,
+    )
+    contents = [m.content for m in seen["messages"]]
+    assert "[skipped question]" in contents
+    assert "should-not-appear" not in contents
+
+
+async def test_next_probe_returns_default_when_no_optimized_doc(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(optimized_mod, "get_latest", lambda _s, user_id: None)
+    result = await orchestrator.next_probe(
+        MagicMock(), MockLLMClient(), user_id=None
+    )
+    assert result.gap is None
+    assert "most recent role" in result.question.lower()
+
+
+async def test_next_probe_phrases_gap_via_llm(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payload = OptimizedPayload(
+        roles=[
+            Role(
+                id="fc",
+                company="FC",
+                title="E",
+                start="2020-01",
+                end="2024-01",
+                summary=None,
+                skills=[],
+                outcome_refs=[],
+            )
+        ],
+    )
+    opt_doc = OptimizedDoc(
+        id="o-1",
+        user_id=None,
+        prose_doc_id=None,
+        version=1,
+        payload=payload,
+        markdown_view=None,
+        source="llm",
+        created_at=datetime.now(UTC),
+    )
+    monkeypatch.setattr(optimized_mod, "get_latest", lambda _s, user_id: opt_doc)
+    monkeypatch.setattr(cost_log_mod, "record", MagicMock())
+
+    llm = MockLLMClient(
+        scripted={
+            orchestrator.PURPOSE_PROBE: "What number would you lead with from FC?"
+        }
+    )
+    result = await orchestrator.next_probe(MagicMock(), llm, user_id=None)
+    assert result.gap is not None
+    assert result.gap.kind == "role.missing_outcomes"
+    assert result.question.startswith("What")
+
+
+def test_reset_content_deletes_three_tables() -> None:
+    supabase = MagicMock()
+    delete_chain = supabase.table.return_value.delete.return_value
+    delete_chain.is_.return_value.execute.return_value.data = []
+
+    result = orchestrator.reset_content(supabase, user_id=None)
+
+    tables_deleted = [c.args[0] for c in supabase.table.call_args_list]
+    assert "experience_prose_docs" in tables_deleted
+    assert "experience_optimized_docs" in tables_deleted
+    assert "experience_conversation_turns" in tables_deleted
+    assert result.prose_versions_deleted == 0
+
+
+def test_llm_turn_response_contract_is_parseable() -> None:
+    """Sanity check: the JSON shape we ask the LLM for round-trips."""
+    raw = _llm_response(
+        assistant_message="Team size?",
+        prose_append="Worked at Acme.",
+        done=False,
+    )
+    parsed = LLMTurnResponse.model_validate_json(raw)
+    assert parsed.assistant_message == "Team size?"
+    assert parsed.prose_append == "Worked at Acme."
+    assert parsed.done is False
+    assert json.loads(raw)["done"] is False

--- a/apps/job-api/tests/test_gap_tracker.py
+++ b/apps/job-api/tests/test_gap_tracker.py
@@ -1,0 +1,161 @@
+"""Pure-function tests for gap_tracker.detect_gaps and top_gap."""
+
+from app.models.experience import OptimizedPayload, Outcome, Role, Skill
+from app.services.experience.gap_tracker import detect_gaps, top_gap
+
+
+def _role(
+    id_: str,
+    *,
+    summary: str | None = None,
+    end: str | None = "2024-01",
+    outcome_refs: list[str] | None = None,
+) -> Role:
+    return Role(
+        id=id_,
+        company=id_,
+        title="Engineer",
+        start="2020-01",
+        end=end,
+        summary=summary,
+        skills=[],
+        outcome_refs=outcome_refs or [],
+    )
+
+
+def _outcome(
+    description: str,
+    *,
+    metric: str | None = None,
+    value: str | None = None,
+    role_ref: str | None = None,
+) -> Outcome:
+    return Outcome(description=description, metric=metric, value=value, role_ref=role_ref)
+
+
+def test_empty_payload_returns_content_empty_gap() -> None:
+    gaps = detect_gaps(OptimizedPayload())
+    assert len(gaps) == 1
+    assert gaps[0].kind == "content.empty"
+
+
+def test_role_without_outcomes_surfaces_gap() -> None:
+    payload = OptimizedPayload(
+        roles=[_role("a", summary="s"), _role("b", summary="s")],
+        outcomes=[_outcome("x", metric="m", value="v", role_ref="a")],
+    )
+    kinds = {g.kind for g in detect_gaps(payload)}
+    assert "role.missing_outcomes" in kinds
+
+
+def test_role_outcome_ref_counts_as_having_outcomes() -> None:
+    payload = OptimizedPayload(
+        roles=[_role("a", summary="s", outcome_refs=["baked-in outcome"])],
+    )
+    kinds = {g.kind for g in detect_gaps(payload)}
+    assert "role.missing_outcomes" not in kinds
+
+
+def test_role_without_summary_surfaces_gap() -> None:
+    payload = OptimizedPayload(
+        roles=[_role("a", summary=None, outcome_refs=["x"])],
+    )
+    kinds = {g.kind for g in detect_gaps(payload)}
+    assert "role.missing_summary" in kinds
+
+
+def test_older_role_without_end_surfaces_gap() -> None:
+    payload = OptimizedPayload(
+        roles=[
+            _role("recent", summary="s", end=None, outcome_refs=["x"]),
+            _role("older", summary="s", end=None, outcome_refs=["x"]),
+        ],
+    )
+    gaps = detect_gaps(payload)
+    end_gaps = [g for g in gaps if g.kind == "role.missing_end_date"]
+    assert len(end_gaps) == 1
+    assert end_gaps[0].ref == "older"
+
+
+def test_outcome_without_metric_surfaces_gap() -> None:
+    payload = OptimizedPayload(
+        roles=[_role("a", summary="s", outcome_refs=["x"])],
+        outcomes=[_outcome("did a thing", role_ref="a")],
+    )
+    kinds = {g.kind for g in detect_gaps(payload)}
+    assert "outcome.missing_metric" in kinds
+
+
+def test_skill_without_evidence_surfaces_gap() -> None:
+    payload = OptimizedPayload(
+        roles=[_role("a", summary="s", outcome_refs=["x"])],
+        skills=[Skill(name="React")],
+    )
+    kinds = {g.kind for g in detect_gaps(payload)}
+    assert "skill.missing_evidence" in kinds
+
+
+def test_gaps_sorted_by_priority_ascending() -> None:
+    payload = OptimizedPayload(
+        roles=[_role("a", summary=None)],
+        skills=[Skill(name="React")],
+    )
+    gaps = detect_gaps(payload)
+    priorities = [g.priority for g in gaps]
+    assert priorities == sorted(priorities)
+
+
+def test_missing_outcomes_beats_missing_summary_in_priority() -> None:
+    payload = OptimizedPayload(
+        roles=[_role("a", summary=None)],
+    )
+    gaps = detect_gaps(payload)
+    outcome_gap = next(g for g in gaps if g.kind == "role.missing_outcomes")
+    summary_gap = next(g for g in gaps if g.kind == "role.missing_summary")
+    assert outcome_gap.priority < summary_gap.priority
+
+
+def test_top_gap_returns_highest_priority() -> None:
+    payload = OptimizedPayload(
+        roles=[_role("a", summary=None)],
+        skills=[Skill(name="React")],
+    )
+    top = top_gap(payload)
+    assert top is not None
+    assert top.kind == "role.missing_outcomes"
+
+
+def test_top_gap_returns_none_when_complete() -> None:
+    payload = OptimizedPayload(
+        summary="s",
+        roles=[
+            _role(
+                "a",
+                summary="good summary",
+                outcome_refs=["x"],
+                end="2024-01",
+            )
+        ],
+        outcomes=[_outcome("cut LCP", metric="LCP", value="2s", role_ref="a")],
+        skills=[Skill(name="React", evidence_refs=["a"])],
+    )
+    assert top_gap(payload) is None
+
+
+def test_later_roles_get_lower_priority_boost() -> None:
+    """Older roles (higher index) should have a larger additive priority value
+    (i.e. be less urgent) than newer ones for the same gap kind."""
+    payload = OptimizedPayload(
+        roles=[
+            _role("newest", summary=None, outcome_refs=["x"]),
+            _role("older", summary=None, outcome_refs=["x"]),
+        ],
+    )
+    gaps = detect_gaps(payload)
+    newest_summary = next(
+        g for g in gaps if g.kind == "role.missing_summary" and g.ref == "newest"
+    )
+    older_summary = next(
+        g for g in gaps if g.kind == "role.missing_summary" and g.ref == "older"
+    )
+    assert newest_summary.priority < older_summary.priority


### PR DESCRIPTION
## Summary

P2d of the canonical resume tailoring system (#185). Full conversation orchestration layer — onboarding interview + update-mode chat + deterministic gap tracker + reset endpoint + skip handling. This is the biggest P2 slice and the last one before P3 (tailor + `.docx` + ATS lint).

Builds on P1 (#481), P2a (#483), P2b (#484), P2c (#485). Targets `feature/resume-tailor`.

## What's in

**Models** — `apps/job-api/app/models/conversation.py`
- `TurnRequest` — client payload: `conversation_type`, `content`, `skipped`.
- `LLMTurnResponse` — **the structured shape the LLM must return** (`assistant_message`, `prose_append`, `done`). The contract surface.
- `TurnResult` / `ProbeResult` / `ResetResult` — endpoint response shapes.
- `Gap` + `GapKind` Literal covering 6 kinds: `role.missing_outcomes`, `role.missing_summary`, `role.missing_end_date`, `outcome.missing_metric`, `skill.missing_evidence`, `content.empty`.

**Gap tracker** — `apps/job-api/app/services/experience/gap_tracker.py`
- Pure function. No LLM. Scans an `OptimizedPayload` for missing slots.
- Priority scale: lower = more urgent. Missing outcomes (10) < missing metric (20) < missing summary (30) < missing end-date (40) < missing skill evidence (50).
- Newer roles get boosted priority via `_role_priority_boost(index, total)` — a missing outcome on the most recent role beats a missing end-date on a 5-year-old one.
- `top_gap(payload)` returns `None` when the doc is complete → the `/next-probe` endpoint flips to "share what you shipped this week".

**Prompts** — `apps/job-api/app/services/conversation/prompts.py`
- `ONBOARDING_SYSTEM`: structured 20–30 question interview. Recent-first, probes for scope / team size / stack / quantified outcomes / trade-offs. Sets `done=true` after 3 positions with outcomes.
- `UPDATE_SYSTEM`: peer-level career log. Acknowledge, ask at most one follow-up if a metric is missing, else end.
- `PROBE_SYSTEM`: turns a JSON gap into one sentence ending in a question mark.
- All three are static → cache-friendly. `cache_system=True` at call sites so the real Anthropic client gets prompt caching.
- **Shared output contract** (repeated once across prompts): LLM may not invent outcomes/metrics/companies/dates/skills, may only append to prose (never rewrite), may return `prose_append=null` when no new career content.

**Orchestrator** — `apps/job-api/app/services/conversation/orchestrator.py`
- `handle_turn(...)` — reads history + current prose, persists user turn, runs LLM via `complete_json(LLMTurnResponse)`, cost-logs under `conversation.{onboarding,update}`, conditionally appends to prose doc (new version), persists assistant turn, returns `TurnResult`. Skipped user turns render as `"[skipped question]"` in history so the LLM can see declines.
- `reset_content(...)` — deletes `experience_prose_docs` / `experience_optimized_docs` / `experience_conversation_turns`. Chunks cascade via FK. **Preferences survive** (they have their own `DELETE /preferences` endpoint).
- `next_probe(...)` — pure orchestration: `gap_tracker.top_gap(optimized.payload)` → LLM phrases it. Returns default onboarding nudge if no optimized doc exists, completion line if no gap.
- **Model routing**: `claude-haiku-4-5` for turns and probes (interactive latency), Sonnet reserved for derive + tailor.

**No auto-derivation on turn.** Interactive chat stays cheap. Users call `POST /experience/derive` explicitly when they want the optimized doc regenerated from accumulated prose. Documented in the orchestrator module docstring.

**Endpoints**
- `POST /experience/conversation/turn` — orchestrated turn.
- `POST /experience/conversation/reset` — content wipe (preserves preferences).
- `GET /experience/conversation/next-probe` — top gap as a question.

## Full flow (onboarding example)

```
POST /experience/conversation/turn
  body: { conversation_type: "onboarding", content: "...", skipped: false }
    ↓
turns.list_turns(...)              ← history
prose.get_latest(...)              ← current prose (for context)
    ↓
turns.append(user turn)
    ↓
complete_json(LLMClient, LLMTurnResponse, cache_system=True,
              system=ONBOARDING_SYSTEM,
              messages=history + [current user turn],
              purpose="conversation.onboarding")
    ↓
cost_log.record(...)
    ↓  if prose_append present:
prose.create_version(existing + "\n\n" + prose_append)
    ↓
turns.append(assistant turn)
    ↓
return TurnResult(assistant_message, prose_updated, prose_version, done)
```

Two side effects per turn: one cost-log row + optionally one new prose doc version. Deterministic from LLM output; nothing auto-chains into derivation.

## What's not in (intentional)

- **No auto-derive after every turn.** Would add LLM cost to every message. User triggers `/experience/derive` explicitly.
- **No Anthropic SDK yet.** Mock only. Swap is a single-file addition when we're ready to pay for real inference.
- **No curated onboarding question bank.** The LLM generates questions from context + current prose. A hand-curated 20–30 question bank can land later as either a seed or a reference the LLM sees in system context.
- **No streaming / no SSE.** Turns are request-response. Streaming adds complexity without user-visible benefit for short assistant messages.

## Test plan

- [x] `uv run ruff check app/ tests/` — passes
- [x] `uv run mypy` strict on new files — no issues
- [x] `uv run pytest` — **199/199** (was 178 before P2d; **+21 new**)
  - 12 gap-tracker tests: empty payload, outcome-refs, summary, end-date-on-older, metric, evidence, priority ordering, role-index boost, `top_gap`, complete-payload returns None
  - 9 orchestrator tests: user+assistant persistence order, prose-append path, no-append path, purpose routing onboarding vs update, skipped-history annotation, no-optimized probe default, LLM-phrased probe, reset hits three tables, `LLMTurnResponse` contract round-trips
- [ ] Apply P1+P2a+P2b+P2c+P2d migrations to Supabase; script a MockLLMClient with realistic scripted responses; walk onboarding end-to-end and confirm prose/optimized/chunks/cost-log rows look right
- [ ] Exercise reset → verify prose/optimized/turns rows gone, preferences preserved

## Up next — end of P2

After #186 (this PR), `feature/resume-tailor` contains the **complete end-to-end content loop**:
- Conversation → prose → derivation → optimized doc → chunks with embeddings
- Gap-driven probing
- Content reset
- Full cost logging across every LLM and embedding call

**P3 is next**: tailor + `python-docx` renderer + ATS linter + feedback-critique regeneration + preferences persistence. First consumer of the retrieval layer built in P2b.

https://claude.ai/code/session_01GiZqgubpGXDBuQSEGNGsbp

---
_Generated by [Claude Code](https://claude.ai/code/session_01GiZqgubpGXDBuQSEGNGsbp)_