### PR TITLE
feat(job-api): real AnthropicLLMClient, env-gated (#185)

### DIFF
--- a/apps/job-api/app/config.py
+++ b/apps/job-api/app/config.py
@@ -1,3 +1,5 @@
+from typing import Literal
+
 from pydantic_settings import BaseSettings
 
 
@@ -9,6 +11,12 @@ class Settings(BaseSettings):
     greenhouse_delay_ms: int = 200
     score_normalizer: int = 30
     allowed_hosts: str = "*"
+
+    # LLM provider — set to "anthropic" to use the real SDK; mock is the safe default.
+    llm_provider: Literal["mock", "anthropic"] = "mock"
+    anthropic_api_key: str = ""
+    anthropic_timeout_seconds: float = 600.0
+    anthropic_max_retries: int = 2
 
     model_config = {"env_file": ".env", "env_file_encoding": "utf-8"}
 

--- a/apps/job-api/app/services/llm/__init__.py
+++ b/apps/job-api/app/services/llm/__init__.py
@@ -1,20 +1,43 @@
 """LLM plumbing module.
 
-Mock-only today. A real Anthropic-backed client is a later phase —
-the Protocol interface makes that swap a single-file addition.
+The `LLMClient` Protocol has two implementations:
+
+- `MockLLMClient` — deterministic fake for tests and local dev.
+- `AnthropicLLMClient` — production, uses the official `anthropic` SDK.
+
+`get_default_client()` picks based on `settings.llm_provider` (env var
+`LLM_PROVIDER=mock|anthropic`). Mock is the default so nothing hits the
+real API unless opted in.
 
 Every consumer (derive, tailor, conversation) tags calls with a `purpose`
 string so cost-log rows can be grouped by feature for spend analysis.
 """
 
+from app.services.llm.anthropic_client import AnthropicLLMClient
 from app.services.llm.client import LLMClient
 from app.services.llm.mock import MockLLMClient
 
-__all__ = ["LLMClient", "MockLLMClient", "get_default_client"]
+__all__ = [
+    "AnthropicLLMClient",
+    "LLMClient",
+    "MockLLMClient",
+    "get_default_client",
+]
 
 
 def get_default_client() -> LLMClient:
-    """Default factory. Returns a MockLLMClient today; will read an
-    LLM_PROVIDER env var when the real Anthropic client lands.
+    """Return the configured LLM client.
+
+    Reads `settings.llm_provider`. `"anthropic"` requires `ANTHROPIC_API_KEY`
+    (via env or `anthropic_api_key` setting); anything else falls back to
+    the mock.
     """
+    from app.config import settings
+
+    if settings.llm_provider == "anthropic":
+        return AnthropicLLMClient(
+            api_key=settings.anthropic_api_key or None,
+            timeout=settings.anthropic_timeout_seconds,
+            max_retries=settings.anthropic_max_retries,
+        )
     return MockLLMClient()

--- a/apps/job-api/app/services/llm/anthropic_client.py
+++ b/apps/job-api/app/services/llm/anthropic_client.py
@@ -1,0 +1,112 @@
+"""Real Anthropic LLM client.
+
+Production implementation of the LLMClient Protocol. Uses the official
+`anthropic` SDK. Swap in via `LLM_PROVIDER=anthropic` env var; mock is
+the default until you explicitly opt in.
+
+Prompt caching note
+-------------------
+`cache_system=True` passes the system prompt as a list with
+`cache_control: {"type": "ephemeral"}`. Anthropic requires a minimum
+cacheable prefix of **4096 tokens for Opus 4.7 / 4.6 / Haiku 4.5** and
+**2048 tokens for Sonnet 4.6**. Below that threshold caching silently
+no-ops (no error, just `cache_creation_input_tokens: 0`). Our current
+system prompts land below 4096 tokens, so caching will activate once
+prompts grow — this is intentional plumbing, not an immediate cost win.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any, cast
+
+from anthropic import AsyncAnthropic
+
+from app.models.llm import LLMResult, LLMUsage, Message, ModelId
+from app.services.llm.pricing import calculate_cost
+
+
+class AnthropicLLMClient:
+    """Implements the LLMClient Protocol. Production-ready."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        timeout: float = 600.0,
+        max_retries: int = 2,
+    ) -> None:
+        self._client = AsyncAnthropic(
+            api_key=api_key,
+            timeout=timeout,
+            max_retries=max_retries,
+        )
+
+    async def complete(
+        self,
+        *,
+        model: ModelId,
+        system: str,
+        messages: list[Message],
+        purpose: str,  # noqa: ARG002 — cost-log grouping label, used by callers not the client
+        max_tokens: int = 4096,
+        cache_system: bool = False,
+    ) -> LLMResult:
+        if not messages:
+            raise ValueError(
+                "AnthropicLLMClient.complete requires at least one message"
+            )
+
+        # System parameter: list form with cache_control when caching is requested;
+        # plain string otherwise. Empty strings become "" (SDK accepts that).
+        system_param: Any
+        if cache_system and system:
+            system_param = [
+                {
+                    "type": "text",
+                    "text": system,
+                    "cache_control": {"type": "ephemeral"},
+                }
+            ]
+        else:
+            system_param = system or ""
+
+        api_messages = [
+            {"role": m.role, "content": m.content} for m in messages
+        ]
+
+        start = time.perf_counter()
+        response = await self._client.messages.create(
+            model=model,
+            max_tokens=max_tokens,
+            system=system_param,
+            messages=cast(Any, api_messages),
+        )
+        latency_ms = int((time.perf_counter() - start) * 1000)
+
+        # Join every text block. Thinking / tool-use blocks are not expected
+        # on this call site (we don't enable thinking, we don't declare tools),
+        # but we defensively filter to type=="text" rather than assuming
+        # response.content[0].
+        text_parts = [b.text for b in response.content if b.type == "text"]
+        content = "".join(text_parts)
+
+        usage = LLMUsage(
+            input_tokens=response.usage.input_tokens,
+            output_tokens=response.usage.output_tokens,
+            cache_read_input_tokens=(
+                getattr(response.usage, "cache_read_input_tokens", 0) or 0
+            ),
+            cache_creation_input_tokens=(
+                getattr(response.usage, "cache_creation_input_tokens", 0) or 0
+            ),
+        )
+        cost = calculate_cost(model, usage)
+
+        return LLMResult(
+            content=content,
+            model=model,
+            usage=usage,
+            cost_usd=cost,
+            latency_ms=latency_ms,
+        )

--- a/apps/job-api/pyproject.toml
+++ b/apps/job-api/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
   "bleach>=6.2",
   "pyjwt>=2.10",
   "python-docx>=1.1",
+  "anthropic>=0.40",
 ]
 
 [dependency-groups]

--- a/apps/job-api/tests/test_llm_anthropic.py
+++ b/apps/job-api/tests/test_llm_anthropic.py
@@ -1,0 +1,235 @@
+"""AnthropicLLMClient tests.
+
+Mock the SDK's `messages.create` at the instance level. Verifies the
+client builds the request correctly (cache_control shape, messages
+passthrough), parses responses into LLMResult (text extraction, usage
+fields including cache tokens), and handles edge cases (empty messages,
+thinking blocks mixed with text).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.models.llm import Message
+from app.services.llm.anthropic_client import AnthropicLLMClient
+
+
+def _fake_response(
+    *,
+    text: str = "hello",
+    input_tokens: int = 100,
+    output_tokens: int = 50,
+    cache_read: int = 0,
+    cache_creation: int = 0,
+    extra_blocks: list[Any] | None = None,
+) -> Any:
+    """Build a mock response object shaped like Anthropic's SDK returns."""
+    text_block = MagicMock()
+    text_block.type = "text"
+    text_block.text = text
+
+    blocks = [text_block] + (extra_blocks or [])
+
+    response = MagicMock()
+    response.content = blocks
+    response.usage.input_tokens = input_tokens
+    response.usage.output_tokens = output_tokens
+    response.usage.cache_read_input_tokens = cache_read
+    response.usage.cache_creation_input_tokens = cache_creation
+    return response
+
+
+def _client_with_mocked_sdk(response: Any) -> tuple[AnthropicLLMClient, AsyncMock]:
+    client = AnthropicLLMClient(api_key="test-key")
+    create_mock = AsyncMock(return_value=response)
+    client._client.messages.create = create_mock  # type: ignore[method-assign]
+    return client, create_mock
+
+
+async def test_complete_returns_parsed_result() -> None:
+    client, _ = _client_with_mocked_sdk(
+        _fake_response(text="response text", input_tokens=120, output_tokens=30)
+    )
+    result = await client.complete(
+        model="claude-haiku-4-5",
+        system="system prompt",
+        messages=[Message(role="user", content="hi")],
+        purpose="test",
+    )
+    assert result.content == "response text"
+    assert result.model == "claude-haiku-4-5"
+    assert result.usage.input_tokens == 120
+    assert result.usage.output_tokens == 30
+
+
+async def test_complete_passes_messages_to_sdk() -> None:
+    client, create_mock = _client_with_mocked_sdk(_fake_response())
+    await client.complete(
+        model="claude-sonnet-4-6",
+        system="sys",
+        messages=[
+            Message(role="user", content="hi"),
+            Message(role="assistant", content="there"),
+            Message(role="user", content="bye"),
+        ],
+        purpose="test",
+    )
+    kwargs = create_mock.call_args.kwargs
+    assert kwargs["model"] == "claude-sonnet-4-6"
+    assert kwargs["messages"] == [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "there"},
+        {"role": "user", "content": "bye"},
+    ]
+
+
+async def test_cache_system_true_uses_list_form_with_cache_control() -> None:
+    client, create_mock = _client_with_mocked_sdk(_fake_response())
+    await client.complete(
+        model="claude-sonnet-4-6",
+        system="cached system",
+        messages=[Message(role="user", content="x")],
+        purpose="test",
+        cache_system=True,
+    )
+    system = create_mock.call_args.kwargs["system"]
+    assert isinstance(system, list)
+    assert len(system) == 1
+    assert system[0]["type"] == "text"
+    assert system[0]["text"] == "cached system"
+    assert system[0]["cache_control"] == {"type": "ephemeral"}
+
+
+async def test_cache_system_false_uses_plain_string() -> None:
+    client, create_mock = _client_with_mocked_sdk(_fake_response())
+    await client.complete(
+        model="claude-sonnet-4-6",
+        system="plain system",
+        messages=[Message(role="user", content="x")],
+        purpose="test",
+        cache_system=False,
+    )
+    assert create_mock.call_args.kwargs["system"] == "plain system"
+
+
+async def test_cache_system_true_but_empty_system_stays_empty_string() -> None:
+    """Don't send an empty list — the SDK accepts "" for no-system."""
+    client, create_mock = _client_with_mocked_sdk(_fake_response())
+    await client.complete(
+        model="claude-haiku-4-5",
+        system="",
+        messages=[Message(role="user", content="x")],
+        purpose="test",
+        cache_system=True,
+    )
+    assert create_mock.call_args.kwargs["system"] == ""
+
+
+async def test_cache_tokens_flow_through() -> None:
+    client, _ = _client_with_mocked_sdk(
+        _fake_response(cache_read=500, cache_creation=1200)
+    )
+    result = await client.complete(
+        model="claude-sonnet-4-6",
+        system="sys",
+        messages=[Message(role="user", content="x")],
+        purpose="test",
+    )
+    assert result.usage.cache_read_input_tokens == 500
+    assert result.usage.cache_creation_input_tokens == 1200
+
+
+async def test_max_tokens_passed_to_sdk() -> None:
+    client, create_mock = _client_with_mocked_sdk(_fake_response())
+    await client.complete(
+        model="claude-sonnet-4-6",
+        system="sys",
+        messages=[Message(role="user", content="x")],
+        purpose="test",
+        max_tokens=8192,
+    )
+    assert create_mock.call_args.kwargs["max_tokens"] == 8192
+
+
+async def test_cost_calculated_from_usage() -> None:
+    client, _ = _client_with_mocked_sdk(
+        _fake_response(input_tokens=1_000_000, output_tokens=0)
+    )
+    result = await client.complete(
+        model="claude-sonnet-4-6",
+        system="sys",
+        messages=[Message(role="user", content="x")],
+        purpose="test",
+    )
+    # Sonnet 4.6 = $3/MTok input, so 1M input tokens = $3.00
+    assert result.cost_usd == pytest.approx(3.0, rel=1e-6)
+
+
+async def test_latency_is_measured() -> None:
+    client, _ = _client_with_mocked_sdk(_fake_response())
+    result = await client.complete(
+        model="claude-haiku-4-5",
+        system="sys",
+        messages=[Message(role="user", content="x")],
+        purpose="test",
+    )
+    assert result.latency_ms >= 0
+
+
+async def test_empty_messages_raises() -> None:
+    client = AnthropicLLMClient(api_key="test-key")
+    with pytest.raises(ValueError, match="at least one message"):
+        await client.complete(
+            model="claude-haiku-4-5",
+            system="sys",
+            messages=[],
+            purpose="test",
+        )
+
+
+async def test_non_text_blocks_are_skipped_in_content() -> None:
+    """Thinking / tool_use blocks shouldn't leak into LLMResult.content."""
+    thinking_block = MagicMock()
+    thinking_block.type = "thinking"
+    thinking_block.thinking = "internal reasoning"
+
+    client, _ = _client_with_mocked_sdk(
+        _fake_response(text="visible text", extra_blocks=[thinking_block])
+    )
+    result = await client.complete(
+        model="claude-opus-4-7",
+        system="sys",
+        messages=[Message(role="user", content="x")],
+        purpose="test",
+    )
+    assert result.content == "visible text"
+    assert "internal reasoning" not in result.content
+
+
+async def test_usage_without_cache_fields_defaults_to_zero() -> None:
+    """Older responses might lack cache fields — don't crash."""
+    response = MagicMock()
+    text_block = MagicMock()
+    text_block.type = "text"
+    text_block.text = "ok"
+    response.content = [text_block]
+    response.usage.input_tokens = 10
+    response.usage.output_tokens = 5
+    response.usage.cache_read_input_tokens = None
+    response.usage.cache_creation_input_tokens = None
+
+    client = AnthropicLLMClient(api_key="test-key")
+    client._client.messages.create = AsyncMock(return_value=response)  # type: ignore[method-assign]
+
+    result = await client.complete(
+        model="claude-haiku-4-5",
+        system="sys",
+        messages=[Message(role="user", content="x")],
+        purpose="test",
+    )
+    assert result.usage.cache_read_input_tokens == 0
+    assert result.usage.cache_creation_input_tokens == 0

