### PR TITLE
feat(job-api): tailor pipeline router + persistence (#185 P3d)

### DIFF
--- a/apps/job-api/app/main.py
+++ b/apps/job-api/app/main.py
@@ -7,7 +7,7 @@ from starlette.types import Receive, Scope, Send
 
 from app.config import settings
 from app.http_client import close_http_client
-from app.routers import experience, jobs, poll, sources, status
+from app.routers import experience, jobs, poll, sources, status, tailor
 from app.supabase_pool import close_supabase, init_supabase
 
 if not settings.allowed_hosts_list:
@@ -54,6 +54,7 @@ app.include_router(jobs.router)
 app.include_router(poll.router)
 app.include_router(sources.router)
 app.include_router(status.router)
+app.include_router(tailor.router)
 
 
 @app.get("/health")

--- a/apps/job-api/app/models/tailor.py
+++ b/apps/job-api/app/models/tailor.py
@@ -1,15 +1,18 @@
-"""Pydantic models for the tailor layer (#185 P3a).
+"""Pydantic models for the tailor layer.
 
 The LLM produces a TailoredResume — a structured representation the
-`.docx` renderer (P3b) will consume. Every claim made in this structure
-must trace back to something in the OptimizedPayload; source refs are
+`.docx` renderer consumes. Every claim made in this structure must
+trace back to something in the OptimizedPayload; source refs are
 mandatory for bullets and roles so a post-hoc hallucination check can
 verify them.
 """
 
+from datetime import datetime
 from typing import Literal
 
 from pydantic import BaseModel, Field
+
+from app.models.ats_lint import LintViolation
 
 ResumeType = Literal["senior-frontend", "fullstack", "frontend-lead", "generic"]
 
@@ -71,9 +74,46 @@ class TailoredResume(BaseModel):
 
 
 class TailorRequest(BaseModel):
-    """Router input shape (consumed in P3d)."""
+    """Router input shape for POST /tailor/resume."""
 
     job_description: str = Field(min_length=1, max_length=20_000)
+    contact: ContactInfo
     critique: str | None = Field(default=None, max_length=5_000)
     resume_type: ResumeType | None = None
     page_budget: Literal[1, 2] = 2
+    job_posting_id: str | None = None
+    """Optional link to a jobs pipeline row (#184)."""
+
+
+class TailoredResumeRecord(BaseModel):
+    """Read shape for a tailored_resumes row."""
+
+    id: str
+    user_id: str | None
+    job_posting_id: str | None
+    resume_type: str
+    jd_snapshot: str
+    jd_snapshot_hash: str
+    payload: TailoredResume
+    storage_path: str | None
+    warnings: list[str]
+    model: str | None
+    input_tokens: int
+    output_tokens: int
+    cost_usd: float
+    latency_ms: int
+    created_at: datetime
+
+
+class TailorResponse(BaseModel):
+    """Router output for POST /tailor/resume on success."""
+
+    record: TailoredResumeRecord
+    lint_warnings: list[LintViolation] = Field(default_factory=list)
+
+
+class TailorLintFailureResponse(BaseModel):
+    """Router output when the linter finds blocking errors."""
+
+    ok: Literal[False] = False
+    violations: list[LintViolation]

--- a/apps/job-api/app/routers/tailor.py
+++ b/apps/job-api/app/routers/tailor.py
@@ -1,0 +1,127 @@
+"""Tailor router (#185 P3d).
+
+POST /tailor/resume — runs the full pipeline (synthesize -> render ->
+lint -> persist -> upload). Returns the record on success; 422 with
+violations on lint failure.
+GET /tailor/resumes — recent tailorings for the user.
+GET /tailor/resumes/{id} — one record.
+GET /tailor/resumes/{id}/download — serves the `.docx` bytes.
+"""
+
+from fastapi import APIRouter, Depends, HTTPException
+from fastapi.responses import Response
+from supabase import Client
+
+from app.dependencies import (
+    get_llm_client,
+    get_supabase,
+    verify_api_key_or_session,
+)
+from app.models.tailor import (
+    TailoredResumeRecord,
+    TailorLintFailureResponse,
+    TailorRequest,
+    TailorResponse,
+)
+from app.services.experience import optimized, preferences
+from app.services.llm.client import LLMClient
+from app.services.tailor import (
+    PipelineLintFailure,
+    PipelineSuccess,
+    persistence,
+    run_tailor_pipeline,
+)
+
+router = APIRouter(
+    prefix="/tailor",
+    tags=["tailor"],
+    dependencies=[Depends(verify_api_key_or_session)],
+)
+
+
+@router.post("/resume", responses={422: {"model": TailorLintFailureResponse}})
+async def create_tailored_resume(
+    body: TailorRequest,
+    supabase: Client = Depends(get_supabase),
+    llm: LLMClient = Depends(get_llm_client),
+) -> TailorResponse:
+    current_optimized = optimized.get_latest(supabase, user_id=None)
+    if current_optimized is None:
+        raise HTTPException(
+            status_code=404,
+            detail="no optimized doc — derive one via POST /experience/derive first",
+        )
+
+    prefs_row = preferences.get(supabase, user_id=None)
+    prefs_payload = prefs_row.payload if prefs_row else None
+
+    result = await run_tailor_pipeline(
+        supabase,
+        llm,
+        user_id=None,
+        optimized=current_optimized,
+        job_description=body.job_description,
+        contact=body.contact,
+        preferences=prefs_payload,
+        critique=body.critique,
+        resume_type=body.resume_type or "generic",
+        page_budget=body.page_budget,
+        job_posting_id=body.job_posting_id,
+    )
+
+    if isinstance(result, PipelineLintFailure):
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "ok": False,
+                "violations": [v.model_dump() for v in result.lint.violations],
+            },
+        )
+
+    assert isinstance(result, PipelineSuccess)
+    return TailorResponse(
+        record=result.record,
+        lint_warnings=result.lint.warnings,
+    )
+
+
+@router.get("/resumes")
+async def list_tailored_resumes(
+    limit: int = 50,
+    supabase: Client = Depends(get_supabase),
+) -> dict[str, list[TailoredResumeRecord]]:
+    rows = persistence.list_recent(supabase, user_id=None, limit=max(1, min(limit, 200)))
+    return {"resumes": rows}
+
+
+@router.get("/resumes/{resume_id}")
+async def get_tailored_resume(
+    resume_id: str,
+    supabase: Client = Depends(get_supabase),
+) -> TailoredResumeRecord:
+    row = persistence.get(supabase, resume_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail="tailored resume not found")
+    return row
+
+
+@router.get("/resumes/{resume_id}/download")
+async def download_tailored_resume(
+    resume_id: str,
+    supabase: Client = Depends(get_supabase),
+) -> Response:
+    row = persistence.get(supabase, resume_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail="tailored resume not found")
+    if not row.storage_path:
+        raise HTTPException(status_code=404, detail="no .docx persisted for this resume")
+    try:
+        data = persistence.download_docx(supabase, row.storage_path)
+    except Exception as exc:
+        raise HTTPException(status_code=502, detail=f"storage fetch failed: {exc}") from exc
+    filename = f"{row.id}.docx"
+    return Response(
+        content=data,
+        media_type=persistence.DOCX_CONTENT_TYPE,
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )

