### PR TITLE
chore: optimize Claude Code workflow configuration

### DIFF
--- a/.claude/agents/a11y-reviewer.md
+++ b/.claude/agents/a11y-reviewer.md
@@ -1,3 +1,9 @@
+---
+name: a11y-reviewer
+description: WCAG 2.1 AA compliance review for interactive elements, focus management, and semantics
+memory: project
+---
+
 # Accessibility Reviewer
 
 Review changed files for WCAG 2.1 AA compliance issues.

--- a/.claude/agents/content-reviewer.md
+++ b/.claude/agents/content-reviewer.md
@@ -1,3 +1,9 @@
+---
+name: content-reviewer
+description: MDX metadata, SEO, structured data, and content style guide compliance
+memory: project
+---
+
 # Content Reviewer
 
 Review changed MDX content files for metadata completeness, ordering consistency, SEO quality, and structured data correctness.

--- a/.claude/agents/e2e-reviewer.md
+++ b/.claude/agents/e2e-reviewer.md
@@ -1,3 +1,9 @@
+---
+name: e2e-reviewer
+description: E2E test coverage, fixture consistency, and Playwright best practices
+memory: project
+---
+
 # E2E Reviewer
 
 Review changed files for E2E test coverage, fixture consistency, and Playwright best practices.

--- a/.claude/agents/nx-reviewer.md
+++ b/.claude/agents/nx-reviewer.md
@@ -1,3 +1,9 @@
+---
+name: nx-reviewer
+description: Monorepo structure, module boundaries, and Nx configuration review
+memory: project
+---
+
 # Nx Reviewer
 
 Review changed files for Nx monorepo structure, module boundary, and configuration issues.

--- a/.claude/agents/perf-reviewer.md
+++ b/.claude/agents/perf-reviewer.md
@@ -1,3 +1,9 @@
+---
+name: perf-reviewer
+description: Performance review for bundle size, rendering cost, and Core Web Vitals
+memory: project
+---
+
 # Performance Reviewer
 
 Review changed files for performance implications in this Next.js 16 + React 19 application.

--- a/.claude/docs/architecture.md
+++ b/.claude/docs/architecture.md
@@ -4,59 +4,10 @@
 
 - **apps/root**: Main Next.js 16 application (App Router)
 - **apps/root-e2e**: Playwright E2E tests
-- **apps/audit-api**: FastAPI service for Lighthouse/axe audits (Playwright)
+- **apps/audit-api**: FastAPI service for Lighthouse/axe audits
 - **apps/job-api**: FastAPI service for job posting CMS
 - **libs/shared/ui**: Shared React component library (@danieljoffe.com/shared-ui)
 - **libs/shared/audit**: Shared audit types and utilities
-
-## App Structure (apps/root/src/)
-
-```
-app/                    # Next.js App Router pages
-├── api/
-│   ├── audit/          # Audit scan, report, status, admin endpoints
-│   ├── email/          # Contact form & email sequence endpoints
-│   └── leads/          # Lead capture endpoint
-├── home/               # Homepage components (Hero, Achievements, etc.)
-├── about/              # About page
-├── audit/              # Audit tool page
-├── blog/               # Blog pages with dynamic [slug] routes
-│   ├── [slug]/         # Blog detail pages
-│   ├── page/[page]/    # Paginated blog index (page 2..N)
-│   └── tags/           # Tag index + tags/[tag] detail routes
-├── experience/         # Experience pages with dynamic [slug] routes
-├── projects/           # Projects pages with dynamic [slug] routes
-│   ├── [slug]/         # Project detail pages
-│   └── tags/           # Tag index + tags/[tag] detail routes
-├── services/           # Services page
-└── thank-you/          # Thank you pages
-components/             # App-specific React components
-├── kit/                # Shared UI primitives (Spinner, ErrorAlert, PostPagination, ListPagination, TagChipStrip, etc.)
-├── BlogSearchAndList   # Client island: blog search + tag filtering
-├── ProjectsGridWithTags # Client island: projects tag filtering
-data/                   # Content data and metadata
-├── content/            # MDX content files (projects/, experience/, blog/)
-├── contentRegistry.ts  # Unified content registry (single data access layer)
-├── contentTypeConfig.ts # Per-type config (basePath, label, contentDir)
-├── contentOrder.ts     # Chronological ordering arrays per content type
-├── metadata/           # Page metadata (SEO, OpenGraph)
-├── structuredData/     # JSON-LD structured data (blog + project auto-derived from MDX)
-├── buildThumbnail.ts   # Derives PostThumbnail shape from MDX metadata
-├── readingTimes.ts     # Pre-computed reading times per post
-├── blog.ts, project.ts, experience.ts  # Slug constants per content type
-├── profileData.ts      # Author profile data
-├── services.ts, offerings.ts, about.ts # Page-specific data
-└── __tests__/          # Data layer test fixtures
-hooks/                  # Custom React hooks (useTableSort, useFocusTrap)
-lib/                    # Utility libraries and configurations (cn, formStyles, badgeStyles)
-state/                  # Global state management
-types/                  # TypeScript type definitions
-utils/                  # Helper functions and constants
-```
-
-## UI Library (libs/shared/ui/src/lib/)
-
-Shared components: Alert, AspectRatio, Avatar, Badge, Breadcrumb, Button, Card, Checkbox, Container, CTACard, Divider, Dropdown, FormFieldError, Grid, GridBg, Heading, Input, Kbd, Loading, Modal, PageContainer, PageLayout, Pagination, ProgressBar, Section, SectionLabel, Select, Sidebar, Skeleton, Spacer, Spinner, Stack, StatsCard, StructuredData, Switch, Table, Tabs, Text, Textarea, ThemeProvider, ThemeToggle, Toast, Tooltip
 
 ## Key Technologies
 