--- a/uv.lock
+++ b/uv.lock
@@ -28,6 +28,25 @@ wheels = [
 ]
 
 [[package]]
+name = "anthropic"
+version = "0.97.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "docstring-parser" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/14/93/f66ea8bfe39f2e6bb9da8e27fa5457ad2520e8f7612dfc547b17fad55c4d/anthropic-0.97.0.tar.gz", hash = "sha256:021e79fd8e21e90ad94dc5ba2bbbd8b1599f424f5b1fab6c06204009cab764be", size = 669502, upload-time = "2026-04-23T20:52:34.445Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/53/b6/8e851369fa661ad0fef2ae6266bf3b7d52b78ccf011720058f4adaca59e2/anthropic-0.97.0-py3-none-any.whl", hash = "sha256:8a1a472dfabcfc0c52ff6a3eecf724ac7e07107a2f6e2367be55ceb42f5d5613", size = 662126, upload-time = "2026-04-23T20:52:32.377Z" },
+]
+
+[[package]]
 name = "anyio"
 version = "4.13.0"
 source = { registry = "https://pypi.org/simple" }
@@ -383,6 +402,24 @@ wheels = [
 ]
 
 [[package]]
+name = "distro"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
+name = "docstring-parser"
+version = "0.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341, upload-time = "2026-04-14T04:09:19.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484, upload-time = "2026-04-14T04:09:18.638Z" },
+]
+
+[[package]]
 name = "fastapi"
 version = "0.135.3"
 source = { registry = "https://pypi.org/simple" }