--- a/apps/job-api/app/services/tailor/__init__.py
+++ b/apps/job-api/app/services/tailor/__init__.py
@@ -1,14 +1,23 @@
-"""Tailor module (#185 P3a).
+"""Tailor module (#185 P3).
 
-LLM-based resume synthesis from an OptimizedPayload + JD. Post-validates
-that every role + bullet traces back to the source career record, so
-hallucinations are caught at generation time rather than in front of an
-employer.
+LLM-based resume synthesis from an OptimizedPayload + JD, with
+post-validation that every role + bullet traces back to the source
+career record. Hallucinations are caught at generation time, not in
+front of an employer.
 
-P3b adds .docx rendering. P3c adds the ATS linter.
-P3d wires this into a POST /tailor/resume endpoint.
+Layout:
+- tailor.py       — LLM synthesis + trace validation (P3a)
+- prompts.py      — TAILOR_SYSTEM (P3a)
+- persistence.py  — tailored_resumes CRUD + Supabase Storage (P3d)
+- pipeline.py     — end-to-end orchestration (P3d)
 """
 
+from app.services.tailor.pipeline import (
+    PipelineLintFailure,
+    PipelineResult,
+    PipelineSuccess,
+    run_tailor_pipeline,
+)
 from app.services.tailor.tailor import (
     DEFAULT_MODEL,
     DEFAULT_PURPOSE,
@@ -20,7 +29,11 @@ from app.services.tailor.tailor import (
 __all__ = [
     "DEFAULT_MODEL",
     "DEFAULT_PURPOSE",
+    "PipelineLintFailure",
+    "PipelineResult",
+    "PipelineSuccess",
     "build_user_message",
+    "run_tailor_pipeline",
     "tailor_resume",
     "validate_trace_refs",
 ]

--- a/apps/job-api/app/services/tailor/persistence.py
+++ b/apps/job-api/app/services/tailor/persistence.py
@@ -1,0 +1,115 @@
+"""Persistence + Supabase Storage for tailored_resumes (#185 P3d).
+
+The pipeline produces a TailoredResume + `.docx` bytes + cost metadata.
+This module handles:
+- uploading the `.docx` to Supabase Storage (bucket: tailored-resumes),
+- inserting the metadata row,
+- reading rows back for listing / download endpoints.
+
+Lint failures do NOT reach this module — the router returns 422 before
+anything gets persisted.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Any, cast
+
+from supabase import Client
+
+from app.models.llm import LLMResult
+from app.models.tailor import TailoredResume, TailoredResumeRecord
+
+TABLE = "tailored_resumes"
+STORAGE_BUCKET = "tailored-resumes"
+DOCX_CONTENT_TYPE = (
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+)
+
+
+def jd_hash(job_description: str) -> str:
+    """Stable hash of the JD text. Lets the dashboard dedupe or link
+    multiple tailorings for the same posting.
+    """
+    return hashlib.sha256(job_description.encode("utf-8")).hexdigest()
+
+
+def _storage_path(user_id: str | None, resume_id: str) -> str:
+    return f"{user_id or 'anon'}/{resume_id}.docx"
+
+
+def upload_docx(
+    supabase: Client,
+    *,
+    user_id: str | None,
+    resume_id: str,
+    docx_bytes: bytes,
+) -> str:
+    """Upload to Supabase Storage. Returns the storage path."""
+    path = _storage_path(user_id, resume_id)
+    supabase.storage.from_(STORAGE_BUCKET).upload(
+        path=path,
+        file=docx_bytes,
+        file_options={"content-type": DOCX_CONTENT_TYPE, "upsert": "true"},
+    )
+    return path
+
+
+def download_docx(supabase: Client, storage_path: str) -> bytes:
+    return supabase.storage.from_(STORAGE_BUCKET).download(storage_path)
+
+
+def persist(
+    supabase: Client,
+    *,
+    user_id: str | None,
+    job_posting_id: str | None,
+    resume: TailoredResume,
+    job_description: str,
+    warnings: list[str],
+    llm_result: LLMResult,
+    storage_path: str | None,
+) -> TailoredResumeRecord:
+    """Insert one tailored_resumes row."""
+    row: dict[str, Any] = {
+        "user_id": user_id,
+        "job_posting_id": job_posting_id,
+        "resume_type": resume.resume_type,
+        "jd_snapshot": job_description,
+        "jd_snapshot_hash": jd_hash(job_description),
+        "payload": resume.model_dump(mode="json"),
+        "storage_path": storage_path,
+        "warnings": warnings,
+        "model": llm_result.model,
+        "input_tokens": llm_result.usage.input_tokens,
+        "output_tokens": llm_result.usage.output_tokens,
+        "cost_usd": llm_result.cost_usd,
+        "latency_ms": llm_result.latency_ms,
+    }
+    resp = supabase.table(TABLE).insert(row).execute()
+    rows = cast(list[dict[str, Any]], resp.data or [])
+    if not rows:
+        raise RuntimeError("Failed to insert tailored_resumes row")
+    return TailoredResumeRecord.model_validate(rows[0])
+
+
+def get(supabase: Client, resume_id: str) -> TailoredResumeRecord | None:
+    resp = (
+        supabase.table(TABLE).select("*").eq("id", resume_id).single().execute()
+    )
+    if not resp.data:
+        return None
+    return TailoredResumeRecord.model_validate(cast(dict[str, Any], resp.data))
+
+
+def list_recent(
+    supabase: Client,
+    *,
+    user_id: str | None,
+    limit: int = 50,
+) -> list[TailoredResumeRecord]:
+    query = supabase.table(TABLE).select("*").order("created_at", desc=True).limit(limit)
+    query = query.is_("user_id", "null") if user_id is None else query.eq("user_id", user_id)
+    resp = query.execute()
+    rows = cast(list[dict[str, Any]], resp.data or [])
+    return [TailoredResumeRecord.model_validate(r) for r in rows]

--- a/apps/job-api/app/services/tailor/pipeline.py
+++ b/apps/job-api/app/services/tailor/pipeline.py
@@ -1,0 +1,143 @@
+"""End-to-end tailor pipeline (#185 P3d).
+
+Glue between the four isolated units:
+  tailor_resume (P3a)  -> render_docx (P3b) -> lint_docx (P3c) -> persist
+
+Splits cleanly between "LLM synthesis" (can fail on hallucination
+trace-check with ValueError) and "format check" (returns LintResult).
+Lint errors short-circuit the pipeline and return without persisting.
+
+The router layer just calls `run_tailor_pipeline(...)` and converts the
+result into an HTTP response.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from supabase import Client
+
+from app.models.ats_lint import LintResult
+from app.models.experience import OptimizedDoc, PreferencesPayload
+from app.models.llm import LLMResult
+from app.models.tailor import (
+    ContactInfo,
+    ResumeType,
+    TailoredResume,
+    TailoredResumeRecord,
+)
+from app.services.ats_lint import lint_docx
+from app.services.docx.renderer import render_docx
+from app.services.llm import cost_log
+from app.services.llm.client import LLMClient
+from app.services.tailor import persistence
+from app.services.tailor.tailor import DEFAULT_PURPOSE, tailor_resume
+
+
+@dataclass
+class PipelineSuccess:
+    record: TailoredResumeRecord
+    resume: TailoredResume
+    warnings: list[str]
+    lint: LintResult
+    llm_result: LLMResult
+
+
+@dataclass
+class PipelineLintFailure:
+    lint: LintResult
+    resume: TailoredResume
+    warnings: list[str]
+    llm_result: LLMResult
+
+
+PipelineResult = PipelineSuccess | PipelineLintFailure
+
+
+async def run_tailor_pipeline(
+    supabase: Client,
+    llm: LLMClient,
+    *,
+    user_id: str | None,
+    optimized: OptimizedDoc,
+    job_description: str,
+    contact: ContactInfo,
+    preferences: PreferencesPayload | None = None,
+    critique: str | None = None,
+    resume_type: ResumeType = "generic",
+    page_budget: int = 2,
+    job_posting_id: str | None = None,
+) -> PipelineResult:
+    """Run the full tailor pipeline end-to-end.
+
+    Returns PipelineSuccess on clean lint, PipelineLintFailure when the
+    rendered doc has blocking errors. On lint failure nothing is
+    persisted and no `.docx` is uploaded — the caller should surface the
+    violations and retry with a critique.
+    """
+    resume, trace_warnings, llm_result = await tailor_resume(
+        llm,
+        optimized=optimized.payload,
+        job_description=job_description,
+        contact=contact,
+        resume_type=resume_type,
+        preferences_rules=(preferences.rules if preferences else None),
+        preferences_avoid=(preferences.avoid if preferences else None),
+        preferences_tone_notes=(preferences.tone_notes if preferences else None),
+        critique=critique,
+        page_budget=page_budget,
+    )
+
+    cost_log.record(
+        supabase,
+        user_id=user_id,
+        purpose=DEFAULT_PURPOSE,
+        result=llm_result,
+        metadata={
+            "optimized_doc_id": optimized.id,
+            "job_posting_id": job_posting_id or "",
+        },
+    )
+
+    docx_bytes = render_docx(resume)
+    lint = lint_docx(docx_bytes)
+    if not lint.ok:
+        return PipelineLintFailure(
+            lint=lint,
+            resume=resume,
+            warnings=trace_warnings,
+            llm_result=llm_result,
+        )
+
+    record = persistence.persist(
+        supabase,
+        user_id=user_id,
+        job_posting_id=job_posting_id,
+        resume=resume,
+        job_description=job_description,
+        warnings=trace_warnings,
+        llm_result=llm_result,
+        storage_path=None,
+    )
+    try:
+        storage_path = persistence.upload_docx(
+            supabase,
+            user_id=user_id,
+            resume_id=record.id,
+            docx_bytes=docx_bytes,
+        )
+    except Exception:
+        storage_path = None
+    if storage_path:
+        supabase.table(persistence.TABLE).update({"storage_path": storage_path}).eq(
+            "id", record.id
+        ).execute()
+        record = record.model_copy(update={"storage_path": storage_path})
+
+    return PipelineSuccess(
+        record=record,
+        resume=resume,
+        warnings=trace_warnings,
+        lint=lint,
+        llm_result=llm_result,
+    )

--- a/apps/job-api/tests/test_tailor_pipeline.py
+++ b/apps/job-api/tests/test_tailor_pipeline.py
@@ -1,0 +1,313 @@
+"""Tailor pipeline end-to-end tests with mocked Supabase + real
+MockLLMClient. Covers success, lint failure, and storage failure paths.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from docx import Document
+
+from app.models.ats_lint import LintResult, LintViolation
+from app.models.experience import (
+    OptimizedDoc,
+    OptimizedPayload,
+    Outcome,
+    PreferencesPayload,
+    Role,
+    Skill,
+)
+from app.models.tailor import (
+    ContactInfo,
+    TailoredBullet,
+    TailoredEducation,
+    TailoredResume,
+    TailoredRole,
+)
+from app.services.llm import cost_log as cost_log_mod
+from app.services.llm.mock import MockLLMClient
+from app.services.tailor.pipeline import (
+    PipelineLintFailure,
+    PipelineSuccess,
+    run_tailor_pipeline,
+)
+from app.services.tailor.tailor import DEFAULT_PURPOSE
+
+
+def _optimized_doc() -> OptimizedDoc:
+    return OptimizedDoc(
+        id="opt-1",
+        user_id=None,
+        prose_doc_id=None,
+        version=1,
+        payload=OptimizedPayload(
+            summary="Senior FE.",
+            roles=[
+                Role(
+                    id="fc",
+                    company="FightCamp",
+                    title="Senior Frontend Engineer",
+                    start="2021-11",
+                    end="2024-04",
+                    summary="Led the PDP rebuild.",
+                    skills=["React"],
+                    outcome_refs=[],
+                )
+            ],
+            skills=[Skill(name="React")],
+            outcomes=[
+                Outcome(
+                    description="Cut mobile load times from 10s to 2s",
+                    metric="LCP",
+                    value="2s",
+                    role_ref="fc",
+                )
+            ],
+        ),
+        markdown_view=None,
+        source="llm",
+        created_at=datetime.now(UTC),
+    )
+
+
+def _contact() -> ContactInfo:
+    return ContactInfo(name="Daniel Joffe", email="daniel@example.com")
+
+
+def _valid_resume_json() -> str:
+    return TailoredResume(
+        summary="Senior FE with a decade of shipped work.",
+        contact=_contact(),
+        experience=[
+            TailoredRole(
+                company="FightCamp",
+                title="Senior Frontend Engineer",
+                start="2021-11",
+                end="2024-04",
+                bullets=[
+                    TailoredBullet(
+                        text="Cut mobile load times from 10s to 2s.",
+                        source_outcome_ref="Cut mobile load times from 10s to 2s",
+                    ),
+                ],
+                source_role_ref="fc",
+            )
+        ],
+        skills=["React"],
+        education=[TailoredEducation(school="UCLA")],
+    ).model_dump_json()
+
+
+def _inserted_record_row(record_id: str = "rec-1") -> dict[str, Any]:
+    """The shape `supabase.table().insert(...).execute().data` returns."""
+    return {
+        "id": record_id,
+        "user_id": None,
+        "job_posting_id": None,
+        "resume_type": "generic",
+        "jd_snapshot": "JD text",
+        "jd_snapshot_hash": "hash",
+        "payload": TailoredResume.model_validate_json(
+            _valid_resume_json()
+        ).model_dump(mode="json"),
+        "storage_path": None,
+        "warnings": [],
+        "model": "claude-sonnet-4-6",
+        "input_tokens": 100,
+        "output_tokens": 50,
+        "cost_usd": 0.001,
+        "latency_ms": 50,
+        "created_at": datetime.now(UTC).isoformat(),
+    }
+
+
+def _make_supabase_mock(*, insert_data: list[dict[str, Any]]) -> MagicMock:
+    supabase = MagicMock()
+    supabase.table.return_value.insert.return_value.execute.return_value.data = (
+        insert_data
+    )
+    supabase.table.return_value.update.return_value.eq.return_value.execute.return_value.data = []
+    supabase.storage.from_.return_value.upload.return_value = None
+    return supabase
+
+
+# ---- Success path ---------------------------------------------------------
+
+
+async def test_success_returns_record_and_persists(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    supabase = _make_supabase_mock(insert_data=[_inserted_record_row()])
+    monkeypatch.setattr(cost_log_mod, "record", MagicMock())
+
+    llm = MockLLMClient(scripted={DEFAULT_PURPOSE: _valid_resume_json()})
+    result = await run_tailor_pipeline(
+        supabase,
+        llm,
+        user_id=None,
+        optimized=_optimized_doc(),
+        job_description="We want a senior FE",
+        contact=_contact(),
+    )
+
+    assert isinstance(result, PipelineSuccess)
+    assert result.record.id == "rec-1"
+    assert result.record.storage_path is not None
+    # upload_docx was called on the storage bucket
+    supabase.storage.from_.assert_any_call("tailored-resumes")
+
+
+async def test_success_cost_logs_under_tailor_purpose(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    supabase = _make_supabase_mock(insert_data=[_inserted_record_row()])
+    cost_record = MagicMock()
+    monkeypatch.setattr(cost_log_mod, "record", cost_record)
+
+    llm = MockLLMClient(scripted={DEFAULT_PURPOSE: _valid_resume_json()})
+    await run_tailor_pipeline(
+        supabase,
+        llm,
+        user_id=None,
+        optimized=_optimized_doc(),
+        job_description="jd",
+        contact=_contact(),
+    )
+    call = cost_record.call_args
+    assert call.kwargs["purpose"] == DEFAULT_PURPOSE
+
+
+async def test_preferences_are_passed_through(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    supabase = _make_supabase_mock(insert_data=[_inserted_record_row()])
+    monkeypatch.setattr(cost_log_mod, "record", MagicMock())
+
+    seen: dict[str, str] = {}
+
+    def responder(latest_user: str, _messages: object) -> str:
+        seen["latest"] = latest_user
+        return _valid_resume_json()
+
+    llm = MockLLMClient(scripted={DEFAULT_PURPOSE: responder})
+    prefs = PreferencesPayload(
+        rules=["lead with performance"],
+        avoid=["em dashes"],
+        tone_notes=["calm confidence"],
+    )
+    await run_tailor_pipeline(
+        supabase,
+        llm,
+        user_id=None,
+        optimized=_optimized_doc(),
+        job_description="jd",
+        contact=_contact(),
+        preferences=prefs,
+    )
+    assert "[Preferences]" in seen["latest"]
+    assert "lead with performance" in seen["latest"]
+    assert "em dashes" in seen["latest"]
+
+
+# ---- Lint failure path ---------------------------------------------------
+
+
+async def test_lint_failure_does_not_persist(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    supabase = _make_supabase_mock(insert_data=[])
+    monkeypatch.setattr(cost_log_mod, "record", MagicMock())
+
+    # Force the linter to report an error.
+    def fake_lint(_b: bytes) -> LintResult:
+        return LintResult(
+            ok=False,
+            violations=[
+                LintViolation(
+                    code="no_tables",
+                    message="simulated lint failure",
+                    severity="error",
+                )
+            ],
+        )
+
+    monkeypatch.setattr("app.services.tailor.pipeline.lint_docx", fake_lint)
+
+    llm = MockLLMClient(scripted={DEFAULT_PURPOSE: _valid_resume_json()})
+    result = await run_tailor_pipeline(
+        supabase,
+        llm,
+        user_id=None,
+        optimized=_optimized_doc(),
+        job_description="jd",
+        contact=_contact(),
+    )
+
+    assert isinstance(result, PipelineLintFailure)
+    assert any(v.code == "no_tables" for v in result.lint.errors)
+    # No insert call for tailored_resumes.
+    supabase.table.return_value.insert.assert_not_called()
+
+
+# ---- Storage failure path (row already persisted, storage_path stays None)
+
+
+async def test_storage_upload_failure_does_not_raise(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    supabase = _make_supabase_mock(insert_data=[_inserted_record_row()])
+    supabase.storage.from_.return_value.upload.side_effect = RuntimeError("s3 down")
+    monkeypatch.setattr(cost_log_mod, "record", MagicMock())
+
+    llm = MockLLMClient(scripted={DEFAULT_PURPOSE: _valid_resume_json()})
+    result = await run_tailor_pipeline(
+        supabase,
+        llm,
+        user_id=None,
+        optimized=_optimized_doc(),
+        job_description="jd",
+        contact=_contact(),
+    )
+    assert isinstance(result, PipelineSuccess)
+    # storage_path remains None when upload raises.
+    assert result.record.storage_path is None
+
+
+# ---- Rendered bytes are a valid .docx -------------------------------------
+
+
+async def test_rendered_output_opens_as_valid_docx(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Sanity check: the pipeline's render_docx output is parseable."""
+    captured: dict[str, bytes] = {}
+
+    from app.services.ats_lint import lint_docx as real_lint
+
+    def capturing_lint(data: bytes) -> LintResult:
+        captured["docx"] = data
+        return real_lint(data)
+
+    supabase = _make_supabase_mock(insert_data=[_inserted_record_row()])
+    monkeypatch.setattr(cost_log_mod, "record", MagicMock())
+    monkeypatch.setattr("app.services.tailor.pipeline.lint_docx", capturing_lint)
+
+    llm = MockLLMClient(scripted={DEFAULT_PURPOSE: _valid_resume_json()})
+    await run_tailor_pipeline(
+        supabase,
+        llm,
+        user_id=None,
+        optimized=_optimized_doc(),
+        job_description="jd",
+        contact=_contact(),
+    )
+
+    import io
+
+    doc = Document(io.BytesIO(captured["docx"]))
+    texts = [p.text for p in doc.paragraphs]
+    assert "Daniel Joffe" in texts[0]
+    assert any("FightCamp" in t for t in texts)

--- a/supabase/migrations/20260423120000_create_tailored_resumes.sql
+++ b/supabase/migrations/20260423120000_create_tailored_resumes.sql
@@ -1,0 +1,39 @@
+-- ============================================
+-- MIGRATION: Create tailored_resumes (#185 P3d)
+-- One row per tailoring attempt. Stores the full TailoredResume payload
+-- (JSONB), the JD snapshot, LLM cost metadata, and a reference to the
+-- `.docx` bytes in Supabase Storage. Failed lints are not persisted.
+-- ============================================
+
+CREATE TABLE IF NOT EXISTS tailored_resumes (
+  id                UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id           UUID,
+  job_posting_id    UUID REFERENCES job_postings(id) ON DELETE SET NULL,
+  resume_type       TEXT NOT NULL,
+  jd_snapshot       TEXT NOT NULL,
+  jd_snapshot_hash  TEXT NOT NULL,
+  payload           JSONB NOT NULL,
+  storage_path      TEXT,
+  warnings          JSONB NOT NULL DEFAULT '[]'::jsonb,
+  model             TEXT,
+  input_tokens      INTEGER DEFAULT 0,
+  output_tokens     INTEGER DEFAULT 0,
+  cost_usd          NUMERIC(10, 6) DEFAULT 0,
+  latency_ms        INTEGER DEFAULT 0,
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_tailored_resumes_job
+  ON tailored_resumes(job_posting_id);
+CREATE INDEX IF NOT EXISTS idx_tailored_resumes_user_created
+  ON tailored_resumes(user_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_tailored_resumes_jd_hash
+  ON tailored_resumes(jd_snapshot_hash);
+
+ALTER TABLE tailored_resumes ENABLE ROW LEVEL SECURITY;
+
+-- Private bucket for generated .docx bytes. Access exclusively via the
+-- service role key used by job-api. No anon policies.
+INSERT INTO storage.buckets (id, name, public)
+VALUES ('tailored-resumes', 'tailored-resumes', FALSE)
+ON CONFLICT (id) DO NOTHING;


### PR DESCRIPTION
## Summary

**P3d — final P3 slice.** `POST /tailor/resume` wires the isolated P3a/P3b/P3c units into a single end-to-end flow. With this merged, `feature/resume-tailor` contains the complete pipeline: **prose → derive → optimized + chunks → tailor → `.docx` → lint → persist → download**. Every LLM/embedding call is cost-logged. Mocks today; real Anthropic + Voyage swap-in is a constructor change.

Builds on P3c (#490). Targets `feature/resume-tailor`.

## Pipeline flow

```
POST /tailor/resume
  body: { job_description, contact, critique?, resume_type?, page_budget?, job_posting_id? }
    ↓
optimized.get_latest()               ← 404 if none
preferences.get()                    ← optional, threaded into LLM
    ↓
tailor_resume(...)                   ← LLM (Sonnet), cache_system=true
  → (resume, trace_warnings, llm_result)
    ↓
cost_log.record(purpose="tailor.resume")
    ↓
render_docx(resume)                  ← .docx bytes
    ↓
lint_docx(bytes)
  → ok?  no  → 422 { violations }  [no persistence, no upload]
     │
     yes
    ↓
persistence.persist(...)              ← tailored_resumes row
    ↓
persistence.upload_docx(...)          ← Supabase Storage bucket:
  → failure swallowed, storage_path stays null; row still persists
    ↓
200 { record, lint_warnings }
```

## What's in

**Migration** — `supabase/migrations/20260423120000_create_tailored_resumes.sql`
- `tailored_resumes` table with JSONB `payload`, JD snapshot + hash, `storage_path`, warnings (hallucination-trace drops), model + tokens + cost + latency.
- Indexed on `(user_id, created_at DESC)`, `(job_posting_id)`, `(jd_snapshot_hash)`.
- RLS enabled (service-role-only).
- `INSERT INTO storage.buckets` creates the private `tailored-resumes` Storage bucket idempotently.

**Models** — `apps/job-api/app/models/tailor.py`
- `TailoredResumeRecord` — read shape.
- `TailorRequest` extended with `contact: ContactInfo` (required), `job_posting_id: str | None` (optional jobs-pipeline link).
- `TailorResponse` (success) + `TailorLintFailureResponse` (422 shape).

**Persistence** — `apps/job-api/app/services/tailor/persistence.py`
- `jd_hash(text)` — stable sha256 hex.
- `upload_docx`, `download_docx` — Supabase Storage via `supabase.storage.from_("tailored-resumes")`.
- `persist`, `get`, `list_recent` — row CRUD.

**Pipeline** — `apps/job-api/app/services/tailor/pipeline.py`
- `run_tailor_pipeline(...) -> PipelineSuccess | PipelineLintFailure` — glue for the four units.
- Lint errors short-circuit **before** persistence or upload — no trash rows.
- Storage upload failures are swallowed: the metadata row survives, `storage_path=None`. Avoids losing cost/audit data for a transient Storage outage.

**Router** — `apps/job-api/app/routers/tailor.py`
- `POST /tailor/resume` — main endpoint; 404 on missing optimized doc, 422 on lint failure.
- `GET /tailor/resumes` — list recent (limit 1-200, default 50).
- `GET /tailor/resumes/{id}` — single record.
- `GET /tailor/resumes/{id}/download` — streams `.docx` bytes from Storage with `Content-Disposition: attachment`.
- All behind `verify_api_key_or_session`.

**Wiring** — `apps/job-api/app/main.py` registers the tailor router.

## What's not in (intentional)

- **No Anthropic SDK, no Voyage SDK.** Mocks still. Every module through the whole P1–P3 chain compiles against Protocols; swapping in real clients is a constructor change at `get_default_client()` in `services/{llm,embeddings}/__init__.py`.
- **No dashboard UI.** P4 lands `apps/root/src/app/tools/jobs/` after #184's jobs list ships.
- **No cover-letter pipeline.** P5 — small additive phase; same renderer + same persistence with `document_type: cover_letter`.

## Design notes

- **Lint failure is a 422**, not a 500 — the caller learns exactly what regressed and can retry with a critique.
- **Storage failure is soft** — the row is the source of truth; Storage is a bytes cache. If the upload fails but the row landed, the caller can hit download later and we'd know to regenerate. For now, download returns 404 when `storage_path` is null.
- **Persistence happens before upload on purpose.** If we uploaded first and row-insert failed, we'd have orphaned bytes. Insert-first lets a failed Storage upload leave a recoverable trail.
- **Cost logging.** `purpose="tailor.resume"` with metadata `{optimized_doc_id, job_posting_id}`. The dashboard's spend-by-purpose view will slice this cleanly.

## Test plan

- [x] `uv run ruff check app/ tests/` — passes
- [x] `uv run mypy` strict on new files — no issues
- [x] `uv run pytest` — **258/258** (was 252; **+6 new**)
  - Success: persists row + calls Storage upload + returns `PipelineSuccess`
  - Cost logs under `tailor.resume`
  - Preferences (rules + avoid + tone notes) flow through to the LLM user message
  - Lint failure does NOT persist, returns `PipelineLintFailure`
  - Storage upload failure leaves `storage_path=None`, row still persisted
  - Rendered bytes open as a valid `.docx` via python-docx parse
- [ ] Apply migration, create the `tailored-resumes` Storage bucket (via SQL), POST a JD, verify row + Storage upload + download endpoint
- [ ] Exercise the 422 path with a deliberately-malformed payload that triggers lint (or mock lint)

## P3 complete

After this merges, `feature/resume-tailor` carries:

| Phase | What | PR |
|---|---|---|
| P1 | Experience foundation (prose, optimized, chunks, preferences, turns) | #481 |
| P2a | Mocked LLM plumbing + cost log | #483 |
| P2b | Mocked embeddings + chunk write path | #484 |
| P2c | Prose → optimized derivation | #485 |
| P2d | Conversation orchestrator + gap tracker | #486 |
| P3a | Tailor service with hallucination trace-check | #488 |
| P3b | ATS-friendly `.docx` renderer | #489 |
| P3c | Deterministic ATS linter | #490 |
| **P3d** | **Tailor pipeline router + persistence** | **this PR** |

**258 tests**, **all green**, **mypy strict clean**.

## Up next

- **P4** — dashboard (`tools/jobs/[id]`, generate buttons, experience editor, chat surface, batch-delete). Waits on #184's jobs list.
- **P5** — cover letters. Additive: same renderer, same persistence, `document_type: cover_letter`.
- Orthogonal: **real Anthropic + Voyage clients** — can land anytime; no consumer changes.

https://claude.ai/code/session_01GiZqgubpGXDBuQSEGNGsbp

---
_Generated by [Claude Code](https://claude.ai/code/session_01GiZqgubpGXDBuQSEGNGsbp)_