### PR TITLE
feat(job-api): deterministic ATS linter over rendered .docx (#185 P3c)

### DIFF
--- a/apps/job-api/app/models/ats_lint.py
+++ b/apps/job-api/app/models/ats_lint.py
@@ -1,0 +1,36 @@
+"""Pydantic models for the ATS linter (#185 P3c).
+
+Deterministic format-check results over a rendered `.docx`. Errors block
+generation; warnings surface to the user but don't fail the pipeline.
+"""
+
+from typing import Literal
+
+from pydantic import BaseModel
+
+Severity = Literal["warning", "error"]
+
+
+class LintViolation(BaseModel):
+    code: str
+    """Stable machine-readable identifier, e.g. 'no_tables'. Use for
+    linking to docs or programmatic responses.
+    """
+
+    message: str
+    severity: Severity
+
+
+class LintResult(BaseModel):
+    ok: bool
+    """True iff no errors (warnings are fine)."""
+
+    violations: list[LintViolation]
+
+    @property
+    def errors(self) -> list[LintViolation]:
+        return [v for v in self.violations if v.severity == "error"]
+
+    @property
+    def warnings(self) -> list[LintViolation]:
+        return [v for v in self.violations if v.severity == "warning"]

--- a/apps/job-api/app/services/ats_lint/__init__.py
+++ b/apps/job-api/app/services/ats_lint/__init__.py
@@ -1,0 +1,13 @@
+"""ATS linter (#185 P3c).
+
+Deterministic format check over the rendered `.docx` bytes. Runs after
+`render_docx` and before the document is persisted or returned to the
+client. Catches regressions if the renderer ever widens its output.
+
+Targets Greenhouse's parser as the floor. See `linter.py` for the rule
+set and `models/ats_lint.py` for the result shape.
+"""
+
+from app.services.ats_lint.linter import lint_docx
+
+__all__ = ["lint_docx"]

--- a/apps/job-api/app/services/ats_lint/linter.py
+++ b/apps/job-api/app/services/ats_lint/linter.py
@@ -1,0 +1,189 @@
+"""Deterministic ATS format linter over rendered `.docx` bytes.
+
+Rules (Greenhouse-floor):
+- valid_docx (error)          — opens as a valid zipped OOXML package
+- no_tables (error)           — `doc.tables` empty
+- no_inline_images (error)    — no `word/media/*` entries in the zip
+- no_text_frames (error)      — no `txbx` in document XML
+- no_shapes (error)           — no `w:drawing` / `w:pict` in document XML
+- experience_heading (error)  — at least one Heading 1 named "Experience"
+- standard_headings (warning) — every Heading 1 in {Summary, Experience, Skills, Education}
+- page_count (warning/error)  — ~paragraph count heuristic: > 80 warn, > 120 error
+
+The renderer module already avoids these failure modes by construction.
+The linter is the safety net — it catches the case where the renderer
+is extended and accidentally reintroduces one.
+"""
+
+from __future__ import annotations
+
+import io
+import zipfile
+
+from docx import Document
+
+from app.models.ats_lint import LintResult, LintViolation
+
+_ALLOWED_HEADING_1_NAMES = {"Summary", "Experience", "Skills", "Education"}
+_PAGE_COUNT_WARN_AT = 80
+_PAGE_COUNT_ERROR_AT = 120
+
+
+def _parse_or_none(data: bytes) -> object | None:
+    try:
+        return Document(io.BytesIO(data))
+    except Exception:
+        return None
+
+
+def _raw_xml_or_empty(doc: object) -> str:
+    try:
+        return str(doc.element.xml)  # type: ignore[attr-defined]
+    except Exception:
+        return ""
+
+
+def _zip_entries(data: bytes) -> list[str]:
+    try:
+        with zipfile.ZipFile(io.BytesIO(data), "r") as zf:
+            return zf.namelist()
+    except zipfile.BadZipFile:
+        return []
+
+
+def _heading_1_texts(doc: object) -> list[str]:
+    out: list[str] = []
+    for para in doc.paragraphs:  # type: ignore[attr-defined]
+        style = getattr(para.style, "name", "") or ""
+        if style == "Heading 1":
+            out.append(para.text)
+    return out
+
+
+def _non_empty_paragraph_count(doc: object) -> int:
+    paragraphs = doc.paragraphs  # type: ignore[attr-defined]
+    return len([p for p in paragraphs if p.text.strip()])
+
+
+def lint_docx(data: bytes) -> LintResult:
+    violations: list[LintViolation] = []
+
+    entries = _zip_entries(data)
+    doc = _parse_or_none(data)
+    if doc is None or not entries:
+        violations.append(
+            LintViolation(
+                code="valid_docx",
+                message="Bytes are not a valid .docx archive.",
+                severity="error",
+            )
+        )
+        return LintResult(ok=False, violations=violations)
+
+    # no_inline_images
+    if any(name.startswith("word/media/") for name in entries):
+        violations.append(
+            LintViolation(
+                code="no_inline_images",
+                message=(
+                    "Document contains inline images (word/media/ entries). "
+                    "ATS parsers routinely drop image content."
+                ),
+                severity="error",
+            )
+        )
+
+    # no_tables
+    if len(doc.tables) > 0:  # type: ignore[attr-defined]
+        violations.append(
+            LintViolation(
+                code="no_tables",
+                message=(
+                    "Document contains tables. Most ATS parsers read tables "
+                    "inconsistently; use single-column paragraph content."
+                ),
+                severity="error",
+            )
+        )
+
+    xml = _raw_xml_or_empty(doc)
+    # no_text_frames
+    if "txbx" in xml:
+        violations.append(
+            LintViolation(
+                code="no_text_frames",
+                message=(
+                    "Document contains text frames (txbx). Text inside frames "
+                    "often does not survive ATS parsing."
+                ),
+                severity="error",
+            )
+        )
+    # no_shapes
+    if "w:drawing" in xml or "w:pict" in xml:
+        violations.append(
+            LintViolation(
+                code="no_shapes",
+                message=(
+                    "Document contains drawings or picture shapes. These are "
+                    "unreadable to ATS parsers."
+                ),
+                severity="error",
+            )
+        )
+
+    headings = _heading_1_texts(doc)
+    # experience_heading
+    if "Experience" not in headings:
+        violations.append(
+            LintViolation(
+                code="experience_heading",
+                message=(
+                    'Missing required Heading 1 "Experience". ATS parsers key '
+                    "off standard section names."
+                ),
+                severity="error",
+            )
+        )
+
+    # standard_headings
+    non_standard = [h for h in headings if h not in _ALLOWED_HEADING_1_NAMES]
+    if non_standard:
+        violations.append(
+            LintViolation(
+                code="standard_headings",
+                message=(
+                    f"Non-standard Heading 1(s): {sorted(set(non_standard))}. "
+                    f"Expected a subset of {sorted(_ALLOWED_HEADING_1_NAMES)}."
+                ),
+                severity="warning",
+            )
+        )
+
+    # page_count
+    paragraph_count = _non_empty_paragraph_count(doc)
+    if paragraph_count > _PAGE_COUNT_ERROR_AT:
+        violations.append(
+            LintViolation(
+                code="page_count",
+                message=(
+                    f"Document has {paragraph_count} non-empty paragraphs; "
+                    f"likely exceeds 3 pages. Tighten content."
+                ),
+                severity="error",
+            )
+        )
+    elif paragraph_count > _PAGE_COUNT_WARN_AT:
+        violations.append(
+            LintViolation(
+                code="page_count",
+                message=(
+                    f"Document has {paragraph_count} non-empty paragraphs; "
+                    f"likely exceeds 2 pages."
+                ),
+                severity="warning",
+            )
+        )
+
+    ok = not any(v.severity == "error" for v in violations)
+    return LintResult(ok=ok, violations=violations)

--- a/apps/job-api/tests/test_ats_lint.py
+++ b/apps/job-api/tests/test_ats_lint.py
@@ -1,0 +1,222 @@
+"""ATS linter tests. Happy path via the real renderer; failure modes
+constructed directly with python-docx to simulate regressions.
+"""
+
+from __future__ import annotations
+
+import io
+import zipfile
+from typing import Any
+
+from docx import Document
+
+from app.models.tailor import (
+    ContactInfo,
+    TailoredBullet,
+    TailoredEducation,
+    TailoredResume,
+    TailoredRole,
+)
+from app.services.ats_lint import lint_docx
+from app.services.docx.renderer import render_docx
+
+
+def _good_resume() -> TailoredResume:
+    return TailoredResume(
+        summary="Senior FE with a decade of shipped work.",
+        contact=ContactInfo(name="Daniel Joffe", email="daniel@example.com"),
+        experience=[
+            TailoredRole(
+                company="FightCamp",
+                title="Senior Frontend Engineer",
+                start="2021-11",
+                end="2024-04",
+                bullets=[
+                    TailoredBullet(
+                        text="Cut mobile load times from 10s to 2s.",
+                        source_outcome_ref="x",
+                    )
+                ],
+                source_role_ref="fc",
+            )
+        ],
+        skills=["React", "TypeScript"],
+        education=[TailoredEducation(school="UCLA")],
+    )
+
+
+def _doc_to_bytes(doc: Any) -> bytes:
+    buf = io.BytesIO()
+    doc.save(buf)
+    return buf.getvalue()
+
+
+def _minimum_valid_doc() -> Any:
+    """A baseline doc with just the required Experience heading so the
+    experience_heading rule passes; other rules stay clean.
+    """
+    doc = Document()
+    doc.add_heading("Experience", level=1)
+    doc.add_paragraph("Role · Company · 2020 - present")
+    return doc
+
+
+def _inject_zip_entry(data: bytes, path: str, contents: bytes) -> bytes:
+    """Append a new entry into a .docx zip. Used to simulate
+    regressions (e.g. stray word/media entries) without forcing
+    python-docx to accept synthetic images.
+    """
+    out = io.BytesIO()
+    with zipfile.ZipFile(io.BytesIO(data), "r") as zin:
+        with zipfile.ZipFile(out, "w", zipfile.ZIP_DEFLATED) as zout:
+            for item in zin.infolist():
+                zout.writestr(item, zin.read(item.filename))
+            zout.writestr(path, contents)
+    return out.getvalue()
+
+
+# ---- Happy path ----------------------------------------------------------
+
+
+def test_good_resume_lints_clean() -> None:
+    result = lint_docx(render_docx(_good_resume()))
+    assert result.ok is True
+    assert result.errors == []
+    assert result.warnings == []
+
+
+# ---- valid_docx -----------------------------------------------------------
+
+
+def test_invalid_bytes_fails_valid_docx() -> None:
+    result = lint_docx(b"not a docx")
+    assert result.ok is False
+    codes = {v.code for v in result.violations}
+    assert "valid_docx" in codes
+
+
+def test_empty_bytes_fails_valid_docx() -> None:
+    result = lint_docx(b"")
+    assert result.ok is False
+
+
+# ---- no_tables -----------------------------------------------------------
+
+
+def test_table_triggers_no_tables_error() -> None:
+    doc = _minimum_valid_doc()
+    doc.add_table(rows=1, cols=2)
+    result = lint_docx(_doc_to_bytes(doc))
+    assert result.ok is False
+    assert any(v.code == "no_tables" for v in result.errors)
+
+
+# ---- no_inline_images ----------------------------------------------------
+
+
+def test_inline_image_triggers_no_inline_images_error() -> None:
+    """Simulate a regression by injecting a word/media/ zip entry
+    directly. This is what `python-docx.add_picture` would produce,
+    without depending on the library accepting synthetic image bytes.
+    """
+    base = _doc_to_bytes(_minimum_valid_doc())
+    with_image = _inject_zip_entry(base, "word/media/image1.png", b"fake-png")
+    result = lint_docx(with_image)
+    assert result.ok is False
+    assert any(v.code == "no_inline_images" for v in result.errors)
+
+
+# ---- experience_heading --------------------------------------------------
+
+
+def test_missing_experience_heading_errors() -> None:
+    doc = Document()
+    doc.add_heading("Summary", level=1)
+    doc.add_paragraph("text")
+    result = lint_docx(_doc_to_bytes(doc))
+    assert result.ok is False
+    codes = {v.code for v in result.errors}
+    assert "experience_heading" in codes
+
+
+# ---- standard_headings ---------------------------------------------------
+
+
+def test_non_standard_heading_is_warning_not_error() -> None:
+    doc = _minimum_valid_doc()
+    doc.add_heading("Hobbies", level=1)
+    result = lint_docx(_doc_to_bytes(doc))
+    assert result.ok is True  # warning, not error
+    codes = {v.code for v in result.warnings}
+    assert "standard_headings" in codes
+
+
+def test_standard_headings_all_allowed_yields_no_warning() -> None:
+    doc = Document()
+    for name in ("Summary", "Experience", "Skills", "Education"):
+        doc.add_heading(name, level=1)
+        doc.add_paragraph("body")
+    result = lint_docx(_doc_to_bytes(doc))
+    assert result.warnings == []
+
+
+# ---- page_count ----------------------------------------------------------
+
+
+def test_short_doc_has_no_page_count_violation() -> None:
+    result = lint_docx(render_docx(_good_resume()))
+    assert not any(v.code == "page_count" for v in result.violations)
+
+
+def test_medium_doc_warns_on_page_count() -> None:
+    doc = _minimum_valid_doc()
+    for i in range(85):
+        doc.add_paragraph(f"filler paragraph {i}")
+    result = lint_docx(_doc_to_bytes(doc))
+    codes = {v.code for v in result.warnings}
+    assert "page_count" in codes
+    assert result.ok is True  # warn, not error
+
+
+def test_large_doc_errors_on_page_count() -> None:
+    doc = _minimum_valid_doc()
+    for i in range(130):
+        doc.add_paragraph(f"filler paragraph {i}")
+    result = lint_docx(_doc_to_bytes(doc))
+    codes = {v.code for v in result.errors}
+    assert "page_count" in codes
+    assert result.ok is False
+
+
+# ---- LintResult shape ----------------------------------------------------
+
+
+def test_result_errors_and_warnings_partition_violations() -> None:
+    doc = _minimum_valid_doc()
+    doc.add_table(rows=1, cols=1)  # error: no_tables
+    doc.add_heading("Hobbies", level=1)  # warning: standard_headings
+    result = lint_docx(_doc_to_bytes(doc))
+    assert len(result.errors) == 1
+    assert len(result.warnings) == 1
+    assert result.errors[0].severity == "error"
+    assert result.warnings[0].severity == "warning"
+    assert len(result.errors) + len(result.warnings) == len(result.violations)
+
+
+def test_ok_flag_mirrors_presence_of_errors() -> None:
+    clean = lint_docx(render_docx(_good_resume()))
+    assert clean.ok is True
+
+    broken = _minimum_valid_doc()
+    broken.add_table(rows=1, cols=1)
+    assert lint_docx(_doc_to_bytes(broken)).ok is False
+
+
+def test_violation_codes_are_stable_machine_ids() -> None:
+    doc = _minimum_valid_doc()
+    doc.add_table(rows=1, cols=1)
+    result = lint_docx(_doc_to_bytes(doc))
+    # Codes are snake_case, lowercase, no spaces.
+    for v in result.violations:
+        assert v.code == v.code.lower()
+        assert " " not in v.code


### PR DESCRIPTION
## Summary

P3c of the canonical resume tailoring system (#185). **Deterministic ATS format validator** over rendered `.docx` bytes. Runs after `render_docx` and before the document is persisted or returned. Errors block generation; warnings surface to the user.

Renderer (P3b) already avoids these failure modes by construction — the linter is the safety net that catches regressions if the renderer is ever extended sloppily. The two are intentionally independent.

Builds on P3b (#489). Targets `feature/resume-tailor`.

## Rules

| Code | Severity | What it catches |
|---|---|---|
| `valid_docx` | error | Bytes aren't a valid zipped OOXML package |
| `no_tables` | error | `doc.tables` non-empty — tables break most ATS parsers |
| `no_inline_images` | error | Any `word/media/*` entry in the zip |
| `no_text_frames` | error | `txbx` in document XML — text inside frames doesn't survive parsing |
| `no_shapes` | error | `w:drawing` or `w:pict` in XML |
| `experience_heading` | error | No Heading 1 named "Experience" — parsers key off standard section names |
| `standard_headings` | warning | Any Heading 1 outside `{Summary, Experience, Skills, Education}` |
| `page_count` | warn / error | Rough heuristic: `> 80` non-empty paragraphs warns (~2 pages), `> 120` errors (~3 pages) |

`LintResult.ok` is true iff no errors. Warnings don't block.

## What's in

**Models** — `apps/job-api/app/models/ats_lint.py`
- `Severity = Literal["warning", "error"]`
- `LintViolation(code, message, severity)` — stable snake_case `code` for programmatic handling
- `LintResult(ok, violations)` + `.errors` / `.warnings` helpers

**Linter** — `apps/job-api/app/services/ats_lint/linter.py`
- `lint_docx(bytes) -> LintResult` — pure function. Tolerant to invalid bytes (returns `valid_docx` error instead of raising).
- Tables / heading / paragraph-count checks via python-docx. Image / zip checks via `zipfile`. XML checks via `doc.element.xml` string matching — cheap and good enough.

## Why split renderer and linter

Renderer and linter enforce **the same rules twice**: once by construction (what the renderer emits), once by validation (what the linter finds). That's the 2026-04-10 "deterministic checks over AI inference" decision in action — the output isn't trusted just because the renderer was careful. If someone extends the renderer with `add_picture()` or a table block, the linter fails loudly.

## Design notes

- **Stable `code` IDs.** `no_tables`, `standard_headings`, etc. — snake_case, lowercase, no spaces. The test suite asserts this so code-handling code stays clean.
- **Warnings ≠ failures.** Non-standard headings (e.g. "Hobbies") warn rather than error — not all non-standard headings actually break Greenhouse. Page count uses a two-tier warn-then-error escalation because resume length is fuzzy.
- **No font check yet.** Calibri is the python-docx default; every rendered doc uses it. Adding a font validator is cheap but would just re-assert what `render_docx` already guarantees — skipped.
- **No `selectable text` check.** python-docx never produces non-selectable text — this is only a concern if the renderer ever uses text frames or images, both of which are already checked.

## What's not in (intentional)

- **No router integration yet.** P3d wires `POST /tailor/resume` to call `render_docx` → `lint_docx` → (if ok) persist + return. If lint fails, return the violations so the caller knows exactly what regressed.
- **No page-count via real layout.** The heuristic is conservative; a proper check would render + measure in headless Word, which is wildly out of scope. The paragraph-count approach has caught layout blowouts in similar tools before.
- **No auto-fix.** Linter reports only. Fixing is the renderer's job.

## Test plan

- [x] `uv run ruff check app/ tests/` — passes
- [x] `uv run mypy` strict on new files — no issues
- [x] `uv run pytest` — **252/252** (was 238; **+14 new**)
  - Happy path: real `render_docx` output lints with zero violations
  - `valid_docx`: invalid bytes, empty bytes
  - `no_tables`: table triggers error
  - `no_inline_images`: zip injection of `word/media/image1.png` triggers error (bypasses python-docx image validation — tests the rule, not the library)
  - `experience_heading`: doc without Experience heading errors
  - `standard_headings`: "Hobbies" is warning not error; all-standard yields no warning
  - `page_count`: short doc clean, 85 paras warn, 130 paras error
  - `LintResult` shape: `ok` mirrors errors; `errors + warnings` count equals `violations`; codes are snake_case

## Up next

- **P3d** — final P3 slice. `POST /tailor/resume` endpoint + `tailored_resumes` Supabase migration + Storage upload + cost logging under `tailor.resume`. Orchestrates tailor → render → lint → persist → return.

https://claude.ai/code/session_01GiZqgubpGXDBuQSEGNGsbp

---
_Generated by [Claude Code](https://claude.ai/code/session_01GiZqgubpGXDBuQSEGNGsbp)_