### PR TITLE
feat(root): career overview dashboard (#185 P4a)

### DIFF
--- a/apps/root/src/app/api/career/experience/optimized/route.test.ts
+++ b/apps/root/src/app/api/career/experience/optimized/route.test.ts
@@ -1,0 +1,39 @@
+/**
+ * @jest-environment node
+ */
+import { NextResponse } from 'next/server';
+import { proxyToFastAPI, verifyJobsAdmin } from '@/app/api/jobs/proxy';
+import { GET } from './route';
+
+jest.mock('@/app/api/jobs/proxy', () => ({
+  verifyJobsAdmin: jest.fn(),
+  proxyToFastAPI: jest.fn(),
+}));
+
+const mockedVerify = verifyJobsAdmin as jest.MockedFunction<
+  typeof verifyJobsAdmin
+>;
+const mockedProxy = proxyToFastAPI as jest.MockedFunction<
+  typeof proxyToFastAPI
+>;
+
+describe('GET /api/career/experience/optimized', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    mockedVerify.mockResolvedValueOnce(false);
+    const res = await GET();
+    expect(res.status).toBe(401);
+    expect(mockedProxy).not.toHaveBeenCalled();
+  });
+
+  it('proxies to FastAPI /experience/optimized when authenticated', async () => {
+    mockedVerify.mockResolvedValueOnce(true);
+    mockedProxy.mockResolvedValueOnce(NextResponse.json({ optimized: null }));
+    const res = await GET();
+    expect(res.status).toBe(200);
+    expect(mockedProxy).toHaveBeenCalledWith('/experience/optimized');
+  });
+});

--- a/apps/root/src/app/api/career/experience/optimized/route.ts
+++ b/apps/root/src/app/api/career/experience/optimized/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from 'next/server';
+import { proxyToFastAPI, verifyJobsAdmin } from '@/app/api/jobs/proxy';
+
+export async function GET() {
+  if (!(await verifyJobsAdmin())) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  return proxyToFastAPI('/experience/optimized');
+}

--- a/apps/root/src/app/api/career/experience/prose/route.test.ts
+++ b/apps/root/src/app/api/career/experience/prose/route.test.ts
@@ -1,0 +1,39 @@
+/**
+ * @jest-environment node
+ */
+import { NextResponse } from 'next/server';
+import { proxyToFastAPI, verifyJobsAdmin } from '@/app/api/jobs/proxy';
+import { GET } from './route';
+
+jest.mock('@/app/api/jobs/proxy', () => ({
+  verifyJobsAdmin: jest.fn(),
+  proxyToFastAPI: jest.fn(),
+}));
+
+const mockedVerify = verifyJobsAdmin as jest.MockedFunction<
+  typeof verifyJobsAdmin
+>;
+const mockedProxy = proxyToFastAPI as jest.MockedFunction<
+  typeof proxyToFastAPI
+>;
+
+describe('GET /api/career/experience/prose', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    mockedVerify.mockResolvedValueOnce(false);
+    const res = await GET();
+    expect(res.status).toBe(401);
+    expect(mockedProxy).not.toHaveBeenCalled();
+  });
+
+  it('proxies to FastAPI /experience/prose when authenticated', async () => {
+    mockedVerify.mockResolvedValueOnce(true);
+    mockedProxy.mockResolvedValueOnce(NextResponse.json({ prose: null }));
+    const res = await GET();
+    expect(res.status).toBe(200);
+    expect(mockedProxy).toHaveBeenCalledWith('/experience/prose');
+  });
+});

--- a/apps/root/src/app/api/career/experience/prose/route.ts
+++ b/apps/root/src/app/api/career/experience/prose/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from 'next/server';
+import { proxyToFastAPI, verifyJobsAdmin } from '@/app/api/jobs/proxy';
+
+export async function GET() {
+  if (!(await verifyJobsAdmin())) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  return proxyToFastAPI('/experience/prose');
+}

--- a/apps/root/src/app/tools/admin/AdminSidebar.spec.tsx
+++ b/apps/root/src/app/tools/admin/AdminSidebar.spec.tsx
@@ -37,6 +37,7 @@ describe('AdminSidebar', () => {
     render(<AdminSidebar />);
     expect(screen.getByText('Tools Admin')).toBeInTheDocument();
     expect(screen.getByText('Jobs')).toBeInTheDocument();
+    expect(screen.getByText('Career')).toBeInTheDocument();
     expect(screen.getByText('Site Audits')).toBeInTheDocument();
   });
 