@@ -66,24 +17,16 @@ Shared components: Alert, AspectRatio, Avatar, Badge, Breadcrumb, Button, Card, 
 - **Animations**: GSAP
 - **Search**: MiniSearch (client-side full-text search on blog index)
 - **Forms**: react-hook-form with yup validation
-- **Error Tracking**: Sentry (client: instrumentation-client.ts, server: sentry.server.config.ts, edge: sentry.edge.config.ts)
-- **Analytics**: Vercel Analytics, Google Analytics
-- **Testing**: Jest + React Testing Library (unit), Playwright (E2E), jest-axe (accessibility)
+- **Error Tracking**: Sentry
+- **Testing**: Jest + RTL (unit), Playwright (E2E), jest-axe (a11y), Vitest (shared-ui)
 
 ## Path Aliases
 
 - `@/` maps to `apps/root/src/` in the root app
 - `@danieljoffe.com/shared-audit` maps to `libs/shared/audit/src/index.ts`
 
-## Nx Plugins
+## Key Patterns
 
-The workspace uses Nx plugins for automatic target inference:
-
-- @nx/js/typescript (typecheck, build)
-- @nx/next/plugin (build, dev, start)
-- @nx/jest/plugin (test)
-- @nx/playwright/plugin (e2e)
-- @nx/eslint/plugin (lint)
-- @nx/storybook/plugin (storybook, build-storybook)
-- @nx/vite/plugin (vitest)
-- @nx/docker (docker-build)
+- Content access goes through `data/contentRegistry.ts` — the single data access layer
+- Shared-ui must only depend on React and Tailwind CSS — no Next.js APIs
+- Kit components (`components/kit/`) wrap Next.js-specific concerns (Link, Image, useRouter)

--- a/.claude/hooks/run-spec-tests.sh
+++ b/.claude/hooks/run-spec-tests.sh
@@ -1,23 +1,41 @@
 #!/bin/bash
-# PostToolUse hook: runs related unit tests when a spec file is edited
+# PostToolUse hook: runs related unit tests when a spec/test file is edited
+# Supports root (Jest), shared-ui (Vitest), and falls back gracefully
 
 command -v jq >/dev/null || exit 0
 
 INPUT=$(cat /dev/stdin)
 FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
 
-# Skip if no file path or not a spec file
+# Skip if no file path or not a test file
 [ -z "$FILE_PATH" ] && exit 0
-echo "$FILE_PATH" | grep -qE '\.spec\.tsx?$' || exit 0
+echo "$FILE_PATH" | grep -qE '\.(spec|test)\.(tsx?|jsx?)$' || exit 0
 
-# Use the spec filename (e.g. "page.spec.tsx") as the pattern for an exact match
 SPEC_FILE=$(basename "$FILE_PATH")
