### PR TITLE
fix(e2e): use pressSequentially for blog search input to trigger React onChange

### DIFF
--- a/apps/root-e2e/src/blog-search.spec.ts
+++ b/apps/root-e2e/src/blog-search.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { waitForHydration } from './fixtures/base.fixture';
+import { fillInput, waitForHydration } from './fixtures/base.fixture';
 
 test.describe('blog search and filtering', () => {
   test.beforeEach(async ({ page }) => {
@@ -23,14 +23,19 @@ test.describe('blog search and filtering', () => {
     const searchInput = page.getByLabel('Search blog posts');
     await expect(searchInput).toBeVisible();
 
-    // Type a search term that should match at least one post
-    await searchInput.fill('performance');
+    // pressSequentially fires real key events so React's onChange on the
+    // controlled Input reliably flips `isSearching` — plain fill() can skip
+    // the onChange handler and leave the aria-live summary unrendered.
+    await fillInput(searchInput, 'performance');
+    await expect(searchInput).toHaveValue('performance');
 
-    // The results-count summary is an aria-live region whose text matches
-    // "N result(s) for \"query\"". Match by text so the locator isn't
-    // ambiguous with any other aria-live region on the page.
-    const resultsSummary = page.getByText(/\d+ results? for "performance"/);
-    await expect(resultsSummary).toBeVisible();
+    // Scope to the aria-live region that carries the results-count text.
+    // useDeferredValue + MiniSearch indexing can be slow on CI, so give it
+    // a generous timeout.
+    const resultsSummary = page
+      .locator('[aria-live="polite"]')
+      .filter({ hasText: /\d+ results? for/ });
+    await expect(resultsSummary).toBeVisible({ timeout: 15000 });
 
     // Verify at least one post is shown
     const postLinks = page.locator(


### PR DESCRIPTION
## Summary

Follow-up to #513. That PR swapped the `[aria-live="polite"]` locator for `getByText(/\d+ results? for "performance"/)` on the theory that locator ambiguity was the root cause. CI disagreed: the test still fails because the aria-live region never renders at all.

### Root cause

`searchInput.fill('performance')` sets the input value but doesn't reliably trigger React's `onChange` on the controlled `Input`. `handleSearchChange` never fires, `query` stays empty, `useDeferredValue` never updates, `isSearching` stays false, and the aria-live summary is not rendered — so `toBeVisible()` times out with "element(s) not found".

This is the same WebKit/Playwright controlled-input quirk that the contact-form specs already work around via the `fillInput` helper (which uses `pressSequentially` with a small per-key delay).

### Fix

- Use `fillInput(searchInput, 'performance')` instead of `fill()` so real key events trigger React's onChange.
- Assert `searchInput.toHaveValue('performance')` as a quick value-settled check before waiting on the summary.
- Keep the aria-live scoping but use `locator('[aria-live="polite"]').filter({ hasText: /\d+ results? for/ })` — more forgiving than `getByText(regex)` for whitespace/entity nuances in the rendered text, and still unambiguous.
- Bump the visibility timeout to 15s to cover the useDeferredValue + MiniSearch indexing window on CI under load.

No changes to other blog-search tests (they currently pass) or the contact-form file.

## Test plan

- [ ] `ci.yml` goes green on `develop` after merge
- [ ] PR #492 (`develop → main` release) clears its `full / full` failure
- [ ] Still outstanding: snapshot regeneration via `workflow_dispatch` (user action) if visual-regression specs need updated baselines

https://claude.ai/code/session_013zsWyQchxCp1Df2rn1vYWc

---
_Generated by [Claude Code](https://claude.ai/code/session_013zsWyQchxCp1Df2rn1vYWc)_