### PR TITLE
feat(job-api): LLM job analysis — scorecard + recommendation (#501)

### DIFF
--- a/apps/job-api/app/main.py
+++ b/apps/job-api/app/main.py
@@ -7,7 +7,7 @@ from starlette.types import Receive, Scope, Send
 
 from app.config import settings
 from app.http_client import close_http_client
-from app.routers import experience, jobs, poll, sources, status, tailor, targets
+from app.routers import analysis, experience, jobs, poll, sources, status, tailor, targets
 from app.supabase_pool import close_supabase, init_supabase
 
 if not settings.allowed_hosts_list:
@@ -49,6 +49,7 @@ app.add_middleware(
     allowed_hosts=settings.allowed_hosts_list,
 )
 
+app.include_router(analysis.router)
 app.include_router(experience.router)
 app.include_router(jobs.router)
 app.include_router(poll.router)

--- a/apps/job-api/app/models/analysis.py
+++ b/apps/job-api/app/models/analysis.py
@@ -1,0 +1,56 @@
+"""Pydantic models for the job analysis feature (#501).
+
+The LLM grades the user's OptimizedPayload against a job description,
+producing a structured scorecard and one-line recommendation. Results
+are cached in the `job_analyses` table.
+"""
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+class SkillMatch(BaseModel):
+    name: str
+    matched: bool
+    confidence: Literal["high", "medium", "low"]
+    evidence: str | None = None
+
+
+class Scorecard(BaseModel):
+    skills_matched: list[SkillMatch]
+    skills_missing: list[str]
+    nice_to_haves: list[str]
+    seniority_fit: Literal["strong", "moderate", "weak"]
+    seniority_rationale: str
+    domain_fit: Literal["strong", "moderate", "weak"]
+    domain_rationale: str
+
+
+class JobAnalysis(BaseModel):
+    """LLM output shape: scorecard + recommendation."""
+
+    scorecard: Scorecard
+    recommendation: str
+
+
+class JobAnalysisRecord(BaseModel):
+    """DB read shape for job_analyses rows."""
+
+    id: str
+    job_posting_id: str
+    user_id: str | None
+    optimized_doc_id: str | None
+    scorecard: Scorecard
+    recommendation: str
+    model: str
+    cost_usd: float
+    latency_ms: int
+    created_at: datetime
+
+
+class AnalyzeRequest(BaseModel):
+    """Router request body. The JD text comes from the frontend."""
+
+    job_description: str = Field(min_length=1, max_length=100_000)

--- a/apps/job-api/app/routers/analysis.py
+++ b/apps/job-api/app/routers/analysis.py
@@ -1,0 +1,87 @@
+"""Analysis router.
+
+POST /analysis/{job_id}  — run or return cached LLM analysis for a job posting.
+"""
+
+from typing import Any, cast
+
+from fastapi import APIRouter, Depends, HTTPException
+from supabase import Client
+
+from app.dependencies import get_llm_client, get_supabase, verify_api_key_or_session
+from app.models.analysis import AnalyzeRequest, JobAnalysisRecord
+from app.services.analysis import persistence
+from app.services.analysis.analyze import DEFAULT_PURPOSE, analyze_job
+from app.services.experience import optimized
+from app.services.llm import cost_log
+from app.services.llm.client import LLMClient
+
+router = APIRouter(
+    prefix="/analysis",
+    tags=["analysis"],
+    dependencies=[Depends(verify_api_key_or_session)],
+)
+
+
+@router.post("/{job_id}")
+async def create_analysis(
+    job_id: str,
+    body: AnalyzeRequest,
+    supabase: Client = Depends(get_supabase),
+    llm: LLMClient = Depends(get_llm_client),
+) -> JobAnalysisRecord:
+    # 1. Check cache
+    cached = persistence.get_cached(supabase, job_id, user_id=None)
+    if cached is not None:
+        return cached
+
+    # 2. Fetch optimized doc
+    current_optimized = optimized.get_latest(supabase, user_id=None)
+    if current_optimized is None:
+        raise HTTPException(
+            status_code=404,
+            detail="No optimized doc found. Derive one via POST /experience/derive first.",
+        )
+
+    # 3. Verify job posting exists
+    resp = (
+        supabase.table("job_postings")
+        .select("id")
+        .eq("id", job_id)
+        .limit(1)
+        .execute()
+    )
+    rows = cast(list[dict[str, Any]], resp.data or [])
+    if not rows:
+        raise HTTPException(status_code=404, detail="Job posting not found.")
+
+    # 4. Run LLM analysis
+    analysis, llm_result = await analyze_job(
+        llm,
+        optimized=current_optimized.payload,
+        job_description=body.job_description,
+    )
+
+    # 5. Log cost
+    cost_log.record(
+        supabase,
+        user_id=None,
+        purpose=DEFAULT_PURPOSE,
+        result=llm_result,
+        metadata={
+            "job_posting_id": job_id,
+            "optimized_doc_id": current_optimized.id,
+        },
+    )
+
+    # 6. Persist
+    record = persistence.persist(
+        supabase,
+        job_posting_id=job_id,
+        user_id=None,
+        optimized_doc_id=current_optimized.id,
+        analysis=analysis,
+        llm_result=llm_result,
+    )
+
+    return record

--- a/apps/job-api/app/services/analysis/__init__.py
+++ b/apps/job-api/app/services/analysis/__init__.py
@@ -1,0 +1,19 @@
+"""Analysis module (#501).
+
+LLM-based job analysis: grades the candidate's OptimizedPayload against
+a job description, producing a structured scorecard and recommendation.
+"""
+
+from app.services.analysis.analyze import (
+    DEFAULT_MODEL,
+    DEFAULT_PURPOSE,
+    analyze_job,
+    build_user_message,
+)
+
+__all__ = [
+    "DEFAULT_MODEL",
+    "DEFAULT_PURPOSE",
+    "analyze_job",
+    "build_user_message",
+]

--- a/apps/job-api/app/services/analysis/analyze.py
+++ b/apps/job-api/app/services/analysis/analyze.py
@@ -1,0 +1,69 @@
+"""LLM-based job analysis: grade OptimizedPayload against a JD.
+
+Pure function. No DB. Cost logging and persistence happen at the
+router layer. Follows the same pattern as tailor.py.
+"""
+
+from __future__ import annotations
+
+from app.models.analysis import JobAnalysis
+from app.models.experience import OptimizedPayload
+from app.models.llm import LLMResult, Message, ModelId
+from app.services.analysis.prompts import ANALYSIS_SYSTEM
+from app.services.llm.client import LLMClient, complete_json
+
+DEFAULT_MODEL: ModelId = "claude-sonnet-4-6"
+DEFAULT_PURPOSE = "job_analysis"
+
+
+def build_user_message(
+    *,
+    optimized: OptimizedPayload,
+    job_description: str,
+    target_context: str | None = None,
+) -> str:
+    """Assemble the variable content for the LLM call.
+
+    The system prompt is static (cache target); everything that changes
+    per call lives here.
+    """
+    sections: list[str] = []
+    sections.append(f"[OptimizedPayload]\n{optimized.model_dump_json(indent=2)}")
+    if target_context:
+        sections.append(f"[TargetContext]\n{target_context}")
+    sections.append(f"[JobDescription]\n{job_description}")
+    return "\n\n".join(sections)
+
+
+async def analyze_job(
+    llm: LLMClient,
+    *,
+    optimized: OptimizedPayload,
+    job_description: str,
+    target_context: str | None = None,
+    model: ModelId = DEFAULT_MODEL,
+    purpose: str = DEFAULT_PURPOSE,
+) -> tuple[JobAnalysis, LLMResult]:
+    """Run the LLM analysis and parse the structured output.
+
+    Returns (analysis, llm_result). Caller is responsible for
+    cost-logging and persistence.
+    """
+    user_message = build_user_message(
+        optimized=optimized,
+        job_description=job_description,
+        target_context=target_context,
+    )
+
+    analysis, result = await complete_json(
+        llm,
+        model=model,
+        system=ANALYSIS_SYSTEM,
+        messages=[Message(role="user", content=user_message)],
+        schema=JobAnalysis,
+        purpose=purpose,
+        cache_system=True,
+        max_tokens=4096,
+    )
+
+    return analysis, result

--- a/apps/job-api/app/services/analysis/persistence.py
+++ b/apps/job-api/app/services/analysis/persistence.py
@@ -1,0 +1,68 @@
+"""Cache CRUD for job_analyses table.
+
+One analysis per (user, job_posting) pair. Subsequent requests for the
+same pair return the cached row without re-running the LLM.
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+from supabase import Client
+
+from app.models.analysis import JobAnalysis, JobAnalysisRecord
+from app.models.llm import LLMResult
+
+TABLE = "job_analyses"
+
+
+def get_cached(
+    supabase: Client,
+    job_posting_id: str,
+    user_id: str | None,
+) -> JobAnalysisRecord | None:
+    """Return the most recent analysis for this job+user, or None."""
+    query = (
+        supabase.table(TABLE)
+        .select("*")
+        .eq("job_posting_id", job_posting_id)
+        .order("created_at", desc=True)
+        .limit(1)
+    )
+    query = (
+        query.is_("user_id", "null")
+        if user_id is None
+        else query.eq("user_id", user_id)
+    )
+    resp = query.execute()
+    rows = cast(list[dict[str, Any]], resp.data or [])
+    if not rows:
+        return None
+    return JobAnalysisRecord.model_validate(rows[0])
+
+
+def persist(
+    supabase: Client,
+    *,
+    job_posting_id: str,
+    user_id: str | None,
+    optimized_doc_id: str | None,
+    analysis: JobAnalysis,
+    llm_result: LLMResult,
+) -> JobAnalysisRecord:
+    """Insert one job_analyses row."""
+    row: dict[str, Any] = {
+        "job_posting_id": job_posting_id,
+        "user_id": user_id,
+        "optimized_doc_id": optimized_doc_id,
+        "scorecard": analysis.scorecard.model_dump(mode="json"),
+        "recommendation": analysis.recommendation,
+        "model": llm_result.model,
+        "cost_usd": llm_result.cost_usd,
+        "latency_ms": llm_result.latency_ms,
+    }
+    resp = supabase.table(TABLE).insert(row).execute()
+    rows = cast(list[dict[str, Any]], resp.data or [])
+    if not rows:
+        raise RuntimeError("Failed to insert job_analyses row")
+    return JobAnalysisRecord.model_validate(rows[0])

--- a/apps/job-api/app/services/analysis/prompts.py
+++ b/apps/job-api/app/services/analysis/prompts.py
@@ -1,0 +1,61 @@
+"""System prompt for job analysis.
+
+Static constant for prompt caching (cache_system=True at call site).
+The variable content (OptimizedPayload + JD) goes in the user message.
+"""
+
+ANALYSIS_SYSTEM = """You are a senior career analyst. Your input is:
+
+1. A structured career record (OptimizedPayload) with roles, skills, outcomes.
+2. A job description (JD).
+3. Optional target context (scoring profile, job target metadata).
+
+Your output is a strict JobAnalysis JSON object. Rules:
+
+SKILL MATCHING:
+- Extract every required and preferred skill from the JD.
+- For each skill, check whether the OptimizedPayload contains evidence \
+of that skill (in roles, skills list, or outcomes).
+- `matched: true` means the candidate demonstrably has the skill. \
+Set `confidence` to "high" if there's a direct match in skills[] or \
+explicit mention in outcomes/roles, "medium" if implied by adjacent \
+skills or role context, "low" if the evidence is thin.
+- `evidence` must cite the specific role, outcome, or skill entry that \
+supports the match. If matched is false, evidence should be null.
+- `skills_missing` lists required skills from the JD with no evidence \
+in the OptimizedPayload. Be honest about gaps.
+- `nice_to_haves` lists preferred/bonus skills from the JD that aren't \
+strictly required.
+
+SENIORITY FIT:
+- Compare the JD's seniority signals (years of experience, leadership \
+expectations, scope of role) against the candidate's career trajectory.
+- "strong": candidate's experience level matches the role.
+- "moderate": close but slightly over/under-qualified.
+- "weak": significant mismatch (e.g. junior role for a senior candidate, \
+or vice versa).
+- `seniority_rationale`: one sentence explaining the assessment.
+
+DOMAIN FIT:
+- Compare the JD's industry, product type, and domain requirements \
+against the candidate's experience domains.
+- "strong": direct domain overlap (same industry, same product type).
+- "moderate": adjacent domain (transferable experience).
+- "weak": no meaningful domain overlap.
+- `domain_rationale`: one sentence explaining the assessment.
+
+RECOMMENDATION:
+- One sentence with a clear judgment: "Apply", "Skip", or \
+"Apply with caveats" followed by the key reason.
+- Be direct. "Apply: strong technical match with 8/10 required skills \
+and direct e-commerce domain experience." or "Skip: role requires 5+ \
+years of ML engineering with no evidence in the candidate's background."
+
+HONESTY:
+- Do not inflate matches. If the evidence is ambiguous, say so.
+- Do not penalize for nice-to-haves that are missing.
+- Weight required skills more heavily than preferred ones.
+
+OUTPUT:
+- Return ONLY the JobAnalysis JSON object. No prose around it. No code fences.
+"""

--- a/apps/job-api/tests/test_analysis.py
+++ b/apps/job-api/tests/test_analysis.py
@@ -1,0 +1,456 @@
+"""Job analysis end-to-end tests with mocked Supabase + MockLLMClient.
+
+Covers: cache hit, cache miss (LLM call + persist + cost log),
+missing optimized doc (404), missing job posting (404), and
+LLM JSON parse error.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from pydantic import ValidationError
+
+from app.models.analysis import (
+    JobAnalysis,
+    JobAnalysisRecord,
+    Scorecard,
+    SkillMatch,
+)
+from app.models.experience import (
+    OptimizedDoc,
+    OptimizedPayload,
+    Outcome,
+    Role,
+    Skill,
+)
+from app.services.analysis.analyze import DEFAULT_PURPOSE, analyze_job, build_user_message
+from app.services.analysis import persistence as persistence_mod
+from app.services.llm import cost_log as cost_log_mod
+from app.services.llm.mock import MockLLMClient
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _optimized_payload() -> OptimizedPayload:
+    return OptimizedPayload(
+        summary="Senior FE engineer.",
+        roles=[
+            Role(
+                id="fc",
+                company="FightCamp",
+                title="Senior Frontend Engineer",
+                start="2021-11",
+                end="2024-04",
+                summary="Led the PDP rebuild.",
+                skills=["React", "TypeScript"],
+                outcome_refs=[],
+            )
+        ],
+        skills=[
+            Skill(name="React"),
+            Skill(name="TypeScript"),
+        ],
+        outcomes=[
+            Outcome(
+                description="Cut mobile load times from 10s to 2s",
+                metric="LCP",
+                value="2s",
+                role_ref="fc",
+            )
+        ],
+    )
+
+
+def _optimized_doc() -> OptimizedDoc:
+    return OptimizedDoc(
+        id="opt-1",
+        user_id=None,
+        prose_doc_id=None,
+        version=1,
+        payload=_optimized_payload(),
+        markdown_view=None,
+        source="llm",
+        created_at=datetime.now(UTC),
+    )
+
+
+def _valid_analysis() -> JobAnalysis:
+    return JobAnalysis(
+        scorecard=Scorecard(
+            skills_matched=[
+                SkillMatch(
+                    name="React",
+                    matched=True,
+                    confidence="high",
+                    evidence="Listed in skills and used at FightCamp",
+                ),
+                SkillMatch(
+                    name="TypeScript",
+                    matched=True,
+                    confidence="high",
+                    evidence="Listed in skills",
+                ),
+            ],
+            skills_missing=["GraphQL"],
+            nice_to_haves=["AWS"],
+            seniority_fit="strong",
+            seniority_rationale="3+ years senior experience matches the role.",
+            domain_fit="moderate",
+            domain_rationale="E-commerce adjacent but not exact match.",
+        ),
+        recommendation="Apply: strong technical match with direct React/TypeScript experience.",
+    )
+
+
+def _valid_analysis_json() -> str:
+    return _valid_analysis().model_dump_json()
+
+
+def _analysis_record_row(record_id: str = "rec-analysis-1") -> dict[str, Any]:
+    """Shape returned by supabase.table().insert(...).execute().data."""
+    return {
+        "id": record_id,
+        "job_posting_id": "job-1",
+        "user_id": None,
+        "optimized_doc_id": "opt-1",
+        "scorecard": _valid_analysis().scorecard.model_dump(mode="json"),
+        "recommendation": _valid_analysis().recommendation,
+        "model": "claude-sonnet-4-6",
+        "cost_usd": 0.001,
+        "latency_ms": 50,
+        "created_at": datetime.now(UTC).isoformat(),
+    }
+
+
+def _make_supabase_mock(
+    *,
+    insert_data: list[dict[str, Any]] | None = None,
+    select_data: list[dict[str, Any]] | None = None,
+) -> MagicMock:
+    supabase = MagicMock()
+    # insert chain
+    supabase.table.return_value.insert.return_value.execute.return_value.data = (
+        insert_data or []
+    )
+    # select chain (for get_cached / job posting check)
+    supabase.table.return_value.select.return_value.eq.return_value.order.return_value.limit.return_value.is_.return_value.execute.return_value.data = (
+        select_data or []
+    )
+    supabase.table.return_value.select.return_value.eq.return_value.order.return_value.limit.return_value.eq.return_value.execute.return_value.data = (
+        select_data or []
+    )
+    return supabase
+
+
+# ---------------------------------------------------------------------------
+# analyze_job (service layer)
+# ---------------------------------------------------------------------------
+
+
+async def test_analyze_job_returns_analysis_and_result() -> None:
+    llm = MockLLMClient(scripted={DEFAULT_PURPOSE: _valid_analysis_json()})
+
+    analysis, result = await analyze_job(
+        llm,
+        optimized=_optimized_payload(),
+        job_description="We want a senior React engineer with TypeScript.",
+    )
+
+    assert analysis.recommendation.startswith("Apply")
+    assert len(analysis.scorecard.skills_matched) == 2
+    assert analysis.scorecard.seniority_fit == "strong"
+    assert result.model == "claude-sonnet-4-6"
+    assert result.cost_usd > 0
+
+
+async def test_analyze_job_includes_target_context_in_message() -> None:
+    seen: dict[str, str] = {}
+
+    def responder(latest_user: str, _messages: object) -> str:
+        seen["latest"] = latest_user
+        return _valid_analysis_json()
+
+    llm = MockLLMClient(scripted={DEFAULT_PURPOSE: responder})
+    await analyze_job(
+        llm,
+        optimized=_optimized_payload(),
+        job_description="JD text",
+        target_context="Target: Senior FE at Acme",
+    )
+    assert "[TargetContext]" in seen["latest"]
+    assert "Senior FE at Acme" in seen["latest"]
+
+
+async def test_analyze_job_json_parse_error_raises() -> None:
+    llm = MockLLMClient(scripted={DEFAULT_PURPOSE: "not valid json"})
+    with pytest.raises(ValidationError):
+        await analyze_job(
+            llm,
+            optimized=_optimized_payload(),
+            job_description="JD text",
+        )
+
+
+# ---------------------------------------------------------------------------
+# build_user_message
+# ---------------------------------------------------------------------------
+
+
+def test_build_user_message_contains_payload_and_jd() -> None:
+    msg = build_user_message(
+        optimized=_optimized_payload(),
+        job_description="We need a React developer.",
+    )
+    assert "[OptimizedPayload]" in msg
+    assert "[JobDescription]" in msg
+    assert "React developer" in msg
+    assert "FightCamp" in msg
+
+
+def test_build_user_message_omits_target_when_none() -> None:
+    msg = build_user_message(
+        optimized=_optimized_payload(),
+        job_description="JD",
+        target_context=None,
+    )
+    assert "[TargetContext]" not in msg
+
+
+# ---------------------------------------------------------------------------
+# persistence
+# ---------------------------------------------------------------------------
+
+
+def test_get_cached_returns_none_on_empty() -> None:
+    supabase = _make_supabase_mock(select_data=[])
+    result = persistence_mod.get_cached(supabase, "job-1", user_id=None)
+    assert result is None
+
+
+def test_get_cached_returns_record_when_exists() -> None:
+    row = _analysis_record_row()
+    supabase = _make_supabase_mock(select_data=[row])
+    result = persistence_mod.get_cached(supabase, "job-1", user_id=None)
+    assert result is not None
+    assert result.id == "rec-analysis-1"
+    assert result.recommendation.startswith("Apply")
+
+
+def test_persist_inserts_and_returns_record() -> None:
+    from app.models.llm import LLMResult, LLMUsage
+
+    supabase = _make_supabase_mock(insert_data=[_analysis_record_row()])
+    llm_result = LLMResult(
+        content="{}",
+        model="claude-sonnet-4-6",
+        usage=LLMUsage(input_tokens=100, output_tokens=50),
+        cost_usd=0.001,
+        latency_ms=50,
+    )
+    record = persistence_mod.persist(
+        supabase,
+        job_posting_id="job-1",
+        user_id=None,
+        optimized_doc_id="opt-1",
+        analysis=_valid_analysis(),
+        llm_result=llm_result,
+    )
+    assert record.id == "rec-analysis-1"
+    supabase.table.return_value.insert.assert_called_once()
+
+
+def test_persist_raises_on_empty_insert() -> None:
+    from app.models.llm import LLMResult, LLMUsage
+
+    supabase = _make_supabase_mock(insert_data=[])
+    llm_result = LLMResult(
+        content="{}",
+        model="claude-sonnet-4-6",
+        usage=LLMUsage(input_tokens=100, output_tokens=50),
+        cost_usd=0.001,
+        latency_ms=50,
+    )
+    with pytest.raises(RuntimeError, match="Failed to insert"):
+        persistence_mod.persist(
+            supabase,
+            job_posting_id="job-1",
+            user_id=None,
+            optimized_doc_id="opt-1",
+            analysis=_valid_analysis(),
+            llm_result=llm_result,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Router integration (via TestClient)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def client(monkeypatch: pytest.MonkeyPatch) -> Any:
+    """FastAPI TestClient with mocked dependencies."""
+    from fastapi.testclient import TestClient
+
+    from app.main import app
+
+    return TestClient(app)
+
+
+async def test_router_cache_hit_skips_llm(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When a cached analysis exists, the LLM should not be called."""
+    from app.routers import analysis as analysis_router
+
+    cached_record = JobAnalysisRecord.model_validate(_analysis_record_row())
+    monkeypatch.setattr(
+        persistence_mod, "get_cached", lambda *_a, **_kw: cached_record
+    )
+
+    llm = MockLLMClient()
+    supabase = MagicMock()
+
+    from fastapi.testclient import TestClient
+
+    from app.main import app
+
+    app.dependency_overrides[get_supabase] = lambda: supabase
+    app.dependency_overrides[get_llm_client] = lambda: llm
+    app.dependency_overrides[verify_api_key_or_session] = lambda: "test"
+
+    try:
+        tc = TestClient(app)
+        resp = tc.post(
+            "/analysis/job-1",
+            json={"job_description": "We want a React engineer."},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["id"] == "rec-analysis-1"
+        assert len(llm.calls) == 0  # LLM was NOT called
+    finally:
+        app.dependency_overrides.clear()
+
+
+async def test_router_cache_miss_runs_llm_and_persists(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cache miss → LLM call → cost log → persist → return record."""
+    from app.routers import analysis as analysis_router
+
+    monkeypatch.setattr(persistence_mod, "get_cached", lambda *_a, **_kw: None)
+    monkeypatch.setattr(cost_log_mod, "record", MagicMock())
+
+    inserted_row = _analysis_record_row()
+    monkeypatch.setattr(
+        persistence_mod,
+        "persist",
+        lambda *_a, **kw: JobAnalysisRecord.model_validate(inserted_row),
+    )
+
+    # Mock optimized.get_latest
+    from app.services.experience import optimized as opt_mod
+
+    monkeypatch.setattr(opt_mod, "get_latest", lambda *_a, **_kw: _optimized_doc())
+
+    llm = MockLLMClient(scripted={DEFAULT_PURPOSE: _valid_analysis_json()})
+
+    # Mock job posting existence check
+    supabase = MagicMock()
+    supabase.table.return_value.select.return_value.eq.return_value.limit.return_value.execute.return_value.data = [
+        {"id": "job-1"}
+    ]
+
+    from fastapi.testclient import TestClient
+
+    from app.main import app
+
+    app.dependency_overrides[get_supabase] = lambda: supabase
+    app.dependency_overrides[get_llm_client] = lambda: llm
+    app.dependency_overrides[verify_api_key_or_session] = lambda: "test"
+
+    try:
+        tc = TestClient(app)
+        resp = tc.post(
+            "/analysis/job-1",
+            json={"job_description": "We want a React engineer."},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["id"] == "rec-analysis-1"
+        assert len(llm.calls) == 1
+        cost_log_mod.record.assert_called_once()
+    finally:
+        app.dependency_overrides.clear()
+
+
+async def test_router_missing_optimized_doc_returns_404(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(persistence_mod, "get_cached", lambda *_a, **_kw: None)
+
+    from app.services.experience import optimized as opt_mod
+
+    monkeypatch.setattr(opt_mod, "get_latest", lambda *_a, **_kw: None)
+
+    from fastapi.testclient import TestClient
+
+    from app.main import app
+
+    app.dependency_overrides[get_supabase] = lambda: MagicMock()
+    app.dependency_overrides[get_llm_client] = lambda: MockLLMClient()
+    app.dependency_overrides[verify_api_key_or_session] = lambda: "test"
+
+    try:
+        tc = TestClient(app)
+        resp = tc.post(
+            "/analysis/job-1",
+            json={"job_description": "JD text"},
+        )
+        assert resp.status_code == 404
+        assert "optimized doc" in resp.json()["detail"].lower()
+    finally:
+        app.dependency_overrides.clear()
+
+
+async def test_router_missing_job_posting_returns_404(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(persistence_mod, "get_cached", lambda *_a, **_kw: None)
+
+    from app.services.experience import optimized as opt_mod
+
+    monkeypatch.setattr(opt_mod, "get_latest", lambda *_a, **_kw: _optimized_doc())
+
+    supabase = MagicMock()
+    supabase.table.return_value.select.return_value.eq.return_value.limit.return_value.execute.return_value.data = []
+
+    from fastapi.testclient import TestClient
+
+    from app.main import app
+
+    app.dependency_overrides[get_supabase] = lambda: supabase
+    app.dependency_overrides[get_llm_client] = lambda: MockLLMClient()
+    app.dependency_overrides[verify_api_key_or_session] = lambda: "test"
+
+    try:
+        tc = TestClient(app)
+        resp = tc.post(
+            "/analysis/job-1",
+            json={"job_description": "JD text"},
+        )
+        assert resp.status_code == 404
+        assert "job posting" in resp.json()["detail"].lower()
+    finally:
+        app.dependency_overrides.clear()
+
+
+# Need these imports for dependency overrides
+from app.dependencies import get_llm_client, get_supabase, verify_api_key_or_session

--- a/supabase/migrations/20260424120004_create_job_analyses.sql
+++ b/supabase/migrations/20260424120004_create_job_analyses.sql
@@ -1,0 +1,19 @@
+-- Job analyses: LLM-generated scorecard + recommendation per job posting.
+-- One row per (user, job_posting) pair. ON DELETE CASCADE cleans up
+-- when the parent job_posting is removed.
+
+CREATE TABLE IF NOT EXISTS job_analyses (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  job_posting_id UUID NOT NULL REFERENCES job_postings(id) ON DELETE CASCADE,
+  user_id UUID,
+  optimized_doc_id UUID,
+  scorecard JSONB NOT NULL,
+  recommendation TEXT NOT NULL,
+  model TEXT NOT NULL,
+  cost_usd NUMERIC NOT NULL DEFAULT 0,
+  latency_ms INTEGER NOT NULL DEFAULT 0,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_job_analyses_job_id ON job_analyses(job_posting_id);
+CREATE INDEX idx_job_analyses_user_job ON job_analyses(user_id, job_posting_id);


### PR DESCRIPTION
## Summary
- `POST /analysis/{job_id}` — on-demand LLM analysis that grades the user's OptimizedPayload against a job description
- Structured scorecard: skills matched (with confidence + evidence), skills missing, nice-to-haves, seniority fit, domain fit
- One-line recommendation with clear judgment (Apply / Skip / Apply with caveats)
- Results cached in `job_analyses` table — repeat views return cached analysis without re-running LLM
- Cost logged to `llm_cost_log` with job + optimized doc metadata
- Graceful 404 if no optimized doc or job posting exists

## Test plan
- [x] 5 service tests (analyze_job, build_user_message, JSON parse error)
- [x] 4 persistence tests (cache hit/miss, insert, insert failure)
- [x] 4 router integration tests (cache hit skips LLM, cache miss runs full flow, missing optimized doc 404, missing job 404)
- [x] Full suite: 422/422 passing
- [x] mypy + ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)