### PR TITLE
feat(job-api): manual JD entry — URL extraction cascade (#500)

### DIFF
--- a/apps/job-api/app/config.py
+++ b/apps/job-api/app/config.py
@@ -21,6 +21,9 @@ class Settings(BaseSettings):
     # URL validation — enable to validate job URLs during polling.
     validate_poll_urls: bool = False
 
+    # Firecrawl — set API key to enable JS-rendered page extraction fallback.
+    firecrawl_api_key: str = ""
+
     # Embeddings provider — set to "voyage" to use the real SDK; mock is the default.
     embeddings_provider: Literal["mock", "voyage"] = "mock"
     voyage_api_key: str = ""

--- a/apps/job-api/app/models/schemas.py
+++ b/apps/job-api/app/models/schemas.py
@@ -21,7 +21,7 @@ class ScoreResult(BaseModel):
     excluded: bool
 
 
-Provider = Literal["greenhouse", "lever", "ashby", "workday", "smartrecruiters", "jsonld"]
+Provider = Literal["greenhouse", "lever", "ashby", "workday", "smartrecruiters", "jsonld", "manual"]
 
 
 class JobPosting(BaseModel):
@@ -87,3 +87,19 @@ class UrlValidateResponse(BaseModel):
     final_url: str
     warnings: list[str]
     rejection_reason: str | None
+
+
+class ManualJobRequest(BaseModel):
+    url: str = Field(max_length=2048)
+    title: str | None = Field(default=None, max_length=500)
+    company_name: str | None = Field(default=None, max_length=200)
+    location: str | None = Field(default=None, max_length=200)
+
+
+class ManualJobResponse(BaseModel):
+    success: bool
+    posting_id: str | None = None
+    extracted: dict[str, str | None]
+    extraction_tier: str
+    warnings: list[str]
+    needs_manual_fields: bool

--- a/apps/job-api/app/routers/jobs.py
+++ b/apps/job-api/app/routers/jobs.py
@@ -1,12 +1,36 @@
-from typing import Any
+import hashlib
+from datetime import UTC, datetime
+from typing import Any, cast
+from urllib.parse import urlparse
 
+import httpx
 from fastapi import APIRouter, Depends, HTTPException, Query
 from postgrest.types import CountMethod
 from supabase import Client
 
 from app.dependencies import get_supabase, verify_api_key_or_session
-from app.models.schemas import UrlValidateRequest, UrlValidateResponse
-from app.services.validate import validate_job_url
+from app.http_client import get_http_client
+from app.models.schemas import (
+    ManualJobRequest,
+    ManualJobResponse,
+    UrlValidateRequest,
+    UrlValidateResponse,
+)
+from app.seed.keyword_config import keyword_config
+from app.services.extract import (
+    MANUAL_SOURCE_ID,
+    ExtractionResult,
+    _extract_from_firecrawl,
+    extract_job_from_html,
+)
+from app.services.sanitize import sanitize_html
+from app.services.scoring import score_job
+from app.services.validate import (
+    is_banned_domain,
+    registrable_domain,
+    validate_format,
+    validate_job_url,
+)
 
 router = APIRouter(
     prefix="/jobs",
@@ -66,6 +90,130 @@ async def validate_url(body: UrlValidateRequest) -> UrlValidateResponse:
         final_url=result.final_url,
         warnings=result.warnings,
         rejection_reason=result.rejection_reason,
+    )
+
+
+@router.post("/manual")
+async def add_manual_job(
+    body: ManualJobRequest,
+    supabase: Client = Depends(get_supabase),
+) -> ManualJobResponse:
+    """Add a job posting by URL. Extracts metadata via cascade."""
+    warnings: list[str] = []
+
+    # Layer 1: Format validation
+    cleaned = validate_format(body.url)
+    if cleaned is None:
+        raise HTTPException(status_code=400, detail="Malformed URL")
+
+    # Layer 2: Banned domain check
+    hostname = urlparse(cleaned).hostname or ""
+    if is_banned_domain(hostname):
+        raise HTTPException(
+            status_code=400,
+            detail=f"Banned domain: {registrable_domain(hostname)}",
+        )
+
+    # Fetch the page
+    client = get_http_client()
+    try:
+        resp = await client.get(cleaned)
+        final_url = str(resp.url)
+    except httpx.HTTPError:
+        raise HTTPException(status_code=400, detail="Failed to fetch URL")
+
+    # Check post-redirect domain
+    final_hostname = urlparse(final_url).hostname or ""
+    if is_banned_domain(final_hostname):
+        raise HTTPException(
+            status_code=400,
+            detail=f"Redirects to banned domain: {registrable_domain(final_hostname)}",
+        )
+    if registrable_domain(hostname) != registrable_domain(final_hostname):
+        warnings.append(
+            f"redirect_domain_change:"
+            f"{registrable_domain(hostname)}->"
+            f"{registrable_domain(final_hostname)}"
+        )
+
+    # Extract metadata
+    html = resp.text if resp.status_code == 200 else ""
+    extraction: ExtractionResult
+    if html:
+        extraction = extract_job_from_html(html, final_url)
+    else:
+        warnings.append(f"http_status:{resp.status_code}")
+        extraction = ExtractionResult(tier="none", warnings=["fetch_non_200"])
+
+    # Tier 3: Firecrawl fallback if extraction found nothing
+    if extraction.tier == "none":
+        fc_result = await _extract_from_firecrawl(final_url)
+        if fc_result:
+            extraction = fc_result
+
+    warnings.extend(extraction.warnings)
+
+    # Merge: user overrides take precedence
+    title = body.title or extraction.title
+    company_name = body.company_name or extraction.company_name or ""
+    location = body.location or extraction.location
+    description_html = extraction.description_html or ""
+
+    extracted_summary = {
+        "title": extraction.title,
+        "company_name": extraction.company_name,
+        "location": extraction.location,
+    }
+
+    # If no title, return partial result asking for manual fields
+    if not title:
+        return ManualJobResponse(
+            success=False,
+            extracted=extracted_summary,
+            extraction_tier=extraction.tier,
+            warnings=warnings,
+            needs_manual_fields=True,
+        )
+
+    # Generate external_id from URL
+    external_id = hashlib.sha256(final_url.encode()).hexdigest()[:16]
+
+    # Score the job
+    score_result = score_job(title, description_html, keyword_config)
+
+    # Upsert into job_postings
+    row = {
+        "external_id": external_id,
+        "source_id": MANUAL_SOURCE_ID,
+        "title": title,
+        "company_name": company_name,
+        "location": location,
+        "department": None,
+        "description_html": sanitize_html(description_html) if description_html else "",
+        "absolute_url": final_url,
+        "score": score_result.score,
+        "score_breakdown": score_result.breakdown.model_dump(),
+        "greenhouse_updated_at": datetime.now(UTC).isoformat(),
+    }
+
+    resp_db = (
+        supabase.table("job_postings")
+        .upsert(row, on_conflict="source_id,external_id")
+        .execute()
+    )
+
+    posting_id = None
+    if resp_db.data:
+        data = cast(dict[str, Any], resp_db.data[0])
+        posting_id = data.get("id")
+
+    return ManualJobResponse(
+        success=True,
+        posting_id=posting_id,
+        extracted=extracted_summary,
+        extraction_tier=extraction.tier,
+        warnings=warnings,
+        needs_manual_fields=False,
     )
 
 

--- a/apps/job-api/app/services/extract.py
+++ b/apps/job-api/app/services/extract.py
@@ -1,0 +1,210 @@
+"""Job metadata extraction from URLs (#500).
+
+Three-tier extraction cascade:
+  1. JSON-LD structured data (gold standard)
+  2. HTML meta/OG tags + heuristics (fallback)
+  3. Firecrawl for JS-rendered pages (gated behind API key)
+"""
+
+import logging
+import re
+from urllib.parse import urlparse
+
+from bs4 import BeautifulSoup
+from pydantic import BaseModel
+
+from app.services.jsonld import _extract_job_postings, _get_location, _get_str
+
+logger = logging.getLogger(__name__)
+
+MANUAL_SOURCE_ID = "00000000-0000-4000-a000-000000000001"
+
+# Patterns for finding job description content areas
+_JOB_CONTENT_SELECTORS = [
+    {"class_": re.compile(r"job[-_]?description", re.I)},
+    {"class_": re.compile(r"job[-_]?details", re.I)},
+    {"class_": re.compile(r"responsibilities", re.I)},
+    {"class_": re.compile(r"qualifications", re.I)},
+    {"id": re.compile(r"job[-_]?description", re.I)},
+    {"id": re.compile(r"job[-_]?details", re.I)},
+]
+
+
+class ExtractionResult(BaseModel):
+    title: str | None = None
+    company_name: str | None = None
+    location: str | None = None
+    description_html: str | None = None
+    tier: str = "none"  # "jsonld" | "html_meta" | "firecrawl" | "none"
+    warnings: list[str] = []
+
+
+def _company_from_domain(url: str) -> str:
+    """Derive a company name from a URL's hostname.
+
+    Examples: jobs.stripe.com → Stripe, careers.google.com → Google
+    """
+    hostname = urlparse(url).hostname or ""
+    parts = hostname.lower().split(".")
+    # Skip common prefixes
+    skip = {"www", "jobs", "careers", "boards", "apply", "hire", "recruiting"}
+    for part in parts:
+        if part not in skip and len(part) > 1:
+            return part.capitalize()
+    # Fallback: second-level domain
+    if len(parts) >= 2:
+        return parts[-2].capitalize()
+    return hostname
+
+
+def _extract_from_jsonld(html: str) -> ExtractionResult | None:
+    """Tier 1: Extract job metadata from JSON-LD structured data."""
+    postings = _extract_job_postings(html)
+    if not postings:
+        return None
+
+    posting = postings[0]
+    title = _get_str(posting, "title") or _get_str(posting, "jobTitle")
+    if not title:
+        return None
+
+    description = _get_str(posting, "description")
+    location = _get_location(posting)
+
+    company = None
+    org = posting.get("hiringOrganization")
+    if isinstance(org, dict):
+        company = _get_str(org, "name")
+
+    return ExtractionResult(
+        title=title,
+        company_name=company or None,
+        location=location,
+        description_html=description or None,
+        tier="jsonld",
+    )
+
+
+def _meta_content(soup: BeautifulSoup, prop: str) -> str | None:
+    """Safely extract string content from a <meta property=...> tag."""
+    tag = soup.find("meta", attrs={"property": prop})
+    if tag:
+        val = tag.get("content")
+        if isinstance(val, str) and val.strip():
+            return val.strip()
+    return None
+
+
+def _meta_name_content(soup: BeautifulSoup, name: str) -> str | None:
+    """Safely extract string content from a <meta name=...> tag."""
+    tag = soup.find("meta", attrs={"name": name})
+    if tag:
+        val = tag.get("content")
+        if isinstance(val, str) and val.strip():
+            return val.strip()
+    return None
+
+
+def _extract_from_html_meta(html: str, url: str) -> ExtractionResult | None:
+    """Tier 2: Extract job metadata from OG tags and HTML heuristics."""
+    soup = BeautifulSoup(html, "html.parser")
+
+    # Title: og:title → <title>
+    title = _meta_content(soup, "og:title")
+    if not title:
+        title_tag = soup.find("title")
+        if title_tag and title_tag.string:
+            title = title_tag.string.strip()
+
+    if not title:
+        return None
+
+    # Company: og:site_name → domain
+    company = _meta_content(soup, "og:site_name")
+    if not company:
+        company = _company_from_domain(url)
+
+    # Description: content area → og:description → meta description
+    description = None
+    for selector in _JOB_CONTENT_SELECTORS:
+        el = soup.find(**selector)  # type: ignore[call-overload]
+        if el:
+            description = str(el)
+            break
+    if not description:
+        description = _meta_content(soup, "og:description")
+    if not description:
+        description = _meta_name_content(soup, "description")
+
+    # Location: og:locale or leave None
+    location: str | None = None
+    locale_val = _meta_content(soup, "og:locale")
+    if locale_val and locale_val != "en_US":
+        location = locale_val
+
+    return ExtractionResult(
+        title=title,
+        company_name=company or None,
+        location=location,
+        description_html=description or None,
+        tier="html_meta",
+    )
+
+
+async def _extract_from_firecrawl(url: str) -> ExtractionResult | None:
+    """Tier 3: Use Firecrawl API for JS-rendered pages (gated)."""
+    from app.config import settings
+
+    if not settings.firecrawl_api_key:
+        return None
+
+    try:
+        from app.http_client import get_http_client
+
+        client = get_http_client()
+        resp = await client.post(
+            "https://api.firecrawl.dev/v1/scrape",
+            json={"url": url, "formats": ["html"]},
+            headers={"Authorization": f"Bearer {settings.firecrawl_api_key}"},
+            timeout=15.0,
+        )
+        if resp.status_code != 200:
+            return None
+
+        data = resp.json().get("data", {})
+        fc_html = data.get("html", "")
+        if not fc_html:
+            return None
+
+        # Run tiers 1+2 on the Firecrawl-rendered HTML
+        result = _extract_from_jsonld(fc_html) or _extract_from_html_meta(fc_html, url)
+        if result:
+            result.tier = "firecrawl"
+        return result
+
+    except Exception:
+        logger.exception("Firecrawl extraction failed for %s", url)
+        return None
+
+
+def extract_job_from_html(html: str, url: str) -> ExtractionResult:
+    """Run the synchronous extraction tiers (1 + 2) on pre-fetched HTML.
+
+    Tier 3 (Firecrawl) requires async and a separate fetch, so it is
+    handled by the caller when tiers 1+2 fail.
+    """
+    # Tier 1: JSON-LD
+    result = _extract_from_jsonld(html)
+    if result:
+        return result
+
+    # Tier 2: HTML meta/OG heuristics
+    result = _extract_from_html_meta(html, url)
+    if result:
+        return result
+
+    # Nothing found
+    return ExtractionResult(
+        tier="none",
+        warnings=["extraction_failed:no_metadata_found"],
+    )

--- a/apps/job-api/app/services/validate.py
+++ b/apps/job-api/app/services/validate.py
@@ -18,7 +18,7 @@ from app.services.jsonld import _extract_job_postings
 _IP_RE = re.compile(r"^\d{1,3}(\.\d{1,3}){3}$")
 
 
-def _validate_format(url: str) -> str | None:
+def validate_format(url: str) -> str | None:
     """Return cleaned URL if valid, None if malformed."""
     cleaned = url.strip()
     if not cleaned:
@@ -74,7 +74,7 @@ BANNED_DOMAINS: frozenset[str] = frozenset(
 )
 
 
-def _registrable_domain(hostname: str) -> str:
+def registrable_domain(hostname: str) -> str:
     """Extract the registrable domain (last two parts) from a hostname."""
     parts = hostname.lower().rstrip(".").split(".")
     if len(parts) >= 2:
@@ -82,8 +82,8 @@ def _registrable_domain(hostname: str) -> str:
     return hostname.lower()
 
 
-def _is_banned(hostname: str) -> bool:
-    return _registrable_domain(hostname) in BANNED_DOMAINS
+def is_banned_domain(hostname: str) -> bool:
+    return registrable_domain(hostname) in BANNED_DOMAINS
 
 
 # ---------------------------------------------------------------------------
@@ -156,7 +156,7 @@ class ValidationResult(BaseModel):
 async def validate_job_url(url: str) -> ValidationResult:
     """Validate a job URL through all four layers."""
     # Layer 1: Format
-    cleaned = _validate_format(url)
+    cleaned = validate_format(url)
     if cleaned is None:
         return ValidationResult(
             is_valid=False,
@@ -166,11 +166,11 @@ async def validate_job_url(url: str) -> ValidationResult:
 
     # Layer 2: Banned domain (pre-redirect)
     hostname = urlparse(cleaned).hostname or ""
-    if _is_banned(hostname):
+    if is_banned_domain(hostname):
         return ValidationResult(
             is_valid=False,
             final_url=cleaned,
-            rejection_reason=f"banned_domain:{_registrable_domain(hostname)}",
+            rejection_reason=f"banned_domain:{registrable_domain(hostname)}",
         )
 
     # Layer 3: Redirect detection + Layer 4: Content verification
@@ -190,21 +190,21 @@ async def validate_job_url(url: str) -> ValidationResult:
 
             # Detect domain change via redirect
             final_hostname = urlparse(final_url).hostname or ""
-            if _registrable_domain(hostname) != _registrable_domain(final_hostname):
+            if registrable_domain(hostname) != registrable_domain(final_hostname):
                 warnings.append(
                     f"redirect_domain_change:"
-                    f"{_registrable_domain(hostname)}->"
-                    f"{_registrable_domain(final_hostname)}"
+                    f"{registrable_domain(hostname)}->"
+                    f"{registrable_domain(final_hostname)}"
                 )
 
             # Layer 2 again: banned check post-redirect
-            if _is_banned(final_hostname):
+            if is_banned_domain(final_hostname):
                 return ValidationResult(
                     is_valid=False,
                     final_url=final_url,
                     rejection_reason=(
                         f"banned_domain_after_redirect:"
-                        f"{_registrable_domain(final_hostname)}"
+                        f"{registrable_domain(final_hostname)}"
                     ),
                 )
 

--- a/apps/job-api/tests/test_extract.py
+++ b/apps/job-api/tests/test_extract.py
@@ -1,0 +1,195 @@
+"""Tests for job metadata extraction service (#500)."""
+
+from app.services.extract import (
+    _company_from_domain,
+    _extract_from_html_meta,
+    _extract_from_jsonld,
+    extract_job_from_html,
+)
+
+# ---------------------------------------------------------------------------
+# Tier 1: JSON-LD extraction
+# ---------------------------------------------------------------------------
+
+
+class TestExtractJsonLD:
+    def test_full_job_posting(self):
+        html = """
+        <html><head>
+        <script type="application/ld+json">
+        {
+            "@type": "JobPosting",
+            "title": "Senior Frontend Engineer",
+            "description": "<p>Build amazing UIs</p>",
+            "hiringOrganization": {"@type": "Organization", "name": "Acme Corp"},
+            "jobLocation": {
+                "@type": "Place",
+                "address": {
+                    "addressLocality": "San Francisco",
+                    "addressRegion": "CA"
+                }
+            }
+        }
+        </script>
+        </head></html>
+        """
+        result = _extract_from_jsonld(html)
+        assert result is not None
+        assert result.title == "Senior Frontend Engineer"
+        assert result.company_name == "Acme Corp"
+        assert result.location == "San Francisco, CA"
+        assert result.description_html == "<p>Build amazing UIs</p>"
+        assert result.tier == "jsonld"
+
+    def test_missing_title_returns_none(self):
+        html = """
+        <html><head>
+        <script type="application/ld+json">
+        {"@type": "JobPosting", "description": "Some description"}
+        </script>
+        </head></html>
+        """
+        result = _extract_from_jsonld(html)
+        assert result is None
+
+    def test_no_jsonld_returns_none(self):
+        html = "<html><body>No structured data here</body></html>"
+        result = _extract_from_jsonld(html)
+        assert result is None
+
+    def test_hiring_organization_missing(self):
+        html = """
+        <html><head>
+        <script type="application/ld+json">
+        {"@type": "JobPosting", "title": "Engineer", "description": "Work here"}
+        </script>
+        </head></html>
+        """
+        result = _extract_from_jsonld(html)
+        assert result is not None
+        assert result.title == "Engineer"
+        assert result.company_name is None
+
+    def test_uses_job_title_field(self):
+        """Some sites use jobTitle instead of title."""
+        html = """
+        <html><head>
+        <script type="application/ld+json">
+        {"@type": "JobPosting", "jobTitle": "Staff Engineer", "description": "x"}
+        </script>
+        </head></html>
+        """
+        result = _extract_from_jsonld(html)
+        assert result is not None
+        assert result.title == "Staff Engineer"
+
+
+# ---------------------------------------------------------------------------
+# Tier 2: HTML meta/OG extraction
+# ---------------------------------------------------------------------------
+
+
+class TestExtractHtmlMeta:
+    def test_og_tags(self):
+        html = """
+        <html><head>
+        <meta property="og:title" content="Software Engineer at Stripe" />
+        <meta property="og:site_name" content="Stripe Careers" />
+        <meta property="og:description" content="Build payment systems" />
+        </head><body></body></html>
+        """
+        result = _extract_from_html_meta(html, "https://stripe.com/jobs/123")
+        assert result is not None
+        assert result.title == "Software Engineer at Stripe"
+        assert result.company_name == "Stripe Careers"
+        assert result.description_html == "Build payment systems"
+        assert result.tier == "html_meta"
+
+    def test_title_tag_fallback(self):
+        html = "<html><head><title>React Developer - Apply Now</title></head><body></body></html>"
+        result = _extract_from_html_meta(html, "https://example.com/jobs/1")
+        assert result is not None
+        assert result.title == "React Developer - Apply Now"
+
+    def test_company_from_domain(self):
+        html = "<html><head><title>Some Job</title></head><body></body></html>"
+        result = _extract_from_html_meta(html, "https://careers.google.com/jobs/1")
+        assert result is not None
+        assert result.company_name == "Google"
+
+    def test_no_title_returns_none(self):
+        html = "<html><head></head><body>No title at all</body></html>"
+        result = _extract_from_html_meta(html, "https://example.com")
+        assert result is None
+
+    def test_description_from_content_area(self):
+        html = """
+        <html><head><title>Engineer</title></head><body>
+        <div class="job-description">
+            <p>Requirements: 5 years experience</p>
+        </div>
+        </body></html>
+        """
+        result = _extract_from_html_meta(html, "https://example.com/jobs/1")
+        assert result is not None
+        assert "Requirements" in (result.description_html or "")
+
+
+# ---------------------------------------------------------------------------
+# Company from domain
+# ---------------------------------------------------------------------------
+
+
+class TestCompanyFromDomain:
+    def test_jobs_subdomain(self):
+        assert _company_from_domain("https://jobs.stripe.com/123") == "Stripe"
+
+    def test_careers_subdomain(self):
+        assert _company_from_domain("https://careers.google.com/jobs") == "Google"
+
+    def test_www_prefix(self):
+        assert _company_from_domain("https://www.example.com/careers") == "Example"
+
+    def test_bare_domain(self):
+        assert _company_from_domain("https://netflix.com/jobs") == "Netflix"
+
+
+# ---------------------------------------------------------------------------
+# Full cascade
+# ---------------------------------------------------------------------------
+
+
+class TestExtractCascade:
+    def test_jsonld_stops_at_tier1(self):
+        html = """
+        <html><head>
+        <title>Fallback Title</title>
+        <script type="application/ld+json">
+        {"@type": "JobPosting", "title": "JSON-LD Title", "description": "desc"}
+        </script>
+        </head></html>
+        """
+        result = extract_job_from_html(html, "https://example.com/jobs/1")
+        assert result.tier == "jsonld"
+        assert result.title == "JSON-LD Title"
+
+    def test_no_jsonld_falls_to_tier2(self):
+        html = """
+        <html><head>
+        <meta property="og:title" content="OG Title" />
+        </head><body></body></html>
+        """
+        result = extract_job_from_html(html, "https://example.com/jobs/1")
+        assert result.tier == "html_meta"
+        assert result.title == "OG Title"
+
+    def test_empty_page_returns_none_tier(self):
+        result = extract_job_from_html("", "https://example.com")
+        assert result.tier == "none"
+        assert result.title is None
+
+    def test_no_metadata_returns_none_tier(self):
+        html = "<html><head></head><body>Just text</body></html>"
+        result = extract_job_from_html(html, "https://example.com")
+        assert result.tier == "none"
+        assert "extraction_failed" in result.warnings[0]

--- a/apps/job-api/tests/test_manual_job.py
+++ b/apps/job-api/tests/test_manual_job.py
@@ -1,0 +1,241 @@
+"""Tests for POST /jobs/manual endpoint (#500)."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+from app.services.extract import MANUAL_SOURCE_ID
+
+
+def _mock_response(
+    status_code: int = 200,
+    text: str = "",
+    url: str = "https://example.com/jobs/123",
+) -> MagicMock:
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = status_code
+    resp.text = text
+    resp.url = httpx.URL(url)
+    return resp
+
+
+JSONLD_HTML = """
+<html><head>
+<script type="application/ld+json">
+{
+    "@type": "JobPosting",
+    "title": "Senior Engineer",
+    "description": "<p>Build things</p>",
+    "hiringOrganization": {"@type": "Organization", "name": "Acme Corp"},
+    "jobLocation": {
+        "@type": "Place",
+        "address": {"addressLocality": "New York", "addressRegion": "NY"}
+    }
+}
+</script>
+</head></html>
+"""
+
+OG_HTML = """
+<html><head>
+<meta property="og:title" content="Product Designer" />
+<meta property="og:site_name" content="Figma" />
+<meta property="og:description" content="Design things" />
+</head><body></body></html>
+"""
+
+
+class TestManualJobEndpoint:
+    @pytest.mark.asyncio
+    async def test_happy_path_jsonld(self, mock_http_client):
+        mock_http_client.get = AsyncMock(
+            return_value=_mock_response(text=JSONLD_HTML)
+        )
+
+        mock_supabase = MagicMock()
+        mock_upsert = MagicMock()
+        mock_upsert.execute = MagicMock(
+            return_value=MagicMock(data=[{"id": "posting-uuid-1"}])
+        )
+        mock_supabase.table.return_value.upsert.return_value = mock_upsert
+
+        from app.models.schemas import ManualJobRequest
+        from app.routers.jobs import add_manual_job
+
+        body = ManualJobRequest(url="https://example.com/jobs/123")
+        result = await add_manual_job(body=body, supabase=mock_supabase)
+
+        assert result.success is True
+        assert result.posting_id == "posting-uuid-1"
+        assert result.extraction_tier == "jsonld"
+        assert result.extracted["title"] == "Senior Engineer"
+        assert result.needs_manual_fields is False
+
+        # Verify upsert was called with correct source_id
+        upsert_call = mock_supabase.table.return_value.upsert.call_args
+        row = upsert_call[0][0]
+        assert row["source_id"] == MANUAL_SOURCE_ID
+        assert row["title"] == "Senior Engineer"
+        assert row["company_name"] == "Acme Corp"
+        assert row["score"] >= 0
+
+    @pytest.mark.asyncio
+    async def test_user_overrides(self, mock_http_client):
+        # Page with OG tags, but user provides their own title
+        mock_http_client.get = AsyncMock(
+            return_value=_mock_response(text=OG_HTML)
+        )
+
+        mock_supabase = MagicMock()
+        mock_supabase.table.return_value.upsert.return_value.execute.return_value = (
+            MagicMock(data=[{"id": "posting-uuid-2"}])
+        )
+
+        from app.models.schemas import ManualJobRequest
+        from app.routers.jobs import add_manual_job
+
+        body = ManualJobRequest(
+            url="https://example.com/jobs/456",
+            title="My Custom Title",
+            company_name="Override Corp",
+        )
+        result = await add_manual_job(body=body, supabase=mock_supabase)
+
+        assert result.success is True
+        # User overrides should win
+        upsert_call = mock_supabase.table.return_value.upsert.call_args
+        row = upsert_call[0][0]
+        assert row["title"] == "My Custom Title"
+        assert row["company_name"] == "Override Corp"
+
+    @pytest.mark.asyncio
+    async def test_malformed_url(self, mock_http_client):
+        from fastapi import HTTPException
+
+        from app.models.schemas import ManualJobRequest
+        from app.routers.jobs import add_manual_job
+
+        body = ManualJobRequest(url="not-a-url")
+        with pytest.raises(HTTPException) as exc_info:
+            await add_manual_job(body=body, supabase=MagicMock())
+        assert exc_info.value.status_code == 400
+        assert "Malformed" in exc_info.value.detail
+
+    @pytest.mark.asyncio
+    async def test_banned_domain(self, mock_http_client):
+        from fastapi import HTTPException
+
+        from app.models.schemas import ManualJobRequest
+        from app.routers.jobs import add_manual_job
+
+        body = ManualJobRequest(url="https://www.ziprecruiter.com/jobs/123")
+        with pytest.raises(HTTPException) as exc_info:
+            await add_manual_job(body=body, supabase=MagicMock())
+        assert exc_info.value.status_code == 400
+        assert "Banned" in exc_info.value.detail
+
+    @pytest.mark.asyncio
+    async def test_extraction_fails_needs_manual_fields(self, mock_http_client):
+        # Empty page with no extractable metadata
+        mock_http_client.get = AsyncMock(
+            return_value=_mock_response(text="<html><body>Nothing</body></html>")
+        )
+
+        from app.models.schemas import ManualJobRequest
+        from app.routers.jobs import add_manual_job
+
+        body = ManualJobRequest(url="https://example.com/opaque-page")
+        result = await add_manual_job(body=body, supabase=MagicMock())
+
+        assert result.success is False
+        assert result.needs_manual_fields is True
+        assert result.posting_id is None
+
+    @pytest.mark.asyncio
+    async def test_extraction_fails_with_user_title_succeeds(self, mock_http_client):
+        # Empty page but user provides a title
+        mock_http_client.get = AsyncMock(
+            return_value=_mock_response(text="<html><body>Nothing</body></html>")
+        )
+
+        mock_supabase = MagicMock()
+        mock_supabase.table.return_value.upsert.return_value.execute.return_value = (
+            MagicMock(data=[{"id": "posting-uuid-3"}])
+        )
+
+        from app.models.schemas import ManualJobRequest
+        from app.routers.jobs import add_manual_job
+
+        body = ManualJobRequest(
+            url="https://example.com/opaque-page",
+            title="Manually Entered Job",
+            company_name="Some Company",
+        )
+        result = await add_manual_job(body=body, supabase=mock_supabase)
+
+        assert result.success is True
+        assert result.posting_id == "posting-uuid-3"
+
+    @pytest.mark.asyncio
+    async def test_dedup_same_url(self, mock_http_client):
+        """Same URL should generate same external_id."""
+        import hashlib
+
+        url = "https://example.com/jobs/same"
+        expected_id = hashlib.sha256(url.encode()).hexdigest()[:16]
+
+        mock_http_client.get = AsyncMock(
+            return_value=_mock_response(text=JSONLD_HTML, url=url)
+        )
+
+        mock_supabase = MagicMock()
+        mock_supabase.table.return_value.upsert.return_value.execute.return_value = (
+            MagicMock(data=[{"id": "uuid"}])
+        )
+
+        from app.models.schemas import ManualJobRequest
+        from app.routers.jobs import add_manual_job
+
+        body = ManualJobRequest(url=url)
+        await add_manual_job(body=body, supabase=mock_supabase)
+
+        upsert_call = mock_supabase.table.return_value.upsert.call_args
+        row = upsert_call[0][0]
+        assert row["external_id"] == expected_id
+
+    @pytest.mark.asyncio
+    async def test_fetch_error(self, mock_http_client):
+        mock_http_client.get = AsyncMock(
+            side_effect=httpx.ConnectError("Connection refused")
+        )
+
+        from fastapi import HTTPException
+
+        from app.models.schemas import ManualJobRequest
+        from app.routers.jobs import add_manual_job
+
+        body = ManualJobRequest(url="https://example.com/jobs/123")
+        with pytest.raises(HTTPException) as exc_info:
+            await add_manual_job(body=body, supabase=MagicMock())
+        assert exc_info.value.status_code == 400
+        assert "fetch" in exc_info.value.detail.lower()
+
+    @pytest.mark.asyncio
+    async def test_redirect_to_banned(self, mock_http_client):
+        mock_http_client.get = AsyncMock(
+            return_value=_mock_response(
+                text="", url="https://www.ziprecruiter.com/redirect"
+            )
+        )
+
+        from fastapi import HTTPException
+
+        from app.models.schemas import ManualJobRequest
+        from app.routers.jobs import add_manual_job
+
+        body = ManualJobRequest(url="https://legit.com/jobs/123")
+        with pytest.raises(HTTPException) as exc_info:
+            await add_manual_job(body=body, supabase=MagicMock())
+        assert exc_info.value.status_code == 400
+        assert "banned" in exc_info.value.detail.lower()

--- a/apps/job-api/tests/test_validate.py
+++ b/apps/job-api/tests/test_validate.py
@@ -7,10 +7,10 @@ import pytest
 
 from app.services.validate import (
     BANNED_DOMAINS,
-    _is_banned,
-    _registrable_domain,
-    _validate_format,
     _verify_content,
+    is_banned_domain,
+    registrable_domain,
+    validate_format,
     validate_job_url,
 )
 
@@ -21,38 +21,38 @@ from app.services.validate import (
 
 class TestValidateFormat:
     def test_valid_https(self):
-        assert _validate_format("https://example.com/jobs/123") is not None
+        assert validate_format("https://example.com/jobs/123") is not None
 
     def test_valid_http(self):
-        assert _validate_format("http://example.com/jobs") is not None
+        assert validate_format("http://example.com/jobs") is not None
 
     def test_missing_scheme(self):
-        assert _validate_format("example.com/jobs") is None
+        assert validate_format("example.com/jobs") is None
 
     def test_ftp_rejected(self):
-        assert _validate_format("ftp://example.com/file") is None
+        assert validate_format("ftp://example.com/file") is None
 
     def test_ip_address_rejected(self):
-        assert _validate_format("https://192.168.1.1/jobs") is None
+        assert validate_format("https://192.168.1.1/jobs") is None
 
     def test_no_dot_rejected(self):
-        assert _validate_format("http://localhost/jobs") is None
+        assert validate_format("http://localhost/jobs") is None
 
     def test_whitespace_stripped(self):
-        result = _validate_format("  https://example.com/jobs  ")
+        result = validate_format("  https://example.com/jobs  ")
         assert result == "https://example.com/jobs"
 
     def test_empty_string(self):
-        assert _validate_format("") is None
+        assert validate_format("") is None
 
     def test_garbage_input(self):
-        assert _validate_format("not a url at all") is None
+        assert validate_format("not a url at all") is None
 
     def test_javascript_protocol(self):
-        assert _validate_format("javascript:alert(1)") is None
+        assert validate_format("javascript:alert(1)") is None
 
     def test_data_uri(self):
-        assert _validate_format("data:text/html,<h1>hi</h1>") is None
+        assert validate_format("data:text/html,<h1>hi</h1>") is None
 
 
 # ---------------------------------------------------------------------------
@@ -62,19 +62,19 @@ class TestValidateFormat:
 
 class TestBannedDomains:
     def test_known_banned(self):
-        assert _is_banned("ziprecruiter.com") is True
+        assert is_banned_domain("ziprecruiter.com") is True
 
     def test_subdomain_of_banned(self):
-        assert _is_banned("jobs.ziprecruiter.com") is True
+        assert is_banned_domain("jobs.ziprecruiter.com") is True
 
     def test_www_subdomain_of_banned(self):
-        assert _is_banned("www.craigslist.org") is True
+        assert is_banned_domain("www.craigslist.org") is True
 
     def test_legit_domain(self):
-        assert _is_banned("greenhouse.io") is False
+        assert is_banned_domain("greenhouse.io") is False
 
     def test_case_insensitive(self):
-        assert _is_banned("ZIPRECRUITER.COM") is True
+        assert is_banned_domain("ZIPRECRUITER.COM") is True
 
     def test_seed_count(self):
         assert len(BANNED_DOMAINS) >= 20
@@ -82,19 +82,19 @@ class TestBannedDomains:
 
 class TestRegistrableDomain:
     def test_www_prefix(self):
-        assert _registrable_domain("www.example.com") == "example.com"
+        assert registrable_domain("www.example.com") == "example.com"
 
     def test_deep_subdomain(self):
-        assert _registrable_domain("jobs.boards.greenhouse.io") == "greenhouse.io"
+        assert registrable_domain("jobs.boards.greenhouse.io") == "greenhouse.io"
 
     def test_bare_domain(self):
-        assert _registrable_domain("example.com") == "example.com"
+        assert registrable_domain("example.com") == "example.com"
 
     def test_trailing_dot(self):
-        assert _registrable_domain("example.com.") == "example.com"
+        assert registrable_domain("example.com.") == "example.com"
 
     def test_uppercase(self):
-        assert _registrable_domain("WWW.EXAMPLE.COM") == "example.com"
+        assert registrable_domain("WWW.EXAMPLE.COM") == "example.com"
 
 
 # ---------------------------------------------------------------------------

--- a/supabase/migrations/20260424120003_seed_manual_job_source.sql
+++ b/supabase/migrations/20260424120003_seed_manual_job_source.sql
@@ -1,0 +1,11 @@
+-- Seed a manual entry source for user-submitted job URLs (#500).
+-- enabled=false prevents the poller from polling this source.
+INSERT INTO job_sources (id, board_token, company_name, provider, enabled)
+VALUES (
+  '00000000-0000-4000-a000-000000000001',
+  'manual',
+  'Manual Entry',
+  'manual',
+  false
+)
+ON CONFLICT (id) DO NOTHING;


### PR DESCRIPTION
## Summary
- Three-tier extraction cascade for adding job postings by URL: JSON-LD structured data (gold), HTML/OG tag heuristics (fallback), Firecrawl for JS-rendered pages (gated behind API key)
- `POST /jobs/manual` endpoint with user overrides, dedup via URL hash, scoring, and HTML sanitization
- Made `validate.py` helpers public (`validate_format`, `is_banned_domain`, `registrable_domain`) for reuse by the manual entry endpoint
- Migration seeds a manual source row (`source_id = 00000000-0000-4000-a000-000000000001`) so manual entries satisfy the FK constraint

## Test plan
- [x] 18 extraction tests (JSON-LD, HTML meta, company-from-domain, cascade)
- [x] 9 endpoint tests (happy path, overrides, banned/malformed URLs, dedup, fetch errors)
- [x] Existing validate tests updated for public function names (39 passing)
- [x] Full suite: 409/409 passing
- [x] mypy + ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)