### PR TITLE
feat(job-api): cover letter pipeline (#185 P5)

### DIFF
--- a/apps/job-api/app/models/tailor.py
+++ b/apps/job-api/app/models/tailor.py
@@ -5,14 +5,22 @@ The LLM produces a TailoredResume — a structured representation the
 trace back to something in the OptimizedPayload; source refs are
 mandatory for bullets and roles so a post-hoc hallucination check can
 verify them.
+
+P5 adds cover letters via the same pipeline. The `document_type`
+discriminator decides which payload shape the LLM produces and which
+renderer is used downstream. Cover letter tracing is aggregate (list
+of referenced outcomes/roles/skills) rather than per-bullet — prose
+doesn't cleanly split into traceable units.
 """
 
 from datetime import datetime
-from typing import Literal
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field
 
 from app.models.ats_lint import LintViolation
+
+DocumentType = Literal["resume", "cover_letter"]
 
 ResumeType = Literal["senior-frontend", "fullstack", "frontend-lead", "generic"]
 
@@ -85,16 +93,79 @@ class TailorRequest(BaseModel):
     """Optional link to a jobs pipeline row (#184)."""
 
 
+# ---------------------------------------------------------------------------
+# Cover letter shapes
+# ---------------------------------------------------------------------------
+
+
+class CoverLetterParagraph(BaseModel):
+    """One paragraph of cover-letter prose."""
+
+    text: str = Field(min_length=1, max_length=1500)
+
+
+class TailoredCoverLetter(BaseModel):
+    """The structured cover letter the docx renderer consumes.
+
+    Tracing is aggregate: the LLM declares which OptimizedPayload items
+    it drew from (outcomes, roles, skills) as lists of refs. Exact
+    per-sentence traceability isn't practical for prose — we validate
+    structurally that the declared refs exist in the source doc.
+    """
+
+    contact: ContactInfo
+    recipient_company: str = Field(min_length=1, max_length=200)
+    recipient_role: str | None = Field(default=None, max_length=200)
+    salutation: str = Field(min_length=1, max_length=200)
+    paragraphs: list[CoverLetterParagraph]
+    closing: str = Field(min_length=1, max_length=100)
+    signature: str = Field(min_length=1, max_length=200)
+
+    jd_snippet: str = Field(default="", max_length=800)
+    preferences_applied: list[str] = Field(default_factory=list)
+
+    source_outcome_refs: list[str] = Field(default_factory=list)
+    """Outcome.description values from the OptimizedPayload this letter drew from."""
+    source_role_refs: list[str] = Field(default_factory=list)
+    """Role.id values from the OptimizedPayload this letter drew from."""
+    source_skill_refs: list[str] = Field(default_factory=list)
+    """Skill.name values from the OptimizedPayload this letter drew from."""
+
+
+class CoverLetterRequest(BaseModel):
+    """Router input shape for POST /tailor/cover-letter."""
+
+    job_description: str = Field(min_length=1, max_length=20_000)
+    company_name: str = Field(min_length=1, max_length=200)
+    role_title: str | None = Field(default=None, max_length=200)
+    contact: ContactInfo
+    critique: str | None = Field(default=None, max_length=5_000)
+    job_posting_id: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Records + responses
+# ---------------------------------------------------------------------------
+
+
 class TailoredResumeRecord(BaseModel):
-    """Read shape for a tailored_resumes row."""
+    """Read shape for a tailored_resumes row.
+
+    `payload` is stored as JSONB; its shape depends on `document_type`:
+    - `"resume"` -> parseable as `TailoredResume`
+    - `"cover_letter"` -> parseable as `TailoredCoverLetter`
+
+    Helpers below do the typed parse at the call site.
+    """
 
     id: str
     user_id: str | None
     job_posting_id: str | None
+    document_type: DocumentType = "resume"
     resume_type: str
     jd_snapshot: str
     jd_snapshot_hash: str
-    payload: TailoredResume
+    payload: dict[str, Any]
     storage_path: str | None
     warnings: list[str]
     model: str | None
@@ -104,9 +175,23 @@ class TailoredResumeRecord(BaseModel):
     latency_ms: int
     created_at: datetime
 
+    def as_resume(self) -> TailoredResume:
+        if self.document_type != "resume":
+            raise ValueError(
+                f"record is document_type={self.document_type!r}, not a resume"
+            )
+        return TailoredResume.model_validate(self.payload)
+
+    def as_cover_letter(self) -> TailoredCoverLetter:
+        if self.document_type != "cover_letter":
+            raise ValueError(
+                f"record is document_type={self.document_type!r}, not a cover letter"
+            )
+        return TailoredCoverLetter.model_validate(self.payload)
+
 
 class TailorResponse(BaseModel):
-    """Router output for POST /tailor/resume on success."""
+    """Router output for POST /tailor/resume and /tailor/cover-letter on success."""
 
     record: TailoredResumeRecord
     lint_warnings: list[LintViolation] = Field(default_factory=list)

--- a/apps/job-api/app/routers/tailor.py
+++ b/apps/job-api/app/routers/tailor.py
@@ -1,11 +1,13 @@
-"""Tailor router (#185 P3d).
+"""Tailor router.
 
-POST /tailor/resume — runs the full pipeline (synthesize -> render ->
-lint -> persist -> upload). Returns the record on success; 422 with
-violations on lint failure.
-GET /tailor/resumes — recent tailorings for the user.
-GET /tailor/resumes/{id} — one record.
-GET /tailor/resumes/{id}/download — serves the `.docx` bytes.
+POST /tailor/resume           — synthesize + render + lint + persist a resume.
+POST /tailor/cover-letter     — same pipeline shape, for cover letters.
+GET  /tailor/resumes          — recent resume tailorings.
+GET  /tailor/cover-letters    — recent cover-letter tailorings.
+GET  /tailor/resumes/{id}     — one record (either type; look up by id).
+GET  /tailor/resumes/{id}/download — serves the `.docx` bytes.
+
+All 422 responses carry the LintFailureResponse shape.
 """
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -18,6 +20,7 @@ from app.dependencies import (
     verify_api_key_or_session,
 )
 from app.models.tailor import (
+    CoverLetterRequest,
     TailoredResumeRecord,
     TailorLintFailureResponse,
     TailorRequest,
@@ -26,9 +29,12 @@ from app.models.tailor import (
 from app.services.experience import optimized, preferences
 from app.services.llm.client import LLMClient
 from app.services.tailor import (
+    CoverLetterPipelineLintFailure,
+    CoverLetterPipelineSuccess,
     PipelineLintFailure,
     PipelineSuccess,
     persistence,
+    run_cover_letter_pipeline,
     run_tailor_pipeline,
 )
 
@@ -85,13 +91,81 @@ async def create_tailored_resume(
     )
 
 
+@router.post(
+    "/cover-letter",
+    responses={422: {"model": TailorLintFailureResponse}},
+)
+async def create_tailored_cover_letter(
+    body: CoverLetterRequest,
+    supabase: Client = Depends(get_supabase),
+    llm: LLMClient = Depends(get_llm_client),
+) -> TailorResponse:
+    current_optimized = optimized.get_latest(supabase, user_id=None)
+    if current_optimized is None:
+        raise HTTPException(
+            status_code=404,
+            detail="no optimized doc — derive one via POST /experience/derive first",
+        )
+
+    prefs_row = preferences.get(supabase, user_id=None)
+    prefs_payload = prefs_row.payload if prefs_row else None
+
+    result = await run_cover_letter_pipeline(
+        supabase,
+        llm,
+        user_id=None,
+        optimized=current_optimized,
+        job_description=body.job_description,
+        company_name=body.company_name,
+        contact=body.contact,
+        role_title=body.role_title,
+        preferences=prefs_payload,
+        critique=body.critique,
+        job_posting_id=body.job_posting_id,
+    )
+
+    if isinstance(result, CoverLetterPipelineLintFailure):
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "ok": False,
+                "violations": [v.model_dump() for v in result.lint.violations],
+            },
+        )
+
+    assert isinstance(result, CoverLetterPipelineSuccess)
+    return TailorResponse(
+        record=result.record,
+        lint_warnings=result.lint.warnings,
+    )
+
+
 @router.get("/resumes")
 async def list_tailored_resumes(
     limit: int = 50,
     supabase: Client = Depends(get_supabase),
 ) -> dict[str, list[TailoredResumeRecord]]:
-    rows = persistence.list_recent(supabase, user_id=None, limit=max(1, min(limit, 200)))
+    rows = persistence.list_recent(
+        supabase,
+        user_id=None,
+        limit=max(1, min(limit, 200)),
+        document_type="resume",
+    )
     return {"resumes": rows}
+
+
+@router.get("/cover-letters")
+async def list_tailored_cover_letters(
+    limit: int = 50,
+    supabase: Client = Depends(get_supabase),
+) -> dict[str, list[TailoredResumeRecord]]:
+    rows = persistence.list_recent(
+        supabase,
+        user_id=None,
+        limit=max(1, min(limit, 200)),
+        document_type="cover_letter",
+    )
+    return {"cover_letters": rows}
 
 
 @router.get("/resumes/{resume_id}")

--- a/apps/job-api/app/services/ats_lint/linter.py
+++ b/apps/job-api/app/services/ats_lint/linter.py
@@ -7,8 +7,14 @@ Rules (Greenhouse-floor):
 - no_text_frames (error)      — no `txbx` in document XML
 - no_shapes (error)           — no `w:drawing` / `w:pict` in document XML
 - experience_heading (error)  — at least one Heading 1 named "Experience"
+                                (resume only — skipped for cover letters)
 - standard_headings (warning) — every Heading 1 in {Summary, Experience, Skills, Education}
+                                (resume only — skipped for cover letters)
 - page_count (warning/error)  — ~paragraph count heuristic: > 80 warn, > 120 error
+
+Document type matters for the heading rules: cover letters don't use
+Heading 1 at all, so enforcing "Experience" would fail every cover
+letter. Pass `document_type="cover_letter"` to skip the heading rules.
 
 The renderer module already avoids these failure modes by construction.
 The linter is the safety net — it catches the case where the renderer
@@ -19,6 +25,7 @@ from __future__ import annotations
 
 import io
 import zipfile
+from typing import Literal
 
 from docx import Document
 
@@ -65,7 +72,11 @@ def _non_empty_paragraph_count(doc: object) -> int:
     return len([p for p in paragraphs if p.text.strip()])
 
 
-def lint_docx(data: bytes) -> LintResult:
+def lint_docx(
+    data: bytes,
+    *,
+    document_type: Literal["resume", "cover_letter"] = "resume",
+) -> LintResult:
     violations: list[LintViolation] = []
 
     entries = _zip_entries(data)
@@ -132,33 +143,35 @@ def lint_docx(data: bytes) -> LintResult:
             )
         )
 
-    headings = _heading_1_texts(doc)
-    # experience_heading
-    if "Experience" not in headings:
-        violations.append(
-            LintViolation(
-                code="experience_heading",
-                message=(
-                    'Missing required Heading 1 "Experience". ATS parsers key '
-                    "off standard section names."
-                ),
-                severity="error",
+    # Heading rules are resume-only. Cover letters are prose — they
+    # intentionally have no Heading 1, so enforcing Experience would
+    # false-positive on every letter.
+    if document_type == "resume":
+        headings = _heading_1_texts(doc)
+        if "Experience" not in headings:
+            violations.append(
+                LintViolation(
+                    code="experience_heading",
+                    message=(
+                        'Missing required Heading 1 "Experience". ATS parsers key '
+                        "off standard section names."
+                    ),
+                    severity="error",
+                )
             )
-        )
 
-    # standard_headings
-    non_standard = [h for h in headings if h not in _ALLOWED_HEADING_1_NAMES]
-    if non_standard:
-        violations.append(
-            LintViolation(
-                code="standard_headings",
-                message=(
-                    f"Non-standard Heading 1(s): {sorted(set(non_standard))}. "
-                    f"Expected a subset of {sorted(_ALLOWED_HEADING_1_NAMES)}."
-                ),
-                severity="warning",
+        non_standard = [h for h in headings if h not in _ALLOWED_HEADING_1_NAMES]
+        if non_standard:
+            violations.append(
+                LintViolation(
+                    code="standard_headings",
+                    message=(
+                        f"Non-standard Heading 1(s): {sorted(set(non_standard))}. "
+                        f"Expected a subset of {sorted(_ALLOWED_HEADING_1_NAMES)}."
+                    ),
+                    severity="warning",
+                )
             )
-        )
 
     # page_count
     paragraph_count = _non_empty_paragraph_count(doc)

--- a/apps/job-api/app/services/docx/__init__.py
+++ b/apps/job-api/app/services/docx/__init__.py
@@ -9,6 +9,10 @@ enforced here. Rendering and linting are kept separate so the linter
 can catch regressions if this module ever widens its output.
 """
 
-from app.services.docx.renderer import format_date, render_docx
+from app.services.docx.renderer import (
+    format_date,
+    render_cover_letter_docx,
+    render_docx,
+)
 
-__all__ = ["render_docx", "format_date"]
+__all__ = ["format_date", "render_cover_letter_docx", "render_docx"]

--- a/apps/job-api/app/services/docx/renderer.py
+++ b/apps/job-api/app/services/docx/renderer.py
@@ -18,7 +18,12 @@ import io
 
 from docx import Document
 
-from app.models.tailor import ContactInfo, TailoredResume, TailoredRole
+from app.models.tailor import (
+    ContactInfo,
+    TailoredCoverLetter,
+    TailoredResume,
+    TailoredRole,
+)
 
 SECTION_SUMMARY = "Summary"
 SECTION_EXPERIENCE = "Experience"
@@ -123,6 +128,55 @@ def render_docx(resume: TailoredResume) -> bytes:
             header_p.add_run(header).bold = True
             if edu.dates:
                 doc.add_paragraph(edu.dates)
+
+    buf = io.BytesIO()
+    doc.save(buf)
+    return buf.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# Cover letter renderer
+# ---------------------------------------------------------------------------
+
+
+def render_cover_letter_docx(letter: TailoredCoverLetter) -> bytes:
+    """Render a TailoredCoverLetter to ATS-friendly `.docx` bytes.
+
+    Simpler structure than a resume: contact header, recipient, salutation,
+    paragraphs, closing, signature. Single column, Calibri, plain paragraphs.
+    No headings (cover letters don't use them).
+    """
+    doc = Document()
+
+    # Contact header: name + contact line
+    title = doc.add_paragraph()
+    name_run = title.add_run(letter.contact.name)
+    name_run.bold = True
+    contact_line = _contact_line(letter.contact)
+    if contact_line:
+        doc.add_paragraph(contact_line)
+
+    doc.add_paragraph()  # blank line before recipient
+
+    # Recipient block
+    recipient = letter.recipient_company
+    if letter.recipient_role:
+        doc.add_paragraph(f"Re: {letter.recipient_role}")
+    doc.add_paragraph(recipient)
+
+    doc.add_paragraph()  # blank line before salutation
+
+    # Salutation
+    doc.add_paragraph(letter.salutation)
+
+    # Body paragraphs
+    for paragraph in letter.paragraphs:
+        doc.add_paragraph(paragraph.text)
+
+    # Closing
+    doc.add_paragraph()
+    doc.add_paragraph(letter.closing)
+    doc.add_paragraph(letter.signature)
 
     buf = io.BytesIO()
     doc.save(buf)

--- a/apps/job-api/app/services/tailor/__init__.py
+++ b/apps/job-api/app/services/tailor/__init__.py
@@ -13,27 +13,43 @@ Layout:
 """
 
 from app.services.tailor.pipeline import (
+    CoverLetterPipelineLintFailure,
+    CoverLetterPipelineResult,
+    CoverLetterPipelineSuccess,
     PipelineLintFailure,
     PipelineResult,
     PipelineSuccess,
+    run_cover_letter_pipeline,
     run_tailor_pipeline,
 )
 from app.services.tailor.tailor import (
+    DEFAULT_COVER_LETTER_PURPOSE,
     DEFAULT_MODEL,
     DEFAULT_PURPOSE,
+    build_cover_letter_user_message,
     build_user_message,
+    tailor_cover_letter,
     tailor_resume,
+    validate_cover_letter_refs,
     validate_trace_refs,
 )
 
 __all__ = [
+    "CoverLetterPipelineLintFailure",
+    "CoverLetterPipelineResult",
+    "CoverLetterPipelineSuccess",
+    "DEFAULT_COVER_LETTER_PURPOSE",
     "DEFAULT_MODEL",
     "DEFAULT_PURPOSE",
     "PipelineLintFailure",
     "PipelineResult",
     "PipelineSuccess",
+    "build_cover_letter_user_message",
     "build_user_message",
+    "run_cover_letter_pipeline",
     "run_tailor_pipeline",
+    "tailor_cover_letter",
     "tailor_resume",
+    "validate_cover_letter_refs",
     "validate_trace_refs",
 ]

--- a/apps/job-api/app/services/tailor/persistence.py
+++ b/apps/job-api/app/services/tailor/persistence.py
@@ -1,9 +1,9 @@
-"""Persistence + Supabase Storage for tailored_resumes (#185 P3d).
+"""Persistence + Supabase Storage for tailored_resumes.
 
-The pipeline produces a TailoredResume + `.docx` bytes + cost metadata.
-This module handles:
+The pipeline produces a TailoredResume or TailoredCoverLetter + `.docx`
+bytes + cost metadata. This module handles:
 - uploading the `.docx` to Supabase Storage (bucket: tailored-resumes),
-- inserting the metadata row,
+- inserting the metadata row with a document_type discriminator,
 - reading rows back for listing / download endpoints.
 
 Lint failures do NOT reach this module — the router returns 422 before
@@ -18,7 +18,12 @@ from typing import Any, cast
 from supabase import Client
 
 from app.models.llm import LLMResult
-from app.models.tailor import TailoredResume, TailoredResumeRecord
+from app.models.tailor import (
+    DocumentType,
+    TailoredCoverLetter,
+    TailoredResume,
+    TailoredResumeRecord,
+)
 
 TABLE = "tailored_resumes"
 STORAGE_BUCKET = "tailored-resumes"
@@ -59,6 +64,14 @@ def download_docx(supabase: Client, storage_path: str) -> bytes:
     return supabase.storage.from_(STORAGE_BUCKET).download(storage_path)
 
 
+def _insert_row(supabase: Client, row: dict[str, Any]) -> TailoredResumeRecord:
+    resp = supabase.table(TABLE).insert(row).execute()
+    rows = cast(list[dict[str, Any]], resp.data or [])
+    if not rows:
+        raise RuntimeError("Failed to insert tailored_resumes row")
+    return TailoredResumeRecord.model_validate(rows[0])
+
+
 def persist(
     supabase: Client,
     *,
@@ -70,10 +83,11 @@ def persist(
     llm_result: LLMResult,
     storage_path: str | None,
 ) -> TailoredResumeRecord:
-    """Insert one tailored_resumes row."""
+    """Insert one tailored_resumes row for a resume."""
     row: dict[str, Any] = {
         "user_id": user_id,
         "job_posting_id": job_posting_id,
+        "document_type": "resume",
         "resume_type": resume.resume_type,
         "jd_snapshot": job_description,
         "jd_snapshot_hash": jd_hash(job_description),
@@ -86,11 +100,42 @@ def persist(
         "cost_usd": llm_result.cost_usd,
         "latency_ms": llm_result.latency_ms,
     }
-    resp = supabase.table(TABLE).insert(row).execute()
-    rows = cast(list[dict[str, Any]], resp.data or [])
-    if not rows:
-        raise RuntimeError("Failed to insert tailored_resumes row")
-    return TailoredResumeRecord.model_validate(rows[0])
+    return _insert_row(supabase, row)
+
+
+def persist_cover_letter(
+    supabase: Client,
+    *,
+    user_id: str | None,
+    job_posting_id: str | None,
+    letter: TailoredCoverLetter,
+    job_description: str,
+    warnings: list[str],
+    llm_result: LLMResult,
+    storage_path: str | None,
+) -> TailoredResumeRecord:
+    """Insert one tailored_resumes row for a cover letter.
+
+    `resume_type` is set to 'generic' since the column is NOT NULL; it's
+    ignored on reads when `document_type == 'cover_letter'`.
+    """
+    row: dict[str, Any] = {
+        "user_id": user_id,
+        "job_posting_id": job_posting_id,
+        "document_type": "cover_letter",
+        "resume_type": "generic",
+        "jd_snapshot": job_description,
+        "jd_snapshot_hash": jd_hash(job_description),
+        "payload": letter.model_dump(mode="json"),
+        "storage_path": storage_path,
+        "warnings": warnings,
+        "model": llm_result.model,
+        "input_tokens": llm_result.usage.input_tokens,
+        "output_tokens": llm_result.usage.output_tokens,
+        "cost_usd": llm_result.cost_usd,
+        "latency_ms": llm_result.latency_ms,
+    }
+    return _insert_row(supabase, row)
 
 
 def get(supabase: Client, resume_id: str) -> TailoredResumeRecord | None:
@@ -107,9 +152,12 @@ def list_recent(
     *,
     user_id: str | None,
     limit: int = 50,
+    document_type: DocumentType | None = None,
 ) -> list[TailoredResumeRecord]:
     query = supabase.table(TABLE).select("*").order("created_at", desc=True).limit(limit)
     query = query.is_("user_id", "null") if user_id is None else query.eq("user_id", user_id)
+    if document_type is not None:
+        query = query.eq("document_type", document_type)
     resp = query.execute()
     rows = cast(list[dict[str, Any]], resp.data or [])
     return [TailoredResumeRecord.model_validate(r) for r in rows]

--- a/apps/job-api/app/services/tailor/pipeline.py
+++ b/apps/job-api/app/services/tailor/pipeline.py
@@ -23,15 +23,21 @@ from app.models.llm import LLMResult
 from app.models.tailor import (
     ContactInfo,
     ResumeType,
+    TailoredCoverLetter,
     TailoredResume,
     TailoredResumeRecord,
 )
 from app.services.ats_lint import lint_docx
-from app.services.docx.renderer import render_docx
+from app.services.docx.renderer import render_cover_letter_docx, render_docx
 from app.services.llm import cost_log
 from app.services.llm.client import LLMClient
 from app.services.tailor import persistence
-from app.services.tailor.tailor import DEFAULT_PURPOSE, tailor_resume
+from app.services.tailor.tailor import (
+    DEFAULT_COVER_LETTER_PURPOSE,
+    DEFAULT_PURPOSE,
+    tailor_cover_letter,
+    tailor_resume,
+)
 
 
 @dataclass
@@ -137,6 +143,121 @@ async def run_tailor_pipeline(
     return PipelineSuccess(
         record=record,
         resume=resume,
+        warnings=trace_warnings,
+        lint=lint,
+        llm_result=llm_result,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Cover letter pipeline
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CoverLetterPipelineSuccess:
+    record: TailoredResumeRecord
+    letter: TailoredCoverLetter
+    warnings: list[str]
+    lint: LintResult
+    llm_result: LLMResult
+
+
+@dataclass
+class CoverLetterPipelineLintFailure:
+    lint: LintResult
+    letter: TailoredCoverLetter
+    warnings: list[str]
+    llm_result: LLMResult
+
+
+CoverLetterPipelineResult = CoverLetterPipelineSuccess | CoverLetterPipelineLintFailure
+
+
+async def run_cover_letter_pipeline(
+    supabase: Client,
+    llm: LLMClient,
+    *,
+    user_id: str | None,
+    optimized: OptimizedDoc,
+    job_description: str,
+    company_name: str,
+    contact: ContactInfo,
+    role_title: str | None = None,
+    preferences: PreferencesPayload | None = None,
+    critique: str | None = None,
+    job_posting_id: str | None = None,
+) -> CoverLetterPipelineResult:
+    """Run the full cover-letter pipeline end-to-end.
+
+    Returns CoverLetterPipelineSuccess on clean lint, CoverLetterPipelineLintFailure
+    when the rendered doc has blocking errors. On lint failure nothing is
+    persisted and no `.docx` is uploaded — the caller should surface the
+    violations and retry with a critique.
+    """
+    letter, trace_warnings, llm_result = await tailor_cover_letter(
+        llm,
+        optimized=optimized.payload,
+        job_description=job_description,
+        company_name=company_name,
+        contact=contact,
+        role_title=role_title,
+        preferences_rules=(preferences.rules if preferences else None),
+        preferences_avoid=(preferences.avoid if preferences else None),
+        preferences_tone_notes=(preferences.tone_notes if preferences else None),
+        critique=critique,
+    )
+
+    cost_log.record(
+        supabase,
+        user_id=user_id,
+        purpose=DEFAULT_COVER_LETTER_PURPOSE,
+        result=llm_result,
+        metadata={
+            "optimized_doc_id": optimized.id,
+            "job_posting_id": job_posting_id or "",
+            "recipient_company": company_name,
+        },
+    )
+
+    docx_bytes = render_cover_letter_docx(letter)
+    lint = lint_docx(docx_bytes, document_type="cover_letter")
+    if not lint.ok:
+        return CoverLetterPipelineLintFailure(
+            lint=lint,
+            letter=letter,
+            warnings=trace_warnings,
+            llm_result=llm_result,
+        )
+
+    record = persistence.persist_cover_letter(
+        supabase,
+        user_id=user_id,
+        job_posting_id=job_posting_id,
+        letter=letter,
+        job_description=job_description,
+        warnings=trace_warnings,
+        llm_result=llm_result,
+        storage_path=None,
+    )
+    try:
+        storage_path = persistence.upload_docx(
+            supabase,
+            user_id=user_id,
+            resume_id=record.id,
+            docx_bytes=docx_bytes,
+        )
+    except Exception:
+        storage_path = None
+    if storage_path:
+        supabase.table(persistence.TABLE).update({"storage_path": storage_path}).eq(
+            "id", record.id
+        ).execute()
+        record = record.model_copy(update={"storage_path": storage_path})
+
+    return CoverLetterPipelineSuccess(
+        record=record,
+        letter=letter,
         warnings=trace_warnings,
         lint=lint,
         llm_result=llm_result,

--- a/apps/job-api/app/services/tailor/prompts.py
+++ b/apps/job-api/app/services/tailor/prompts.py
@@ -1,7 +1,7 @@
-"""System prompt for resume tailoring.
+"""System prompts for resume and cover-letter tailoring.
 
-Constants on purpose: the prompt is static across every tailoring call,
-which makes it a perfect prompt-caching target (90% discount on cache
+Constants on purpose: prompts are static across every tailoring call,
+which makes them perfect prompt-caching targets (90% discount on cache
 reads, 25% surcharge on cache writes — net positive after the second call).
 
 The variable content (OptimizedPayload, JD, preferences, critique) goes
@@ -73,5 +73,70 @@ systems" → re-order bullets/summary accordingly.
 
 OUTPUT:
 - Return ONLY the TailoredResume JSON object. No prose around it. No code fences.
+- Populate `jd_snippet` with the first ~500 chars of the JD for audit.
+"""
+
+
+COVER_LETTER_SYSTEM = """You are a senior cover-letter writer. Your input is:
+
+1. A structured career record (OptimizedPayload) with roles, skills, outcomes.
+2. A job description (JD) + recipient company name + optional role title.
+3. Optional preferences (persistent style/content biases).
+4. Optional critique (what to change from a prior draft).
+
+Your output is a strict TailoredCoverLetter JSON object. Rules:
+
+HALLUCINATION CONTAINMENT (non-negotiable):
+- Every outcome you reference must have its exact description appear in \
+`source_outcome_refs` — and that description must match an entry in the \
+OptimizedPayload's `outcomes[].description` list.
+- Every role you reference must appear in `source_role_refs` with the \
+exact `roles[].id` from the OptimizedPayload.
+- Every skill you name must appear in `source_skill_refs` with its \
+`skills[].name` from the OptimizedPayload.
+- Do not reference companies, metrics, dates, or facts absent from the \
+OptimizedPayload. Paraphrase is fine; invention is not.
+- If the OptimizedPayload is thin, the letter is short. Don't pad.
+
+STRUCTURE:
+- 3 to 4 paragraphs total. Target 250–400 words.
+- Paragraph 1: Why this role, and one headline credential (a specific \
+outcome or a role-fit signal) from the candidate's background. Name the \
+company in this paragraph.
+- Paragraph 2-3: Two or three concrete connections between the \
+candidate's experience and what the JD asks for. Each connection should \
+reference a specific outcome or role.
+- Final paragraph: Brief closing with an ask (conversation, next step).
+- `recipient_company` is populated from the input company name.
+- `recipient_role` is populated from the input role title if provided.
+- `salutation`: "Dear {Company} Hiring Team," (or "Dear Hiring Manager," \
+if the caller did not specify a company). No flowery openers.
+- `closing`: "Sincerely," or "Best regards,".
+- `signature`: the candidate's name from ContactInfo.
+
+WRITING STYLE:
+- First-person singular. Past tense for prior roles, present tense for \
+current role.
+- Direct and peer-level. No "I am writing to express my interest..."
+- No filler verbs (leveraging, spanning, diving into, unlocking, empowering).
+- No em dashes. Use periods, colons, or commas.
+- Be specific. "Cut mobile LCP from 10s to 2s" lands; "I drove impact on \
+performance" doesn't.
+
+ATS CONSTRAINTS (this is a Greenhouse-floor ATS-parseable document):
+- Single-column layout, standard paragraphs, no tables, no icons.
+
+PREFERENCES:
+- Every rule in `preferences.rules` should influence the output. Record \
+which you honored in `preferences_applied`.
+- `preferences.avoid` is a hard filter.
+
+CRITIQUE:
+- If critique is provided, treat it as the correction relative to an \
+implicit prior draft.
+
+OUTPUT:
+- Return ONLY the TailoredCoverLetter JSON object. No prose around it. \
+No code fences.
 - Populate `jd_snippet` with the first ~500 chars of the JD for audit.
 """

--- a/apps/job-api/app/services/tailor/tailor.py
+++ b/apps/job-api/app/services/tailor/tailor.py
@@ -19,14 +19,16 @@ from app.models.tailor import (
     ContactInfo,
     ResumeType,
     TailoredBullet,
+    TailoredCoverLetter,
     TailoredResume,
     TailoredRole,
 )
 from app.services.llm.client import LLMClient, complete_json
-from app.services.tailor.prompts import TAILOR_SYSTEM
+from app.services.tailor.prompts import COVER_LETTER_SYSTEM, TAILOR_SYSTEM
 
 DEFAULT_MODEL: ModelId = "claude-sonnet-4-6"
 DEFAULT_PURPOSE = "tailor.resume"
+DEFAULT_COVER_LETTER_PURPOSE = "tailor.cover_letter"
 
 
 def build_user_message(
@@ -166,4 +168,135 @@ async def tailor_resume(
     )
 
     cleaned, warnings = validate_trace_refs(parsed, optimized)
+    return cleaned, warnings, result
+
+
+# ---------------------------------------------------------------------------
+# Cover letters
+# ---------------------------------------------------------------------------
+
+
+def build_cover_letter_user_message(
+    *,
+    optimized: OptimizedPayload,
+    job_description: str,
+    company_name: str,
+    contact: ContactInfo,
+    role_title: str | None,
+    preferences_text: str | None,
+    critique: str | None,
+) -> str:
+    """Assemble the variable content for the LLM call.
+
+    The system prompt is static (cache target); everything that changes
+    per call lives here.
+    """
+    sections: list[str] = []
+    sections.append(f"[OptimizedPayload]\n{optimized.model_dump_json(indent=2)}")
+    sections.append(f"[ContactInfo]\n{contact.model_dump_json(indent=2)}")
+    sections.append(f"[RecipientCompany] {company_name}")
+    if role_title:
+        sections.append(f"[RoleTitle] {role_title}")
+    if preferences_text:
+        sections.append(f"[Preferences]\n{preferences_text}")
+    if critique:
+        sections.append(f"[Critique]\n{critique}")
+    sections.append(f"[JobDescription]\n{job_description}")
+    return "\n\n".join(sections)
+
+
+def validate_cover_letter_refs(
+    letter: TailoredCoverLetter,
+    optimized: OptimizedPayload,
+) -> tuple[TailoredCoverLetter, list[str]]:
+    """Drop refs that don't trace back to the OptimizedPayload. Returns
+    the cleaned letter + warnings for each dropped ref.
+
+    Unlike the resume trace check, cover letters reference refs in
+    aggregate (not per-bullet). We drop invalid refs rather than raise
+    because a cover letter's prose may still be salvageable even if one
+    claimed ref is off — the prose itself is what the user ships.
+    Callers should surface warnings to the user.
+    """
+    valid_role_ids = {r.id for r in optimized.roles}
+    valid_outcome_descriptions = {o.description for o in optimized.outcomes}
+    valid_skill_names = {s.name for s in optimized.skills}
+
+    warnings: list[str] = []
+
+    kept_role_refs: list[str] = []
+    for ref in letter.source_role_refs:
+        if ref in valid_role_ids:
+            kept_role_refs.append(ref)
+        else:
+            warnings.append(f"Dropped unknown role_ref: {ref!r}")
+
+    kept_outcome_refs: list[str] = []
+    for ref in letter.source_outcome_refs:
+        if ref in valid_outcome_descriptions:
+            kept_outcome_refs.append(ref)
+        else:
+            warnings.append(f"Dropped unknown outcome_ref: {ref[:60]!r}")
+
+    kept_skill_refs: list[str] = []
+    for ref in letter.source_skill_refs:
+        if ref in valid_skill_names:
+            kept_skill_refs.append(ref)
+        else:
+            warnings.append(f"Dropped unknown skill_ref: {ref!r}")
+
+    cleaned = letter.model_copy(
+        update={
+            "source_role_refs": kept_role_refs,
+            "source_outcome_refs": kept_outcome_refs,
+            "source_skill_refs": kept_skill_refs,
+        }
+    )
+    return cleaned, warnings
+
+
+async def tailor_cover_letter(
+    llm: LLMClient,
+    *,
+    optimized: OptimizedPayload,
+    job_description: str,
+    company_name: str,
+    contact: ContactInfo,
+    role_title: str | None = None,
+    preferences_rules: list[str] | None = None,
+    preferences_avoid: list[str] | None = None,
+    preferences_tone_notes: list[str] | None = None,
+    critique: str | None = None,
+    model: ModelId = DEFAULT_MODEL,
+    purpose: str = DEFAULT_COVER_LETTER_PURPOSE,
+) -> tuple[TailoredCoverLetter, list[str], LLMResult]:
+    """Run the LLM and post-validate that declared refs trace back.
+
+    Returns (letter, warnings, llm_result). Caller is responsible for
+    cost-logging and persistence.
+    """
+    user_message = build_cover_letter_user_message(
+        optimized=optimized,
+        job_description=job_description,
+        company_name=company_name,
+        contact=contact,
+        role_title=role_title,
+        preferences_text=_preferences_text(
+            preferences_rules, preferences_avoid, preferences_tone_notes
+        ),
+        critique=critique,
+    )
+
+    parsed, result = await complete_json(
+        llm,
+        model=model,
+        system=COVER_LETTER_SYSTEM,
+        messages=[Message(role="user", content=user_message)],
+        schema=TailoredCoverLetter,
+        purpose=purpose,
+        cache_system=True,
+        max_tokens=4096,
+    )
+
+    cleaned, warnings = validate_cover_letter_refs(parsed, optimized)
     return cleaned, warnings, result

--- a/apps/job-api/tests/test_cover_letter.py
+++ b/apps/job-api/tests/test_cover_letter.py
@@ -1,0 +1,551 @@
+"""Cover letter pipeline tests: tailor service, renderer, linter, pipeline.
+
+Covers the P5 additions to the tailor pipeline. Uses MockLLMClient for
+LLM interactions and patched service dependencies for DB side effects.
+"""
+
+from __future__ import annotations
+
+import io
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from docx import Document
+
+from app.models.ats_lint import LintResult, LintViolation
+from app.models.experience import (
+    OptimizedDoc,
+    OptimizedPayload,
+    Outcome,
+    PreferencesPayload,
+    Role,
+    Skill,
+)
+from app.models.tailor import (
+    ContactInfo,
+    CoverLetterParagraph,
+    TailoredCoverLetter,
+)
+from app.services.ats_lint import lint_docx
+from app.services.docx.renderer import render_cover_letter_docx, render_docx
+from app.services.llm import cost_log as cost_log_mod
+from app.services.llm.mock import MockLLMClient
+from app.services.tailor import pipeline as pipeline_module
+from app.services.tailor.pipeline import (
+    CoverLetterPipelineLintFailure,
+    CoverLetterPipelineSuccess,
+    run_cover_letter_pipeline,
+)
+from app.services.tailor.prompts import COVER_LETTER_SYSTEM
+from app.services.tailor.tailor import (
+    DEFAULT_COVER_LETTER_PURPOSE,
+    build_cover_letter_user_message,
+    tailor_cover_letter,
+    validate_cover_letter_refs,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _optimized_payload() -> OptimizedPayload:
+    return OptimizedPayload(
+        summary="Senior FE.",
+        roles=[
+            Role(
+                id="fc",
+                company="FightCamp",
+                title="Senior Frontend Engineer",
+                start="2021-11",
+                end="2024-04",
+                summary="Led the PDP rebuild.",
+                skills=["React"],
+                outcome_refs=[],
+            )
+        ],
+        skills=[Skill(name="React"), Skill(name="TypeScript")],
+        outcomes=[
+            Outcome(
+                description="Cut mobile load times from 10s to 2s",
+                metric="LCP",
+                value="2s",
+                role_ref="fc",
+            )
+        ],
+    )
+
+
+def _optimized_doc() -> OptimizedDoc:
+    return OptimizedDoc(
+        id="opt-1",
+        user_id=None,
+        prose_doc_id=None,
+        version=1,
+        payload=_optimized_payload(),
+        markdown_view=None,
+        source="llm",
+        created_at=datetime.now(UTC),
+    )
+
+
+def _contact() -> ContactInfo:
+    return ContactInfo(name="Daniel Joffe", email="daniel@example.com")
+
+
+def _valid_letter(
+    *,
+    outcome_refs: list[str] | None = None,
+    role_refs: list[str] | None = None,
+    skill_refs: list[str] | None = None,
+) -> TailoredCoverLetter:
+    return TailoredCoverLetter(
+        contact=_contact(),
+        recipient_company="Acme Corp",
+        recipient_role="Senior FE",
+        salutation="Dear Acme Hiring Team,",
+        paragraphs=[
+            CoverLetterParagraph(text="I am applying for the Senior FE role at Acme."),
+            CoverLetterParagraph(text="At FightCamp I cut mobile load times from 10s to 2s."),
+            CoverLetterParagraph(text="I would welcome a conversation."),
+        ],
+        closing="Sincerely,",
+        signature="Daniel Joffe",
+        source_outcome_refs=outcome_refs
+        if outcome_refs is not None
+        else ["Cut mobile load times from 10s to 2s"],
+        source_role_refs=role_refs if role_refs is not None else ["fc"],
+        source_skill_refs=skill_refs if skill_refs is not None else ["React"],
+    )
+
+
+def _valid_letter_json(**kwargs: Any) -> str:
+    return _valid_letter(**kwargs).model_dump_json()
+
+
+def _inserted_record_row(record_id: str = "rec-1") -> dict[str, Any]:
+    letter = _valid_letter()
+    return {
+        "id": record_id,
+        "user_id": None,
+        "job_posting_id": None,
+        "document_type": "cover_letter",
+        "resume_type": "generic",
+        "jd_snapshot": "JD text",
+        "jd_snapshot_hash": "hash",
+        "payload": letter.model_dump(mode="json"),
+        "storage_path": None,
+        "warnings": [],
+        "model": "claude-sonnet-4-6",
+        "input_tokens": 100,
+        "output_tokens": 80,
+        "cost_usd": 0.002,
+        "latency_ms": 60,
+        "created_at": datetime.now(UTC).isoformat(),
+    }
+
+
+def _make_supabase_mock(*, insert_data: list[dict[str, Any]]) -> MagicMock:
+    supabase = MagicMock()
+    supabase.table.return_value.insert.return_value.execute.return_value.data = (
+        insert_data
+    )
+    supabase.table.return_value.update.return_value.eq.return_value.execute.return_value.data = []
+    supabase.storage.from_.return_value.upload.return_value = None
+    return supabase
+
+
+# ---------------------------------------------------------------------------
+# System prompt sanity
+# ---------------------------------------------------------------------------
+
+
+def test_cover_letter_system_prompt_mentions_core_rules() -> None:
+    assert "TailoredCoverLetter JSON" in COVER_LETTER_SYSTEM
+    assert "source_outcome_refs" in COVER_LETTER_SYSTEM
+    assert "source_role_refs" in COVER_LETTER_SYSTEM
+    assert "source_skill_refs" in COVER_LETTER_SYSTEM
+    assert "Do not reference companies, metrics, dates, or facts absent" in COVER_LETTER_SYSTEM
+    assert "No em dashes" in COVER_LETTER_SYSTEM
+
+
+# ---------------------------------------------------------------------------
+# build_cover_letter_user_message
+# ---------------------------------------------------------------------------
+
+
+def test_build_cover_letter_user_message_includes_all_sections() -> None:
+    msg = build_cover_letter_user_message(
+        optimized=_optimized_payload(),
+        job_description="We want a senior FE.",
+        company_name="Acme",
+        contact=_contact(),
+        role_title="Senior FE",
+        preferences_text='{"rules": ["present tense"]}',
+        critique="Lead with the PDP rebuild.",
+    )
+    for tag in (
+        "[OptimizedPayload]",
+        "[ContactInfo]",
+        "[RecipientCompany] Acme",
+        "[RoleTitle] Senior FE",
+        "[Preferences]",
+        "[Critique]",
+        "[JobDescription]",
+    ):
+        assert tag in msg
+
+
+def test_build_cover_letter_user_message_omits_role_title_when_absent() -> None:
+    msg = build_cover_letter_user_message(
+        optimized=_optimized_payload(),
+        job_description="jd",
+        company_name="Acme",
+        contact=_contact(),
+        role_title=None,
+        preferences_text=None,
+        critique=None,
+    )
+    assert "[RoleTitle]" not in msg
+    assert "[Preferences]" not in msg
+    assert "[Critique]" not in msg
+
+
+# ---------------------------------------------------------------------------
+# validate_cover_letter_refs
+# ---------------------------------------------------------------------------
+
+
+def test_validate_drops_unknown_role_ref() -> None:
+    letter = _valid_letter(role_refs=["fc", "ghost-role"])
+    cleaned, warnings = validate_cover_letter_refs(letter, _optimized_payload())
+    assert cleaned.source_role_refs == ["fc"]
+    assert any("ghost-role" in w for w in warnings)
+
+
+def test_validate_drops_unknown_outcome_ref() -> None:
+    letter = _valid_letter(
+        outcome_refs=[
+            "Cut mobile load times from 10s to 2s",
+            "Raised Series D of $1B",  # invented
+        ]
+    )
+    cleaned, warnings = validate_cover_letter_refs(letter, _optimized_payload())
+    assert cleaned.source_outcome_refs == ["Cut mobile load times from 10s to 2s"]
+    assert any("Raised Series D" in w for w in warnings)
+
+
+def test_validate_drops_unknown_skill_ref() -> None:
+    letter = _valid_letter(skill_refs=["React", "COBOL"])
+    cleaned, warnings = validate_cover_letter_refs(letter, _optimized_payload())
+    assert cleaned.source_skill_refs == ["React"]
+    assert any("COBOL" in w for w in warnings)
+
+
+def test_validate_keeps_all_valid_refs() -> None:
+    letter = _valid_letter()
+    cleaned, warnings = validate_cover_letter_refs(letter, _optimized_payload())
+    assert cleaned.source_role_refs == ["fc"]
+    assert cleaned.source_outcome_refs == ["Cut mobile load times from 10s to 2s"]
+    assert cleaned.source_skill_refs == ["React"]
+    assert warnings == []
+
+
+# ---------------------------------------------------------------------------
+# tailor_cover_letter end-to-end
+# ---------------------------------------------------------------------------
+
+
+async def test_tailor_cover_letter_parses_and_returns_result() -> None:
+    llm = MockLLMClient(scripted={DEFAULT_COVER_LETTER_PURPOSE: _valid_letter_json()})
+    letter, warnings, result = await tailor_cover_letter(
+        llm,
+        optimized=_optimized_payload(),
+        job_description="We want a senior FE",
+        company_name="Acme",
+        contact=_contact(),
+    )
+    assert isinstance(letter, TailoredCoverLetter)
+    assert letter.recipient_company == "Acme Corp"
+    assert len(letter.paragraphs) == 3
+    assert result.cost_usd > 0
+    assert warnings == []
+
+
+async def test_tailor_cover_letter_cost_logs_under_default_purpose() -> None:
+    llm = MockLLMClient(scripted={DEFAULT_COVER_LETTER_PURPOSE: _valid_letter_json()})
+    await tailor_cover_letter(
+        llm,
+        optimized=_optimized_payload(),
+        job_description="jd",
+        company_name="Acme",
+        contact=_contact(),
+    )
+    assert llm.calls[0]["purpose"] == DEFAULT_COVER_LETTER_PURPOSE
+
+
+async def test_tailor_cover_letter_enables_system_cache() -> None:
+    llm = MockLLMClient(scripted={DEFAULT_COVER_LETTER_PURPOSE: _valid_letter_json()})
+    await tailor_cover_letter(
+        llm,
+        optimized=_optimized_payload(),
+        job_description="jd",
+        company_name="Acme",
+        contact=_contact(),
+    )
+    assert llm.calls[0]["cache_system"] is True
+
+
+async def test_tailor_cover_letter_drops_hallucinated_refs() -> None:
+    llm = MockLLMClient(
+        scripted={
+            DEFAULT_COVER_LETTER_PURPOSE: _valid_letter_json(
+                outcome_refs=["Cut mobile load times from 10s to 2s", "Invented win"],
+                role_refs=["fc"],
+                skill_refs=["React"],
+            )
+        }
+    )
+    letter, warnings, _ = await tailor_cover_letter(
+        llm,
+        optimized=_optimized_payload(),
+        job_description="jd",
+        company_name="Acme",
+        contact=_contact(),
+    )
+    assert letter.source_outcome_refs == ["Cut mobile load times from 10s to 2s"]
+    assert any("Invented win" in w for w in warnings)
+
+
+# ---------------------------------------------------------------------------
+# render_cover_letter_docx
+# ---------------------------------------------------------------------------
+
+
+def _parse(doc_bytes: bytes) -> Any:
+    return Document(io.BytesIO(doc_bytes))
+
+
+def test_render_cover_letter_returns_valid_docx() -> None:
+    letter = _valid_letter()
+    doc = _parse(render_cover_letter_docx(letter))
+    texts = [p.text for p in doc.paragraphs]
+    assert "Daniel Joffe" in texts
+    assert "Acme Corp" in texts
+    assert any("Re: Senior FE" in t for t in texts)
+    assert "Dear Acme Hiring Team," in texts
+    assert any("FightCamp" in t for t in texts)
+    assert "Sincerely," in texts
+
+
+def test_render_cover_letter_omits_re_line_when_no_role() -> None:
+    letter = _valid_letter().model_copy(update={"recipient_role": None})
+    doc = _parse(render_cover_letter_docx(letter))
+    texts = [p.text for p in doc.paragraphs]
+    assert not any(t.startswith("Re:") for t in texts)
+
+
+def test_render_cover_letter_has_no_tables() -> None:
+    letter = _valid_letter()
+    doc = _parse(render_cover_letter_docx(letter))
+    assert len(doc.tables) == 0
+
+
+def test_render_cover_letter_has_no_heading_1() -> None:
+    letter = _valid_letter()
+    doc = _parse(render_cover_letter_docx(letter))
+    heading_1s = [p for p in doc.paragraphs if p.style.name == "Heading 1"]
+    assert heading_1s == []
+
+
+# ---------------------------------------------------------------------------
+# lint_docx document_type awareness
+# ---------------------------------------------------------------------------
+
+
+def test_lint_cover_letter_skips_experience_heading_rule() -> None:
+    letter = _valid_letter()
+    result = lint_docx(render_cover_letter_docx(letter), document_type="cover_letter")
+    codes = {v.code for v in result.violations}
+    assert "experience_heading" not in codes
+    assert "standard_headings" not in codes
+    assert result.ok is True
+
+
+def test_lint_resume_still_requires_experience_heading() -> None:
+    """Regression check — the default document_type stays 'resume'."""
+    letter = _valid_letter()
+    # Render as cover letter (no headings), then lint as resume — must fail.
+    result = lint_docx(render_cover_letter_docx(letter))
+    codes = {v.code for v in result.errors}
+    assert "experience_heading" in codes
+
+
+def test_lint_cover_letter_still_catches_tables() -> None:
+    """Format rules apart from headings still apply to cover letters."""
+    from docx import Document as NewDocument
+
+    doc = NewDocument()
+    doc.add_paragraph("body")
+    doc.add_table(rows=1, cols=1)
+    buf = io.BytesIO()
+    doc.save(buf)
+    result = lint_docx(buf.getvalue(), document_type="cover_letter")
+    assert any(v.code == "no_tables" for v in result.errors)
+
+
+# ---------------------------------------------------------------------------
+# run_cover_letter_pipeline
+# ---------------------------------------------------------------------------
+
+
+async def test_pipeline_success_returns_record_and_uploads(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    supabase = _make_supabase_mock(insert_data=[_inserted_record_row()])
+    monkeypatch.setattr(cost_log_mod, "record", MagicMock())
+
+    llm = MockLLMClient(scripted={DEFAULT_COVER_LETTER_PURPOSE: _valid_letter_json()})
+    result = await run_cover_letter_pipeline(
+        supabase,
+        llm,
+        user_id=None,
+        optimized=_optimized_doc(),
+        job_description="jd",
+        company_name="Acme",
+        contact=_contact(),
+    )
+    assert isinstance(result, CoverLetterPipelineSuccess)
+    assert result.record.document_type == "cover_letter"
+    supabase.storage.from_.assert_any_call("tailored-resumes")
+
+
+async def test_pipeline_cost_logs_under_tailor_cover_letter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    supabase = _make_supabase_mock(insert_data=[_inserted_record_row()])
+    cost_record = MagicMock()
+    monkeypatch.setattr(cost_log_mod, "record", cost_record)
+
+    llm = MockLLMClient(scripted={DEFAULT_COVER_LETTER_PURPOSE: _valid_letter_json()})
+    await run_cover_letter_pipeline(
+        supabase,
+        llm,
+        user_id=None,
+        optimized=_optimized_doc(),
+        job_description="jd",
+        company_name="Acme",
+        contact=_contact(),
+    )
+    assert cost_record.call_args.kwargs["purpose"] == DEFAULT_COVER_LETTER_PURPOSE
+    assert (
+        cost_record.call_args.kwargs["metadata"]["recipient_company"] == "Acme"
+    )
+
+
+async def test_pipeline_preferences_are_passed_through(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    supabase = _make_supabase_mock(insert_data=[_inserted_record_row()])
+    monkeypatch.setattr(cost_log_mod, "record", MagicMock())
+
+    seen: dict[str, str] = {}
+
+    def responder(latest_user: str, _messages: object) -> str:
+        seen["latest"] = latest_user
+        return _valid_letter_json()
+
+    llm = MockLLMClient(scripted={DEFAULT_COVER_LETTER_PURPOSE: responder})
+    prefs = PreferencesPayload(
+        rules=["lead with performance"],
+        avoid=["em dashes"],
+        tone_notes=[],
+    )
+    await run_cover_letter_pipeline(
+        supabase,
+        llm,
+        user_id=None,
+        optimized=_optimized_doc(),
+        job_description="jd",
+        company_name="Acme",
+        contact=_contact(),
+        preferences=prefs,
+    )
+    assert "[Preferences]" in seen["latest"]
+    assert "lead with performance" in seen["latest"]
+
+
+async def test_pipeline_lint_failure_does_not_persist(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    supabase = _make_supabase_mock(insert_data=[])
+    monkeypatch.setattr(cost_log_mod, "record", MagicMock())
+
+    def fake_lint(_b: bytes, *, document_type: str = "resume") -> LintResult:
+        return LintResult(
+            ok=False,
+            violations=[
+                LintViolation(
+                    code="no_tables",
+                    message="simulated lint failure",
+                    severity="error",
+                )
+            ],
+        )
+
+    monkeypatch.setattr(pipeline_module, "lint_docx", fake_lint)
+
+    llm = MockLLMClient(scripted={DEFAULT_COVER_LETTER_PURPOSE: _valid_letter_json()})
+    result = await run_cover_letter_pipeline(
+        supabase,
+        llm,
+        user_id=None,
+        optimized=_optimized_doc(),
+        job_description="jd",
+        company_name="Acme",
+        contact=_contact(),
+    )
+    assert isinstance(result, CoverLetterPipelineLintFailure)
+    supabase.table.return_value.insert.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Regression: resume pipeline still works after P5 changes
+# ---------------------------------------------------------------------------
+
+
+def test_resume_pipeline_still_lints_clean() -> None:
+    """After P5 added document_type, render_docx + lint_docx default path
+    should stay green on a clean resume."""
+    from app.models.tailor import (
+        TailoredBullet,
+        TailoredEducation,
+        TailoredResume,
+        TailoredRole,
+    )
+
+    resume = TailoredResume(
+        summary="Senior FE with shipped work.",
+        contact=_contact(),
+        experience=[
+            TailoredRole(
+                company="FightCamp",
+                title="Senior FE",
+                start="2021-11",
+                end="2024-04",
+                bullets=[
+                    TailoredBullet(
+                        text="Cut mobile load times from 10s to 2s.",
+                        source_outcome_ref="x",
+                    )
+                ],
+                source_role_ref="fc",
+            )
+        ],
+        skills=["React"],
+        education=[TailoredEducation(school="UCLA")],
+    )
+    result = lint_docx(render_docx(resume))
+    assert result.ok is True

--- a/supabase/migrations/20260424120000_add_document_type.sql
+++ b/supabase/migrations/20260424120000_add_document_type.sql
@@ -1,0 +1,13 @@
+-- ============================================
+-- MIGRATION: Add document_type to tailored_resumes (#185 P5)
+-- The same table now holds both resumes and cover letters. The payload
+-- JSONB shape differs per document_type (TailoredResume vs
+-- TailoredCoverLetter). Existing rows default to 'resume'.
+-- ============================================
+
+ALTER TABLE tailored_resumes
+  ADD COLUMN IF NOT EXISTS document_type TEXT NOT NULL DEFAULT 'resume'
+    CHECK (document_type IN ('resume', 'cover_letter'));
+
+CREATE INDEX IF NOT EXISTS idx_tailored_resumes_document_type
+  ON tailored_resumes(document_type, created_at DESC);


### PR DESCRIPTION
## Summary

Cover letters as a sibling `document_type` alongside resumes, riding the same tailor pipeline (synthesize → render → lint → persist → upload). Reuses the shared LLM client, cost-log table, persistence table, Storage bucket, and hallucination-containment discipline. **Additive** — no breaking changes to the resume path.

Targets `feature/resume-tailor`.

## What's in

**Migration** — `supabase/migrations/20260424120000_add_document_type.sql`
- Adds `document_type TEXT NOT NULL DEFAULT 'resume'` with `CHECK ('resume','cover_letter')` to `tailored_resumes`.
- Indexed on `(document_type, created_at DESC)` for cheap dashboard filtering.
- Existing rows default to `'resume'`.

**Models** — `apps/job-api/app/models/tailor.py`
- `DocumentType` Literal.
- `CoverLetterParagraph` (prose paragraph, ≤ 1500 chars).
- `TailoredCoverLetter` — contact, recipient_company, recipient_role, salutation, paragraphs[], closing, signature, jd_snippet, preferences_applied. **Aggregate tracing**: `source_outcome_refs`, `source_role_refs`, `source_skill_refs` as lists. Per-bullet tracing doesn't fit prose; the letter declares which OptimizedPayload items it drew from and the validator confirms those exist.
- `CoverLetterRequest` — JD + `company_name` + optional `role_title` + contact + critique + optional `job_posting_id`.
- `TailoredResumeRecord` — added `document_type` discriminator; `payload` relaxed to `dict[str, Any]` at the DB-read boundary with `as_resume()` / `as_cover_letter()` typed-parse helpers.

**Prompt** — `services/tailor/prompts.py`
- `COVER_LETTER_SYSTEM`. Static, cache-friendly. Encodes: hallucination containment (every declared ref must match the OptimizedPayload exactly); 3–4 paragraphs, 250–400 words; first-person singular with past/present tense split; no filler verbs; no em dashes; ATS single-column constraint.

**Tailor service** — `services/tailor/tailor.py`
- `build_cover_letter_user_message(...)` — assembles per-call variable content.
- `validate_cover_letter_refs(letter, optimized) -> (cleaned, warnings)` — drops unknown outcome/role/skill refs with a warning. Doesn't raise — prose is salvageable even if one ref is off; caller surfaces warnings.
- `tailor_cover_letter(...)` — Sonnet 4.6 default, `cache_system=True`, `max_tokens=4096`, purpose `"tailor.cover_letter"`.

**Renderer** — `services/docx/renderer.py`
- `render_cover_letter_docx(letter)`. Simpler shape than the resume: no headings, no bullets. Contact header → optional `Re:` line → recipient → salutation → paragraphs → closing → signature.

**ATS linter** — `services/ats_lint/linter.py`
- `lint_docx(bytes, *, document_type="resume")`. For `cover_letter`, the `experience_heading` and `standard_headings` rules are skipped (cover letters have no Heading 1). Every other rule still applies.

**Persistence** — `services/tailor/persistence.py`
- `persist_cover_letter(...)` sibling of `persist(...)`. Writes to the same `tailored_resumes` table with `document_type="cover_letter"`.
- `list_recent(..., document_type=None)` gains an optional filter.

**Pipeline** — `services/tailor/pipeline.py`
- `CoverLetterPipelineSuccess` / `CoverLetterPipelineLintFailure` dataclasses.
- `run_cover_letter_pipeline(...)` — full orchestration. Same short-circuit: lint errors abort before persistence; Storage upload failures leave the row with `storage_path=None`.

**Router** — `apps/job-api/app/routers/tailor.py`
- `POST /tailor/cover-letter` — main endpoint; 422 on lint failure.
- `GET /tailor/cover-letters` — filtered list.
- `GET /tailor/resumes` — now explicitly filters `document_type="resume"` (was returning everything before).
- Shared detail + download endpoints (`/tailor/resumes/{id}`, `/tailor/resumes/{id}/download`) work on either type since they look up by id.

## Design notes

- **Tracing model differs from resumes.** Resume tracing is per-bullet (exact outcome description or role-summary substring). Cover letter tracing is aggregate — the LLM declares `source_outcome_refs`, `source_role_refs`, `source_skill_refs` as lists, and we validate those exist. Prose can't cleanly split into traceable units.
- **One table, two payload shapes.** `tailored_resumes.payload` is JSONB and holds either `TailoredResume` or `TailoredCoverLetter` depending on `document_type`. The record type's `as_resume()` / `as_cover_letter()` helpers do the typed parse.
- **`resume_type="generic"` for cover letters.** Placeholder because the column is NOT NULL; not read when `document_type == "cover_letter"`.
- **ATS linter skips heading rules for cover letters.** They don't use Heading 1 at all — enforcing "Experience" would fail every letter. Tables, images, text frames, shapes, page count still apply.

## Test plan

- [x] `uv run ruff check app/ tests/` — passes
- [x] `uv run mypy` strict on touched files — no issues
- [x] `uv run pytest` — **301/301** (was 278; **+23 new**)
  - Prompt sanity (non-negotiable rules present)
  - `build_cover_letter_user_message` all-sections + omission paths
  - `validate_cover_letter_refs` drops unknown outcome / role / skill refs; keeps valid ones; warns on each drop
  - End-to-end `tailor_cover_letter` (parses, cost-logs under correct purpose, `cache_system=True`, hallucinated refs dropped)
  - Renderer (valid `.docx`, includes all blocks, `Re:` omitted when no role, no tables, no Heading 1)
  - Linter document-type awareness (cover letter skips experience_heading; resume still requires it; tables still caught)
  - Pipeline (success persists + uploads, cost-log purpose + metadata carries `recipient_company`, preferences passthrough, lint failure skips persist)
  - Regression: resume pipeline still lints clean after the shared linter change
- [ ] Set `LLM_PROVIDER=anthropic`, POST `/tailor/cover-letter` with a real JD, inspect the generated letter + persisted row + downloaded `.docx`

## What's not in (intentional)

- **No streaming.** Cover letters are short; no need.
- **No separate cover-letter table.** Same table + discriminator. Simpler schema, one persistence module, one Storage path convention.
- **No rename of `TailoredResumeRecord`.** It's the shared read shape now but the name sticks to avoid a breaking churn. Consider renaming in a later refactor if it bothers us.
- **No UI.** P4 dashboard still pending.

## Up next

- **Field-test** end-to-end (real Anthropic + real Voyage, both document types).
- **P4 — dashboard** (blocked on #184 jobs list or stub).

https://claude.ai/code/session_01GiZqgubpGXDBuQSEGNGsbp

---
_Generated by [Claude Code](https://claude.ai/code/session_01GiZqgubpGXDBuQSEGNGsbp)_