### PR TITLE
feat(job-api): tailor service with hallucination trace-checking (#185 P3a)

### DIFF
--- a/apps/job-api/app/models/tailor.py
+++ b/apps/job-api/app/models/tailor.py
@@ -1,0 +1,79 @@
+"""Pydantic models for the tailor layer (#185 P3a).
+
+The LLM produces a TailoredResume — a structured representation the
+`.docx` renderer (P3b) will consume. Every claim made in this structure
+must trace back to something in the OptimizedPayload; source refs are
+mandatory for bullets and roles so a post-hoc hallucination check can
+verify them.
+"""
+
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+ResumeType = Literal["senior-frontend", "fullstack", "frontend-lead", "generic"]
+
+
+class ContactInfo(BaseModel):
+    """Header fields. Lives outside the experience doc — passed in by
+    the caller (profile store or request body; TBD in P3d).
+    """
+
+    name: str
+    email: str | None = None
+    phone: str | None = None
+    location: str | None = None
+    website: str | None = None
+    linkedin: str | None = None
+
+
+class TailoredBullet(BaseModel):
+    """A single achievement line under a role.
+
+    `source_outcome_ref` ties back to an `Outcome.description` or an
+    explicit fact the role summary already stated. If the LLM can't
+    produce one, the bullet is suspect.
+    """
+
+    text: str = Field(min_length=1, max_length=400)
+    source_outcome_ref: str | None = None
+
+
+class TailoredRole(BaseModel):
+    company: str
+    title: str
+    location: str | None = None
+    start: str
+    end: str | None = None
+    bullets: list[TailoredBullet] = Field(default_factory=list)
+    source_role_ref: str
+    """Must equal a Role.id from the OptimizedPayload."""
+
+
+class TailoredEducation(BaseModel):
+    school: str
+    degree: str | None = None
+    dates: str | None = None
+
+
+class TailoredResume(BaseModel):
+    """The structured resume the docx renderer consumes."""
+
+    summary: str = Field(min_length=1, max_length=600)
+    contact: ContactInfo
+    experience: list[TailoredRole]
+    skills: list[str]
+    education: list[TailoredEducation] = Field(default_factory=list)
+
+    resume_type: ResumeType = "generic"
+    jd_snippet: str = Field(default="", max_length=800)
+    preferences_applied: list[str] = Field(default_factory=list)
+
+
+class TailorRequest(BaseModel):
+    """Router input shape (consumed in P3d)."""
+
+    job_description: str = Field(min_length=1, max_length=20_000)
+    critique: str | None = Field(default=None, max_length=5_000)
+    resume_type: ResumeType | None = None
+    page_budget: Literal[1, 2] = 2

--- a/apps/job-api/app/services/tailor/__init__.py
+++ b/apps/job-api/app/services/tailor/__init__.py
@@ -1,0 +1,26 @@
+"""Tailor module (#185 P3a).
+
+LLM-based resume synthesis from an OptimizedPayload + JD. Post-validates
+that every role + bullet traces back to the source career record, so
+hallucinations are caught at generation time rather than in front of an
+employer.
+
+P3b adds .docx rendering. P3c adds the ATS linter.
+P3d wires this into a POST /tailor/resume endpoint.
+"""
+
+from app.services.tailor.tailor import (
+    DEFAULT_MODEL,
+    DEFAULT_PURPOSE,
+    build_user_message,
+    tailor_resume,
+    validate_trace_refs,
+)
+
+__all__ = [
+    "DEFAULT_MODEL",
+    "DEFAULT_PURPOSE",
+    "build_user_message",
+    "tailor_resume",
+    "validate_trace_refs",
+]

--- a/apps/job-api/app/services/tailor/prompts.py
+++ b/apps/job-api/app/services/tailor/prompts.py
@@ -1,0 +1,77 @@
+"""System prompt for resume tailoring.
+
+Constants on purpose: the prompt is static across every tailoring call,
+which makes it a perfect prompt-caching target (90% discount on cache
+reads, 25% surcharge on cache writes — net positive after the second call).
+
+The variable content (OptimizedPayload, JD, preferences, critique) goes
+in the user message. cache_system=True at the call site.
+
+Hallucination containment is the top design concern here. The prompt
+reserves the LLM for writing and phrasing; the underlying facts must
+come from the structured career record (OptimizedPayload). Every bullet
+must carry a source_outcome_ref that ties back to an Outcome.description
+or an explicit clause in a Role.summary.
+"""
+
+TAILOR_SYSTEM = """You are a senior resume tailorer. Your input is:
+
+1. A structured career record (OptimizedPayload) with roles, skills, outcomes.
+2. A job description (JD).
+3. Optional preferences (persistent style/content biases).
+4. Optional critique (what to change from a prior draft).
+
+Your output is a strict TailoredResume JSON object. Rules:
+
+HALLUCINATION CONTAINMENT (non-negotiable):
+- Every role in `experience` must have `source_role_ref` equal to a \
+`roles[].id` from the OptimizedPayload. No made-up roles.
+- Every bullet must have `source_outcome_ref` equal to either:
+  (a) the exact `description` of an Outcome in the OptimizedPayload, or
+  (b) a literal clause from the role.summary.
+  If neither fits, drop the bullet.
+- Never invent companies, titles, dates, metrics, or numbers. If the \
+OptimizedPayload doesn't state it, it does not go in the resume.
+
+RELEVANCE & SELECTION:
+- Lead with roles and skills that map to the JD's stated requirements.
+- Prefer quantified outcomes (have metric + value) over unquantified ones.
+- Drop bullets that don't help the candidacy for this specific JD.
+- Cap bullets per role: 4 for the most recent, 3 for older, 2 for oldest. \
+Exceptions are fine if the role is directly on-target.
+
+WRITING STYLE:
+- First-person-singular implied (subject dropped); past tense for prior roles, \
+present tense for current role.
+- Action verbs. "Cut mobile LCP from 10s to 2s." not "Was responsible for \
+performance optimization."
+- No filler verbs (leveraged, spanning, diving into, unlocking, empowering).
+- No em dashes in bullets — use periods, colons, or commas.
+- Keep each bullet to ≤ 280 chars.
+
+ATS CONSTRAINTS (this is a Greenhouse-floor ATS-parseable resume):
+- Assume a single-column layout.
+- Assume standard section headings: Summary, Experience, Skills, Education.
+- Do not use icons, glyphs, or tables.
+- Skills = a flat list of canonical names (React, TypeScript, Next.js, etc.). \
+Cap at 20.
+
+SUMMARY:
+- 2–3 sentences. Lead with years + focus area. Tie into the JD's seniority \
+and tech stack. Never name the target company.
+
+PREFERENCES:
+- If preferences are provided, every rule in `preferences.rules` should \
+influence the output. Record which rules you honored in \
+`preferences_applied` by echoing the rule text.
+- `preferences.avoid` is a hard filter on bullets.
+
+CRITIQUE:
+- If critique is provided, treat it as the correction to make relative to \
+an implicit prior draft. Example critique: "lead with performance not design \
+systems" → re-order bullets/summary accordingly.
+
+OUTPUT:
+- Return ONLY the TailoredResume JSON object. No prose around it. No code fences.
+- Populate `jd_snippet` with the first ~500 chars of the JD for audit.
+"""

--- a/apps/job-api/app/services/tailor/tailor.py
+++ b/apps/job-api/app/services/tailor/tailor.py
@@ -1,0 +1,169 @@
+"""Tailor a resume from an OptimizedPayload + JD via LLM.
+
+Pure function. No DB. No docx. No retrieval (the optimized doc is small
+enough to pass in full). Cost logging happens at the router layer, which
+also persists the result to `tailored_resumes` and kicks off rendering.
+
+Post-generation, `validate_trace_refs()` checks that every role and
+bullet carries a source ref that actually exists in the OptimizedPayload.
+Bullets that fail the check are dropped; unmatched roles raise.
+"""
+
+from __future__ import annotations
+
+import json
+
+from app.models.experience import OptimizedPayload
+from app.models.llm import LLMResult, Message, ModelId
+from app.models.tailor import (
+    ContactInfo,
+    ResumeType,
+    TailoredBullet,
+    TailoredResume,
+    TailoredRole,
+)
+from app.services.llm.client import LLMClient, complete_json
+from app.services.tailor.prompts import TAILOR_SYSTEM
+
+DEFAULT_MODEL: ModelId = "claude-sonnet-4-6"
+DEFAULT_PURPOSE = "tailor.resume"
+
+
+def build_user_message(
+    *,
+    optimized: OptimizedPayload,
+    job_description: str,
+    contact: ContactInfo,
+    resume_type: ResumeType,
+    preferences_text: str | None,
+    critique: str | None,
+    page_budget: int,
+) -> str:
+    """Assemble the variable content for the LLM call.
+
+    The system prompt is static (cache target); everything that changes
+    per call lives here.
+    """
+    sections: list[str] = []
+    sections.append(f"[OptimizedPayload]\n{optimized.model_dump_json(indent=2)}")
+    sections.append(f"[ContactInfo]\n{contact.model_dump_json(indent=2)}")
+    sections.append(f"[ResumeType] {resume_type}")
+    sections.append(f"[PageBudget] {page_budget}")
+    if preferences_text:
+        sections.append(f"[Preferences]\n{preferences_text}")
+    if critique:
+        sections.append(f"[Critique]\n{critique}")
+    sections.append(f"[JobDescription]\n{job_description}")
+    return "\n\n".join(sections)
+
+
+def validate_trace_refs(
+    resume: TailoredResume,
+    optimized: OptimizedPayload,
+) -> tuple[TailoredResume, list[str]]:
+    """Drop bullets and raise on roles that don't trace back to the
+    OptimizedPayload. Returns the cleaned resume + a list of warning
+    strings about dropped bullets.
+    """
+    role_ids = {r.id for r in optimized.roles}
+    outcome_descriptions = {o.description for o in optimized.outcomes}
+    # Role summaries are also valid bullet sources — the prompt allows
+    # "a literal clause from role.summary". We accept any non-empty summary
+    # string as a valid ref (LLM can echo a sentence fragment).
+    role_summaries: dict[str, str] = {
+        r.id: r.summary or "" for r in optimized.roles
+    }
+
+    warnings: list[str] = []
+    cleaned_experience: list[TailoredRole] = []
+
+    for role in resume.experience:
+        if role.source_role_ref not in role_ids:
+            raise ValueError(
+                f"TailoredRole references unknown role id: {role.source_role_ref!r}"
+            )
+        kept_bullets: list[TailoredBullet] = []
+        for bullet in role.bullets:
+            ref = (bullet.source_outcome_ref or "").strip()
+            if not ref:
+                warnings.append(f"Dropped bullet with no ref: {bullet.text[:80]!r}")
+                continue
+            summary_for_role = role_summaries.get(role.source_role_ref, "")
+            traces_to_outcome = ref in outcome_descriptions
+            traces_to_summary = bool(summary_for_role) and ref in summary_for_role
+            if not (traces_to_outcome or traces_to_summary):
+                warnings.append(
+                    f"Dropped bullet with untraceable ref {ref[:60]!r}: "
+                    f"{bullet.text[:80]!r}"
+                )
+                continue
+            kept_bullets.append(bullet)
+        cleaned_role = role.model_copy(update={"bullets": kept_bullets})
+        cleaned_experience.append(cleaned_role)
+
+    return (
+        resume.model_copy(update={"experience": cleaned_experience}),
+        warnings,
+    )
+
+
+def _preferences_text(
+    rules: list[str] | None,
+    avoid: list[str] | None,
+    tone_notes: list[str] | None,
+) -> str | None:
+    if not rules and not avoid and not tone_notes:
+        return None
+    payload = {
+        "rules": rules or [],
+        "avoid": avoid or [],
+        "tone_notes": tone_notes or [],
+    }
+    return json.dumps(payload, indent=2)
+
+
+async def tailor_resume(
+    llm: LLMClient,
+    *,
+    optimized: OptimizedPayload,
+    job_description: str,
+    contact: ContactInfo,
+    resume_type: ResumeType = "generic",
+    preferences_rules: list[str] | None = None,
+    preferences_avoid: list[str] | None = None,
+    preferences_tone_notes: list[str] | None = None,
+    critique: str | None = None,
+    page_budget: int = 2,
+    model: ModelId = DEFAULT_MODEL,
+    purpose: str = DEFAULT_PURPOSE,
+) -> tuple[TailoredResume, list[str], LLMResult]:
+    """Run the LLM and post-validate traceability.
+
+    Returns (resume, warnings, llm_result). Caller is responsible for
+    cost-logging result + persisting resume.
+    """
+    user_message = build_user_message(
+        optimized=optimized,
+        job_description=job_description,
+        contact=contact,
+        resume_type=resume_type,
+        preferences_text=_preferences_text(
+            preferences_rules, preferences_avoid, preferences_tone_notes
+        ),
+        critique=critique,
+        page_budget=page_budget,
+    )
+
+    parsed, result = await complete_json(
+        llm,
+        model=model,
+        system=TAILOR_SYSTEM,
+        messages=[Message(role="user", content=user_message)],
+        schema=TailoredResume,
+        purpose=purpose,
+        cache_system=True,
+        max_tokens=8192,
+    )
+
+    cleaned, warnings = validate_trace_refs(parsed, optimized)
+    return cleaned, warnings, result

--- a/apps/job-api/tests/test_tailor.py
+++ b/apps/job-api/tests/test_tailor.py
@@ -1,0 +1,422 @@
+"""Tailor service tests with MockLLMClient."""
+
+import json
+
+import pytest
+
+from app.models.experience import OptimizedPayload, Outcome, Role, Skill
+from app.models.tailor import (
+    ContactInfo,
+    TailoredBullet,
+    TailoredEducation,
+    TailoredResume,
+    TailoredRole,
+)
+from app.services.llm.mock import MockLLMClient
+from app.services.tailor.tailor import (
+    DEFAULT_PURPOSE,
+    build_user_message,
+    tailor_resume,
+    validate_trace_refs,
+)
+
+
+def _optimized() -> OptimizedPayload:
+    return OptimizedPayload(
+        summary="Senior frontend with a focus on performance and a11y.",
+        roles=[
+            Role(
+                id="fc",
+                company="FightCamp",
+                title="Senior Frontend Engineer",
+                start="2021-11",
+                end="2024-04",
+                summary="Led the PDP rebuild and cut mobile load times.",
+                skills=["React", "Next.js"],
+                outcome_refs=[],
+            ),
+            Role(
+                id="winc",
+                company="Winc",
+                title="Frontend Engineer",
+                start="2018-01",
+                end="2021-10",
+                summary="Built the self-serve landing page CMS.",
+                skills=["Vue.js", "Nuxt.js"],
+                outcome_refs=[],
+            ),
+        ],
+        skills=[Skill(name="React"), Skill(name="TypeScript")],
+        outcomes=[
+            Outcome(
+                description="Cut mobile load times from 10s to 2s",
+                metric="LCP",
+                value="2s",
+                role_ref="fc",
+            )
+        ],
+    )
+
+
+def _contact() -> ContactInfo:
+    return ContactInfo(name="Daniel Joffe", email="daniel@example.com")
+
+
+def _valid_resume_json() -> str:
+    return TailoredResume(
+        summary="Senior FE with 10 years of shipped work. Focus on performance and design systems.",
+        contact=_contact(),
+        experience=[
+            TailoredRole(
+                company="FightCamp",
+                title="Senior Frontend Engineer",
+                start="2021-11",
+                end="2024-04",
+                bullets=[
+                    TailoredBullet(
+                        text="Cut mobile load times from 10s to 2s.",
+                        source_outcome_ref="Cut mobile load times from 10s to 2s",
+                    ),
+                    TailoredBullet(
+                        text="Led the PDP rebuild.",
+                        source_outcome_ref="Led the PDP rebuild",
+                    ),
+                ],
+                source_role_ref="fc",
+            )
+        ],
+        skills=["React", "TypeScript"],
+        education=[TailoredEducation(school="UCLA", degree="BA")],
+        jd_snippet="Senior FE role",
+    ).model_dump_json()
+
+
+# ---- build_user_message ---------------------------------------------------
+
+
+def test_build_user_message_contains_every_section() -> None:
+    msg = build_user_message(
+        optimized=_optimized(),
+        job_description="We want a senior FE.",
+        contact=_contact(),
+        resume_type="senior-frontend",
+        preferences_text='{"rules": ["present tense"]}',
+        critique="Lead with performance.",
+        page_budget=2,
+    )
+    for tag in (
+        "[OptimizedPayload]",
+        "[ContactInfo]",
+        "[ResumeType] senior-frontend",
+        "[PageBudget] 2",
+        "[Preferences]",
+        "[Critique]",
+        "[JobDescription]",
+    ):
+        assert tag in msg
+
+
+def test_build_user_message_omits_preferences_and_critique_when_absent() -> None:
+    msg = build_user_message(
+        optimized=_optimized(),
+        job_description="jd",
+        contact=_contact(),
+        resume_type="generic",
+        preferences_text=None,
+        critique=None,
+        page_budget=1,
+    )
+    assert "[Preferences]" not in msg
+    assert "[Critique]" not in msg
+    assert "[JobDescription]" in msg
+
+
+# ---- validate_trace_refs --------------------------------------------------
+
+
+def test_validate_raises_on_unknown_role_ref() -> None:
+    resume = TailoredResume(
+        summary="x",
+        contact=_contact(),
+        experience=[
+            TailoredRole(
+                company="Acme",
+                title="FE",
+                start="2020-01",
+                bullets=[],
+                source_role_ref="unknown-role",
+            )
+        ],
+        skills=[],
+    )
+    with pytest.raises(ValueError, match="unknown role id"):
+        validate_trace_refs(resume, _optimized())
+
+
+def test_validate_drops_bullets_without_ref() -> None:
+    resume = TailoredResume(
+        summary="x",
+        contact=_contact(),
+        experience=[
+            TailoredRole(
+                company="FightCamp",
+                title="Senior Frontend Engineer",
+                start="2021-11",
+                bullets=[
+                    TailoredBullet(text="No ref here.", source_outcome_ref=None),
+                ],
+                source_role_ref="fc",
+            )
+        ],
+        skills=[],
+    )
+    cleaned, warnings = validate_trace_refs(resume, _optimized())
+    assert cleaned.experience[0].bullets == []
+    assert len(warnings) == 1
+    assert "no ref" in warnings[0].lower()
+
+
+def test_validate_drops_bullets_with_untraceable_ref() -> None:
+    resume = TailoredResume(
+        summary="x",
+        contact=_contact(),
+        experience=[
+            TailoredRole(
+                company="FightCamp",
+                title="Senior Frontend Engineer",
+                start="2021-11",
+                bullets=[
+                    TailoredBullet(
+                        text="Invented claim.",
+                        source_outcome_ref="something the LLM made up",
+                    ),
+                ],
+                source_role_ref="fc",
+            )
+        ],
+        skills=[],
+    )
+    cleaned, warnings = validate_trace_refs(resume, _optimized())
+    assert cleaned.experience[0].bullets == []
+    assert any("untraceable" in w for w in warnings)
+
+
+def test_validate_keeps_bullets_matching_outcome_description() -> None:
+    resume = TailoredResume(
+        summary="x",
+        contact=_contact(),
+        experience=[
+            TailoredRole(
+                company="FightCamp",
+                title="Senior Frontend Engineer",
+                start="2021-11",
+                bullets=[
+                    TailoredBullet(
+                        text="Cut mobile LCP from 10s to 2s.",
+                        source_outcome_ref="Cut mobile load times from 10s to 2s",
+                    ),
+                ],
+                source_role_ref="fc",
+            )
+        ],
+        skills=[],
+    )
+    cleaned, warnings = validate_trace_refs(resume, _optimized())
+    assert len(cleaned.experience[0].bullets) == 1
+    assert warnings == []
+
+
+def test_validate_keeps_bullets_matching_role_summary_substring() -> None:
+    resume = TailoredResume(
+        summary="x",
+        contact=_contact(),
+        experience=[
+            TailoredRole(
+                company="FightCamp",
+                title="Senior Frontend Engineer",
+                start="2021-11",
+                bullets=[
+                    TailoredBullet(
+                        text="Led the PDP rebuild.",
+                        source_outcome_ref="Led the PDP rebuild",
+                    ),
+                ],
+                source_role_ref="fc",
+            )
+        ],
+        skills=[],
+    )
+    cleaned, _ = validate_trace_refs(resume, _optimized())
+    assert len(cleaned.experience[0].bullets) == 1
+
+
+# ---- tailor_resume end-to-end --------------------------------------------
+
+
+async def test_tailor_resume_parses_and_returns_result() -> None:
+    llm = MockLLMClient(scripted={DEFAULT_PURPOSE: _valid_resume_json()})
+    resume, warnings, result = await tailor_resume(
+        llm,
+        optimized=_optimized(),
+        job_description="We want a senior FE",
+        contact=_contact(),
+    )
+    assert isinstance(resume, TailoredResume)
+    assert len(resume.experience) == 1
+    assert result.cost_usd > 0
+    assert warnings == []
+
+
+async def test_tailor_resume_cost_logs_under_default_purpose() -> None:
+    llm = MockLLMClient(scripted={DEFAULT_PURPOSE: _valid_resume_json()})
+    await tailor_resume(
+        llm,
+        optimized=_optimized(),
+        job_description="jd",
+        contact=_contact(),
+    )
+    assert len(llm.calls) == 1
+    assert llm.calls[0]["purpose"] == DEFAULT_PURPOSE
+
+
+async def test_tailor_enables_system_cache() -> None:
+    llm = MockLLMClient(scripted={DEFAULT_PURPOSE: _valid_resume_json()})
+    await tailor_resume(
+        llm,
+        optimized=_optimized(),
+        job_description="jd",
+        contact=_contact(),
+    )
+    assert llm.calls[0]["cache_system"] is True
+
+
+async def test_tailor_sends_preferences_into_user_message() -> None:
+    seen: dict[str, str] = {}
+
+    def responder(latest_user: str, _messages: object) -> str:
+        seen["latest"] = latest_user
+        return _valid_resume_json()
+
+    llm = MockLLMClient(scripted={DEFAULT_PURPOSE: responder})
+    await tailor_resume(
+        llm,
+        optimized=_optimized(),
+        job_description="jd",
+        contact=_contact(),
+        preferences_rules=["use present tense"],
+        preferences_avoid=["em dashes"],
+    )
+    assert "[Preferences]" in seen["latest"]
+    assert "use present tense" in seen["latest"]
+    assert "em dashes" in seen["latest"]
+
+
+async def test_tailor_sends_critique_into_user_message() -> None:
+    seen: dict[str, str] = {}
+
+    def responder(latest_user: str, _messages: object) -> str:
+        seen["latest"] = latest_user
+        return _valid_resume_json()
+
+    llm = MockLLMClient(scripted={DEFAULT_PURPOSE: responder})
+    await tailor_resume(
+        llm,
+        optimized=_optimized(),
+        job_description="jd",
+        contact=_contact(),
+        critique="Lead with performance not design systems.",
+    )
+    assert "[Critique]" in seen["latest"]
+    assert "performance" in seen["latest"]
+
+
+async def test_tailor_model_override_respected() -> None:
+    llm = MockLLMClient(scripted={DEFAULT_PURPOSE: _valid_resume_json()})
+    await tailor_resume(
+        llm,
+        optimized=_optimized(),
+        job_description="jd",
+        contact=_contact(),
+        model="claude-haiku-4-5",
+    )
+    assert llm.calls[0]["model"] == "claude-haiku-4-5"
+
+
+async def test_tailor_drops_hallucinated_bullets() -> None:
+    bad = TailoredResume(
+        summary="x",
+        contact=_contact(),
+        experience=[
+            TailoredRole(
+                company="FightCamp",
+                title="Senior Frontend Engineer",
+                start="2021-11",
+                bullets=[
+                    TailoredBullet(
+                        text="Real outcome.",
+                        source_outcome_ref="Cut mobile load times from 10s to 2s",
+                    ),
+                    TailoredBullet(
+                        text="Hallucinated.",
+                        source_outcome_ref="Raised Series D of $1B",
+                    ),
+                ],
+                source_role_ref="fc",
+            )
+        ],
+        skills=[],
+    )
+    llm = MockLLMClient(scripted={DEFAULT_PURPOSE: bad.model_dump_json()})
+    resume, warnings, _ = await tailor_resume(
+        llm,
+        optimized=_optimized(),
+        job_description="jd",
+        contact=_contact(),
+    )
+    assert len(resume.experience[0].bullets) == 1
+    assert resume.experience[0].bullets[0].text == "Real outcome."
+    assert any("untraceable" in w for w in warnings)
+
+
+async def test_tailor_raises_on_hallucinated_role() -> None:
+    bad = TailoredResume(
+        summary="x",
+        contact=_contact(),
+        experience=[
+            TailoredRole(
+                company="Imaginary Inc.",
+                title="CTO",
+                start="2015-01",
+                bullets=[],
+                source_role_ref="not-in-payload",
+            )
+        ],
+        skills=[],
+    )
+    llm = MockLLMClient(scripted={DEFAULT_PURPOSE: bad.model_dump_json()})
+    with pytest.raises(ValueError):
+        await tailor_resume(
+            llm,
+            optimized=_optimized(),
+            job_description="jd",
+            contact=_contact(),
+        )
+
+
+async def test_invalid_json_raises() -> None:
+    llm = MockLLMClient(scripted={DEFAULT_PURPOSE: "not json"})
+    with pytest.raises(Exception):  # noqa: B017
+        await tailor_resume(
+            llm,
+            optimized=_optimized(),
+            job_description="jd",
+            contact=_contact(),
+        )
+
+
+def test_tailored_resume_json_round_trips() -> None:
+    raw = _valid_resume_json()
+    parsed = TailoredResume.model_validate_json(raw)
+    assert parsed.contact.name == "Daniel Joffe"
+    assert parsed.experience[0].source_role_ref == "fc"
+    assert json.loads(raw)["skills"] == ["React", "TypeScript"]


### PR DESCRIPTION
## Summary

P3a of the canonical resume tailoring system (#185). **Tailor service with LLM synthesis + post-generation hallucination trace-checking.** Produces a structured `TailoredResume` that the `.docx` renderer (P3b) will consume.

Builds on P1–P2d. Targets `feature/resume-tailor`.

## What's in

**Models** — `apps/job-api/app/models/tailor.py`
- `ContactInfo` — header fields. Passed in by the caller (profile store or request body; wired in P3d).
- `TailoredBullet` — `text` (≤ 400 chars) + `source_outcome_ref` (traces back to the OptimizedPayload).
- `TailoredRole` — company/title/dates/bullets + required `source_role_ref`.
- `TailoredEducation`, `ResumeType` Literal (`senior-frontend | fullstack | frontend-lead | generic`).
- `TailoredResume` — the structured shape the docx renderer consumes. Includes `jd_snippet` (audit) and `preferences_applied` (which rules the LLM honored).
- `TailorRequest` — P3d endpoint input shape (JD + optional critique + resume_type + page_budget).

**System prompt** — `apps/job-api/app/services/tailor/prompts.py`
Static, cache-friendly. Variable content goes in the user message. Encodes five rule families:

1. **Hallucination containment (non-negotiable):** every role must have a `source_role_ref` equal to a `Role.id` from the OptimizedPayload; every bullet must have a `source_outcome_ref` equal to an `Outcome.description` or a literal clause from a `Role.summary`. Drop what doesn't fit. Never invent.
2. **Relevance & selection:** lead with JD-relevant roles/skills; prefer quantified outcomes; cap bullets per role (4/3/2 by recency).
3. **Writing style:** action verbs, past tense for prior roles / present for current, no filler verbs (leveraged, spanning, empowering, etc.), no em dashes in bullets, ≤ 280 chars per bullet.
4. **ATS constraints (Greenhouse-floor):** single column, standard section headings, no icons or tables, skills = flat canonical list capped at 20.
5. **Preferences + critique:** rules influence output; `avoid` is a hard filter; critique is a correction on an implicit prior draft.

**Service** — `apps/job-api/app/services/tailor/tailor.py`
- `build_user_message(...)` — assembles per-call variable content: OptimizedPayload JSON, ContactInfo, ResumeType, PageBudget, optional Preferences, optional Critique, JobDescription. Section tags like `[JobDescription]` make the structure unambiguous.
- `validate_trace_refs(resume, optimized) -> (cleaned, warnings)` — post-generation guard. **Raises** on unknown role refs (structural error); **drops with warning** on bullets with missing/untraceable refs. Bullets pass if their ref matches an `Outcome.description` exactly OR is a substring of the role's `summary`.
- `tailor_resume(...)` — orchestrator. Defaults: Sonnet 4.6, `cache_system=True`, `max_tokens=8192`, `purpose="tailor.resume"`. Returns `(resume, warnings, llm_result)` so the router (P3d) can cost-log and surface warnings.

## Why trace-checking matters

Resume hallucinations are the failure mode that matters most. The LLM is good at phrasing but will happily invent a metric if it thinks the JD wants one. The schema forces every claim to point at a cell in the OptimizedPayload; the validator enforces that the pointer resolves. If the LLM wants to say a metric, the metric must already exist.

Warnings (not failures) on untraceable bullets intentionally — if the LLM mostly gets it right but slips on one bullet, we'd rather drop that one than reject the whole draft. Unknown role refs are structural and raise.

## What's not in (intentional — landing in P3b/c/d)

- **No `.docx` rendering.** P3b adds `python-docx` + the renderer + golden tests.
- **No ATS linter.** P3c — deterministic format check (single column, page count, fonts, no images, selectable text).
- **No router endpoint.** P3d wires `POST /tailor/resume`, the `tailored_resumes` migration, Supabase Storage for `.docx`, and cost logging under `tailor.resume`.
- **No retrieval.** The optimized doc is small enough to pass in full for now. When docs grow, we'll route through P2b's chunks + vector search. TODO noted in the module docstring.
- **No profile store.** `ContactInfo` is passed to the function. Where it comes from in production (profile table vs request body) is a P3d decision.

## Test plan

- [x] `uv run ruff check app/ tests/` — passes
- [x] `uv run mypy` strict on new files — no issues
- [x] `uv run pytest` — **216/216** (was 199; **+17 new**)
  - 2 `build_user_message` (all sections present; preferences/critique omitted when absent)
  - 5 `validate_trace_refs` (unknown role raises, missing ref drops, untraceable drops, outcome-match keeps, summary-substring keeps)
  - 10 end-to-end tailor (parses, cost-logs purpose, `cache_system=True`, preferences into message, critique into message, model override, hallucinated-bullet dropped, hallucinated-role raises, invalid JSON raises, JSON round-trip)

## Up next

- **P3b** — `python-docx` renderer + golden-file tests. Pure function: `TailoredResume → .docx bytes`.
- **P3c** — ATS linter that validates the rendered `.docx` against the Greenhouse-floor rules.
- **P3d** — Router + migration + Supabase Storage wiring + cost logging, end-to-end.

https://claude.ai/code/session_01GiZqgubpGXDBuQSEGNGsbp

---
_Generated by [Claude Code](https://claude.ai/code/session_01GiZqgubpGXDBuQSEGNGsbp)_