### PR TITLE
feat: experience annotations — per-target emphasis/exclusion (#499)

### DIFF
--- a/apps/job-api/app/models/conversation.py
+++ b/apps/job-api/app/models/conversation.py
@@ -4,7 +4,7 @@ from typing import Literal
 
 from pydantic import BaseModel, Field
 
-from app.models.experience import ConversationType
+from app.models.experience import AnnotationAction, AnnotationRefType, ConversationType
 
 GapKind = Literal[
     "role.missing_outcomes",
@@ -33,6 +33,16 @@ class TurnRequest(BaseModel):
     skipped: bool = False
 
 
+class LLMAnnotationDirective(BaseModel):
+    """Parsed annotation intent from a conversation turn (#499)."""
+
+    action: AnnotationAction
+    ref_type: AnnotationRefType
+    ref_value: str
+    target_label: str | None = None
+    reason: str | None = None
+
+
 class LLMTurnResponse(BaseModel):
     """The structured shape the LLM must return.
 
@@ -40,11 +50,13 @@ class LLMTurnResponse(BaseModel):
     - `prose_append`: optional chunk of narrative to append to the prose doc.
       The LLM can only *append*, never rewrite existing prose.
     - `done`: true when the orchestrator should stop probing for this phase.
+    - `annotation`: optional annotation directive parsed from user intent (#499).
     """
 
     assistant_message: str = Field(min_length=1, max_length=10_000)
     prose_append: str | None = None
     done: bool = False
+    annotation: LLMAnnotationDirective | None = None
 
 
 class TurnResult(BaseModel):

--- a/apps/job-api/app/models/experience.py
+++ b/apps/job-api/app/models/experience.py
@@ -16,6 +16,8 @@ ConversationType = Literal["onboarding", "update"]
 TurnRole = Literal["user", "assistant", "system"]
 ChunkType = Literal["role", "skill", "outcome", "summary"]
 OptimizedDocSource = Literal["llm", "user_edit"]
+AnnotationAction = Literal["emphasize", "exclude", "de-emphasize"]
+AnnotationRefType = Literal["role", "skill", "outcome"]
 
 
 # ---------------------------------------------------------------------------
@@ -48,11 +50,23 @@ class Skill(BaseModel):
     years: float | None = None
 
 
+class Annotation(BaseModel):
+    """User directive for per-target emphasis or exclusion (#499)."""
+
+    id: str
+    action: AnnotationAction
+    ref_type: AnnotationRefType
+    ref_value: str
+    target_label: str | None = None
+    reason: str | None = None
+
+
 class OptimizedPayload(BaseModel):
     summary: str | None = None
     roles: list[Role] = Field(default_factory=list)
     skills: list[Skill] = Field(default_factory=list)
     outcomes: list[Outcome] = Field(default_factory=list)
+    annotations: list[Annotation] = Field(default_factory=list)
 
 
 class PreferencesPayload(BaseModel):
@@ -118,6 +132,14 @@ class Preferences(BaseModel):
 # ---------------------------------------------------------------------------
 # Request shapes (router inputs)
 # ---------------------------------------------------------------------------
+
+class AnnotationCreate(BaseModel):
+    action: AnnotationAction
+    ref_type: AnnotationRefType
+    ref_value: str = Field(min_length=1, max_length=500)
+    target_label: str | None = None
+    reason: str | None = None
+
 
 class ProseDocCreate(BaseModel):
     content: str = Field(min_length=1, max_length=500_000)

--- a/apps/job-api/app/models/tailor.py
+++ b/apps/job-api/app/models/tailor.py
@@ -91,6 +91,8 @@ class TailorRequest(BaseModel):
     page_budget: Literal[1, 2] = 2
     job_posting_id: str | None = None
     """Optional link to a jobs pipeline row (#184)."""
+    target_label: str | None = None
+    """Target label for annotation resolution (#499)."""
 
 
 # ---------------------------------------------------------------------------
@@ -141,6 +143,8 @@ class CoverLetterRequest(BaseModel):
     contact: ContactInfo
     critique: str | None = Field(default=None, max_length=5_000)
     job_posting_id: str | None = None
+    target_label: str | None = None
+    """Target label for annotation resolution (#499)."""
 
 
 # ---------------------------------------------------------------------------

--- a/apps/job-api/app/routers/experience.py
+++ b/apps/job-api/app/routers/experience.py
@@ -24,6 +24,8 @@ from app.models.conversation import (
     TurnResult,
 )
 from app.models.experience import (
+    Annotation,
+    AnnotationCreate,
     ConversationType,
     OptimizedDoc,
     OptimizedDocUpsert,
@@ -39,6 +41,7 @@ from app.models.experience import OptimizedPayload
 from app.services.conversation import orchestrator
 from app.services.embeddings.client import EmbeddingsClient
 from app.services.experience import (
+    annotations,
     chunks,
     derive,
     gap_tracker,
@@ -170,6 +173,16 @@ async def upload_resume(
             result=result,
             metadata={"prose_doc_id": prose_doc.id, "prose_version": prose_doc.version},
         )
+
+        # Carry forward annotations from previous optimized doc (#499)
+        previous_opt = optimized.get_latest(supabase, user_id=None)
+        if previous_opt and previous_opt.payload.annotations:
+            valid = annotations.validate_annotation_refs(
+                previous_opt.payload.annotations, payload
+            )
+            if valid:
+                payload = payload.model_copy(update={"annotations": valid})
+
         doc = optimized.create_version(
             supabase,
             user_id=None,
@@ -253,6 +266,15 @@ async def derive_optimized(
         metadata={"prose_doc_id": prose_doc.id, "prose_version": prose_doc.version},
     )
 
+    # Carry forward annotations from the previous optimized doc (#499)
+    previous = optimized.get_latest(supabase, user_id=None)
+    if previous and previous.payload.annotations:
+        valid = annotations.validate_annotation_refs(
+            previous.payload.annotations, payload
+        )
+        if valid:
+            payload = payload.model_copy(update={"annotations": valid})
+
     doc = optimized.create_version(
         supabase,
         user_id=None,
@@ -280,6 +302,40 @@ async def get_gap_health(
     if doc is None:
         return gap_tracker.gap_health(OptimizedPayload())
     return gap_tracker.gap_health(doc.payload)
+
+
+# ---- Annotations (#499) ---------------------------------------------------
+
+
+@router.get("/annotations")
+async def list_annotations(
+    supabase: Client = Depends(get_supabase),
+) -> dict[str, list[Annotation]]:
+    return {"annotations": annotations.list_annotations(supabase, user_id=None)}
+
+
+@router.post("/annotations", status_code=201)
+async def add_annotation(
+    body: AnnotationCreate,
+    supabase: Client = Depends(get_supabase),
+) -> OptimizedDoc:
+    try:
+        return annotations.add_annotation(supabase, user_id=None, body=body)
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
+@router.delete("/annotations/{annotation_id}")
+async def delete_annotation(
+    annotation_id: str,
+    supabase: Client = Depends(get_supabase),
+) -> OptimizedDoc:
+    try:
+        return annotations.remove_annotation(
+            supabase, user_id=None, annotation_id=annotation_id
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
 
 
 # ---- Preferences ----------------------------------------------------------

--- a/apps/job-api/app/routers/tailor.py
+++ b/apps/job-api/app/routers/tailor.py
@@ -96,6 +96,7 @@ async def create_tailored_resume(
         resume_type=body.resume_type or "generic",
         page_budget=body.page_budget,
         job_posting_id=body.job_posting_id,
+        target_label=body.target_label,
     )
 
     if isinstance(result, PipelineLintFailure):
@@ -160,6 +161,7 @@ async def create_tailored_cover_letter(
         preferences=prefs_payload,
         critique=body.critique,
         job_posting_id=body.job_posting_id,
+        target_label=body.target_label,
     )
 
     if isinstance(result, CoverLetterPipelineLintFailure):

--- a/apps/job-api/app/services/conversation/orchestrator.py
+++ b/apps/job-api/app/services/conversation/orchestrator.py
@@ -27,7 +27,7 @@ from app.models.conversation import (
     ResetResult,
     TurnResult,
 )
-from app.models.experience import ConversationType
+from app.models.experience import AnnotationCreate, ConversationType
 from app.models.llm import Message, ModelId
 from app.services.conversation.prompts import (
     ONBOARDING_SYSTEM,
@@ -35,6 +35,7 @@ from app.services.conversation.prompts import (
     UPDATE_SYSTEM,
 )
 from app.services.experience import gap_tracker, optimized, prose, turns
+from app.services.experience import annotations as annotation_svc
 from app.services.llm import cost_log
 from app.services.llm.client import LLMClient, complete_json
 
@@ -156,6 +157,23 @@ async def handle_turn(
         )
         new_prose_version = new_doc.version
         prose_updated = True
+
+    # Persist annotation directive if the LLM parsed one (#499)
+    if parsed.annotation:
+        try:
+            annotation_svc.add_annotation(
+                supabase,
+                user_id=user_id,
+                body=AnnotationCreate(
+                    action=parsed.annotation.action,
+                    ref_type=parsed.annotation.ref_type,
+                    ref_value=parsed.annotation.ref_value,
+                    target_label=parsed.annotation.target_label,
+                    reason=parsed.annotation.reason,
+                ),
+            )
+        except ValueError:
+            pass  # No optimized doc yet — skip annotation
 
     turns.append(
         supabase,

--- a/apps/job-api/app/services/conversation/prompts.py
+++ b/apps/job-api/app/services/conversation/prompts.py
@@ -15,7 +15,20 @@ _SHARED_OUTPUT_CONTRACT = """Return a strict JSON object matching this schema \
 the user just gave you fresh career content. Must be the user's claim restated \
 in third-person-neutral or first-person-singular. Never a summary. Never \
 invention.",
-  "done": boolean — true when the current phase has enough content to stop probing
+  "done": boolean — true when the current phase has enough content to stop probing,
+  "annotation": object or null — if the user expressed an annotation directive \
+(emphasis, exclusion, or de-emphasis for resume tailoring), parse it here. \
+Shape: {"action": "emphasize"|"exclude"|"de-emphasize", "ref_type": \
+"role"|"skill"|"outcome", "ref_value": "the id, name, or description", \
+"target_label": "target name or null for global", "reason": "user's stated \
+intent or null"}. Only populate when the user explicitly asks to emphasize, \
+exclude, or de-emphasize something for their resumes. Examples: \
+"don't include my helpdesk role on engineering resumes" -> {"action": "exclude", \
+"ref_type": "role", "ref_value": "helpdesk-support", "target_label": \
+"Frontend Engineer", "reason": "not relevant to engineering"}. \
+"emphasize the roadmap work for PM targets" -> {"action": "emphasize", \
+"ref_type": "outcome", "ref_value": "roadmap", "target_label": \
+"Product Manager", "reason": "user wants to highlight PM-relevant work"}.
 }
 
 Rules:
@@ -26,6 +39,7 @@ not say.
 - If the user skipped a question (skipped=true in the turn metadata), \
 acknowledge gracefully and ask the next question.
 - Keep assistant_message short and direct — one concrete question at a time.
+- annotation and prose_append can coexist in one response.
 """
 
 

--- a/apps/job-api/app/services/experience/annotations.py
+++ b/apps/job-api/app/services/experience/annotations.py
@@ -1,0 +1,232 @@
+"""Annotation helpers for per-target emphasis/exclusion (#499).
+
+Annotations are structured directives stored on OptimizedPayload. They
+control what the tailor emphasizes, de-emphasizes, or excludes when
+generating a resume or cover letter for a specific target.
+
+CRUD operations (add/remove) create a new optimized doc version with
+source='user_edit', following the same versioning pattern as manual
+payload edits.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any, cast
+
+from supabase import Client
+
+from app.models.experience import (
+    Annotation,
+    AnnotationCreate,
+    Outcome,
+    OptimizedDoc,
+    OptimizedPayload,
+)
+from app.services.experience import optimized
+
+
+def add_annotation(
+    supabase: Client,
+    user_id: str | None,
+    body: AnnotationCreate,
+) -> OptimizedDoc:
+    """Add an annotation to the latest optimized doc, creating a new version."""
+    latest = optimized.get_latest(supabase, user_id=user_id)
+    if latest is None:
+        raise ValueError("no optimized doc to annotate")
+
+    annotation = Annotation(
+        id=str(uuid.uuid4()),
+        action=body.action,
+        ref_type=body.ref_type,
+        ref_value=body.ref_value,
+        target_label=body.target_label,
+        reason=body.reason,
+    )
+    updated_payload = latest.payload.model_copy(
+        update={"annotations": [*latest.payload.annotations, annotation]}
+    )
+    return optimized.create_version(
+        supabase,
+        user_id=user_id,
+        payload=updated_payload,
+        prose_doc_id=latest.prose_doc_id,
+        source="user_edit",
+    )
+
+
+def remove_annotation(
+    supabase: Client,
+    user_id: str | None,
+    annotation_id: str,
+) -> OptimizedDoc:
+    """Remove an annotation by ID, creating a new version."""
+    latest = optimized.get_latest(supabase, user_id=user_id)
+    if latest is None:
+        raise ValueError("no optimized doc")
+
+    kept = [a for a in latest.payload.annotations if a.id != annotation_id]
+    if len(kept) == len(latest.payload.annotations):
+        raise ValueError(f"annotation not found: {annotation_id}")
+
+    updated_payload = latest.payload.model_copy(update={"annotations": kept})
+    return optimized.create_version(
+        supabase,
+        user_id=user_id,
+        payload=updated_payload,
+        prose_doc_id=latest.prose_doc_id,
+        source="user_edit",
+    )
+
+
+def list_annotations(
+    supabase: Client,
+    user_id: str | None,
+) -> list[Annotation]:
+    """Return all annotations from the latest optimized doc."""
+    latest = optimized.get_latest(supabase, user_id=user_id)
+    if latest is None:
+        return []
+    return latest.payload.annotations
+
+
+# ---------------------------------------------------------------------------
+# Pure functions (no DB) — used at tailor time
+# ---------------------------------------------------------------------------
+
+
+def resolve_for_target(
+    annotations: list[Annotation],
+    target_label: str | None,
+) -> tuple[list[Annotation], list[Annotation], list[Annotation]]:
+    """Partition annotations into (emphasize, exclude, de_emphasize) lists
+    that apply to the given target.
+
+    An annotation applies if:
+    - Its target_label is None (global), OR
+    - Its target_label matches the given target_label (case-insensitive)
+    """
+    target_lower = target_label.lower() if target_label else None
+
+    def _matches(a: Annotation) -> bool:
+        if a.target_label is None:
+            return True
+        if target_lower is not None and a.target_label.lower() == target_lower:
+            return True
+        return False
+
+    emphasize: list[Annotation] = []
+    exclude: list[Annotation] = []
+    de_emphasize: list[Annotation] = []
+
+    for a in annotations:
+        if not _matches(a):
+            continue
+        if a.action == "emphasize":
+            emphasize.append(a)
+        elif a.action == "exclude":
+            exclude.append(a)
+        elif a.action == "de-emphasize":
+            de_emphasize.append(a)
+
+    return emphasize, exclude, de_emphasize
+
+
+def apply_exclusions(
+    payload: OptimizedPayload,
+    exclusions: list[Annotation],
+) -> OptimizedPayload:
+    """Return a copy of the payload with excluded items removed.
+
+    Handles each ref_type:
+    - role: remove by role.id, cascade-remove outcomes with that role_ref
+    - skill: remove by skill.name (case-insensitive)
+    - outcome: remove where ref_value is a substring of outcome.description
+    """
+    if not exclusions:
+        return payload
+
+    excluded_role_ids: set[str] = set()
+    excluded_skill_names: set[str] = set()
+    excluded_outcome_substrings: list[str] = []
+
+    for ex in exclusions:
+        if ex.ref_type == "role":
+            excluded_role_ids.add(ex.ref_value)
+        elif ex.ref_type == "skill":
+            excluded_skill_names.add(ex.ref_value.lower())
+        elif ex.ref_type == "outcome":
+            excluded_outcome_substrings.append(ex.ref_value.lower())
+
+    roles = [r for r in payload.roles if r.id not in excluded_role_ids]
+    skills = [
+        s for s in payload.skills if s.name.lower() not in excluded_skill_names
+    ]
+
+    def _outcome_excluded(o: Outcome) -> bool:
+        if o.role_ref and o.role_ref in excluded_role_ids:
+            return True
+        desc_lower = o.description.lower()
+        return any(sub in desc_lower for sub in excluded_outcome_substrings)
+
+    outcomes = [o for o in payload.outcomes if not _outcome_excluded(o)]
+
+    return payload.model_copy(
+        update={
+            "roles": roles,
+            "skills": skills,
+            "outcomes": outcomes,
+        }
+    )
+
+
+def build_annotations_text(
+    emphasize: list[Annotation],
+    de_emphasize: list[Annotation],
+) -> str | None:
+    """Format emphasis/de-emphasis annotations as prompt directives."""
+    if not emphasize and not de_emphasize:
+        return None
+
+    lines: list[str] = []
+
+    if emphasize:
+        lines.append("EMPHASIZE (prioritize these items):")
+        for a in emphasize:
+            reason = f" (reason: {a.reason})" if a.reason else ""
+            lines.append(f"- {a.ref_type} \"{a.ref_value}\"{reason}")
+
+    if de_emphasize:
+        lines.append("DE-EMPHASIZE (include only if space allows):")
+        for a in de_emphasize:
+            reason = f" (reason: {a.reason})" if a.reason else ""
+            lines.append(f"- {a.ref_type} \"{a.ref_value}\"{reason}")
+
+    return "\n".join(lines)
+
+
+def validate_annotation_refs(
+    annotations: list[Annotation],
+    payload: OptimizedPayload,
+) -> list[Annotation]:
+    """Drop annotations whose ref_value no longer matches anything in the payload.
+
+    Used during re-derivation to carry forward only valid annotations.
+    """
+    role_ids = {r.id for r in payload.roles}
+    skill_names = {s.name.lower() for s in payload.skills}
+    outcome_descs = [o.description.lower() for o in payload.outcomes]
+
+    valid: list[Annotation] = []
+    for a in annotations:
+        if a.ref_type == "role" and a.ref_value in role_ids:
+            valid.append(a)
+        elif a.ref_type == "skill" and a.ref_value.lower() in skill_names:
+            valid.append(a)
+        elif a.ref_type == "outcome" and any(
+            a.ref_value.lower() in desc for desc in outcome_descs
+        ):
+            valid.append(a)
+
+    return valid

--- a/apps/job-api/app/services/tailor/pipeline.py
+++ b/apps/job-api/app/services/tailor/pipeline.py
@@ -29,6 +29,11 @@ from app.models.tailor import (
 )
 from app.services.ats_lint import lint_docx
 from app.services.docx.renderer import render_cover_letter_docx, render_docx
+from app.services.experience.annotations import (
+    apply_exclusions,
+    build_annotations_text,
+    resolve_for_target,
+)
 from app.services.llm import cost_log
 from app.services.llm.client import LLMClient
 from app.services.tailor import persistence
@@ -73,6 +78,7 @@ async def run_tailor_pipeline(
     resume_type: ResumeType = "generic",
     page_budget: int = 2,
     job_posting_id: str | None = None,
+    target_label: str | None = None,
 ) -> PipelineResult:
     """Run the full tailor pipeline end-to-end.
 
@@ -81,15 +87,23 @@ async def run_tailor_pipeline(
     persisted and no `.docx` is uploaded — the caller should surface the
     violations and retry with a critique.
     """
+    # Resolve annotations for the target (#499)
+    emphasize, exclude, de_emph = resolve_for_target(
+        optimized.payload.annotations, target_label
+    )
+    filtered_payload = apply_exclusions(optimized.payload, exclude)
+    annotations_text = build_annotations_text(emphasize, de_emph)
+
     resume, trace_warnings, llm_result = await tailor_resume(
         llm,
-        optimized=optimized.payload,
+        optimized=filtered_payload,
         job_description=job_description,
         contact=contact,
         resume_type=resume_type,
         preferences_rules=(preferences.rules if preferences else None),
         preferences_avoid=(preferences.avoid if preferences else None),
         preferences_tone_notes=(preferences.tone_notes if preferences else None),
+        annotations_text=annotations_text,
         critique=critique,
         page_budget=page_budget,
     )
@@ -187,6 +201,7 @@ async def run_cover_letter_pipeline(
     preferences: PreferencesPayload | None = None,
     critique: str | None = None,
     job_posting_id: str | None = None,
+    target_label: str | None = None,
 ) -> CoverLetterPipelineResult:
     """Run the full cover-letter pipeline end-to-end.
 
@@ -195,9 +210,16 @@ async def run_cover_letter_pipeline(
     persisted and no `.docx` is uploaded — the caller should surface the
     violations and retry with a critique.
     """
+    # Resolve annotations for the target (#499)
+    emphasize, exclude, de_emph = resolve_for_target(
+        optimized.payload.annotations, target_label
+    )
+    filtered_payload = apply_exclusions(optimized.payload, exclude)
+    annotations_text = build_annotations_text(emphasize, de_emph)
+
     letter, trace_warnings, llm_result = await tailor_cover_letter(
         llm,
-        optimized=optimized.payload,
+        optimized=filtered_payload,
         job_description=job_description,
         company_name=company_name,
         contact=contact,
@@ -205,6 +227,7 @@ async def run_cover_letter_pipeline(
         preferences_rules=(preferences.rules if preferences else None),
         preferences_avoid=(preferences.avoid if preferences else None),
         preferences_tone_notes=(preferences.tone_notes if preferences else None),
+        annotations_text=annotations_text,
         critique=critique,
     )
 

--- a/apps/job-api/app/services/tailor/prompts.py
+++ b/apps/job-api/app/services/tailor/prompts.py
@@ -66,6 +66,18 @@ influence the output. Record which rules you honored in \
 `preferences_applied` by echoing the rule text.
 - `preferences.avoid` is a hard filter on bullets.
 
+ANNOTATIONS:
+- If [Annotations] is provided, it contains user directives about what to \
+emphasize or de-emphasize for this specific target.
+- "EMPHASIZE" items should be prioritized in content selection — lead with \
+these roles, outcomes, and skills even if they aren't the closest JD match.
+- "DE-EMPHASIZE" items should be included only if space allows after all \
+emphasized and JD-relevant content is placed.
+- Excluded items have already been removed from the OptimizedPayload — you \
+will not see them, so don't reference them.
+- Annotations reflect explicit user intent and take precedence over \
+JD-derived relevance signals.
+
 CRITIQUE:
 - If critique is provided, treat it as the correction to make relative to \
 an implicit prior draft. Example critique: "lead with performance not design \
@@ -130,6 +142,18 @@ PREFERENCES:
 - Every rule in `preferences.rules` should influence the output. Record \
 which you honored in `preferences_applied`.
 - `preferences.avoid` is a hard filter.
+
+ANNOTATIONS:
+- If [Annotations] is provided, it contains user directives about what to \
+emphasize or de-emphasize for this specific target.
+- "EMPHASIZE" items should be prioritized in content selection — lead with \
+these roles, outcomes, and skills even if they aren't the closest JD match.
+- "DE-EMPHASIZE" items should be included only if space allows after all \
+emphasized and JD-relevant content is placed.
+- Excluded items have already been removed from the OptimizedPayload — you \
+will not see them, so don't reference them.
+- Annotations reflect explicit user intent and take precedence over \
+JD-derived relevance signals.
 
 CRITIQUE:
 - If critique is provided, treat it as the correction relative to an \

--- a/apps/job-api/app/services/tailor/tailor.py
+++ b/apps/job-api/app/services/tailor/tailor.py
@@ -38,6 +38,7 @@ def build_user_message(
     contact: ContactInfo,
     resume_type: ResumeType,
     preferences_text: str | None,
+    annotations_text: str | None,
     critique: str | None,
     page_budget: int,
 ) -> str:
@@ -53,6 +54,8 @@ def build_user_message(
     sections.append(f"[PageBudget] {page_budget}")
     if preferences_text:
         sections.append(f"[Preferences]\n{preferences_text}")
+    if annotations_text:
+        sections.append(f"[Annotations]\n{annotations_text}")
     if critique:
         sections.append(f"[Critique]\n{critique}")
     sections.append(f"[JobDescription]\n{job_description}")
@@ -134,6 +137,7 @@ async def tailor_resume(
     preferences_rules: list[str] | None = None,
     preferences_avoid: list[str] | None = None,
     preferences_tone_notes: list[str] | None = None,
+    annotations_text: str | None = None,
     critique: str | None = None,
     page_budget: int = 2,
     model: ModelId = DEFAULT_MODEL,
@@ -152,6 +156,7 @@ async def tailor_resume(
         preferences_text=_preferences_text(
             preferences_rules, preferences_avoid, preferences_tone_notes
         ),
+        annotations_text=annotations_text,
         critique=critique,
         page_budget=page_budget,
     )
@@ -184,6 +189,7 @@ def build_cover_letter_user_message(
     contact: ContactInfo,
     role_title: str | None,
     preferences_text: str | None,
+    annotations_text: str | None,
     critique: str | None,
 ) -> str:
     """Assemble the variable content for the LLM call.
@@ -199,6 +205,8 @@ def build_cover_letter_user_message(
         sections.append(f"[RoleTitle] {role_title}")
     if preferences_text:
         sections.append(f"[Preferences]\n{preferences_text}")
+    if annotations_text:
+        sections.append(f"[Annotations]\n{annotations_text}")
     if critique:
         sections.append(f"[Critique]\n{critique}")
     sections.append(f"[JobDescription]\n{job_description}")
@@ -266,6 +274,7 @@ async def tailor_cover_letter(
     preferences_rules: list[str] | None = None,
     preferences_avoid: list[str] | None = None,
     preferences_tone_notes: list[str] | None = None,
+    annotations_text: str | None = None,
     critique: str | None = None,
     model: ModelId = DEFAULT_MODEL,
     purpose: str = DEFAULT_COVER_LETTER_PURPOSE,
@@ -284,6 +293,7 @@ async def tailor_cover_letter(
         preferences_text=_preferences_text(
             preferences_rules, preferences_avoid, preferences_tone_notes
         ),
+        annotations_text=annotations_text,
         critique=critique,
     )
 

--- a/apps/job-api/tests/test_annotations.py
+++ b/apps/job-api/tests/test_annotations.py
@@ -1,0 +1,264 @@
+"""Pure-function tests for annotation helpers (#499)."""
+
+from app.models.experience import Annotation, OptimizedPayload, Outcome, Role, Skill
+from app.services.experience.annotations import (
+    apply_exclusions,
+    build_annotations_text,
+    resolve_for_target,
+    validate_annotation_refs,
+)
+
+
+def _ann(
+    action: str = "exclude",
+    ref_type: str = "role",
+    ref_value: str = "helpdesk",
+    target_label: str | None = None,
+    reason: str | None = None,
+) -> Annotation:
+    return Annotation(
+        id="ann-1",
+        action=action,
+        ref_type=ref_type,
+        ref_value=ref_value,
+        target_label=target_label,
+        reason=reason,
+    )
+
+
+def _role(
+    id_: str,
+    *,
+    summary: str | None = None,
+    outcome_refs: list[str] | None = None,
+) -> Role:
+    return Role(
+        id=id_,
+        company=id_,
+        title="Engineer",
+        start="2020-01",
+        end="2024-01",
+        summary=summary,
+        skills=[],
+        outcome_refs=outcome_refs or [],
+    )
+
+
+def _outcome(
+    description: str,
+    *,
+    role_ref: str | None = None,
+) -> Outcome:
+    return Outcome(description=description, role_ref=role_ref)
+
+
+# ---- resolve_for_target ---------------------------------------------------
+
+
+class TestResolveForTarget:
+    def test_global_annotations_apply_to_all_targets(self) -> None:
+        ann = _ann(action="exclude", target_label=None)
+        emph, excl, de = resolve_for_target([ann], "Frontend Engineer")
+        assert len(excl) == 1
+        assert len(emph) == 0
+        assert len(de) == 0
+
+    def test_target_specific_matches_label(self) -> None:
+        ann = _ann(action="emphasize", target_label="Frontend Engineer")
+        emph, excl, de = resolve_for_target([ann], "Frontend Engineer")
+        assert len(emph) == 1
+
+    def test_target_specific_case_insensitive(self) -> None:
+        ann = _ann(action="exclude", target_label="frontend engineer")
+        emph, excl, de = resolve_for_target([ann], "Frontend Engineer")
+        assert len(excl) == 1
+
+    def test_target_specific_does_not_match_other_label(self) -> None:
+        ann = _ann(action="exclude", target_label="Backend Engineer")
+        emph, excl, de = resolve_for_target([ann], "Frontend Engineer")
+        assert len(excl) == 0
+
+    def test_mixed_global_and_target_specific(self) -> None:
+        anns = [
+            _ann(action="exclude", target_label=None, ref_value="helpdesk"),
+            _ann(action="emphasize", target_label="PM", ref_value="roadmap"),
+            _ann(action="de-emphasize", target_label=None, ref_value="old-role"),
+        ]
+        emph, excl, de = resolve_for_target(anns, "PM")
+        assert len(excl) == 1  # global exclude
+        assert len(emph) == 1  # PM-specific emphasize
+        assert len(de) == 1    # global de-emphasize
+
+    def test_no_target_label_returns_only_global(self) -> None:
+        anns = [
+            _ann(action="exclude", target_label=None),
+            _ann(action="emphasize", target_label="Frontend"),
+        ]
+        emph, excl, de = resolve_for_target(anns, None)
+        assert len(excl) == 1
+        assert len(emph) == 0
+
+
+# ---- apply_exclusions ------------------------------------------------------
+
+
+class TestApplyExclusions:
+    def test_exclude_role_removes_role(self) -> None:
+        payload = OptimizedPayload(
+            roles=[_role("keep"), _role("helpdesk")],
+        )
+        result = apply_exclusions(payload, [_ann(ref_value="helpdesk")])
+        assert [r.id for r in result.roles] == ["keep"]
+
+    def test_exclude_role_cascades_outcomes(self) -> None:
+        payload = OptimizedPayload(
+            roles=[_role("keep"), _role("helpdesk")],
+            outcomes=[
+                _outcome("Good work", role_ref="keep"),
+                _outcome("Bad work", role_ref="helpdesk"),
+            ],
+        )
+        result = apply_exclusions(payload, [_ann(ref_value="helpdesk")])
+        assert len(result.outcomes) == 1
+        assert result.outcomes[0].description == "Good work"
+
+    def test_exclude_skill_removes_by_name(self) -> None:
+        payload = OptimizedPayload(
+            skills=[Skill(name="React"), Skill(name="Java")],
+        )
+        result = apply_exclusions(
+            payload, [_ann(ref_type="skill", ref_value="Java")]
+        )
+        assert [s.name for s in result.skills] == ["React"]
+
+    def test_exclude_skill_case_insensitive(self) -> None:
+        payload = OptimizedPayload(
+            skills=[Skill(name="React"), Skill(name="Java")],
+        )
+        result = apply_exclusions(
+            payload, [_ann(ref_type="skill", ref_value="java")]
+        )
+        assert [s.name for s in result.skills] == ["React"]
+
+    def test_exclude_outcome_by_substring(self) -> None:
+        payload = OptimizedPayload(
+            outcomes=[
+                _outcome("Cut LCP from 10s to 2s"),
+                _outcome("Built dashboard"),
+            ],
+        )
+        result = apply_exclusions(
+            payload, [_ann(ref_type="outcome", ref_value="Cut LCP")]
+        )
+        assert len(result.outcomes) == 1
+        assert result.outcomes[0].description == "Built dashboard"
+
+    def test_empty_exclusions_returns_unchanged(self) -> None:
+        payload = OptimizedPayload(
+            roles=[_role("a")],
+            skills=[Skill(name="React")],
+        )
+        result = apply_exclusions(payload, [])
+        assert len(result.roles) == 1
+        assert len(result.skills) == 1
+
+    def test_annotations_preserved_through_exclusion(self) -> None:
+        """apply_exclusions should not strip annotations from the payload."""
+        ann = _ann(action="emphasize", ref_value="a")
+        payload = OptimizedPayload(
+            roles=[_role("a"), _role("b")],
+            annotations=[Annotation(
+                id="keep-me", action="emphasize", ref_type="role",
+                ref_value="a", target_label=None, reason=None,
+            )],
+        )
+        result = apply_exclusions(payload, [_ann(ref_value="b")])
+        assert len(result.annotations) == 1
+
+
+# ---- build_annotations_text ------------------------------------------------
+
+
+class TestBuildAnnotationsText:
+    def test_emphasize_only(self) -> None:
+        text = build_annotations_text(
+            [_ann(action="emphasize", ref_value="roadmap", reason="PM targets")],
+            [],
+        )
+        assert text is not None
+        assert "EMPHASIZE" in text
+        assert "roadmap" in text
+        assert "PM targets" in text
+
+    def test_de_emphasize_only(self) -> None:
+        text = build_annotations_text(
+            [],
+            [_ann(action="de-emphasize", ref_value="old-role")],
+        )
+        assert text is not None
+        assert "DE-EMPHASIZE" in text
+        assert "old-role" in text
+
+    def test_both_combined(self) -> None:
+        text = build_annotations_text(
+            [_ann(action="emphasize", ref_value="roadmap")],
+            [_ann(action="de-emphasize", ref_value="old-role")],
+        )
+        assert text is not None
+        assert "EMPHASIZE" in text
+        assert "DE-EMPHASIZE" in text
+
+    def test_empty_returns_none(self) -> None:
+        assert build_annotations_text([], []) is None
+
+
+# ---- validate_annotation_refs ----------------------------------------------
+
+
+class TestValidateAnnotationRefs:
+    def test_valid_role_ref_kept(self) -> None:
+        payload = OptimizedPayload(roles=[_role("fightcamp")])
+        anns = [_ann(ref_type="role", ref_value="fightcamp")]
+        assert len(validate_annotation_refs(anns, payload)) == 1
+
+    def test_stale_role_ref_dropped(self) -> None:
+        payload = OptimizedPayload(roles=[_role("fightcamp")])
+        anns = [_ann(ref_type="role", ref_value="deleted-role")]
+        assert len(validate_annotation_refs(anns, payload)) == 0
+
+    def test_valid_skill_ref_kept(self) -> None:
+        payload = OptimizedPayload(skills=[Skill(name="React")])
+        anns = [_ann(ref_type="skill", ref_value="React")]
+        assert len(validate_annotation_refs(anns, payload)) == 1
+
+    def test_skill_ref_case_insensitive(self) -> None:
+        payload = OptimizedPayload(skills=[Skill(name="React")])
+        anns = [_ann(ref_type="skill", ref_value="react")]
+        assert len(validate_annotation_refs(anns, payload)) == 1
+
+    def test_valid_outcome_ref_substring_match(self) -> None:
+        payload = OptimizedPayload(
+            outcomes=[_outcome("Cut LCP from 10s to 2s")],
+        )
+        anns = [_ann(ref_type="outcome", ref_value="Cut LCP")]
+        assert len(validate_annotation_refs(anns, payload)) == 1
+
+    def test_stale_outcome_ref_dropped(self) -> None:
+        payload = OptimizedPayload(
+            outcomes=[_outcome("Built dashboard")],
+        )
+        anns = [_ann(ref_type="outcome", ref_value="Cut LCP")]
+        assert len(validate_annotation_refs(anns, payload)) == 0
+
+    def test_mixed_valid_and_stale(self) -> None:
+        payload = OptimizedPayload(
+            roles=[_role("fightcamp")],
+            skills=[Skill(name="React")],
+        )
+        anns = [
+            _ann(ref_type="role", ref_value="fightcamp"),
+            _ann(ref_type="role", ref_value="deleted"),
+            _ann(ref_type="skill", ref_value="React"),
+        ]
+        result = validate_annotation_refs(anns, payload)
+        assert len(result) == 2

--- a/apps/job-api/tests/test_cover_letter.py
+++ b/apps/job-api/tests/test_cover_letter.py
@@ -184,6 +184,7 @@ def test_build_cover_letter_user_message_includes_all_sections() -> None:
         contact=_contact(),
         role_title="Senior FE",
         preferences_text='{"rules": ["present tense"]}',
+        annotations_text="EMPHASIZE: role roadmap",
         critique="Lead with the PDP rebuild.",
     )
     for tag in (
@@ -192,6 +193,7 @@ def test_build_cover_letter_user_message_includes_all_sections() -> None:
         "[RecipientCompany] Acme",
         "[RoleTitle] Senior FE",
         "[Preferences]",
+        "[Annotations]",
         "[Critique]",
         "[JobDescription]",
     ):
@@ -206,10 +208,12 @@ def test_build_cover_letter_user_message_omits_role_title_when_absent() -> None:
         contact=_contact(),
         role_title=None,
         preferences_text=None,
+        annotations_text=None,
         critique=None,
     )
     assert "[RoleTitle]" not in msg
     assert "[Preferences]" not in msg
+    assert "[Annotations]" not in msg
     assert "[Critique]" not in msg
 
 

--- a/apps/job-api/tests/test_tailor.py
+++ b/apps/job-api/tests/test_tailor.py
@@ -101,6 +101,7 @@ def test_build_user_message_contains_every_section() -> None:
         contact=_contact(),
         resume_type="senior-frontend",
         preferences_text='{"rules": ["present tense"]}',
+        annotations_text="EMPHASIZE: role roadmap",
         critique="Lead with performance.",
         page_budget=2,
     )
@@ -110,6 +111,7 @@ def test_build_user_message_contains_every_section() -> None:
         "[ResumeType] senior-frontend",
         "[PageBudget] 2",
         "[Preferences]",
+        "[Annotations]",
         "[Critique]",
         "[JobDescription]",
     ):
@@ -123,10 +125,12 @@ def test_build_user_message_omits_preferences_and_critique_when_absent() -> None
         contact=_contact(),
         resume_type="generic",
         preferences_text=None,
+        annotations_text=None,
         critique=None,
         page_budget=1,
     )
     assert "[Preferences]" not in msg
+    assert "[Annotations]" not in msg
     assert "[Critique]" not in msg
     assert "[JobDescription]" in msg
 

--- a/apps/root/src/app/tools/admin/career/CareerOverview.spec.tsx
+++ b/apps/root/src/app/tools/admin/career/CareerOverview.spec.tsx
@@ -51,6 +51,7 @@ const optimizedDoc: OptimizedDoc = {
         role_ref: 'fc',
       },
     ],
+    annotations: [],
   },
   markdown_view: null,
   source: 'llm',

--- a/apps/root/src/app/tools/admin/career/types.ts
+++ b/apps/root/src/app/tools/admin/career/types.ts
@@ -33,11 +33,24 @@ export interface Skill {
   years: number | null;
 }
 
+export type AnnotationAction = 'emphasize' | 'exclude' | 'de-emphasize';
+export type AnnotationRefType = 'role' | 'skill' | 'outcome';
+
+export interface Annotation {
+  id: string;
+  action: AnnotationAction;
+  ref_type: AnnotationRefType;
+  ref_value: string;
+  target_label: string | null;
+  reason: string | null;
+}
+
 export interface OptimizedPayload {
   summary: string | null;
   roles: Role[];
   skills: Skill[];
   outcomes: Outcome[];
+  annotations: Annotation[];
 }
 
 export type OptimizedDocSource = 'llm' | 'user_edit';


### PR DESCRIPTION
## Summary

- **Annotation model + CRUD** — structured `Annotation` metadata on `OptimizedPayload` with REST endpoints (`GET/POST/DELETE /experience/annotations`). Mutations version the optimized doc (`source="user_edit"`).
- **Tailor integration** — exclusions are deterministically stripped from the payload before the LLM call (can't be hallucinated); emphasis/de-emphasis directives are injected as prompt text in a new `[Annotations]` section.
- **Re-derivation carry-forward** — when prose is re-derived, annotations from the previous version are validated against the new payload and carried forward (stale refs pruned).
- **Conversation integration** — `LLMAnnotationDirective` lets the LLM parse annotation intent from natural language (e.g., "exclude my helpdesk role from engineering resumes").
- **Frontend types** mirrored in `CareerOverview` TypeScript interfaces.

## Test plan

- [x] 24 unit tests for annotation service (`test_annotations.py`): resolve, exclusion cascades, prompt formatting, stale ref pruning
- [x] Updated `test_tailor.py` and `test_cover_letter.py` for `annotations_text` param
- [x] `CareerOverview.spec.tsx` fixture updated with `annotations: []`
- [x] Full backend suite passes (520 tests)
- [x] mypy clean
- [x] TypeScript compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)