@@ -592,10 +629,101 @@ wheels = [
 ]
 
 [[package]]
+name = "jiter"
+version = "0.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/c1/0cddc6eb17d4c53a99840953f95dd3accdc5cfc7a337b0e9b26476276be9/jiter-0.14.0.tar.gz", hash = "sha256:e8a39e66dac7153cf3f964a12aad515afa8d74938ec5cc0018adcdae5367c79e", size = 165725, upload-time = "2026-04-10T14:28:42.01Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/1f/198ae537fccb7080a0ed655eb56abf64a92f79489dfbf79f40fa34225bcd/jiter-0.14.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:7e791e247b8044512e070bd1f3633dc08350d32776d2d6e7473309d0edf256a2", size = 316896, upload-time = "2026-04-10T14:26:01.986Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/34/da67cff3fce964a36d03c3e365fb0f8726ade2a6cfd4d3c70107e216ead6/jiter-0.14.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:71527ce13fd5a0c4e40ad37331f8c547177dbb2dd0a93e5278b6a5eecf748804", size = 321085, upload-time = "2026-04-10T14:26:03.364Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/36/4c72e67180d4e71a4f5dcf7886d0840e83c49ab11788172177a77570326e/jiter-0.14.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:02c4a7ab56f746014874f2c525584c0daca1dec37f66fd707ecef3b7e5c2228c", size = 347393, upload-time = "2026-04-10T14:26:05.314Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/db/9b39e09ceafa9878235c0fc29e3e3f9b12a4c6a98ea3085b998cadf3accc/jiter-0.14.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:376e9dafff914253bb9d46cdc5f7965607fbe7feb0a491c34e35f92b2770702e", size = 372937, upload-time = "2026-04-10T14:26:06.884Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/96/0dcba1d7a82c1b720774b48ef239376addbaf30df24c34742ac4a57b67b2/jiter-0.14.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:23ad2a7a9da1935575c820428dd8d2490ce4d23189691ce33da1fc0a58e14e1c", size = 463646, upload-time = "2026-04-10T14:26:08.345Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/e3/f61b71543e746e6b8b805e7755814fc242715c16f1dba58e1cbccb8032c2/jiter-0.14.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:54b3ddf5786bc7732d293bba3411ac637ecfa200a39983166d1df86a59a43c9f", size = 380225, upload-time = "2026-04-10T14:26:10.161Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/5e/0ddeb7096aca099114abe36c4921016e8d251e6f35f5890240b31f1f60ae/jiter-0.14.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5c001d5a646c2a50dc055dd526dad5d5245969e8234d2b1131d0451e81f3a373", size = 358682, upload-time = "2026-04-10T14:26:11.574Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/d1/fe0c46cd7fda9cad8f1ff9ad217dc61f1e4280b21052ec6dfe88c1446ef2/jiter-0.14.0-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:834bb5bdabca2e91592a03d373838a8d0a1b8bbde7077ae6913fd2fc51812d00", size = 359973, upload-time = "2026-04-10T14:26:13.316Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/21/f5317f91729b501019184771c80d60abd89907009e7bfa6c7e348c5bdd44/jiter-0.14.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4e9178be60e229b1b2b0710f61b9e24d1f4f8556985a83ff4c4f95920eea7314", size = 397568, upload-time = "2026-04-10T14:26:15.212Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/05/79d8f33fb2bf168db0df5c9cd16fe440a8ada57e929d3677b22712c2568f/jiter-0.14.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:a7e4ccff04ec03614e62c613e976a3a5860dc9714ce8266f44328bdc8b1cab2c", size = 522535, upload-time = "2026-04-10T14:26:16.956Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/00/d1e3ff3d2a465e67f08507d74bafb2dcd29eba91dc939820e39e8dea38b8/jiter-0.14.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:69539d936fb5d55caf6ecd33e2e884de083ff0ea28579780d56c4403094bb8d9", size = 556709, upload-time = "2026-04-10T14:26:18.5Z" },
+    { url = "https://files.pythonhosted.org/packages/60/5b/bbb2189f62ace8d95e869aa4c84c9946616f301e2d02895a6f20dcc3bba3/jiter-0.14.0-cp311-cp311-win32.whl", hash = "sha256:4927d09b3e572787cc5e0a5318601448e1ab9391bcef95677f5840c2d00eaa6d", size = 208660, upload-time = "2026-04-10T14:26:20.511Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/86/c500b53dcbf08575f5963e536ebd757a1f7c568272ba5d180b212c9a87fb/jiter-0.14.0-cp311-cp311-win_amd64.whl", hash = "sha256:42d6ed359ac49eb922fdd565f209c57340aa06d589c84c8413e42a0f9ae1b842", size = 204659, upload-time = "2026-04-10T14:26:22.152Z" },
+    { url = "https://files.pythonhosted.org/packages/75/4a/a676249049d42cb29bef82233e4fe0524d414cbe3606c7a4b311193c2f77/jiter-0.14.0-cp311-cp311-win_arm64.whl", hash = "sha256:6dd689f5f4a5a33747b28686e051095beb214fe28cfda5e9fe58a295a788f593", size = 194772, upload-time = "2026-04-10T14:26:23.458Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/68/7390a418f10897da93b158f2d5a8bd0bcd73a0f9ec3bb36917085bb759ef/jiter-0.14.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:2fb2ce3a7bc331256dfb14cefc34832366bb28a9aca81deaf43bbf2a5659e607", size = 316295, upload-time = "2026-04-10T14:26:24.887Z" },
+    { url = "https://files.pythonhosted.org/packages/60/a0/5854ac00ff63551c52c6c89534ec6aba4b93474e7924d64e860b1c94165b/jiter-0.14.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5252a7ca23785cef5d02d4ece6077a1b556a410c591b379f82091c3001e14844", size = 315898, upload-time = "2026-04-10T14:26:26.601Z" },
+    { url = "https://files.pythonhosted.org/packages/41/a1/4f44832650a16b18e8391f1bf1d6ca4909bc738351826bcc198bba4357f4/jiter-0.14.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c409578cbd77c338975670ada777add4efd53379667edf0aceea730cabede6fb", size = 343730, upload-time = "2026-04-10T14:26:28.326Z" },
+    { url = "https://files.pythonhosted.org/packages/48/64/a329e9d469f86307203594b1707e11ae51c3348d03bfd514a5f997870012/jiter-0.14.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7ede4331a1899d604463369c730dbb961ffdc5312bc7f16c41c2896415b1304a", size = 370102, upload-time = "2026-04-10T14:26:30.089Z" },
+    { url = "https://files.pythonhosted.org/packages/94/c1/5e3dfc59635aa4d4c7bd20a820ac1d09b8ed851568356802cf1c08edb3cf/jiter-0.14.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:92cd8b6025981a041f5310430310b55b25ca593972c16407af8837d3d7d2ca01", size = 461335, upload-time = "2026-04-10T14:26:31.911Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/1b/dd157009dbc058f7b00108f545ccb72a2d56461395c4fc7b9cfdccb00af4/jiter-0.14.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:351bf6eda4e3a7ceb876377840c702e9a3e4ecc4624dbfb2d6463c67ae52637d", size = 378536, upload-time = "2026-04-10T14:26:33.595Z" },
+    { url = "https://files.pythonhosted.org/packages/91/78/256013667b7c10b8834f8e6e54cd3e562d4c6e34227a1596addccc05e38c/jiter-0.14.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c1dcfbeb93d9ecd9ca128bbf8910120367777973fa193fb9a39c31237d8df165", size = 353859, upload-time = "2026-04-10T14:26:35.098Z" },
+    { url = "https://files.pythonhosted.org/packages/de/d9/137d65ade9093a409fe80955ce60b12bb753722c986467aeda47faf450ad/jiter-0.14.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:ae039aaef8de3f8157ecc1fdd4d85043ac4f57538c245a0afaecb8321ec951c3", size = 357626, upload-time = "2026-04-10T14:26:36.685Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/48/76750835b87029342727c1a268bea8878ab988caf81ee4e7b880900eeb5a/jiter-0.14.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7d9d51eb96c82a9652933bd769fe6de66877d6eb2b2440e281f2938c51b5643e", size = 393172, upload-time = "2026-04-10T14:26:38.097Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/60/456c4e81d5c8045279aefe60e9e483be08793828800a4e64add8fdde7f2a/jiter-0.14.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:d824ca4148b705970bf4e120924a212fdfca9859a73e42bd7889a63a4ea6bb98", size = 520300, upload-time = "2026-04-10T14:26:39.532Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/9f/2020e0984c235f678dced38fe4eec3058cf528e6af36ebf969b410305941/jiter-0.14.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:ff3a6465b3a0f54b1a430f45c3c0ba7d61ceb45cbc3e33f9e1a7f638d690baf3", size = 553059, upload-time = "2026-04-10T14:26:40.991Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/32/e2d298e1a22a4bbe6062136d1c7192db7dba003a6975e51d9a9eecabc4c2/jiter-0.14.0-cp312-cp312-win32.whl", hash = "sha256:5dec7c0a3e98d2a3f8a2e67382d0d7c3ac60c69103a4b271da889b4e8bb1e129", size = 206030, upload-time = "2026-04-10T14:26:42.517Z" },
+    { url = "https://files.pythonhosted.org/packages/36/ac/96369141b3d8a4a8e4590e983085efe1c436f35c0cda940dd76d942e3e40/jiter-0.14.0-cp312-cp312-win_amd64.whl", hash = "sha256:fc7e37b4b8bc7e80a63ad6cfa5fc11fab27dbfea4cc4ae644b1ab3f273dc348f", size = 201603, upload-time = "2026-04-10T14:26:44.328Z" },
+    { url = "https://files.pythonhosted.org/packages/01/c3/75d847f264647017d7e3052bbcc8b1e24b95fa139c320c5f5066fa7a0bdd/jiter-0.14.0-cp312-cp312-win_arm64.whl", hash = "sha256:ee4a72f12847ef29b072aee9ad5474041ab2924106bdca9fcf5d7d965853e057", size = 191525, upload-time = "2026-04-10T14:26:46Z" },
+    { url = "https://files.pythonhosted.org/packages/97/2a/09f70020898507a89279659a1afe3364d57fc1b2c89949081975d135f6f5/jiter-0.14.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:af72f204cf4d44258e5b4c1745130ac45ddab0e71a06333b01de660ab4187a94", size = 315502, upload-time = "2026-04-10T14:26:47.697Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/be/080c96a45cd74f9fce5db4fd68510b88087fb37ffe2541ff73c12db92535/jiter-0.14.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4b77da71f6e819be5fbcec11a453fde5b1d0267ef6ed487e2a392fd8e14e4e3a", size = 314870, upload-time = "2026-04-10T14:26:49.149Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/5e/2d0fee155826a968a832cc32438de5e2a193292c8721ca70d0b53e58245b/jiter-0.14.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:77f4ea612fe8b84b8b04e51d0e78029ecf3466348e25973f953de6e6a59aa4c1", size = 343406, upload-time = "2026-04-10T14:26:50.762Z" },
+    { url = "https://files.pythonhosted.org/packages/70/af/bf9ee0d3a4f8dc0d679fc1337f874fe60cdbf841ebbb304b374e1c9aaceb/jiter-0.14.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:62fe2451f8fcc0240261e6a4df18ecbcd58327857e61e625b2393ea3b468aac9", size = 369415, upload-time = "2026-04-10T14:26:52.188Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/83/8e8561eadba31f4d3948a5b712fb0447ec71c3560b57a855449e7b8ddc98/jiter-0.14.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6112f26f5afc75bcb475787d29da3aa92f9d09c7858f632f4be6ffe607be82e9", size = 461456, upload-time = "2026-04-10T14:26:53.611Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/c9/c5299e826a5fe6108d172b344033f61c69b1bb979dd8d9ddd4278a160971/jiter-0.14.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:215a6cb8fb7dc702aa35d475cc00ddc7f970e5c0b1417fb4b4ac5d82fa2a29db", size = 378488, upload-time = "2026-04-10T14:26:55.211Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/37/c16d9d15c0a471b8644b1abe3c82668092a707d9bedcf076f24ff2e380cd/jiter-0.14.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fc4ab96a30fb3cb2c7e0cd33f7616c8860da5f5674438988a54ac717caccdbaa", size = 353242, upload-time = "2026-04-10T14:26:56.705Z" },
+    { url = "https://files.pythonhosted.org/packages/58/ea/8050cb0dc654e728e1bfacbc0c640772f2181af5dedd13ae70145743a439/jiter-0.14.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:3a99c1387b1f2928f799a9de899193484d66206a50e98233b6b088a7f0c1edb2", size = 356823, upload-time = "2026-04-10T14:26:58.281Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/3b/cf71506d270e5f84d97326bf220e47aed9b95e9a4a060758fb07772170ab/jiter-0.14.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ab18d11074485438695f8d34a1b6da61db9754248f96d51341956607a8f39985", size = 392564, upload-time = "2026-04-10T14:27:00.018Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/cc/8c6c74a3efb5bd671bfd14f51e8a73375464ca914b1551bc3b40e26ac2c9/jiter-0.14.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:801028dcfc26ac0895e4964cbc0fd62c73be9fd4a7d7b1aaf6e5790033a719b7", size = 520322, upload-time = "2026-04-10T14:27:01.664Z" },
+    { url = "https://files.pythonhosted.org/packages/41/24/68d7b883ec959884ddf00d019b2e0e82ba81b167e1253684fa90519ce33c/jiter-0.14.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:ad425b087aafb4a1c7e1e98a279200743b9aaf30c3e0ba723aec93f061bd9bc8", size = 552619, upload-time = "2026-04-10T14:27:03.316Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/89/b1a0985223bbf3150ff9e8f46f98fc9360c1de94f48abe271bbe1b465682/jiter-0.14.0-cp313-cp313-win32.whl", hash = "sha256:882bcb9b334318e233950b8be366fe5f92c86b66a7e449e76975dfd6d776a01f", size = 205699, upload-time = "2026-04-10T14:27:04.662Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/19/3f339a5a7f14a11730e67f6be34f9d5105751d547b615ef593fa122a5ded/jiter-0.14.0-cp313-cp313-win_amd64.whl", hash = "sha256:9b8c571a5dba09b98bd3462b5a53f27209a5cbbe85670391692ede71974e979f", size = 201323, upload-time = "2026-04-10T14:27:06.139Z" },
+    { url = "https://files.pythonhosted.org/packages/50/56/752dd89c84be0e022a8ea3720bcfa0a8431db79a962578544812ce061739/jiter-0.14.0-cp313-cp313-win_arm64.whl", hash = "sha256:34f19dcc35cb1abe7c369b3756babf8c7f04595c0807a848df8f26ef8298ef92", size = 191099, upload-time = "2026-04-10T14:27:07.564Z" },
+    { url = "https://files.pythonhosted.org/packages/91/28/292916f354f25a1fe8cf2c918d1415c699a4a659ae00be0430e1c5d9ffea/jiter-0.14.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e89bcd7d426a75bb4952c696b267075790d854a07aad4c9894551a82c5b574ab", size = 320880, upload-time = "2026-04-10T14:27:09.326Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/c7/b002a7d8b8957ac3d469bd59c18ef4b1595a5216ae0de639a287b9816023/jiter-0.14.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7b25beaa0d4447ea8c7ae0c18c688905d34840d7d0b937f2f7bdd52162c98a40", size = 346563, upload-time = "2026-04-10T14:27:11.287Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/3b/f8d07580d8706021d255a6356b8fab13ee4c869412995550ce6ed4ddf97d/jiter-0.14.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:651a8758dd413c51e3b7f6557cdc6921faf70b14106f45f969f091f5cda990ea", size = 357928, upload-time = "2026-04-10T14:27:12.729Z" },
+    { url = "https://files.pythonhosted.org/packages/47/5b/ac1a974da29e35507230383110ffec59998b290a8732585d04e19a9eb5ba/jiter-0.14.0-cp313-cp313t-win_amd64.whl", hash = "sha256:e1a7eead856a5038a8d291f1447176ab0b525c77a279a058121b5fccee257f6f", size = 203519, upload-time = "2026-04-10T14:27:14.125Z" },
+    { url = "https://files.pythonhosted.org/packages/96/6d/9fc8433d667d2454271378a79747d8c76c10b51b482b454e6190e511f244/jiter-0.14.0-cp313-cp313t-win_arm64.whl", hash = "sha256:2e692633a12cda97e352fdcd1c4acc971b1c28707e1e33aeef782b0cbf051975", size = 190113, upload-time = "2026-04-10T14:27:16.638Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/1e/354ed92461b165bd581f9ef5150971a572c873ec3b68a916d5aa91da3cc2/jiter-0.14.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:6f396837fc7577871ca8c12edaf239ed9ccef3bbe39904ae9b8b63ce0a48b140", size = 315277, upload-time = "2026-04-10T14:27:18.109Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/95/8c7c7028aa8636ac21b7a55faef3e34215e6ed0cbf5ae58258427f621aa3/jiter-0.14.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a4d50ea3d8ba4176f79754333bd35f1bbcd28e91adc13eb9b7ca91bc52a6cef9", size = 315923, upload-time = "2026-04-10T14:27:19.603Z" },
+    { url = "https://files.pythonhosted.org/packages/47/40/e2a852a44c4a089f2681a16611b7ce113224a80fd8504c46d78491b47220/jiter-0.14.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce17f8a050447d1b4153bda4fb7d26e6a9e74eb4f4a41913f30934c5075bf615", size = 344943, upload-time = "2026-04-10T14:27:21.262Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/1f/670f92adee1e9895eac41e8a4d623b6da68c4d46249d8b556b60b63f949e/jiter-0.14.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f4f1c4b125e1652aefbc2e2c1617b60a160ab789d180e3d423c41439e5f32850", size = 369725, upload-time = "2026-04-10T14:27:22.766Z" },
+    { url = "https://files.pythonhosted.org/packages/01/2f/541c9ba567d05de1c4874a0f8f8c5e3fd78e2b874266623da9a775cf46e0/jiter-0.14.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:be808176a6a3a14321d18c603f2d40741858a7c4fc982f83232842689fe86dd9", size = 461210, upload-time = "2026-04-10T14:27:24.315Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/a9/c31cbec09627e0d5de7aeaec7690dba03e090caa808fefd8133137cf45bc/jiter-0.14.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:26679d58ba816f88c3849306dd58cb863a90a1cf352cdd4ef67e30ccf8a77994", size = 380002, upload-time = "2026-04-10T14:27:26.155Z" },
+    { url = "https://files.pythonhosted.org/packages/50/02/3c05c1666c41904a2f607475a73e7a4763d1cbde2d18229c4f85b22dc253/jiter-0.14.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:80381f5a19af8fa9aef743f080e34f6b25ebd89656475f8cf0470ec6157052aa", size = 354678, upload-time = "2026-04-10T14:27:27.701Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/97/e15b33545c2b13518f560d695f974b9891b311641bdcf178d63177e8801e/jiter-0.14.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:004df5fdb8ecbd6d99f3227df18ba1a259254c4359736a2e6f036c944e02d7c5", size = 358920, upload-time = "2026-04-10T14:27:29.256Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/d2/8b1461def6b96ba44530df20d07ef7a1c7da22f3f9bf1727e2d611077bf1/jiter-0.14.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:cff5708f7ed0fa098f2b53446c6fa74c48469118e5cd7497b4f1cd569ab06928", size = 394512, upload-time = "2026-04-10T14:27:31.344Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/88/837566dd6ed6e452e8d3205355afd484ce44b2533edfa4ed73a298ea893e/jiter-0.14.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:2492e5f06c36a976d25c7cc347a60e26d5470178d44cde1b9b75e60b4e519f28", size = 521120, upload-time = "2026-04-10T14:27:33.299Z" },
+    { url = "https://files.pythonhosted.org/packages/89/6b/b00b45c4d1b4c031777fe161d620b755b5b02cdade1e316dcb46e4471d63/jiter-0.14.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:7609cfbe3a03d37bfdbf5052012d5a879e72b83168a363deae7b3a26564d57de", size = 553668, upload-time = "2026-04-10T14:27:34.868Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/d8/6fe5b42011d19397433d345716eac16728ac241862a2aac9c91923c7509a/jiter-0.14.0-cp314-cp314-win32.whl", hash = "sha256:7282342d32e357543565286b6450378c3cd402eea333fc1ebe146f1fabb306fc", size = 207001, upload-time = "2026-04-10T14:27:36.455Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/43/5c2e08da1efad5e410f0eaaabeadd954812612c33fbbd8fd5328b489139d/jiter-0.14.0-cp314-cp314-win_amd64.whl", hash = "sha256:bd77945f38866a448e73b0b7637366afa814d4617790ecd88a18ca74377e6c02", size = 202187, upload-time = "2026-04-10T14:27:38Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/1f/6e39ac0b4cdfa23e606af5b245df5f9adaa76f35e0c5096790da430ca506/jiter-0.14.0-cp314-cp314-win_arm64.whl", hash = "sha256:f2d4c61da0821ee42e0cdf5489da60a6d074306313a377c2b35af464955a3611", size = 192257, upload-time = "2026-04-10T14:27:39.504Z" },
+    { url = "https://files.pythonhosted.org/packages/05/57/7dbc0ffbbb5176a27e3518716608aa464aee2e2887dc938f0b900a120449/jiter-0.14.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1bf7ff85517dd2f20a5750081d2b75083c1b269cf75afc7511bdf1f9548beb3b", size = 323441, upload-time = "2026-04-10T14:27:41.039Z" },
+    { url = "https://files.pythonhosted.org/packages/83/6e/7b3314398d8983f06b557aa21b670511ec72d3b79a68ee5e4d9bff972286/jiter-0.14.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c8ef8791c3e78d6c6b157c6d360fbb5c715bebb8113bc6a9303c5caff012754a", size = 348109, upload-time = "2026-04-10T14:27:42.552Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/4f/8dc674bcd7db6dba566de73c08c763c337058baff1dbeb34567045b27cdc/jiter-0.14.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e74663b8b10da1fe0f4e4703fd7980d24ad17174b6bb35d8498d6e3ebce2ae6a", size = 368328, upload-time = "2026-04-10T14:27:44.574Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/5f/188e09a1f20906f98bbdec44ed820e19f4e8eb8aff88b9d1a5a497587ff3/jiter-0.14.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1aca29ba52913f78362ec9c2da62f22cdc4c3083313403f90c15460979b84d9b", size = 463301, upload-time = "2026-04-10T14:27:46.717Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/f0/19046ef965ed8f349e8554775bb12ff4352f443fbe12b95d31f575891256/jiter-0.14.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8b39b7d87a952b79949af5fef44d2544e58c21a28da7f1bae3ef166455c61746", size = 378891, upload-time = "2026-04-10T14:27:48.32Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/c3/da43bd8431ee175695777ee78cf0e93eacbb47393ff493f18c45231b427d/jiter-0.14.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:78d918a68b26e9fab068c2b5453577ef04943ab2807b9a6275df2a812599a310", size = 360749, upload-time = "2026-04-10T14:27:49.88Z" },
+    { url = "https://files.pythonhosted.org/packages/72/26/e054771be889707c6161dbdec9c23d33a9ec70945395d70f07cfea1e9a6f/jiter-0.14.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:b08997c35aee1201c1a5361466a8fb9162d03ae7bf6568df70b6c859f1e654a4", size = 358526, upload-time = "2026-04-10T14:27:51.504Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/0f/7bea65ea2a6d91f2bf989ff11a18136644392bf2b0497a1fa50934c30a9c/jiter-0.14.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:260bf7ca20704d58d41f669e5e9fe7fe2fa72901a6b324e79056f5d52e9c9be2", size = 393926, upload-time = "2026-04-10T14:27:53.368Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a1/b1ff7d70deef61ac0b7c6c2f12d2ace950cdeecb4fdc94500a0926802857/jiter-0.14.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:37826e3df29e60f30a382f9294348d0238ef127f4b5d7f5f8da78b5b9e050560", size = 521052, upload-time = "2026-04-10T14:27:55.058Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/7b/3b0649983cbaf15eda26a414b5b1982e910c67bd6f7b1b490f3cfc76896a/jiter-0.14.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:645be49c46f2900937ba0eaf871ad5183c96858c0af74b6becc7f4e367e36e06", size = 553716, upload-time = "2026-04-10T14:27:57.269Z" },
+    { url = "https://files.pythonhosted.org/packages/97/f8/33d78c83bd93ae0c0af05293a6660f88a1977caef39a6d72a84afab94ce0/jiter-0.14.0-cp314-cp314t-win32.whl", hash = "sha256:2f7877ed45118de283786178eceaf877110abacd04fde31efff3940ae9672674", size = 207957, upload-time = "2026-04-10T14:27:59.285Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/ac/2b760516c03e2227826d1f7025d89bf6bf6357a28fe75c2a2800873c50bf/jiter-0.14.0-cp314-cp314t-win_amd64.whl", hash = "sha256:14c0cb10337c49f5eafe8e7364daca5e29a020ea03580b8f8e6c597fed4e1588", size = 204690, upload-time = "2026-04-10T14:28:00.962Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/2e/a44c20c58aeed0355f2d326969a181696aeb551a25195f47563908a815be/jiter-0.14.0-cp314-cp314t-win_arm64.whl", hash = "sha256:5419d4aa2024961da9fe12a9cfe7484996735dca99e8e090b5c88595ef1951ff", size = 191338, upload-time = "2026-04-10T14:28:02.853Z" },
+    { url = "https://files.pythonhosted.org/packages/32/a1/ef34ca2cab2962598591636a1804b93645821201cc0095d4a93a9a329c9d/jiter-0.14.0-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:a25ffa2dbbdf8721855612f6dca15c108224b12d0c4024d0ac3d7902132b4211", size = 311366, upload-time = "2026-04-10T14:28:27.943Z" },
+    { url = "https://files.pythonhosted.org/packages/60/bb/520576a532a6b8a6f42747afed289c8448c879a34d7802fe2c832d4fd38f/jiter-0.14.0-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:0ac9cbaa86c10996b92bd12c91659b60f939f8e28fcfa6bc11a0e90a774ce95b", size = 309873, upload-time = "2026-04-10T14:28:29.688Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/7c/c16db114ea1f2f532f198aa8dc39585026af45af362c69a0492f31bc4821/jiter-0.14.0-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:844e73b6c56b505e9e169234ea3bdea2ea43f769f847f47ac559ba1d2361ebea", size = 344816, upload-time = "2026-04-10T14:28:31.348Z" },
+    { url = "https://files.pythonhosted.org/packages/99/8f/15e7741ff19e9bcd4d753f7ff22f988fd54592f134ca13701c13ea8c20e0/jiter-0.14.0-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e52c076f187405fc21523c746c04399c9af8ece566077ed147b2126f2bcba577", size = 351445, upload-time = "2026-04-10T14:28:33.093Z" },
+    { url = "https://files.pythonhosted.org/packages/21/42/9042c3f3019de4adcb8c16591c325ec7255beea9fcd33a42a43f3b0b1000/jiter-0.14.0-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:fbd9e482663ca9d005d051330e4d2d8150bb208a209409c10f7e7dfdf7c49da9", size = 308810, upload-time = "2026-04-10T14:28:34.673Z" },
+    { url = "https://files.pythonhosted.org/packages/60/cf/a7e19b308bd86bb04776803b1f01a5f9a287a4c55205f4708827ee487fbf/jiter-0.14.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:33a20d838b91ef376b3a56896d5b04e725c7df5bc4864cc6569cf046a8d73b6d", size = 308443, upload-time = "2026-04-10T14:28:36.658Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/44/e26ede3f0caeff93f222559cb0cc4ca68579f07d009d7b6010c5b586f9b1/jiter-0.14.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:432c4db5255d86a259efde91e55cb4c8d18c0521d844c9e2e7efcce3899fb016", size = 343039, upload-time = "2026-04-10T14:28:38.356Z" },
+    { url = "https://files.pythonhosted.org/packages/da/e9/1f9ada30cef7b05e74bb06f52127e7a724976c225f46adb65c37b1dadfb6/jiter-0.14.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:67f00d94b281174144d6532a04b66a12cb866cbdc47c3af3bfe2973677f9861a", size = 349613, upload-time = "2026-04-10T14:28:40.066Z" },
+]
+
+[[package]]
 name = "job-api"
 version = "0.1.0"
 source = { virtual = "apps/job-api" }
 dependencies = [
+    { name = "anthropic" },
     { name = "beautifulsoup4" },
     { name = "bleach" },
     { name = "fastapi" },
@@ -618,6 +746,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "anthropic", specifier = ">=0.40" },
     { name = "beautifulsoup4", specifier = ">=4.13" },
     { name = "bleach", specifier = ">=6.2" },
     { name = "fastapi", specifier = ">=0.115" },
