### PR TITLE
feat(root): jobs list + detail views for Fitted (#508)

### DIFF
--- a/apps/root/src/app/api/career/experience/gap-health/route.ts
+++ b/apps/root/src/app/api/career/experience/gap-health/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse } from 'next/server';
-import { proxyToFastAPI, verifyJobsAdmin } from '@/app/api/jobs/proxy';
+import { proxyToFastAPI, verifyJobsAccess } from '@/app/api/jobs/proxy';
 
 export async function GET() {
-  if (!(await verifyJobsAdmin())) {
+  if (!(await verifyJobsAccess())) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
   return proxyToFastAPI('/experience/gap-health');

--- a/apps/root/src/app/api/career/experience/optimized/route.test.ts
+++ b/apps/root/src/app/api/career/experience/optimized/route.test.ts
@@ -2,16 +2,16 @@
  * @jest-environment node
  */
 import { NextResponse } from 'next/server';
-import { proxyToFastAPI, verifyJobsAdmin } from '@/app/api/jobs/proxy';
+import { proxyToFastAPI, verifyJobsAccess } from '@/app/api/jobs/proxy';
 import { GET } from './route';
 
 jest.mock('@/app/api/jobs/proxy', () => ({
-  verifyJobsAdmin: jest.fn(),
+  verifyJobsAccess: jest.fn(),
   proxyToFastAPI: jest.fn(),
 }));
 
-const mockedVerify = verifyJobsAdmin as jest.MockedFunction<
-  typeof verifyJobsAdmin
+const mockedVerify = verifyJobsAccess as jest.MockedFunction<
+  typeof verifyJobsAccess
 >;
 const mockedProxy = proxyToFastAPI as jest.MockedFunction<
   typeof proxyToFastAPI

--- a/apps/root/src/app/api/career/experience/optimized/route.ts
+++ b/apps/root/src/app/api/career/experience/optimized/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse } from 'next/server';
-import { proxyToFastAPI, verifyJobsAdmin } from '@/app/api/jobs/proxy';
+import { proxyToFastAPI, verifyJobsAccess } from '@/app/api/jobs/proxy';
 
 export async function GET() {
-  if (!(await verifyJobsAdmin())) {
+  if (!(await verifyJobsAccess())) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
   return proxyToFastAPI('/experience/optimized');

--- a/apps/root/src/app/api/career/experience/prose/route.test.ts
+++ b/apps/root/src/app/api/career/experience/prose/route.test.ts
@@ -2,16 +2,16 @@
  * @jest-environment node
  */
 import { NextResponse } from 'next/server';
-import { proxyToFastAPI, verifyJobsAdmin } from '@/app/api/jobs/proxy';
+import { proxyToFastAPI, verifyJobsAccess } from '@/app/api/jobs/proxy';
 import { GET } from './route';
 
 jest.mock('@/app/api/jobs/proxy', () => ({
-  verifyJobsAdmin: jest.fn(),
+  verifyJobsAccess: jest.fn(),
   proxyToFastAPI: jest.fn(),
 }));
 
-const mockedVerify = verifyJobsAdmin as jest.MockedFunction<
-  typeof verifyJobsAdmin
+const mockedVerify = verifyJobsAccess as jest.MockedFunction<
+  typeof verifyJobsAccess
 >;
 const mockedProxy = proxyToFastAPI as jest.MockedFunction<
   typeof proxyToFastAPI

--- a/apps/root/src/app/api/career/experience/prose/route.ts
+++ b/apps/root/src/app/api/career/experience/prose/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse } from 'next/server';
-import { proxyToFastAPI, verifyJobsAdmin } from '@/app/api/jobs/proxy';
+import { proxyToFastAPI, verifyJobsAccess } from '@/app/api/jobs/proxy';
 
 export async function GET() {
-  if (!(await verifyJobsAdmin())) {
+  if (!(await verifyJobsAccess())) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
   return proxyToFastAPI('/experience/prose');

--- a/apps/root/src/app/api/jobs/[id]/status/route.test.ts
+++ b/apps/root/src/app/api/jobs/[id]/status/route.test.ts
@@ -2,16 +2,16 @@
  * @jest-environment node
  */
 import { NextRequest, NextResponse } from 'next/server';
-import { verifyJobsAdmin, proxyToFastAPI } from '../../proxy';
+import { verifyJobsAccess, proxyToFastAPI } from '../../proxy';
 import { POST } from './route';
 
 jest.mock('../../proxy', () => ({
-  verifyJobsAdmin: jest.fn(),
+  verifyJobsAccess: jest.fn(),
   proxyToFastAPI: jest.fn(),
 }));
 
-const mockedVerify = verifyJobsAdmin as jest.MockedFunction<
-  typeof verifyJobsAdmin
+const mockedVerify = verifyJobsAccess as jest.MockedFunction<
+  typeof verifyJobsAccess
 >;
 const mockedProxy = proxyToFastAPI as jest.MockedFunction<
   typeof proxyToFastAPI

--- a/apps/root/src/app/api/jobs/[id]/status/route.ts
+++ b/apps/root/src/app/api/jobs/[id]/status/route.ts
@@ -1,11 +1,11 @@
 import { type NextRequest, NextResponse } from 'next/server';
-import { verifyJobsAdmin, proxyToFastAPI } from '../../proxy';
+import { verifyJobsAccess, proxyToFastAPI } from '../../proxy';
 
 export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
-  if (!(await verifyJobsAdmin())) {
+  if (!(await verifyJobsAccess())) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 

--- a/apps/root/src/app/api/jobs/analysis/[id]/route.ts
+++ b/apps/root/src/app/api/jobs/analysis/[id]/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
-import { verifyJobsAccess, proxyToFastAPI } from '../proxy';
+import { verifyJobsAccess, proxyToFastAPI } from '../../proxy';
 
-export async function DELETE(
+export async function POST(
   _request: Request,
   { params }: { params: Promise<{ id: string }> }
 ) {
@@ -10,5 +10,5 @@ export async function DELETE(
   }
 
   const { id } = await params;
-  return proxyToFastAPI(`/jobs/${id}`, { method: 'DELETE' });
+  return proxyToFastAPI(`/analysis/${id}`, { method: 'POST' });
 }

--- a/apps/root/src/app/api/jobs/poll/route.test.ts
+++ b/apps/root/src/app/api/jobs/poll/route.test.ts
@@ -2,16 +2,16 @@
  * @jest-environment node
  */
 import { NextRequest, NextResponse } from 'next/server';
-import { verifyJobsAdmin, proxyToFastAPI } from '../proxy';
+import { verifyJobsAccess, proxyToFastAPI } from '../proxy';
 import { POST } from './route';
 
 jest.mock('../proxy', () => ({
-  verifyJobsAdmin: jest.fn(),
+  verifyJobsAccess: jest.fn(),
   proxyToFastAPI: jest.fn(),
 }));
 
-const mockedVerify = verifyJobsAdmin as jest.MockedFunction<
-  typeof verifyJobsAdmin
+const mockedVerify = verifyJobsAccess as jest.MockedFunction<
+  typeof verifyJobsAccess
 >;
 const mockedProxy = proxyToFastAPI as jest.MockedFunction<
   typeof proxyToFastAPI

--- a/apps/root/src/app/api/jobs/poll/route.ts
+++ b/apps/root/src/app/api/jobs/poll/route.ts
@@ -1,6 +1,6 @@
 import { timingSafeEqual } from 'node:crypto';
 import { type NextRequest, NextResponse } from 'next/server';
-import { verifyJobsAdmin, proxyToFastAPI } from '../proxy';
+import { verifyJobsAccess, proxyToFastAPI } from '../proxy';
 
 function constantTimeEqual(a: string, b: string): boolean {
   const aBuf = Buffer.from(a, 'utf8');
@@ -17,7 +17,7 @@ export async function POST(request: NextRequest) {
     : '';
   const isCron = !!cronSecret && constantTimeEqual(presented, cronSecret);
 
-  if (!isCron && !(await verifyJobsAdmin())) {
+  if (!isCron && !(await verifyJobsAccess())) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 

--- a/apps/root/src/app/api/jobs/proxy.test.ts
+++ b/apps/root/src/app/api/jobs/proxy.test.ts
@@ -1,30 +1,52 @@
 /**
  * @jest-environment node
  */
+const mockGetUser = jest.fn();
+
 jest.mock('@/lib/adminSession', () => ({
   readAdminSession: jest.fn(),
   readAdminSessionToken: jest.fn(),
 }));
+jest.mock('@/lib/supabase/auth-server', () => ({
+  createAuthServerClient: () =>
+    Promise.resolve({ auth: { getUser: mockGetUser } }),
+}));
 
 import { readAdminSession } from '@/lib/adminSession';
-import { verifyJobsAdmin } from './proxy';
+import { verifyJobsAccess } from './proxy';
 
 const mockedReadAdminSession = readAdminSession as jest.MockedFunction<
   typeof readAdminSession
 >;
 
-describe('verifyJobsAdmin', () => {
+describe('verifyJobsAccess', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  it('returns true when a valid session exists', async () => {
+  it('returns true when an admin session exists', async () => {
     mockedReadAdminSession.mockResolvedValueOnce({ sub: 'tools-admin' });
-    await expect(verifyJobsAdmin()).resolves.toBe(true);
+    await expect(verifyJobsAccess()).resolves.toBe(true);
+    expect(mockGetUser).not.toHaveBeenCalled();
   });
 
-  it('returns false when no session exists', async () => {
+  it('returns true when Supabase session exists (no admin session)', async () => {
     mockedReadAdminSession.mockResolvedValueOnce(null);
-    await expect(verifyJobsAdmin()).resolves.toBe(false);
+    mockGetUser.mockResolvedValueOnce({
+      data: { user: { id: 'user-123' } },
+    });
+    await expect(verifyJobsAccess()).resolves.toBe(true);
+  });
+
+  it('returns false when neither admin nor Supabase session exists', async () => {
+    mockedReadAdminSession.mockResolvedValueOnce(null);
+    mockGetUser.mockResolvedValueOnce({ data: { user: null } });
+    await expect(verifyJobsAccess()).resolves.toBe(false);
+  });
+
+  it('returns false when Supabase auth throws', async () => {
+    mockedReadAdminSession.mockResolvedValueOnce(null);
+    mockGetUser.mockRejectedValueOnce(new Error('cookie error'));
+    await expect(verifyJobsAccess()).resolves.toBe(false);
   });
 });

--- a/apps/root/src/app/api/jobs/proxy.ts
+++ b/apps/root/src/app/api/jobs/proxy.ts
@@ -1,12 +1,25 @@
 import { NextResponse } from 'next/server';
 import { readAdminSession, readAdminSessionToken } from '@/lib/adminSession';
+import { createAuthServerClient } from '@/lib/supabase/auth-server';
 
 const JOB_API_URL = process.env['JOB_API_URL'] ?? '';
 const JOB_API_KEY = process.env['JOB_API_KEY'] ?? '';
 
-export async function verifyJobsAdmin(): Promise<boolean> {
-  const session = await readAdminSession();
-  return session !== null;
+/**
+ * Verify access: accepts either an admin session cookie (admin dashboard)
+ * or a valid Supabase session (Fitted app via magic link).
+ */
+export async function verifyJobsAccess(): Promise<boolean> {
+  const adminSession = await readAdminSession();
+  if (adminSession !== null) return true;
+
+  try {
+    const supabase = await createAuthServerClient();
+    const { data } = await supabase.auth.getUser();
+    return data.user !== null;
+  } catch {
+    return false;
+  }
 }
 
 export async function proxyToFastAPI(

--- a/apps/root/src/app/api/jobs/route.test.ts
+++ b/apps/root/src/app/api/jobs/route.test.ts
@@ -2,16 +2,16 @@
  * @jest-environment node
  */
 import { NextRequest, NextResponse } from 'next/server';
-import { verifyJobsAdmin, proxyToFastAPI } from './proxy';
+import { verifyJobsAccess, proxyToFastAPI } from './proxy';
 import { GET } from './route';
 
 jest.mock('./proxy', () => ({
-  verifyJobsAdmin: jest.fn(),
+  verifyJobsAccess: jest.fn(),
   proxyToFastAPI: jest.fn(),
 }));
 
-const mockedVerify = verifyJobsAdmin as jest.MockedFunction<
-  typeof verifyJobsAdmin
+const mockedVerify = verifyJobsAccess as jest.MockedFunction<
+  typeof verifyJobsAccess
 >;
 const mockedProxy = proxyToFastAPI as jest.MockedFunction<
   typeof proxyToFastAPI

--- a/apps/root/src/app/api/jobs/route.ts
+++ b/apps/root/src/app/api/jobs/route.ts
@@ -1,8 +1,8 @@
 import { type NextRequest, NextResponse } from 'next/server';
-import { verifyJobsAdmin, proxyToFastAPI } from './proxy';
+import { verifyJobsAccess, proxyToFastAPI } from './proxy';
 
 export async function GET(request: NextRequest) {
-  if (!(await verifyJobsAdmin())) {
+  if (!(await verifyJobsAccess())) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 

--- a/apps/root/src/app/api/jobs/sources/detect/route.test.ts
+++ b/apps/root/src/app/api/jobs/sources/detect/route.test.ts
@@ -2,16 +2,16 @@
  * @jest-environment node
  */
 import { NextRequest, NextResponse } from 'next/server';
-import { verifyJobsAdmin, proxyToFastAPI } from '../../proxy';
+import { verifyJobsAccess, proxyToFastAPI } from '../../proxy';
 import { GET } from './route';
 
 jest.mock('../../proxy', () => ({
-  verifyJobsAdmin: jest.fn(),
+  verifyJobsAccess: jest.fn(),
   proxyToFastAPI: jest.fn(),
 }));
 
-const mockedVerify = verifyJobsAdmin as jest.MockedFunction<
-  typeof verifyJobsAdmin
+const mockedVerify = verifyJobsAccess as jest.MockedFunction<
+  typeof verifyJobsAccess
 >;
 const mockedProxy = proxyToFastAPI as jest.MockedFunction<
   typeof proxyToFastAPI

--- a/apps/root/src/app/api/jobs/sources/detect/route.ts
+++ b/apps/root/src/app/api/jobs/sources/detect/route.ts
@@ -1,8 +1,8 @@
 import { type NextRequest, NextResponse } from 'next/server';
-import { verifyJobsAdmin, proxyToFastAPI } from '../../proxy';
+import { verifyJobsAccess, proxyToFastAPI } from '../../proxy';
 
 export async function GET(request: NextRequest) {
-  if (!(await verifyJobsAdmin())) {
+  if (!(await verifyJobsAccess())) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 

--- a/apps/root/src/app/api/jobs/sources/route.test.ts
+++ b/apps/root/src/app/api/jobs/sources/route.test.ts
@@ -2,16 +2,16 @@
  * @jest-environment node
  */
 import { NextRequest, NextResponse } from 'next/server';
-import { verifyJobsAdmin, proxyToFastAPI } from '../proxy';
+import { verifyJobsAccess, proxyToFastAPI } from '../proxy';
 import { GET, POST } from './route';
 
 jest.mock('../proxy', () => ({
-  verifyJobsAdmin: jest.fn(),
+  verifyJobsAccess: jest.fn(),
   proxyToFastAPI: jest.fn(),
 }));
 
-const mockedVerify = verifyJobsAdmin as jest.MockedFunction<
-  typeof verifyJobsAdmin
+const mockedVerify = verifyJobsAccess as jest.MockedFunction<
+  typeof verifyJobsAccess
 >;
 const mockedProxy = proxyToFastAPI as jest.MockedFunction<
   typeof proxyToFastAPI

--- a/apps/root/src/app/api/jobs/sources/route.ts
+++ b/apps/root/src/app/api/jobs/sources/route.ts
@@ -1,5 +1,5 @@
 import { type NextRequest, NextResponse } from 'next/server';
-import { verifyJobsAdmin, proxyToFastAPI } from '../proxy';
+import { verifyJobsAccess, proxyToFastAPI } from '../proxy';
 
 type SourceAction =
   | { action: 'add'; board_token: string; company_name: string }
@@ -7,7 +7,7 @@ type SourceAction =
   | { action: 'seed' };
 
 export async function GET() {
-  if (!(await verifyJobsAdmin())) {
+  if (!(await verifyJobsAccess())) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
@@ -15,7 +15,7 @@ export async function GET() {
 }
 
 export async function POST(request: NextRequest) {
-  if (!(await verifyJobsAdmin())) {
+  if (!(await verifyJobsAccess())) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 

--- a/apps/root/src/app/api/jobs/sources/verify/route.test.ts
+++ b/apps/root/src/app/api/jobs/sources/verify/route.test.ts
@@ -2,16 +2,16 @@
  * @jest-environment node
  */
 import { NextRequest, NextResponse } from 'next/server';
-import { verifyJobsAdmin, proxyToFastAPI } from '../../proxy';
+import { verifyJobsAccess, proxyToFastAPI } from '../../proxy';
 import { GET } from './route';
 
 jest.mock('../../proxy', () => ({
-  verifyJobsAdmin: jest.fn(),
+  verifyJobsAccess: jest.fn(),
   proxyToFastAPI: jest.fn(),
 }));
 
-const mockedVerify = verifyJobsAdmin as jest.MockedFunction<
-  typeof verifyJobsAdmin
+const mockedVerify = verifyJobsAccess as jest.MockedFunction<
+  typeof verifyJobsAccess
 >;
 const mockedProxy = proxyToFastAPI as jest.MockedFunction<
   typeof proxyToFastAPI

--- a/apps/root/src/app/api/jobs/sources/verify/route.ts
+++ b/apps/root/src/app/api/jobs/sources/verify/route.ts
@@ -1,8 +1,8 @@
 import { type NextRequest, NextResponse } from 'next/server';
-import { verifyJobsAdmin, proxyToFastAPI } from '../../proxy';
+import { verifyJobsAccess, proxyToFastAPI } from '../../proxy';
 
 export async function GET(request: NextRequest) {
-  if (!(await verifyJobsAdmin())) {
+  if (!(await verifyJobsAccess())) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 

--- a/apps/root/src/app/api/jobs/tailor/batch/[id]/route.ts
+++ b/apps/root/src/app/api/jobs/tailor/batch/[id]/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
-import { verifyJobsAccess, proxyToFastAPI } from '../proxy';
+import { verifyJobsAccess, proxyToFastAPI } from '../../../proxy';
 
-export async function DELETE(
+export async function GET(
   _request: Request,
   { params }: { params: Promise<{ id: string }> }
 ) {
@@ -10,5 +10,5 @@ export async function DELETE(
   }
 
   const { id } = await params;
-  return proxyToFastAPI(`/jobs/${id}`, { method: 'DELETE' });
+  return proxyToFastAPI(`/tailor/batch/${id}`);
 }

--- a/apps/root/src/app/api/jobs/tailor/batch/route.ts
+++ b/apps/root/src/app/api/jobs/tailor/batch/route.ts
@@ -1,0 +1,11 @@
+import { NextResponse } from 'next/server';
+import { verifyJobsAccess, proxyToFastAPI } from '../../proxy';
+
+export async function POST(request: Request) {
+  if (!(await verifyJobsAccess())) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const body = await request.json();
+  return proxyToFastAPI('/tailor/batch', { method: 'POST', body });
+}

--- a/apps/root/src/app/fitted/(app)/FittedSidebar.tsx
+++ b/apps/root/src/app/fitted/(app)/FittedSidebar.tsx
@@ -4,6 +4,7 @@ import { useState, useCallback, useEffect, useRef } from 'react';
 import { usePathname, useRouter } from 'next/navigation';
 import {
   LayoutDashboard,
+  Briefcase,
   User,
   BarChart3,
   Menu,
@@ -23,6 +24,12 @@ const NAV_ITEMS: (SidebarItem & { href: string })[] = [
     label: 'Dashboard',
     href: '/fitted',
     icon: <LayoutDashboard className='size-4' aria-hidden />,
+  },
+  {
+    id: 'jobs',
+    label: 'Jobs',
+    href: '/fitted/jobs',
+    icon: <Briefcase className='size-4' aria-hidden />,
   },
   {
     id: 'profile',

--- a/apps/root/src/app/fitted/(app)/jobs/BatchActionBar.tsx
+++ b/apps/root/src/app/fitted/(app)/jobs/BatchActionBar.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import Button from '@/components/Button';
+
+interface BatchActionBarProps {
+  selectedCount: number;
+  onClear: () => void;
+  onBatchGenerate: () => void;
+  onBatchDelete: () => void;
+  generating: boolean;
+}
+
+export default function BatchActionBar({
+  selectedCount,
+  onClear,
+  onBatchGenerate,
+  onBatchDelete,
+  generating,
+}: BatchActionBarProps) {
+  if (selectedCount === 0) return null;
+
+  return (
+    <div className='fixed bottom-4 left-1/2 -translate-x-1/2 z-40 flex items-center gap-3 rounded-xl border border-border bg-surface px-4 py-3 shadow-lg'>
+      <span className='text-sm font-medium text-text-primary'>
+        {selectedCount} selected
+      </span>
+      <Button
+        name='batch-deselect'
+        variant='outline'
+        size='sm'
+        onClick={onClear}
+      >
+        Deselect all
+      </Button>
+      <Button
+        name='batch-generate'
+        variant='primary'
+        size='sm'
+        onClick={onBatchGenerate}
+        disabled={generating}
+      >
+        {generating ? 'Generating...' : 'Generate resumes'}
+      </Button>
+      <Button
+        name='batch-delete'
+        variant='error'
+        size='sm'
+        onClick={onBatchDelete}
+      >
+        Delete selected
+      </Button>
+    </div>
+  );
+}

--- a/apps/root/src/app/fitted/(app)/jobs/JobDetailPanel.tsx
+++ b/apps/root/src/app/fitted/(app)/jobs/JobDetailPanel.tsx
@@ -1,0 +1,240 @@
+'use client';
+
+import { useState } from 'react';
+import { Badge } from '@danieljoffe.com/shared-ui/Badge';
+import { Skeleton } from '@danieljoffe.com/shared-ui/Skeleton';
+import { Text } from '@danieljoffe.com/shared-ui/Text';
+import Button from '@/components/Button';
+import { useToast } from '@/state/Toast/ToastProvider';
+import { JOB_STATUSES, type JobAnalysis, type JobPosting } from './types';
+
+interface JobDetailPanelProps {
+  posting: JobPosting;
+  onDelete: (() => void) | undefined;
+  onStatusChange: ((status: string) => void) | undefined;
+}
+
+export default function JobDetailPanel({
+  posting,
+  onDelete,
+  onStatusChange,
+}: JobDetailPanelProps) {
+  const [status, setStatus] = useState(posting.status);
+  const [updating, setUpdating] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [analysis, setAnalysis] = useState<JobAnalysis | null>(null);
+  const [analyzing, setAnalyzing] = useState(false);
+  const [analysisError, setAnalysisError] = useState<string | null>(null);
+  const { toast } = useToast();
+
+  async function updateStatus(newStatus: string) {
+    setUpdating(true);
+    try {
+      const res = await fetch(`/api/jobs/${posting.id}/status`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status: newStatus }),
+      });
+      if (res.ok) {
+        setStatus(newStatus);
+        onStatusChange?.(newStatus);
+      } else {
+        toast({ variant: 'error', title: 'Failed to update status' });
+      }
+    } catch {
+      toast({ variant: 'error', title: 'Failed to update status' });
+    } finally {
+      setUpdating(false);
+    }
+  }
+
+  async function handleAnalyze() {
+    setAnalyzing(true);
+    setAnalysisError(null);
+    try {
+      const res = await fetch(`/api/jobs/analysis/${posting.id}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ job_description: '' }),
+      });
+      if (res.ok) {
+        const data = (await res.json()) as JobAnalysis;
+        setAnalysis(data);
+      } else {
+        setAnalysisError('Analysis failed. The job may lack a description.');
+      }
+    } catch {
+      setAnalysisError('Network error running analysis.');
+    } finally {
+      setAnalyzing(false);
+    }
+  }
+
+  async function handleDelete() {
+    /* eslint-disable no-alert -- personal tool, native confirm is fine */
+    if (
+      !window.confirm(`Delete "${posting.title}" from ${posting.company_name}?`)
+    )
+      /* eslint-enable no-alert */
+      return;
+    setDeleting(true);
+    try {
+      const res = await fetch(`/api/jobs/${posting.id}`, { method: 'DELETE' });
+      if (res.ok) {
+        toast({ variant: 'success', title: 'Job deleted' });
+        onDelete?.();
+      } else {
+        toast({ variant: 'error', title: 'Failed to delete job' });
+      }
+    } catch {
+      toast({ variant: 'error', title: 'Failed to delete job' });
+    } finally {
+      setDeleting(false);
+    }
+  }
+
+  const breakdown = posting.score_breakdown;
+
+  return (
+    <div className='border-t border-border bg-surface-tertiary p-4 space-y-4'>
+      {/* Score breakdown */}
+      <div>
+        <Text variant='caption' className='mb-1'>
+          Score Breakdown
+        </Text>
+        {breakdown ? (
+          <div className='flex flex-wrap gap-2'>
+            {Object.entries(breakdown).map(([key, value]) => (
+              <Badge
+                key={key}
+                variant={value > 0 ? 'info' : value < 0 ? 'error' : 'default'}
+                size='sm'
+              >
+                {key}: {value}
+              </Badge>
+            ))}
+          </div>
+        ) : (
+          <Text variant='meta'>No breakdown available</Text>
+        )}
+      </div>
+
+      {/* Status buttons */}
+      <div>
+        <Text variant='caption' className='mb-1'>
+          Status
+        </Text>
+        <div className='flex flex-wrap gap-2'>
+          {JOB_STATUSES.map(s => (
+            <Button
+              key={s}
+              name={`status-${s}`}
+              variant={status === s ? 'primary' : 'outline'}
+              size='sm'
+              disabled={updating || status === s}
+              onClick={() => updateStatus(s)}
+            >
+              {s.replace('_', ' ')}
+            </Button>
+          ))}
+        </div>
+      </div>
+
+      {/* LLM Analysis */}
+      <div>
+        <Text variant='caption' className='mb-1'>
+          LLM Analysis
+        </Text>
+        {analysis ? (
+          <div className='space-y-2'>
+            <Text variant='body'>{analysis.recommendation}</Text>
+            <div className='flex flex-wrap gap-2'>
+              <Badge
+                variant={
+                  analysis.scorecard.seniority_fit === 'strong'
+                    ? 'success'
+                    : analysis.scorecard.seniority_fit === 'moderate'
+                      ? 'warning'
+                      : 'error'
+                }
+                size='sm'
+              >
+                Seniority: {analysis.scorecard.seniority_fit}
+              </Badge>
+              <Badge
+                variant={
+                  analysis.scorecard.domain_fit === 'strong'
+                    ? 'success'
+                    : analysis.scorecard.domain_fit === 'moderate'
+                      ? 'warning'
+                      : 'error'
+                }
+                size='sm'
+              >
+                Domain: {analysis.scorecard.domain_fit}
+              </Badge>
+            </div>
+            {analysis.scorecard.skills_missing.length > 0 && (
+              <div>
+                <Text variant='meta' className='mb-1'>
+                  Missing skills
+                </Text>
+                <div className='flex flex-wrap gap-1'>
+                  {analysis.scorecard.skills_missing.map(skill => (
+                    <Badge key={skill} variant='error' size='sm'>
+                      {skill}
+                    </Badge>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        ) : analyzing ? (
+          <Skeleton variant='text' lines={3} />
+        ) : (
+          <div>
+            {analysisError && (
+              <Text variant='error' className='mb-2'>
+                {analysisError}
+              </Text>
+            )}
+            <Button
+              name='analyze-job'
+              variant='secondary'
+              size='sm'
+              onClick={handleAnalyze}
+            >
+              Analyze
+            </Button>
+          </div>
+        )}
+      </div>
+
+      {/* Actions */}
+      <div className='flex gap-2'>
+        {posting.absolute_url && (
+          <Button
+            as='link'
+            href={posting.absolute_url}
+            target='_blank'
+            rel='noopener noreferrer'
+            variant='secondary'
+            size='sm'
+            name='view-posting-url'
+          >
+            View posting
+          </Button>
+        )}
+        <Button
+          name='delete-posting'
+          variant='error'
+          size='sm'
+          onClick={handleDelete}
+          disabled={deleting}
+        >
+          {deleting ? 'Deleting...' : 'Delete'}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/root/src/app/fitted/(app)/jobs/JobsFilter.tsx
+++ b/apps/root/src/app/fitted/(app)/jobs/JobsFilter.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { Input } from '@danieljoffe.com/shared-ui/Input';
+import { Select } from '@danieljoffe.com/shared-ui/Select';
+import { JOB_STATUSES, type JobsFilterState } from './types';
+
+interface JobsFilterProps {
+  filters: JobsFilterState;
+  onChange: (f: JobsFilterState) => void;
+}
+
+const STATUS_OPTIONS = [
+  { value: '', label: 'All statuses' },
+  ...JOB_STATUSES.map(s => ({ value: s, label: s.replace('_', ' ') })),
+];
+
+export default function JobsFilter({ filters, onChange }: JobsFilterProps) {
+  const [searchDraft, setSearchDraft] = useState(filters.search);
+  const timerRef = useRef<ReturnType<typeof setTimeout>>();
+
+  useEffect(() => {
+    timerRef.current = setTimeout(() => {
+      if (searchDraft !== filters.search) {
+        onChange({ ...filters, search: searchDraft });
+      }
+    }, 300);
+    return () => clearTimeout(timerRef.current);
+  }, [searchDraft, filters, onChange]);
+
+  return (
+    <div className='flex flex-wrap items-end gap-3'>
+      <div className='w-28'>
+        <Input
+          label='Min score'
+          type='number'
+          size='sm'
+          min={0}
+          max={100}
+          value={filters.minScore}
+          onChange={e => onChange({ ...filters, minScore: e.target.value })}
+          placeholder='0'
+        />
+      </div>
+      <div className='w-40'>
+        <Select
+          label='Status'
+          size='sm'
+          options={STATUS_OPTIONS}
+          value={filters.status}
+          onChange={e => onChange({ ...filters, status: e.target.value })}
+        />
+      </div>
+      <div className='flex-1 min-w-[200px]'>
+        <Input
+          label='Search'
+          size='sm'
+          value={searchDraft}
+          onChange={e => setSearchDraft(e.target.value)}
+          placeholder='Search by title...'
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/root/src/app/fitted/(app)/jobs/JobsList.tsx
+++ b/apps/root/src/app/fitted/(app)/jobs/JobsList.tsx
@@ -1,0 +1,153 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Heading } from '@danieljoffe.com/shared-ui/Heading';
+import { useToast } from '@/state/Toast/ToastProvider';
+import BatchActionBar from './BatchActionBar';
+import JobsFilter from './JobsFilter';
+import JobsListTable from './JobsListTable';
+import type { JobsFilterState } from './types';
+
+const INITIAL_FILTERS: JobsFilterState = {
+  minScore: '',
+  status: '',
+  search: '',
+};
+
+const BATCH_POLL_INTERVAL = 3000;
+
+export default function JobsList() {
+  const [filters, setFilters] = useState<JobsFilterState>(INITIAL_FILTERS);
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [refreshKey, setRefreshKey] = useState(0);
+  const [generating, setGenerating] = useState(false);
+  const pollRef = useRef<ReturnType<typeof setInterval>>();
+  const { toast } = useToast();
+
+  // Cleanup polling on unmount
+  useEffect(() => {
+    return () => {
+      if (pollRef.current) clearInterval(pollRef.current);
+    };
+  }, []);
+
+  const handleBatchGenerate = useCallback(async () => {
+    if (selectedIds.size === 0) return;
+
+    setGenerating(true);
+    try {
+      const res = await fetch('/api/jobs/tailor/batch', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          job_posting_ids: [...selectedIds],
+          contact: {},
+        }),
+      });
+
+      if (!res.ok) {
+        const err = await res.json().catch(() => null);
+        toast({
+          variant: 'error',
+          title:
+            (err as Record<string, string> | null)?.detail ??
+            'Batch generation failed',
+        });
+        setGenerating(false);
+        return;
+      }
+
+      const { batch_id } = (await res.json()) as { batch_id: string };
+
+      // Poll for completion
+      pollRef.current = setInterval(async () => {
+        try {
+          const pollRes = await fetch(`/api/jobs/tailor/batch/${batch_id}`);
+          if (!pollRes.ok) return;
+
+          const batch = (await pollRes.json()) as {
+            status: string;
+            completed: number;
+            failed: number;
+            total: number;
+          };
+
+          if (batch.status === 'completed' || batch.status === 'failed') {
+            clearInterval(pollRef.current);
+            pollRef.current = undefined;
+            setGenerating(false);
+            setSelectedIds(new Set());
+            setRefreshKey(k => k + 1);
+
+            if (batch.failed > 0) {
+              toast({
+                variant: 'warning',
+                title: `Batch done: ${batch.completed} succeeded, ${batch.failed} failed`,
+              });
+            } else {
+              toast({
+                variant: 'success',
+                title: `${batch.completed} resumes generated`,
+              });
+            }
+          }
+        } catch {
+          // polling error — keep trying
+        }
+      }, BATCH_POLL_INTERVAL);
+    } catch {
+      toast({ variant: 'error', title: 'Network error starting batch' });
+      setGenerating(false);
+    }
+  }, [selectedIds, toast]);
+
+  const handleBatchDelete = useCallback(async () => {
+    if (selectedIds.size === 0) return;
+
+    /* eslint-disable no-alert -- personal tool */
+    if (!window.confirm(`Delete ${selectedIds.size} jobs?`)) return;
+    /* eslint-enable no-alert */
+
+    let deleted = 0;
+    for (const id of selectedIds) {
+      try {
+        const res = await fetch(`/api/jobs/${id}`, { method: 'DELETE' });
+        if (res.ok) deleted++;
+      } catch {
+        // continue with remaining
+      }
+    }
+
+    toast({
+      variant: deleted > 0 ? 'success' : 'error',
+      title: deleted > 0 ? `Deleted ${deleted} jobs` : 'Failed to delete jobs',
+    });
+    setSelectedIds(new Set());
+    setRefreshKey(k => k + 1);
+  }, [selectedIds, toast]);
+
+  return (
+    <div className='flex flex-col gap-6'>
+      <Heading variant='component' as='h1'>
+        Jobs
+      </Heading>
+
+      <JobsFilter filters={filters} onChange={setFilters} />
+
+      <JobsListTable
+        filters={filters}
+        selectedIds={selectedIds}
+        onSelectionChange={setSelectedIds}
+        refreshKey={refreshKey}
+      />
+
+      <BatchActionBar
+        selectedCount={selectedIds.size}
+        onClear={() => setSelectedIds(new Set())}
+        onBatchGenerate={handleBatchGenerate}
+        onBatchDelete={handleBatchDelete}
+        generating={generating}
+      />
+    </div>
+  );
+}

--- a/apps/root/src/app/fitted/(app)/jobs/JobsListTable.tsx
+++ b/apps/root/src/app/fitted/(app)/jobs/JobsListTable.tsx
@@ -1,0 +1,246 @@
+'use client';
+
+import { Fragment, useMemo, useState } from 'react';
+import { Badge } from '@danieljoffe.com/shared-ui/Badge';
+import { Pagination } from '@danieljoffe.com/shared-ui/Pagination';
+import { Spinner } from '@danieljoffe.com/shared-ui/Spinner';
+import { Text } from '@danieljoffe.com/shared-ui/Text';
+import { useAdminTableFetch } from '@/hooks/useAdminTableFetch';
+import { cn } from '@/lib/cn';
+import JobDetailPanel from './JobDetailPanel';
+import type { JobPosting, JobsFilterState, JobsSortColumn } from './types';
+
+interface JobsListTableProps {
+  filters: JobsFilterState;
+  selectedIds: Set<string>;
+  onSelectionChange: (ids: Set<string>) => void;
+  refreshKey: number;
+}
+
+function ScoreBadge({ score }: { score: number }) {
+  const variant = score >= 70 ? 'success' : score >= 40 ? 'warning' : 'error';
+  return <Badge variant={variant}>{score}</Badge>;
+}
+
+function StatusBadge({ status }: { status: string }) {
+  const variant =
+    status === 'applied'
+      ? 'success'
+      : status === 'saved' || status === 'resume_draft'
+        ? 'info'
+        : status === 'rejected'
+          ? 'error'
+          : 'default';
+  return <Badge variant={variant}>{status.replace('_', ' ')}</Badge>;
+}
+
+function timeAgo(dateStr: string): string {
+  const diff = Date.now() - new Date(dateStr).getTime();
+  const days = Math.floor(diff / 86400000);
+  if (days === 0) return 'today';
+  if (days === 1) return '1d ago';
+  return `${days}d ago`;
+}
+
+export default function JobsListTable({
+  filters,
+  selectedIds,
+  onSelectionChange,
+  refreshKey,
+}: JobsListTableProps) {
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+  const [deleteKey, setDeleteKey] = useState(0);
+
+  const extraParams = useMemo(() => {
+    const params: Record<string, string> = {};
+    if (filters.minScore) params.min_score = filters.minScore;
+    if (filters.status) params.status = filters.status;
+    if (filters.search) params.search = filters.search;
+    const combined = refreshKey + deleteKey;
+    if (combined) params._r = String(combined);
+    return params;
+  }, [filters, refreshKey, deleteKey]);
+
+  const {
+    data: postings,
+    loading,
+    page,
+    setPage,
+    totalPages,
+    handleSort,
+    sortIndicator,
+  } = useAdminTableFetch<JobPosting, JobsSortColumn>({
+    endpoint: '/api/jobs',
+    defaultSort: 'score',
+    pageSize: 20,
+    dataKey: 'postings',
+    extraParams,
+  });
+
+  const allOnPageSelected =
+    postings.length > 0 && postings.every(p => selectedIds.has(p.id));
+
+  function toggleSelectAll() {
+    const next = new Set(selectedIds);
+    if (allOnPageSelected) {
+      for (const p of postings) next.delete(p.id);
+    } else {
+      for (const p of postings) next.add(p.id);
+    }
+    onSelectionChange(next);
+  }
+
+  function toggleSelect(id: string) {
+    const next = new Set(selectedIds);
+    if (next.has(id)) {
+      next.delete(id);
+    } else {
+      next.add(id);
+    }
+    onSelectionChange(next);
+  }
+
+  if (loading && postings.length === 0) {
+    return (
+      <div className='flex justify-center py-12'>
+        <Spinner aria-label='Loading jobs' />
+      </div>
+    );
+  }
+
+  if (postings.length === 0) {
+    return (
+      <Text variant='body' className='text-center py-12 text-text-tertiary'>
+        No jobs found. Try adjusting filters or adding jobs manually.
+      </Text>
+    );
+  }
+
+  const COLUMNS: { key: JobsSortColumn; label: string }[] = [
+    { key: 'score', label: 'Score' },
+    { key: 'title', label: 'Title' },
+    { key: 'company_name', label: 'Company' },
+    { key: 'created_at', label: 'Date' },
+  ];
+
+  return (
+    <div>
+      <div className='overflow-x-auto'>
+        <table className='w-full text-sm'>
+          <thead>
+            <tr className='border-b border-border text-left'>
+              <th scope='col' className='px-3 py-2 w-10'>
+                <input
+                  type='checkbox'
+                  checked={allOnPageSelected}
+                  onChange={toggleSelectAll}
+                  aria-label='Select all on this page'
+                  className='accent-brand-500'
+                />
+              </th>
+              {COLUMNS.map(col => (
+                <th
+                  key={col.key}
+                  scope='col'
+                  className='px-3 py-2 font-medium text-text-secondary cursor-pointer hover:text-text-primary'
+                  onClick={() => handleSort(col.key)}
+                >
+                  {col.label} {sortIndicator(col.key)}
+                </th>
+              ))}
+              <th
+                scope='col'
+                className='px-3 py-2 font-medium text-text-secondary'
+              >
+                Status
+              </th>
+              <th
+                scope='col'
+                className='px-3 py-2 font-medium text-text-secondary'
+              >
+                Location
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {postings.map(job => (
+              <Fragment key={job.id}>
+                <tr
+                  className={cn(
+                    'border-b border-border hover:bg-surface-secondary cursor-pointer transition-colors',
+                    expandedId === job.id && 'bg-surface-secondary'
+                  )}
+                  onClick={() =>
+                    setExpandedId(expandedId === job.id ? null : job.id)
+                  }
+                >
+                  <td className='px-3 py-2'>
+                    <input
+                      type='checkbox'
+                      checked={selectedIds.has(job.id)}
+                      onChange={() => toggleSelect(job.id)}
+                      onClick={e => e.stopPropagation()}
+                      aria-label={`Select ${job.title}`}
+                      className='accent-brand-500'
+                    />
+                  </td>
+                  <td className='px-3 py-2'>
+                    <ScoreBadge score={job.score} />
+                  </td>
+                  <td className='px-3 py-2 font-medium'>
+                    {job.absolute_url ? (
+                      <a
+                        href={job.absolute_url}
+                        target='_blank'
+                        rel='noopener noreferrer'
+                        className='text-brand-500 hover:text-brand-600'
+                        onClick={e => e.stopPropagation()}
+                      >
+                        {job.title}
+                      </a>
+                    ) : (
+                      job.title
+                    )}
+                  </td>
+                  <td className='px-3 py-2'>{job.company_name}</td>
+                  <td className='px-3 py-2 text-text-tertiary'>
+                    {timeAgo(job.first_seen_at)}
+                  </td>
+                  <td className='px-3 py-2'>
+                    <StatusBadge status={job.status} />
+                  </td>
+                  <td className='px-3 py-2 text-text-tertiary truncate max-w-[150px]'>
+                    {job.location ?? '\u2014'}
+                  </td>
+                </tr>
+                {expandedId === job.id && (
+                  <tr>
+                    <td colSpan={7} className='p-0'>
+                      <JobDetailPanel
+                        posting={job}
+                        onDelete={() => {
+                          setExpandedId(null);
+                          setDeleteKey(k => k + 1);
+                        }}
+                        onStatusChange={undefined}
+                      />
+                    </td>
+                  </tr>
+                )}
+              </Fragment>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      {totalPages > 1 && (
+        <div className='mt-4 flex justify-center'>
+          <Pagination
+            currentPage={page}
+            totalPages={totalPages}
+            onPageChange={setPage}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/root/src/app/fitted/(app)/jobs/loading.tsx
+++ b/apps/root/src/app/fitted/(app)/jobs/loading.tsx
@@ -1,0 +1,19 @@
+import { Skeleton } from '@danieljoffe.com/shared-ui/Skeleton';
+
+export default function FittedJobsLoading() {
+  return (
+    <div className='flex flex-col gap-6'>
+      <Skeleton variant='text' className='h-8 w-32' />
+      <div className='flex gap-3'>
+        <Skeleton variant='rectangular' className='h-10 w-28' />
+        <Skeleton variant='rectangular' className='h-10 w-40' />
+        <Skeleton variant='rectangular' className='h-10 flex-1' />
+      </div>
+      <div className='space-y-2'>
+        {Array.from({ length: 8 }, (_, i) => (
+          <Skeleton key={i} variant='rectangular' className='h-12 w-full' />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/root/src/app/fitted/(app)/jobs/page.tsx
+++ b/apps/root/src/app/fitted/(app)/jobs/page.tsx
@@ -1,0 +1,10 @@
+import type { Metadata } from 'next';
+import JobsList from './JobsList';
+
+export const metadata: Metadata = {
+  title: 'Jobs',
+};
+
+export default function FittedJobsPage() {
+  return <JobsList />;
+}

--- a/apps/root/src/app/fitted/(app)/jobs/types.ts
+++ b/apps/root/src/app/fitted/(app)/jobs/types.ts
@@ -1,0 +1,60 @@
+export const JOB_STATUSES = [
+  'new',
+  'saved',
+  'applied',
+  'rejected',
+  'archived',
+  'resume_draft',
+] as const;
+
+export type JobStatus = (typeof JOB_STATUSES)[number];
+
+export interface JobPosting {
+  id: string;
+  external_id: string;
+  title: string;
+  company_name: string;
+  location: string | null;
+  absolute_url: string | null;
+  score: number;
+  score_breakdown: Record<string, number> | null;
+  status: string;
+  first_seen_at: string;
+  created_at: string;
+}
+
+export interface JobsFilterState {
+  minScore: string;
+  status: string;
+  search: string;
+}
+
+export type JobsSortColumn = 'score' | 'created_at' | 'company_name' | 'title';
+
+export interface SkillMatch {
+  name: string;
+  matched: boolean;
+  confidence: 'high' | 'medium' | 'low';
+  evidence: string | null;
+}
+
+export interface Scorecard {
+  skills_matched: SkillMatch[];
+  skills_missing: string[];
+  nice_to_haves: string[];
+  seniority_fit: 'strong' | 'moderate' | 'weak';
+  seniority_rationale: string;
+  domain_fit: 'strong' | 'moderate' | 'weak';
+  domain_rationale: string;
+}
+
+export interface JobAnalysis {
+  id: string;
+  job_posting_id: string;
+  scorecard: Scorecard;
+  recommendation: string;
+  model: string;
+  cost_usd: number;
+  latency_ms: number;
+  created_at: string;
+}


### PR DESCRIPTION
## Summary
- **Auth bridging**: `verifyJobsAdmin` → `verifyJobsAccess` — accepts both admin session cookies and Supabase magic link sessions so Fitted users can access the jobs API proxy routes
- **Jobs list page** at `/fitted/jobs` with sortable table, checkbox selection for batch operations, inline detail expansion with on-demand LLM analysis, status management, and filter bar (min score, status, debounced search)
- **Batch operations**: floating action bar for batch resume generation (with polling) and batch delete
- **New proxy routes**: `POST /api/jobs/analysis/[id]`, `POST /api/jobs/tailor/batch`, `GET /api/jobs/tailor/batch/[id]`
- **Sidebar**: Added Jobs nav item with Briefcase icon

## Test plan
- [x] `pnpm tsc --noEmit` — zero errors
- [x] Proxy auth tests pass (4/4) — admin session, Supabase session, no session, error cases
- [x] All route tests pass (31 suites, 163 tests)
- [ ] Manual: navigate to `/fitted/jobs`, verify list loads and filters work
- [ ] Manual: expand a row, verify score breakdown and status buttons
- [ ] Manual: test batch selection across pages
- [ ] Manual: verify dark mode renders correctly
- [ ] Manual: verify mobile responsive layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)