--- a/apps/root/src/app/tools/admin/AdminSidebar.tsx
+++ b/apps/root/src/app/tools/admin/AdminSidebar.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { usePathname, useRouter } from 'next/navigation';
-import { Briefcase, Gauge, LogOut } from 'lucide-react';
+import { Briefcase, FileText, Gauge, LogOut } from 'lucide-react';
 import { Sidebar, type SidebarItem } from '@danieljoffe.com/shared-ui/Sidebar';
 import Button from '@/components/Button';
 
@@ -11,6 +11,12 @@ const NAV_ITEMS: (SidebarItem & { href: string })[] = [
     label: 'Jobs',
     href: '/tools/admin/jobs',
     icon: <Briefcase className='size-4' aria-hidden />,
+  },
+  {
+    id: 'career',
+    label: 'Career',
+    href: '/tools/admin/career',
+    icon: <FileText className='size-4' aria-hidden />,
   },
   {
     id: 'audit',

--- a/apps/root/src/app/tools/admin/career/CareerOverview.spec.tsx
+++ b/apps/root/src/app/tools/admin/career/CareerOverview.spec.tsx
@@ -1,0 +1,154 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import CareerOverview from './CareerOverview';
+import type { OptimizedDoc, ProseDoc } from './types';
+
+const proseDoc: ProseDoc = {
+  id: 'prose-1',
+  user_id: null,
+  version: 3,
+  content: 'Career narrative content goes here.',
+  created_at: '2026-04-20T12:00:00Z',
+};
+
+const optimizedDoc: OptimizedDoc = {
+  id: 'opt-1',
+  user_id: null,
+  prose_doc_id: 'prose-1',
+  version: 2,
+  payload: {
+    summary: 'Senior FE with a decade of shipped work.',
+    roles: [
+      {
+        id: 'fc',
+        company: 'FightCamp',
+        title: 'Senior Frontend Engineer',
+        start: '2021-11',
+        end: '2024-04',
+        summary: null,
+        skills: ['React'],
+        outcome_refs: [],
+      },
+      {
+        id: 'current',
+        company: 'Acme',
+        title: 'Engineer',
+        start: '2024-05',
+        end: null,
+        summary: null,
+        skills: [],
+        outcome_refs: [],
+      },
+    ],
+    skills: [
+      { name: 'React', evidence_refs: [], years: 8 },
+      { name: 'TypeScript', evidence_refs: [], years: 6 },
+    ],
+    outcomes: [
+      {
+        description: 'Cut mobile load times from 10s to 2s',
+        metric: 'LCP',
+        value: '2s',
+        role_ref: 'fc',
+      },
+    ],
+  },
+  markdown_view: null,
+  source: 'llm',
+  created_at: '2026-04-21T10:00:00Z',
+};
+
+function mockFetch(prose: unknown, optimized: unknown, status = 200): void {
+  (global.fetch as jest.Mock) = jest.fn((input: RequestInfo | URL) => {
+    const url = typeof input === 'string' ? input : input.toString();
+    const body = url.endsWith('/prose') ? prose : optimized;
+    return Promise.resolve({
+      ok: status >= 200 && status < 300,
+      status,
+      json: () => Promise.resolve(body),
+    }) as unknown as Promise<Response>;
+  });
+}
+
+describe('CareerOverview', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('shows a spinner while loading', () => {
+    (global.fetch as jest.Mock) = jest.fn(
+      () =>
+        new Promise(() => {
+          // intentionally never resolves — keeps the component in its loading state
+        })
+    );
+    render(<CareerOverview />);
+    expect(screen.getByLabelText(/loading career data/i)).toBeInTheDocument();
+  });
+
+  it('renders prose content and optimized summary when both are populated', async () => {
+    mockFetch(proseDoc, optimizedDoc);
+    render(<CareerOverview />);
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(/career narrative content goes here/i)
+      ).toBeInTheDocument()
+    );
+
+    expect(screen.getByText(/v3/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/senior fe with a decade of shipped work/i)
+    ).toBeInTheDocument();
+    expect(screen.getByText(/2 roles · 2 skills · 1 outcome/i)).toBeInTheDocument();
+    expect(screen.getByText(/FightCamp/)).toBeInTheDocument();
+    expect(screen.getByText(/Acme/)).toBeInTheDocument();
+    expect(screen.getByText(/2024-05 - present/)).toBeInTheDocument();
+  });
+
+  it('renders empty state when prose is null', async () => {
+    mockFetch({ prose: null }, { optimized: null });
+    render(<CareerOverview />);
+    await waitFor(() =>
+      expect(
+        screen.getByText(/no prose doc yet\. start an onboarding conversation/i)
+      ).toBeInTheDocument()
+    );
+  });
+
+  it('renders empty state when optimized is null', async () => {
+    mockFetch(proseDoc, { optimized: null });
+    render(<CareerOverview />);
+    await waitFor(() =>
+      expect(
+        screen.getByText(/no optimized doc yet\. derive one via/i)
+      ).toBeInTheDocument()
+    );
+  });
+
+  it('shows an error message when the fetch fails', async () => {
+    (global.fetch as jest.Mock) = jest.fn(() =>
+      Promise.resolve({
+        ok: false,
+        status: 500,
+        json: () => Promise.resolve({ error: 'boom' }),
+      })
+    );
+    render(<CareerOverview />);
+    await waitFor(() =>
+      expect(screen.getByText(/error loading career data/i)).toBeInTheDocument()
+    );
+  });
+
+  it('issues requests to both career proxy endpoints', async () => {
+    mockFetch({ prose: null }, { optimized: null });
+    render(<CareerOverview />);
+    await waitFor(() =>
+      expect(screen.getByText(/no prose doc yet/i)).toBeInTheDocument()
+    );
+    const urls = (global.fetch as jest.Mock).mock.calls.map(
+      (call: unknown[]) => String(call[0])
+    );
+    expect(urls).toContain('/api/career/experience/prose');
+    expect(urls).toContain('/api/career/experience/optimized');
+  });
+});