+
+# Determine project and test args from file path
+case "$FILE_PATH" in
+  */libs/shared/ui/*)
+    PROJECT="@danieljoffe.com/shared-ui"
+    TEST_ARGS="-- $SPEC_FILE"
+    ;;
+  */apps/root/*)
+    PROJECT="root"
+    TEST_ARGS="-- --testPathPatterns=$SPEC_FILE --no-coverage"
+    ;;
+  *)
+    # Default to root for backward compatibility
+    PROJECT="root"
+    TEST_ARGS="-- --testPathPatterns=$SPEC_FILE --no-coverage"
+    ;;
+esac
+
 # macOS doesn't have `timeout`; use perl one-liner as portable fallback
 if command -v timeout >/dev/null 2>&1; then
-  OUTPUT=$(timeout 60 npx nx test root -- --testPathPatterns="$SPEC_FILE" --no-coverage 2>&1)
+  OUTPUT=$(timeout 60 pnpm nx test "$PROJECT" $TEST_ARGS 2>&1)
   RC=$?
 else
-  OUTPUT=$(perl -e 'alarm 60; exec @ARGV' npx nx test root -- --testPathPatterns="$SPEC_FILE" --no-coverage 2>&1)
+  OUTPUT=$(perl -e 'alarm 60; exec @ARGV' pnpm nx test "$PROJECT" $TEST_ARGS 2>&1)
   RC=$?
 fi
 
@@ -27,7 +45,7 @@ if [ $RC -eq 124 ] || [ $RC -eq 142 ]; then
   exit 2
 fi
 
-SUMMARY=$(echo "$OUTPUT" | grep -E '(Tests:|Test Suites:)' | head -2)
+SUMMARY=$(echo "$OUTPUT" | grep -E '(Tests:|Test Suites:|Test Files:)' | head -2)
 
 if [ $RC -eq 0 ]; then
   echo "PASS: $SUMMARY" >&2

--- a/.claude/rules/content.md
+++ b/.claude/rules/content.md
@@ -1,0 +1,15 @@
+---
+paths:
+  - '**/*.mdx'
+  - '**/data/content/**'
+  - '**/data/contentOrder*'
+  - '**/data/contentRegistry*'
+  - '**/data/blog*'
+  - '**/data/project*'
+  - '**/data/experience*'
+  - '**/data/buildThumbnail*'
+  - '**/data/readingTimes*'
+---
+
+@.claude/docs/content-posts.md
+@.claude/docs/content-style-guide.md

--- a/.claude/rules/planning.md
+++ b/.claude/rules/planning.md
@@ -1,0 +1,20 @@
+# Research Before Planning
+
+When the user asks to plan, design, or architect a feature or change:
+
+1. Identify the libraries, frameworks, and APIs involved in the planned work
+2. Use context7 (`resolve-library-id` then `query-docs`) to fetch current documentation for each relevant technology
+3. Ground your plan in current API surfaces and best practices, not training data
+4. Cite documentation sources when making specific technical recommendations
+
+This applies when the user says things like: "plan", "design", "architect", "how should we", "what's the best approach", "let's think about how to", "strategy for".
+
+# Context-Mode for Large Output
+
+Route commands that produce >20 lines of output through context-mode MCP tools, not native Bash/Read:
+
+- **`ctx_batch_execute`**: test suites, lint/mypy, git diffs, git log, any verbose Bash command
+- **`ctx_search`**: retrieve specifics from previously indexed output
+- **`ctx_execute` / `ctx_execute_file`**: analyze large output, log processing, data transforms
+
+Still use native tools for: `Read` on files you intend to `Edit`, `Grep`/`Glob` for targeted search, `Edit`/`Write` for modifications, short Bash commands (git add, commit, push, mkdir).

--- a/.claude/rules/python.md
+++ b/.claude/rules/python.md
@@ -1,0 +1,50 @@
+---
+paths:
+  - 'apps/job-api/**'
+  - 'apps/audit-api/**'
+  - '**/pyproject.toml'
+  - '**/conftest.py'
+---
+
+# Python / FastAPI Conventions
+
+## Stack
+
+- Python 3.11+, FastAPI 0.115+, Pydantic 2.7+ (pydantic-settings)
+- Supabase SDK (no SQLAlchemy) — database via REST API
+- pytest 8.3 + pytest-asyncio 0.25 (`asyncio_mode = "auto"`)
+- Ruff for linting and formatting (line-length 100)
+- Mypy strict mode
+
+## Patterns
+
+- **Async-first**: All handlers and I/O are async
+- **Lifespan**: Use `@asynccontextmanager async def lifespan(app)` for startup/shutdown — not deprecated `on_startup`/`on_shutdown`
+- **Routers**: `APIRouter(prefix="/route", tags=["tag"])` with `response_model` on endpoints
+- **Dependencies**: `Depends(get_settings)` for config, `Depends(get_supabase)` for DB, `Depends(verify_api_key)` for auth
+- **Settings**: pydantic-settings `BaseSettings` in `app/config.py`, injected via `Depends`
+- **Validation**: Pydantic v2 `Field(min_length=..., ge=...)` and `@field_validator` — not v1 `@validator`
+- **Type hints**: Use `X | None` union syntax, not `Optional[X]`
+
+## Testing
+
+- Tests in `tests/` with `conftest.py` for env var overrides and fixtures
+- File naming: `test_<feature>.py` (e.g., `test_health.py`, `test_gap_tracker.py`)
+- Async tests: `async def test_*()` — pytest-asyncio handles the event loop
+- Mocks: `MagicMock` / `AsyncMock` for HTTP clients and external services
+- Run via: `pnpm nx test job-api` or `pnpm nx test audit-api`
+
+## Project Structure
+
+```
+app/
+├── main.py          # FastAPI app, lifespan, middleware, router registration
+├── config.py        # pydantic-settings BaseSettings
+├── dependencies.py  # Depends() providers (DB, auth, settings)
+├── routers/         # APIRouter modules
+├── services/        # Business logic
+├── models/          # Pydantic schemas (request/response)
+tests/
+├── conftest.py      # Fixtures, env overrides
+└── test_*.py        # Test files
+```