@@ -1768,6 +1897,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "sniffio"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Drop-in real implementation of the `LLMClient` Protocol using the official `anthropic` SDK. **Mock remains the default**; flip `LLM_PROVIDER=anthropic` to use the real client. No consumer code changes — the Protocol was designed for this, and `get_default_client()` is the only seam that moves.

Targets `feature/resume-tailor`.

## What's in

**Dependency**
- `anthropic>=0.40` added to `apps/job-api/pyproject.toml`. Lockfile regenerated via `uv sync`.

**Config** — `apps/job-api/app/config.py`
- `llm_provider: Literal["mock", "anthropic"] = "mock"` — opt-in explicit.
- `anthropic_api_key: str = ""` — falls back to `ANTHROPIC_API_KEY` env var via the SDK.
- `anthropic_timeout_seconds: float = 600.0` — matches SDK default.
- `anthropic_max_retries: int = 2` — matches SDK default. Both configurable.

**Client** — `apps/job-api/app/services/llm/anthropic_client.py`
- `AnthropicLLMClient` wraps `AsyncAnthropic`.
- **System prompt caching:** `cache_system=True` → system passed as `[{"type": "text", "text": system, "cache_control": {"type": "ephemeral"}}]`. `cache_system=False` → plain string. Empty system stays `""` either way (the SDK accepts that).
- **Response mapping:** `response.content` is a list of content blocks; filters `type == "text"` and joins `.text` — defensive against thinking/tool_use blocks we don't enable today but might later.
- **Usage:** pulls `input_tokens`, `output_tokens`, and the two cache fields (`cache_read_input_tokens`, `cache_creation_input_tokens`), defaulting to 0 if the SDK response omits them.
- **Latency:** `time.perf_counter()` before/after the call.
- **Cost:** calculated via existing `calculate_cost(model, usage)` from the P2a pricing table.