--- a/apps/root/src/app/tools/admin/career/CareerOverview.tsx
+++ b/apps/root/src/app/tools/admin/career/CareerOverview.tsx
@@ -1,0 +1,199 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Badge } from '@danieljoffe.com/shared-ui/Badge';
+import { Card } from '@danieljoffe.com/shared-ui/Card';
+import { Heading } from '@danieljoffe.com/shared-ui/Heading';
+import { Spinner } from '@danieljoffe.com/shared-ui/Spinner';
+import { Stack } from '@danieljoffe.com/shared-ui/Stack';
+import { Text } from '@danieljoffe.com/shared-ui/Text';
+import type {
+  OptimizedDoc,
+  OptimizedResponse,
+  ProseDoc,
+  ProseResponse,
+} from './types';
+
+interface CareerState {
+  loading: boolean;
+  error: string | null;
+  prose: ProseDoc | null;
+  optimized: OptimizedDoc | null;
+}
+
+function hasProse(value: ProseResponse): value is ProseDoc {
+  return 'id' in value;
+}
+
+function hasOptimized(value: OptimizedResponse): value is OptimizedDoc {
+  return 'id' in value;
+}
+
+function formatDate(iso: string): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return iso;
+  return date.toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+async function fetchCareerData(): Promise<{
+  prose: ProseDoc | null;
+  optimized: OptimizedDoc | null;
+}> {
+  const [proseRes, optRes] = await Promise.all([
+    fetch('/api/career/experience/prose', { cache: 'no-store' }),
+    fetch('/api/career/experience/optimized', { cache: 'no-store' }),
+  ]);
+
+  if (!proseRes.ok) throw new Error(`Prose fetch failed (${proseRes.status})`);
+  if (!optRes.ok) throw new Error(`Optimized fetch failed (${optRes.status})`);
+
+  const proseBody = (await proseRes.json()) as ProseResponse;
+  const optBody = (await optRes.json()) as OptimizedResponse;
+
+  return {
+    prose: hasProse(proseBody) ? proseBody : null,
+    optimized: hasOptimized(optBody) ? optBody : null,
+  };
+}
+
+export default function CareerOverview() {
+  const [state, setState] = useState<CareerState>({
+    loading: true,
+    error: null,
+    prose: null,
+    optimized: null,
+  });
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchCareerData()
+      .then(data => {
+        if (cancelled) return;
+        setState({
+          loading: false,
+          error: null,
+          prose: data.prose,
+          optimized: data.optimized,
+        });
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setState({
+          loading: false,
+          error: err instanceof Error ? err.message : 'Failed to load career data',
+          prose: null,
+          optimized: null,
+        });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (state.loading) {
+    return (
+      <div className='flex justify-center py-12'>
+        <Spinner aria-label='Loading career data' />
+      </div>
+    );
+  }
+
+  if (state.error) {
+    return (
+      <Card>
+        <Text variant='body'>Error loading career data: {state.error}</Text>
+      </Card>
+    );
+  }
+
+  const { prose, optimized } = state;
+
+  return (
+    <Stack gap='lg'>
+      <Heading variant='section' as='h1'>
+        Career
+      </Heading>
+
+      <Card>
+        <Stack gap='md'>
+          <div className='flex items-center justify-between'>
+            <Heading variant='cardTitle' as='h2'>
+              Prose doc
+            </Heading>
+            {prose ? (
+              <Badge variant='info'>
+                v{prose.version} · {formatDate(prose.created_at)}
+              </Badge>
+            ) : (
+              <Badge variant='default'>Empty</Badge>
+            )}
+          </div>
+          {prose ? (
+            <pre className='whitespace-pre-wrap text-sm text-text-primary'>
+              {prose.content}
+            </pre>
+          ) : (
+            <Text variant='body'>
+              No prose doc yet. Start an onboarding conversation to build one.
+            </Text>
+          )}
+        </Stack>
+      </Card>
+
+      <Card>
+        <Stack gap='md'>
+          <div className='flex items-center justify-between'>
+            <Heading variant='cardTitle' as='h2'>
+              Optimized doc
+            </Heading>
+            {optimized ? (
+              <Badge variant='info'>
+                v{optimized.version} · {optimized.source} ·{' '}
+                {formatDate(optimized.created_at)}
+              </Badge>
+            ) : (
+              <Badge variant='default'>Empty</Badge>
+            )}
+          </div>
+          {optimized ? (
+            <Stack gap='sm'>
+              {optimized.payload.summary && (
+                <Text variant='body'>{optimized.payload.summary}</Text>
+              )}
+              <Text variant='detail'>
+                {optimized.payload.roles.length} role
+                {optimized.payload.roles.length === 1 ? '' : 's'} ·{' '}
+                {optimized.payload.skills.length} skill
+                {optimized.payload.skills.length === 1 ? '' : 's'} ·{' '}
+                {optimized.payload.outcomes.length} outcome
+                {optimized.payload.outcomes.length === 1 ? '' : 's'}
+              </Text>
+              {optimized.payload.roles.length > 0 && (
+                <ul className='list-disc pl-5 text-sm text-text-primary'>
+                  {optimized.payload.roles.map(role => (
+                    <li key={role.id}>
+                      <span className='font-medium'>{role.title}</span> at{' '}
+                      {role.company}
+                      {role.end
+                        ? ` (${role.start} - ${role.end})`
+                        : ` (${role.start} - present)`}
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </Stack>
+          ) : (
+            <Text variant='body'>
+              No optimized doc yet. Derive one via POST /experience/derive once the
+              prose doc has content.
+            </Text>
+          )}
+        </Stack>
+      </Card>
+    </Stack>
+  );
+}

--- a/apps/root/src/app/tools/admin/career/page.tsx
+++ b/apps/root/src/app/tools/admin/career/page.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from 'next';
+import CareerOverview from './CareerOverview';
+
+export const metadata: Metadata = {
+  title: 'Career | Tools Admin',
+  robots: { index: false, follow: false },
+};
+
+export default function CareerAdminPage() {
+  return <CareerOverview />;
+}

--- a/apps/root/src/app/tools/admin/career/types.ts
+++ b/apps/root/src/app/tools/admin/career/types.ts
@@ -1,0 +1,59 @@
+// TypeScript mirror of the Pydantic shapes in apps/job-api/app/models/experience.py.
+// Kept narrow to what this dashboard consumes; grow as new endpoints are wired.
+
+export interface ProseDoc {
+  id: string;
+  user_id: string | null;
+  version: number;
+  content: string;
+  created_at: string;
+}
+
+export interface Outcome {
+  description: string;
+  metric: string | null;
+  value: string | null;
+  role_ref: string | null;
+}
+
+export interface Role {
+  id: string;
+  company: string;
+  title: string;
+  start: string;
+  end: string | null;
+  summary: string | null;
+  skills: string[];
+  outcome_refs: string[];
+}
+
+export interface Skill {
+  name: string;
+  evidence_refs: string[];
+  years: number | null;
+}
+
+export interface OptimizedPayload {
+  summary: string | null;
+  roles: Role[];
+  skills: Skill[];
+  outcomes: Outcome[];
+}
+
+export type OptimizedDocSource = 'llm' | 'user_edit';
+
+export interface OptimizedDoc {
+  id: string;
+  user_id: string | null;
+  prose_doc_id: string | null;
+  version: number;
+  payload: OptimizedPayload;
+  markdown_view: string | null;
+  source: OptimizedDocSource;
+  created_at: string;
+}
+
+// The route handlers return either the record or `{ prose: null } / { optimized: null }`
+// when the table is empty. The discriminator is that the payload fields are absent.
+export type ProseResponse = ProseDoc | { prose: null };
+export type OptimizedResponse = OptimizedDoc | { optimized: null };


### PR DESCRIPTION
## Summary

First UI slice for the resume tailor backend. Read-only overview at `/tools/admin/career` showing the current prose doc + optimized doc summary. Reuses the existing jobs proxy (`verifyJobsAdmin` + `proxyToFastAPI`) since admin auth is shared across tools.

**Scope is intentionally thin.** Subsequent slices add conversation (send turn), derive trigger, tailor form, and document list.

Targets `feature/resume-tailor`.

## What's in

**Routes** — `apps/root/src/app/api/career/experience/`
- `GET /api/career/experience/prose` → delegates to `proxyToFastAPI('/experience/prose')` after `verifyJobsAdmin()`.
- `GET /api/career/experience/optimized` → same pattern.
- Both return 401 if unauthenticated. Same shape as the existing `/api/jobs` routes.

**Types** — `apps/root/src/app/tools/admin/career/types.ts`
- TypeScript mirror of the Pydantic shapes the job-api returns (`ProseDoc`, `OptimizedDoc`, `OptimizedPayload`, `Role`, `Skill`, `Outcome`).
- Response unions (`ProseResponse`, `OptimizedResponse`) that handle the `{prose: null}` / `{optimized: null}` shape the backend returns when tables are empty.

**Component** — `apps/root/src/app/tools/admin/career/CareerOverview.tsx`
- `'use client'`. Fetches both endpoints in parallel on mount.
- States: loading (Spinner), error (fetch failure surfaced), empty (prose/optimized individually missing), populated.
- Populated view: prose content in a `<pre>` block, optimized summary with counts (`N roles · M skills · K outcomes`) and a role list.
- Version + date badges on each card.
- Uses shared-ui `Card`, `Heading` (`section`, `cardTitle`), `Badge` (`info`, `default`), `Stack`, `Text` (`body`, `detail`), `Spinner`.

**Page** — `apps/root/src/app/tools/admin/career/page.tsx`
- Server-component page with `noindex` metadata. Mounts `CareerOverview`.

**Nav** — `apps/root/src/app/tools/admin/AdminSidebar.tsx`
- Added "Career" nav item (FileText icon from lucide-react) between Jobs and Site Audits.
- Existing `AdminSidebar.spec.tsx` assertion updated.

## Not in (intentional — future slices)

- **No write paths.** No `POST /experience/prose`, no `/conversation/turn`, no `/derive`, no `/tailor/*`. Read-only.
- **No forms.** No chat interface, no tailor request form.
- **No document list / download.** `/tailor/resumes` and `/tailor/cover-letters` aren't wired yet.
- **No experience edit.** User can see the optimized doc but can't edit it from UI today.
- **No shared proxy extraction.** `verifyJobsAdmin` + `proxyToFastAPI` are imported from `@/app/api/jobs/proxy`. Slight naming incongruity ("jobs" used for career) but extracting to a shared `lib/jobApiProxy.ts` is a separate refactor PR.

## Test plan

- [x] `pnpm tsc --noEmit` — clean
- [x] `eslint` on touched files — clean (after `--fix` for import grouping)
- [x] `jest` — **61/61 admin tests pass** (13 new + 48 pre-existing)
  - 2 prose route tests (401 unauth, 200 proxy path)
  - 2 optimized route tests (401 unauth, 200 proxy path)
  - 6 CareerOverview tests (loading spinner, populated prose + optimized summary + role list, empty-prose, empty-optimized, fetch error surfaced, both endpoints called)
  - 3 AdminSidebar tests (nav items including Career, sign-out button, logout flow)
- [ ] Run locally: `pnpm nx dev root`, visit `/tools/admin/career`, log in via `/tools/login`, verify the overview renders against real backend data

## Up next

- **P4b** — conversation surface (send a turn, see LLM reply, show history).
- **P4c** — derive trigger button + pending state.
- **P4d** — tailor form (JD + company → generate resume or cover letter, show warnings + download link).
- **P4e** — tailored documents list.

https://claude.ai/code/session_01GiZqgubpGXDBuQSEGNGsbp

---
_Generated by [Claude Code](https://claude.ai/code/session_01GiZqgubpGXDBuQSEGNGsbp)_