--- a/.claude/rules/sentry.md
+++ b/.claude/rules/sentry.md
@@ -1,0 +1,14 @@
+---
+paths:
+  - '**/sentry*'
+  - '**/instrumentation*'
+  - '**/global-error*'
+---
+
+# Sentry Integration
+
+Use `import * as Sentry from "@sentry/nextjs"` for all Sentry functionality.
+
+- Exception catching: `Sentry.captureException(error)`
+- Tracing spans: `Sentry.startSpan({ op: 'ui.click', name: 'Button Click' }, span => { ... })`
+- Logging: `const { logger } = Sentry` then `logger.info('message', { key: value })`

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -1,0 +1,44 @@
+---
+paths:
+  - '**/*.spec.*'
+  - '**/*.test.*'
+  - '**/*.stories.*'
+  - '**/jest.config*'
+  - '**/vitest.config*'
+  - '**/playwright.config*'
+  - '**/test-setup*'
+---
+
+# Testing Conventions
+
+## Unit Tests
+
+- Jest config: `apps/root/jest.config.ts`, setup: `apps/root/src/test-setup.ts`
+- GSAP plugins mocked in `apps/root/__mocks__/`
+- Coverage threshold: 65% minimum (branches, functions, lines, statements)
+- Shared-ui uses Vitest (`libs/shared/ui/vitest.config.ts`)
+
+## E2E Tests
+
+- Playwright config: `apps/root-e2e/playwright.config.ts`
+- CI runs Chromium only; local runs all browsers + mobile
+- Snapshot updates via `workflow_dispatch` with `update-snapshots: true`
+
+## Storybook Interaction Tests
+
+Stories with `play` functions follow these rules strictly:
+
+- **Query by role first.** `getByRole('button', { name: 'Label' })` — never `getByText` for interactive elements. `getByText` only for non-interactive content.
+- **Always `waitFor` after state changes.** Any `userEvent` that triggers React state needs `waitFor` on subsequent assertions.
+- **Never assert CSS classes.** No `toHaveClass('opacity-0')`. Assert ARIA attributes (`aria-hidden`, `aria-pressed`, `aria-expanded`), DOM state (`toBeDisabled()`, `toBeChecked()`), or presence/absence.
+- **No `.tagName` checks.** Assert absence of a role instead.
+- **Use `step()` for 3+ sequential interactions.** Groups related phases for self-documenting Interactions panel.
+- **Every `fn()` spy must be asserted.** Dead spies are noise — remove or assert them.
+- **Use `{ hidden: true }` for `aria-hidden` elements.**
+
+## CI Pipelines
+
+- `ci.yml`: Push to `develop` + PRs (except to `main`). Runs lint, typecheck, test, build, e2e (PR only), Chromatic, Lighthouse.
+- `ci-preview.yml`: PRs to `main` (release validation). Source branch must be `develop`.
+- Docs-only PRs skip CI via `changes` job shell check. `ci-status` gate still passes.
+- Branch protection requires `ci-status` (not `ci`) so docs-only PRs can merge.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,20 +22,14 @@ pnpm pom                  # Full quality gate: typecheck → lint → format →
 
 ### Pre-Push Checklist
 