**Factory** — `apps/job-api/app/services/llm/__init__.py`
- `get_default_client()` reads `settings.llm_provider`. `"anthropic"` returns `AnthropicLLMClient`; anything else returns `MockLLMClient`.

## Prompt-caching gotcha (flagged)

Anthropic's minimum cacheable prefix is **4096 tokens for Opus 4.7 / Opus 4.6 / Haiku 4.5** and **2048 tokens for Sonnet 4.6**. Our current system prompts land below those thresholds:

| Prompt | Approx tokens | Cacheable on Sonnet 4.6? | Cacheable on Opus / Haiku? |
|---|---:|:---:|:---:|
| `derive` (experience extraction) | ~500 | ❌ | ❌ |
| `tailor` (resume synthesis) | ~1000 | ❌ | ❌ |
| `conversation` (onboarding / update) | ~800 | ❌ | ❌ |
| `probe` (gap-tracker phrasing) | ~200 | ❌ | ❌ |

So `cache_system=True` at call sites is **intentional plumbing that silently no-ops today**. No error, no cost regression — just deferred benefit until prompts grow. No action needed on this PR; just something to know when reading the system prompts.

## SDK built-ins used rather than reinvented

- **Retries** — SDK's default `max_retries=2` handles 429, 5xx, and connection errors with exponential backoff. No custom retry loop.
- **Timeouts** — SDK's 10-minute default; exposed as a config setting for override.
- **Auth** — Defaults to `ANTHROPIC_API_KEY` env var; explicit override via `anthropic_api_key` setting.
- **Async** — `AsyncAnthropic` used throughout. No sync/async duality.

