### PR TITLE
fix(e2e): blog search aria-live whitespace

### DIFF
--- a/apps/root-e2e/src/blog-search.spec.ts
+++ b/apps/root-e2e/src/blog-search.spec.ts
@@ -55,9 +55,11 @@ test.describe('blog search and filtering', () => {
     const initialCount = await postLinks.count();
 
     // Search to filter down
-    await searchInput.fill('performance');
-    const resultsSummary = page.locator('[aria-live="polite"]');
-    await expect(resultsSummary).toBeVisible();
+    await fillInput(searchInput, 'performance');
+    const resultsSummary = page
+      .locator('[aria-live="polite"]')
+      .filter({ hasText: /\d+ results? for/ });
+    await expect(resultsSummary).toBeVisible({ timeout: 15000 });
 
     // Clear search
     await searchInput.fill('');
@@ -93,7 +95,7 @@ test.describe('blog search and filtering', () => {
 
   test('selecting a tag clears the search input', async ({ page }) => {
     const searchInput = page.getByLabel('Search blog posts');
-    await searchInput.fill('test query');
+    await fillInput(searchInput, 'test query');
     await expect(searchInput).toHaveValue('test query');
 
     // Click a tag chip
@@ -114,7 +116,7 @@ test.describe('blog search and filtering', () => {
 
     // Now type in search
     const searchInput = page.getByLabel('Search blog posts');
-    await searchInput.fill('performance');
+    await fillInput(searchInput, 'performance');
 
     // Tag should be deselected
     await expect(firstTagButton).toHaveAttribute('aria-pressed', 'false');
@@ -133,7 +135,7 @@ test.describe('blog search and filtering', () => {
 
     // Search to activate filtering
     const searchInput = page.getByLabel('Search blog posts');
-    await searchInput.fill('performance');
+    await fillInput(searchInput, 'performance');
 
     // Pagination should be hidden
     await expect(pagination).toBeHidden();

--- a/apps/root/src/components/BlogSearchAndList.tsx
+++ b/apps/root/src/components/BlogSearchAndList.tsx
@@ -135,17 +135,13 @@ export function BlogSearchAndList({
 
       {isSearching && (
         <Text variant='meta' as='p' aria-live='polite'>
-          {searchResults.length}{' '}
-          {searchResults.length === 1 ? 'result' : 'results'} for &quot;
-          {trimmedQuery}&quot;
+          {`${searchResults.length} ${searchResults.length === 1 ? 'result' : 'results'} for "${trimmedQuery}"`}
         </Text>
       )}
 
       {isFiltering && !isSearching && (
         <Text variant='meta' as='p' aria-live='polite'>
-          {tagResults.length} {tagResults.length === 1 ? 'post' : 'posts'}{' '}
-          tagged &quot;
-          {activeTag}&quot;
+          {`${tagResults.length} ${tagResults.length === 1 ? 'post' : 'posts'} tagged "${activeTag}"`}
         </Text>
       )}
 

--- a/apps/root/src/components/ProjectsGridWithTags.tsx
+++ b/apps/root/src/components/ProjectsGridWithTags.tsx
@@ -52,9 +52,7 @@ export function ProjectsGridWithTags({
 
       {isFiltering && (
         <Text variant='meta' as='p' aria-live='polite'>
-          {tagResults.length}{' '}
-          {tagResults.length === 1 ? 'case study' : 'case studies'} tagged
-          &quot;{activeTag}&quot;
+          {`${tagResults.length} ${tagResults.length === 1 ? 'case study' : 'case studies'} tagged "${activeTag}"`}
         </Text>
       )}
 


### PR DESCRIPTION
## Summary
- JSX whitespace trimming stripped the space between "results" and "for" in the blog search `aria-live` region, rendering `10 resultsfor "performance"` instead of `10 results for "performance"`. The E2E test regex `/\d+ results? for/` couldn't match, causing consistent CI failures.
- Replaced multiline JSX text interpolation with template literals in `BlogSearchAndList`, `ProjectsGridWithTags` for predictable spacing.
- Updated all controlled input interactions in `blog-search.spec.ts` to use `fillInput()` (pressSequentially) instead of `fill()` to reliably trigger React's onChange on CI.

## Test plan
- [x] All 10 blog-search E2E tests pass locally on Chromium
- [x] All 6 project-tags E2E tests pass locally on Chromium
- [x] 11/11 unit tests pass for BlogSearchAndList + ProjectsGridWithTags
- [x] Typecheck clean
- [x] Pre-commit hooks (lint, format, typecheck) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)