-Before pushing any changes, **always** run:
-
-```bash
-pnpm tsc --noEmit         # Must have zero errors
-pnpm nx test root         # All tests must pass
-```
-
-Do not push if either command fails. Fix the issue first.
+Before pushing, **always** run `pnpm tsc --noEmit` and `pnpm nx test root`. Do not push if either fails.
 
 ### Git Branching
 
 - **`develop`** is the default base branch for all PRs
 - **`main`** is production — only `develop` merges into `main`
 - Never open a PR targeting `main` directly from a feature branch
+- **Always use remote refs**: `git fetch origin` first, use `origin/main`, `origin/develop` — never stale local branches
 - **Keep `develop` in sync with `main`**: Before creating or updating a PR, check if `develop` is behind `main` (`git log develop..main --oneline`). If so, merge `main` into `develop` and push. Flag merge conflicts for the user.
 
 ### TypeScript
@@ -52,17 +46,17 @@ Do not push if either command fails. Fix the issue first.
 
 ## Detailed Guides
 
-For in-depth reference, see these docs (loaded on demand):
+Always loaded:
 
-- **All commands**: @.claude/docs/commands.md
 - **Architecture & structure**: @.claude/docs/architecture.md
-- **Content posts (MDX)**: @.claude/docs/content-posts.md
 - **Coding conventions**: @.claude/docs/coding-conventions.md
-- **Testing & CI**: @.claude/docs/testing.md
-- **ESLint details**: @.claude/docs/eslint.md
-- **Git workflow**: @.claude/docs/git-workflow.md
-- **Sentry integration**: @.claude/docs/sentry.md
-- **Content style guide**: @.claude/docs/content-style-guide.md
+
+Loaded contextually via `.claude/rules/` (path-scoped — only when editing matching files):
+
+- **Content posts & style guide** — MDX and content data files
+- **Testing & CI** — spec, test, story, and config files
+- **Sentry integration** — Sentry and instrumentation files
+- **Python / FastAPI** — job-api and audit-api files
 
 ## Skills & Agents
 
@@ -90,7 +84,8 @@ The workspace includes Claude Code skills and agents for common workflows:
   - `nx-reviewer` — module boundaries and workspace structure
   - `e2e-reviewer` — Playwright test coverage
 
-- **Docs** (`.claude/docs/`): Reference documentation loaded via `@import`
+- **Rules** (`.claude/rules/`): Path-scoped instructions loaded only when editing matching files
+- **Docs** (`.claude/docs/`): Reference documentation (always-loaded via CLAUDE.md, or contextual via rules)
 
 ## Session Persistence (context-mode plugin)
 
@@ -129,6 +124,16 @@ Session state is managed by the [context-mode](https://github.com/mksglu/context
 - The `nx-generate` skill handles generator discovery internally - don't call nx_docs just to look up generator syntax
 
 <!-- nx configuration end-->
+
+## Summary Instructions
+
+When summarizing this conversation, always preserve:
+
+- The current task objective and acceptance criteria
+- File paths that have been read or modified
+- Test results and error messages
+- Decisions made and the reasoning behind them
+- Which rules files were loaded and why
 
 ## General Guidelines for working with NextJS
 


### PR DESCRIPTION
## Summary

- **Permissions**: Consolidated allowlist from 377 → 90 wildcard entries (settings.local.json, not committed — applied locally)
- **Path-scoped rules**: Created `.claude/rules/` with content, testing, sentry, Python/FastAPI, and planning rules that load only when editing matching files
- **Context budget**: Reduced always-loaded effective lines from 352 → 214 (trimmed architecture.md, removed redundant imports for commands/git-workflow/eslint)
- **Agent memory**: Added `memory: project` to 5 review agents for cross-session pattern learning
- **Test runner hook**: Enhanced with multi-project support (root Jest + shared-ui Vitest) and `pnpm nx` alignment
- **Planning rule**: Auto-triggers context7 documentation lookup when planning/designing features
- **Context-mode rule**: Always-loaded rule to route large outputs through context-mode MCP tools
- **Python hooks**: Added Ruff format + check on `.py` file edits
- **Compaction**: Added summary instructions for context preservation during compression

## Test plan

- [ ] Verify path-scoped rules load when editing matching files (e.g., `.mdx` triggers content rules)
- [ ] Verify rules don't load for non-matching files (e.g., editing `.tsx` should not load Python rules)
- [ ] Verify test runner hook works for both `apps/root/` (Jest) and `libs/shared/ui/` (Vitest) spec files
- [ ] Verify Ruff hook formats `.py` files on edit (requires ruff in PATH)
- [ ] Confirm agent memory frontmatter doesn't break existing `/pr-review` workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)