## Model IDs

`claude-opus-4-7`, `claude-sonnet-4-6`, `claude-haiku-4-5` are **valid API names as-is** — no date suffixes, no aliases needed. The existing `ModelId` Literal in `models/llm.py` passes straight through to the SDK.

## Test plan

- [x] `uv run ruff check app/ tests/` — passes
- [x] `uv run mypy` strict on new files — no issues
- [x] `uv run pytest` — **270/270** (was 258; **+12 new**)
  - Parse response into `LLMResult` (content, model, usage)
  - Messages list passthrough
  - `cache_system=True` → list form with `cache_control`
  - `cache_system=False` → plain string
  - `cache_system=True` + empty system → still `""` (don't emit empty-list)
  - Cache tokens flow through from `response.usage`
  - `max_tokens` passed to SDK
  - Cost calculated via pricing table (1M input tokens on Sonnet 4.6 ≈ $3.00)
  - Latency measured (`≥ 0`)
  - Empty messages raises `ValueError`
  - Non-text blocks (thinking, etc.) filtered out of `content`
  - Missing cache fields default to 0 (SDK version skew safety)
- [ ] Set `ANTHROPIC_API_KEY` + `LLM_PROVIDER=anthropic` on a dev environment, call `POST /experience/derive` end-to-end, confirm the cost-log row has realistic token counts and cost.
- [ ] Same for `POST /tailor/resume`.

## What's not in (intentional)

- **No retry logic beyond the SDK defaults.** The SDK handles 429 + 5xx with backoff. If we need custom policy (rate-limit-aware queueing, circuit breaker) we add it later.
- **No Voyage swap yet.** Same pattern, different PR.
- **No streaming.** Our max_tokens defaults (4096 for conversation/derive, 8192 for tailor) are well under the SDK's ~16K non-streaming ceiling. Adding streaming is a quality-of-life improvement, not a blocker.
- **No prompt length audit / optimization.** Worth doing once real LLM runs surface actual quality issues. Current prompts are deliberate and not speculative.

## Up next

- **Real Voyage embedding client** (same pattern, `voyageai` SDK, env-gate `EMBEDDINGS_PROVIDER=voyage`).
- **P5 — cover letters.**
- **P4 — dashboard.**

https://claude.ai/code/session_01GiZqgubpGXDBuQSEGNGsbp

---
_Generated by [Claude Code](https://claude.ai/code/session_01GiZqgubpGXDBuQSEGNGsbp)_