### PR TITLE
feat(job-api, root): resume lifecycle — edit, approve, export (#505)

### DIFF
--- a/apps/job-api/app/routers/tailor.py
+++ b/apps/job-api/app/routers/tailor.py
@@ -42,6 +42,8 @@ from app.models.tailor import (
 from app.services.batch import create_batch, get_batch, process_batch
 from app.services.experience import optimized, preferences
 from app.services.llm.client import LLMClient
+from app.services.ats_lint.linter import lint_docx
+from app.services.docx.renderer import render_docx
 from app.services.experience import gap_tracker
 from app.services.tailor import (
     CoverLetterPipelineLintFailure,
@@ -265,6 +267,156 @@ async def list_tailored_cover_letters(
         document_type="cover_letter",
     )
     return {"cover_letters": rows}
+
+
+# ---- Resume lifecycle (#505) -------------------------------------------------
+
+
+@router.get("/resumes/by-job/{job_posting_id}")
+async def get_resume_by_job(
+    job_posting_id: str,
+    supabase: Client = Depends(get_supabase),
+) -> TailoredResumeRecord:
+    """Most recent resume for a given job posting."""
+    row = persistence.get_by_job(supabase, job_posting_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail="no resume found for this job posting")
+    return row
+
+
+@router.post("/resumes/export-zip")
+async def export_resumes_zip(
+    body: BulkExportRequest,
+    supabase: Client = Depends(get_supabase),
+) -> Response:
+    """Download approved resumes as a single .zip archive."""
+    records: list[TailoredResumeRecord] = []
+    unapproved: list[str] = []
+    for rid in body.resume_ids:
+        row = persistence.get(supabase, rid)
+        if row is None:
+            raise HTTPException(status_code=404, detail=f"resume not found: {rid}")
+        if row.approved_at is None:
+            unapproved.append(rid)
+        records.append(row)
+
+    if unapproved:
+        raise HTTPException(
+            status_code=400,
+            detail=f"resumes not yet approved: {', '.join(unapproved)}",
+        )
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        for rec in records:
+            if not rec.storage_path:
+                continue
+            docx_bytes = persistence.download_docx(supabase, rec.storage_path)
+            resume = rec.as_resume()
+            # Build a descriptive filename from the first experience entry
+            company = "unknown"
+            title = "resume"
+            if resume.experience:
+                company = resume.experience[0].company
+                title = resume.experience[0].title
+            safe = re.sub(r"[^\w\s-]", "", f"{company}_{title}")
+            safe = re.sub(r"\s+", "_", safe).strip("_")[:80]
+            zf.writestr(f"{safe}.docx", docx_bytes)
+
+    buf.seek(0)
+    return Response(
+        content=buf.getvalue(),
+        media_type="application/zip",
+        headers={"Content-Disposition": 'attachment; filename="resumes.zip"'},
+    )
+
+
+@router.patch("/resumes/{resume_id}")
+async def edit_tailored_resume(
+    resume_id: str,
+    body: ResumeEditRequest,
+    supabase: Client = Depends(get_supabase),
+) -> TailorResponse:
+    """Edit a draft resume. Rejected if already approved."""
+    row = persistence.get(supabase, resume_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail="tailored resume not found")
+    if row.document_type != "resume":
+        raise HTTPException(status_code=400, detail="only resumes can be edited")
+    if row.approved_at is not None:
+        raise HTTPException(status_code=409, detail="resume already approved — cannot edit")
+
+    current = row.as_resume()
+
+    # Merge non-None fields from the edit request
+    updates: dict[str, Any] = {}
+    if body.summary is not None:
+        updates["summary"] = body.summary
+    if body.skills is not None:
+        updates["skills"] = body.skills
+    if body.experience is not None:
+        updates["experience"] = body.experience
+    if body.education is not None:
+        updates["education"] = body.education
+
+    updated = current.model_copy(update=updates)
+
+    # Re-render and re-lint
+    docx_bytes = render_docx(updated)
+    lint_result = lint_docx(docx_bytes, document_type="resume")
+
+    if lint_result.errors:
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "ok": False,
+                "violations": [v.model_dump() for v in lint_result.violations],
+            },
+        )
+
+    # Persist updated payload and re-upload .docx
+    new_payload = updated.model_dump(mode="json")
+    storage_path = persistence.upload_docx(
+        supabase,
+        user_id=row.user_id,
+        resume_id=resume_id,
+        docx_bytes=docx_bytes,
+    )
+    record = persistence.update_payload(
+        supabase, resume_id, new_payload, storage_path=storage_path
+    )
+
+    return TailorResponse(record=record, lint_warnings=lint_result.warnings)
+
+
+@router.post("/resumes/{resume_id}/approve")
+async def approve_tailored_resume(
+    resume_id: str,
+    supabase: Client = Depends(get_supabase),
+) -> TailoredResumeRecord:
+    """Approve (lock) a resume. Idempotent if already approved."""
+    row = persistence.get(supabase, resume_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail="tailored resume not found")
+    if row.document_type != "resume":
+        raise HTTPException(status_code=400, detail="only resumes can be approved")
+
+    # Idempotent: if already approved, just return it
+    if row.approved_at is not None:
+        return row
+
+    record = persistence.approve(supabase, resume_id)
+
+    # Advance linked job posting to resume_ready
+    if row.job_posting_id:
+        supabase.table("job_postings").update(
+            {"status": "resume_ready"}
+        ).eq("id", row.job_posting_id).execute()
+
+    return record
+
+
+# ---- Single resume lookup + download ----------------------------------------
 
 
 @router.get("/resumes/{resume_id}")

--- a/apps/job-api/tests/test_resume_lifecycle.py
+++ b/apps/job-api/tests/test_resume_lifecycle.py
@@ -1,0 +1,534 @@
+"""Tests for resume lifecycle: edit, approve, export-zip, get-by-job (#505)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pydantic import ValidationError
+
+from app.models.ats_lint import LintResult, LintViolation
+from app.models.tailor import (
+    BulkExportRequest,
+    ContactInfo,
+    ResumeEditRequest,
+    TailoredBullet,
+    TailoredResume,
+    TailoredResumeRecord,
+    TailoredRole,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_NOW = datetime.now(UTC)
+
+_CONTACT = ContactInfo(name="Daniel Joffe", email="d@example.com")
+
+_RESUME = TailoredResume(
+    summary="Original summary",
+    contact=_CONTACT,
+    experience=[
+        TailoredRole(
+            company="Acme",
+            title="Engineer",
+            start="2023-01",
+            end="2024-01",
+            bullets=[TailoredBullet(text="Built things", source_outcome_ref="o-1")],
+            source_role_ref="role-1",
+        ),
+    ],
+    skills=["Python", "TypeScript"],
+)
+
+
+def _make_record(
+    *,
+    approved_at: datetime | None = None,
+    document_type: str = "resume",
+    storage_path: str | None = "anon/rec-1.docx",
+    job_posting_id: str | None = "job-1",
+) -> TailoredResumeRecord:
+    return TailoredResumeRecord(
+        id="rec-1",
+        user_id=None,
+        job_posting_id=job_posting_id,
+        document_type=document_type,
+        resume_type="generic",
+        jd_snapshot="JD text",
+        jd_snapshot_hash="abc123",
+        payload=_RESUME.model_dump(),
+        storage_path=storage_path,
+        warnings=[],
+        model="claude-sonnet-4-6",
+        input_tokens=100,
+        output_tokens=50,
+        cost_usd=0.001,
+        latency_ms=50,
+        created_at=_NOW,
+        approved_at=approved_at,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Model validation
+# ---------------------------------------------------------------------------
+
+
+class TestResumeEditRequestValidation:
+    def test_valid_partial_update(self) -> None:
+        req = ResumeEditRequest(summary="New summary")
+        assert req.summary == "New summary"
+        assert req.skills is None
+        assert req.experience is None
+
+    def test_rejects_empty_summary(self) -> None:
+        with pytest.raises(ValidationError):
+            ResumeEditRequest(summary="")
+
+    def test_rejects_too_long_summary(self) -> None:
+        with pytest.raises(ValidationError):
+            ResumeEditRequest(summary="x" * 601)
+
+
+class TestBulkExportRequestValidation:
+    def test_valid_request(self) -> None:
+        req = BulkExportRequest(resume_ids=["r-1", "r-2"])
+        assert len(req.resume_ids) == 2
+
+    def test_rejects_empty_list(self) -> None:
+        with pytest.raises(ValidationError):
+            BulkExportRequest(resume_ids=[])
+
+    def test_rejects_over_20(self) -> None:
+        with pytest.raises(ValidationError):
+            BulkExportRequest(resume_ids=[f"r-{i}" for i in range(21)])
+
+
+# ---------------------------------------------------------------------------
+# Persistence helpers
+# ---------------------------------------------------------------------------
+
+
+class TestPersistenceHelpers:
+    def test_update_payload(self) -> None:
+        from app.services.tailor.persistence import update_payload
+
+        supabase = MagicMock()
+        updated_record = _make_record()
+        supabase.table.return_value.update.return_value.eq.return_value.execute.return_value.data = [
+            updated_record.model_dump(mode="json")
+        ]
+
+        result = update_payload(supabase, "rec-1", {"summary": "Updated"})
+        assert result.id == "rec-1"
+        supabase.table.assert_called_with("tailored_resumes")
+
+    def test_update_payload_with_storage_path(self) -> None:
+        from app.services.tailor.persistence import update_payload
+
+        supabase = MagicMock()
+        updated_record = _make_record()
+        supabase.table.return_value.update.return_value.eq.return_value.execute.return_value.data = [
+            updated_record.model_dump(mode="json")
+        ]
+
+        result = update_payload(
+            supabase, "rec-1", {"summary": "Updated"}, storage_path="anon/rec-1.docx"
+        )
+        assert result.id == "rec-1"
+        # Verify the update call included storage_path
+        call_args = supabase.table.return_value.update.call_args
+        assert call_args[0][0]["storage_path"] == "anon/rec-1.docx"
+
+    def test_approve(self) -> None:
+        from app.services.tailor.persistence import approve
+
+        supabase = MagicMock()
+        approved_record = _make_record(approved_at=_NOW)
+        supabase.table.return_value.update.return_value.eq.return_value.execute.return_value.data = [
+            approved_record.model_dump(mode="json")
+        ]
+
+        result = approve(supabase, "rec-1")
+        assert result.id == "rec-1"
+        assert result.approved_at is not None
+
+    def test_get_by_job_found(self) -> None:
+        from app.services.tailor.persistence import get_by_job
+
+        supabase = MagicMock()
+        record = _make_record()
+        chain = supabase.table.return_value.select.return_value
+        chain = chain.eq.return_value.eq.return_value
+        chain.order.return_value.limit.return_value.execute.return_value.data = [
+            record.model_dump(mode="json")
+        ]
+
+        result = get_by_job(supabase, "job-1")
+        assert result is not None
+        assert result.id == "rec-1"
+
+    def test_get_by_job_not_found(self) -> None:
+        from app.services.tailor.persistence import get_by_job
+
+        supabase = MagicMock()
+        chain = supabase.table.return_value.select.return_value
+        chain = chain.eq.return_value.eq.return_value
+        chain.order.return_value.limit.return_value.execute.return_value.data = []
+
+        result = get_by_job(supabase, "nonexistent")
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Edit endpoint
+# ---------------------------------------------------------------------------
+
+
+class TestEditResume:
+    @pytest.mark.asyncio
+    async def test_edit_success(self) -> None:
+        from fastapi import HTTPException
+
+        from app.routers import tailor as tailor_router
+
+        supabase = MagicMock()
+        record = _make_record()
+        updated_record = _make_record()
+
+        with (
+            patch(
+                "app.services.tailor.persistence.get",
+                return_value=record,
+            ),
+            patch(
+                "app.routers.tailor.render_docx",
+                return_value=b"fake-docx-bytes",
+            ),
+            patch(
+                "app.routers.tailor.lint_docx",
+                return_value=LintResult(ok=True, violations=[]),
+            ),
+            patch(
+                "app.services.tailor.persistence.upload_docx",
+                return_value="anon/rec-1.docx",
+            ),
+            patch(
+                "app.services.tailor.persistence.update_payload",
+                return_value=updated_record,
+            ),
+        ):
+            result = await tailor_router.edit_tailored_resume(
+                resume_id="rec-1",
+                body=ResumeEditRequest(summary="Updated summary"),
+                supabase=supabase,
+            )
+
+        assert result.record.id == "rec-1"
+
+    @pytest.mark.asyncio
+    async def test_edit_not_found(self) -> None:
+        from fastapi import HTTPException
+
+        from app.routers import tailor as tailor_router
+
+        supabase = MagicMock()
+
+        with (
+            patch("app.services.tailor.persistence.get", return_value=None),
+            pytest.raises(HTTPException) as exc_info,
+        ):
+            await tailor_router.edit_tailored_resume(
+                resume_id="nonexistent",
+                body=ResumeEditRequest(summary="New"),
+                supabase=supabase,
+            )
+        assert exc_info.value.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_edit_rejected_if_approved(self) -> None:
+        from fastapi import HTTPException
+
+        from app.routers import tailor as tailor_router
+
+        supabase = MagicMock()
+        record = _make_record(approved_at=_NOW)
+
+        with (
+            patch("app.services.tailor.persistence.get", return_value=record),
+            pytest.raises(HTTPException) as exc_info,
+        ):
+            await tailor_router.edit_tailored_resume(
+                resume_id="rec-1",
+                body=ResumeEditRequest(summary="New"),
+                supabase=supabase,
+            )
+        assert exc_info.value.status_code == 409
+
+    @pytest.mark.asyncio
+    async def test_edit_rejected_for_cover_letter(self) -> None:
+        from fastapi import HTTPException
+
+        from app.routers import tailor as tailor_router
+
+        supabase = MagicMock()
+        record = _make_record(document_type="cover_letter")
+
+        with (
+            patch("app.services.tailor.persistence.get", return_value=record),
+            pytest.raises(HTTPException) as exc_info,
+        ):
+            await tailor_router.edit_tailored_resume(
+                resume_id="rec-1",
+                body=ResumeEditRequest(summary="New"),
+                supabase=supabase,
+            )
+        assert exc_info.value.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_edit_lint_failure(self) -> None:
+        from fastapi import HTTPException
+
+        from app.routers import tailor as tailor_router
+
+        supabase = MagicMock()
+        record = _make_record()
+
+        with (
+            patch("app.services.tailor.persistence.get", return_value=record),
+            patch(
+                "app.routers.tailor.render_docx",
+                return_value=b"fake-docx-bytes",
+            ),
+            patch(
+                "app.routers.tailor.lint_docx",
+                return_value=LintResult(
+                    ok=False,
+                    violations=[
+                        LintViolation(
+                            code="page_overflow",
+                            message="Too many pages",
+                            severity="error",
+                        )
+                    ],
+                ),
+            ),
+            pytest.raises(HTTPException) as exc_info,
+        ):
+            await tailor_router.edit_tailored_resume(
+                resume_id="rec-1",
+                body=ResumeEditRequest(summary="New"),
+                supabase=supabase,
+            )
+        assert exc_info.value.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Approve endpoint
+# ---------------------------------------------------------------------------
+
+
+class TestApproveResume:
+    @pytest.mark.asyncio
+    async def test_approve_success(self) -> None:
+        from app.routers import tailor as tailor_router
+
+        supabase = MagicMock()
+        record = _make_record()
+        approved_record = _make_record(approved_at=_NOW)
+
+        with (
+            patch("app.services.tailor.persistence.get", return_value=record),
+            patch(
+                "app.services.tailor.persistence.approve",
+                return_value=approved_record,
+            ),
+        ):
+            result = await tailor_router.approve_tailored_resume(
+                resume_id="rec-1",
+                supabase=supabase,
+            )
+
+        assert result.approved_at is not None
+        # Verify job status was updated to resume_ready
+        supabase.table.assert_any_call("job_postings")
+
+    @pytest.mark.asyncio
+    async def test_approve_idempotent(self) -> None:
+        from app.routers import tailor as tailor_router
+
+        supabase = MagicMock()
+        already_approved = _make_record(approved_at=_NOW)
+
+        with patch(
+            "app.services.tailor.persistence.get",
+            return_value=already_approved,
+        ):
+            result = await tailor_router.approve_tailored_resume(
+                resume_id="rec-1",
+                supabase=supabase,
+            )
+
+        assert result.approved_at is not None
+
+    @pytest.mark.asyncio
+    async def test_approve_not_found(self) -> None:
+        from fastapi import HTTPException
+
+        from app.routers import tailor as tailor_router
+
+        supabase = MagicMock()
+
+        with (
+            patch("app.services.tailor.persistence.get", return_value=None),
+            pytest.raises(HTTPException) as exc_info,
+        ):
+            await tailor_router.approve_tailored_resume(
+                resume_id="nonexistent",
+                supabase=supabase,
+            )
+        assert exc_info.value.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_approve_rejected_for_cover_letter(self) -> None:
+        from fastapi import HTTPException
+
+        from app.routers import tailor as tailor_router
+
+        supabase = MagicMock()
+        record = _make_record(document_type="cover_letter")
+
+        with (
+            patch("app.services.tailor.persistence.get", return_value=record),
+            pytest.raises(HTTPException) as exc_info,
+        ):
+            await tailor_router.approve_tailored_resume(
+                resume_id="rec-1",
+                supabase=supabase,
+            )
+        assert exc_info.value.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# Export zip endpoint
+# ---------------------------------------------------------------------------
+
+
+class TestExportZip:
+    @pytest.mark.asyncio
+    async def test_export_zip_success(self) -> None:
+        import zipfile as zf
+        from io import BytesIO
+
+        from app.routers import tailor as tailor_router
+
+        supabase = MagicMock()
+        record = _make_record(approved_at=_NOW)
+
+        with (
+            patch("app.services.tailor.persistence.get", return_value=record),
+            patch(
+                "app.services.tailor.persistence.download_docx",
+                return_value=b"fake-docx",
+            ),
+        ):
+            result = await tailor_router.export_resumes_zip(
+                body=BulkExportRequest(resume_ids=["rec-1"]),
+                supabase=supabase,
+            )
+
+        assert result.media_type == "application/zip"
+        # Verify it's a valid zip
+        with zf.ZipFile(BytesIO(result.body)) as z:
+            assert len(z.namelist()) == 1
+            name = z.namelist()[0]
+            assert name.endswith(".docx")
+            assert "Acme" in name
+
+    @pytest.mark.asyncio
+    async def test_export_zip_rejects_unapproved(self) -> None:
+        from fastapi import HTTPException
+
+        from app.routers import tailor as tailor_router
+
+        supabase = MagicMock()
+        unapproved = _make_record(approved_at=None)
+
+        with (
+            patch("app.services.tailor.persistence.get", return_value=unapproved),
+            pytest.raises(HTTPException) as exc_info,
+        ):
+            await tailor_router.export_resumes_zip(
+                body=BulkExportRequest(resume_ids=["rec-1"]),
+                supabase=supabase,
+            )
+        assert exc_info.value.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_export_zip_not_found(self) -> None:
+        from fastapi import HTTPException
+
+        from app.routers import tailor as tailor_router
+
+        supabase = MagicMock()
+
+        with (
+            patch("app.services.tailor.persistence.get", return_value=None),
+            pytest.raises(HTTPException) as exc_info,
+        ):
+            await tailor_router.export_resumes_zip(
+                body=BulkExportRequest(resume_ids=["nonexistent"]),
+                supabase=supabase,
+            )
+        assert exc_info.value.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Get by job endpoint
+# ---------------------------------------------------------------------------
+
+
+class TestGetByJob:
+    @pytest.mark.asyncio
+    async def test_get_by_job_found(self) -> None:
+        from app.routers import tailor as tailor_router
+
+        supabase = MagicMock()
+        record = _make_record()
+
+        with patch(
+            "app.services.tailor.persistence.get_by_job",
+            return_value=record,
+        ):
+            result = await tailor_router.get_resume_by_job(
+                job_posting_id="job-1",
+                supabase=supabase,
+            )
+
+        assert result.id == "rec-1"
+        assert result.job_posting_id == "job-1"
+
+    @pytest.mark.asyncio
+    async def test_get_by_job_not_found(self) -> None:
+        from fastapi import HTTPException
+
+        from app.routers import tailor as tailor_router
+
+        supabase = MagicMock()
+
+        with (
+            patch(
+                "app.services.tailor.persistence.get_by_job",
+                return_value=None,
+            ),
+            pytest.raises(HTTPException) as exc_info,
+        ):
+            await tailor_router.get_resume_by_job(
+                job_posting_id="nonexistent",
+                supabase=supabase,
+            )
+        assert exc_info.value.status_code == 404

--- a/apps/root/src/app/api/jobs/proxy.ts
+++ b/apps/root/src/app/api/jobs/proxy.ts
@@ -28,9 +28,10 @@ export async function proxyToFastAPI(
     method?: string;
     body?: unknown;
     searchParams?: URLSearchParams;
+    binary?: boolean;
   } = {}
 ): Promise<NextResponse> {
-  const { method = 'GET', body, searchParams } = options;
+  const { method = 'GET', body, searchParams, binary = false } = options;
   const qs = searchParams ? `?${searchParams.toString()}` : '';
   const url = `${JOB_API_URL}${path}${qs}`;
 
@@ -46,6 +47,21 @@ export async function proxyToFastAPI(
       },
       body: body ? JSON.stringify(body) : null,
     });
+
+    // Binary mode: pass through raw bytes with original headers
+    if (binary) {
+      const buffer = await res.arrayBuffer();
+      return new NextResponse(buffer, {
+        status: res.status,
+        headers: {
+          'Content-Type':
+            res.headers.get('Content-Type') ?? 'application/octet-stream',
+          ...(res.headers.get('Content-Disposition')
+            ? { 'Content-Disposition': res.headers.get('Content-Disposition')! }
+            : {}),
+        },
+      });
+    }
 
     const rawBody = await res.text();
     try {

--- a/apps/root/src/app/api/jobs/tailor/[id]/approve/route.ts
+++ b/apps/root/src/app/api/jobs/tailor/[id]/approve/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from 'next/server';
+import { verifyJobsAccess, proxyToFastAPI } from '../../../../proxy';
+
+export async function POST(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  if (!(await verifyJobsAccess())) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { id } = await params;
+  return proxyToFastAPI(`/tailor/resumes/${id}/approve`, { method: 'POST' });
+}

--- a/apps/root/src/app/api/jobs/tailor/[id]/download/route.ts
+++ b/apps/root/src/app/api/jobs/tailor/[id]/download/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from 'next/server';
+import { verifyJobsAccess, proxyToFastAPI } from '../../../../proxy';
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  if (!(await verifyJobsAccess())) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { id } = await params;
+  return proxyToFastAPI(`/tailor/resumes/${id}/download`, { binary: true });
+}

--- a/apps/root/src/app/api/jobs/tailor/[id]/route.ts
+++ b/apps/root/src/app/api/jobs/tailor/[id]/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from 'next/server';
+import { verifyJobsAccess, proxyToFastAPI } from '../../../proxy';
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  if (!(await verifyJobsAccess())) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { id } = await params;
+  return proxyToFastAPI(`/tailor/resumes/${id}`);
+}
+
+export async function PATCH(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  if (!(await verifyJobsAccess())) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { id } = await params;
+  const body = await request.json();
+  return proxyToFastAPI(`/tailor/resumes/${id}`, { method: 'PATCH', body });
+}

--- a/apps/root/src/app/api/jobs/tailor/by-job/[id]/route.ts
+++ b/apps/root/src/app/api/jobs/tailor/by-job/[id]/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from 'next/server';
+import { verifyJobsAccess, proxyToFastAPI } from '../../../../proxy';
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  if (!(await verifyJobsAccess())) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { id } = await params;
+  return proxyToFastAPI(`/tailor/resumes/by-job/${id}`);
+}

--- a/apps/root/src/app/api/jobs/tailor/export-zip/route.ts
+++ b/apps/root/src/app/api/jobs/tailor/export-zip/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from 'next/server';
+import { verifyJobsAccess, proxyToFastAPI } from '../../../proxy';
+
+export async function POST(request: Request) {
+  if (!(await verifyJobsAccess())) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const body = await request.json();
+  return proxyToFastAPI('/tailor/resumes/export-zip', {
+    method: 'POST',
+    body,
+    binary: true,
+  });
+}

--- a/apps/root/src/app/fitted/(app)/jobs/BatchActionBar.tsx
+++ b/apps/root/src/app/fitted/(app)/jobs/BatchActionBar.tsx
@@ -7,7 +7,10 @@ interface BatchActionBarProps {
   onClear: () => void;
   onBatchGenerate: () => void;
   onBatchDelete: () => void;
+  onBatchExport: () => void;
   generating: boolean;
+  exporting: boolean;
+  hasApproved: boolean;
 }
 
 export default function BatchActionBar({
@@ -15,7 +18,10 @@ export default function BatchActionBar({
   onClear,
   onBatchGenerate,
   onBatchDelete,
+  onBatchExport,
   generating,
+  exporting,
+  hasApproved,
 }: BatchActionBarProps) {
   if (selectedCount === 0) return null;
 
@@ -41,6 +47,17 @@ export default function BatchActionBar({
       >
         {generating ? 'Generating...' : 'Generate resumes'}
       </Button>
+      {hasApproved && (
+        <Button
+          name='batch-export'
+          variant='secondary'
+          size='sm'
+          onClick={onBatchExport}
+          disabled={exporting}
+        >
+          {exporting ? 'Exporting...' : 'Export approved (.zip)'}
+        </Button>
+      )}
       <Button
         name='batch-delete'
         variant='error'

--- a/apps/root/src/app/fitted/(app)/jobs/JobDetailPanel.tsx
+++ b/apps/root/src/app/fitted/(app)/jobs/JobDetailPanel.tsx
@@ -6,6 +6,7 @@ import { Skeleton } from '@danieljoffe.com/shared-ui/Skeleton';
 import { Text } from '@danieljoffe.com/shared-ui/Text';
 import Button from '@/components/Button';
 import { useToast } from '@/state/Toast/ToastProvider';
+import ResumeEditor from './ResumeEditor';
 import { JOB_STATUSES, type JobAnalysis, type JobPosting } from './types';
 
 interface JobDetailPanelProps {
@@ -25,6 +26,7 @@ export default function JobDetailPanel({
   const [analysis, setAnalysis] = useState<JobAnalysis | null>(null);
   const [analyzing, setAnalyzing] = useState(false);
   const [analysisError, setAnalysisError] = useState<string | null>(null);
+  const [showEditor, setShowEditor] = useState(false);
   const { toast } = useToast();
 
   async function updateStatus(newStatus: string) {
@@ -209,6 +211,51 @@ export default function JobDetailPanel({
           </div>
         )}
       </div>
+
+      {/* Resume lifecycle */}
+      {(status === 'resume_draft' || status === 'resume_ready') && (
+        <div>
+          <Text variant='caption' className='mb-1'>
+            Resume
+          </Text>
+          {status === 'resume_draft' && (
+            <Button
+              name='review-resume'
+              variant='primary'
+              size='sm'
+              onClick={() => setShowEditor(true)}
+            >
+              Review Resume
+            </Button>
+          )}
+          {status === 'resume_ready' && (
+            <div className='flex items-center gap-2'>
+              <Badge variant='success' size='sm'>
+                Approved
+              </Badge>
+              <Button
+                name='download-approved-resume'
+                variant='secondary'
+                size='sm'
+                onClick={() => setShowEditor(true)}
+              >
+                View / Download
+              </Button>
+            </div>
+          )}
+          <ResumeEditor
+            jobPostingId={posting.id}
+            companyName={posting.company_name}
+            jobTitle={posting.title}
+            isOpen={showEditor}
+            onClose={() => setShowEditor(false)}
+            onApproved={() => {
+              setStatus('resume_ready');
+              onStatusChange?.('resume_ready');
+            }}
+          />
+        </div>
+      )}
 
       {/* Actions */}
       <div className='flex gap-2'>

--- a/apps/root/src/app/fitted/(app)/jobs/JobsList.tsx
+++ b/apps/root/src/app/fitted/(app)/jobs/JobsList.tsx
@@ -21,6 +21,7 @@ export default function JobsList() {
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [refreshKey, setRefreshKey] = useState(0);
   const [generating, setGenerating] = useState(false);
+  const [exporting, setExporting] = useState(false);
   const pollRef = useRef<ReturnType<typeof setInterval>>();
   const { toast } = useToast();
 
@@ -101,6 +102,63 @@ export default function JobsList() {
     }
   }, [selectedIds, toast]);
 
+  const handleBatchExport = useCallback(async () => {
+    if (selectedIds.size === 0) return;
+    setExporting(true);
+    try {
+      // First, fetch resume IDs for selected jobs
+      const resumeIds: string[] = [];
+      for (const jobId of selectedIds) {
+        try {
+          const res = await fetch(`/api/jobs/tailor/by-job/${jobId}`);
+          if (res.ok) {
+            const record = (await res.json()) as {
+              id: string;
+              approved_at: string | null;
+            };
+            if (record.approved_at) {
+              resumeIds.push(record.id);
+            }
+          }
+        } catch {
+          // skip jobs without resumes
+        }
+      }
+
+      if (resumeIds.length === 0) {
+        toast({ variant: 'warning', title: 'No approved resumes to export' });
+        return;
+      }
+
+      const res = await fetch('/api/jobs/tailor/export-zip', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ resume_ids: resumeIds }),
+      });
+
+      if (!res.ok) {
+        toast({ variant: 'error', title: 'Export failed' });
+        return;
+      }
+
+      const blob = await res.blob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = 'resumes.zip';
+      a.click();
+      URL.revokeObjectURL(url);
+      toast({
+        variant: 'success',
+        title: `Exported ${resumeIds.length} resumes`,
+      });
+    } catch {
+      toast({ variant: 'error', title: 'Network error exporting resumes' });
+    } finally {
+      setExporting(false);
+    }
+  }, [selectedIds, toast]);
+
   const handleBatchDelete = useCallback(async () => {
     if (selectedIds.size === 0) return;
 
@@ -146,7 +204,10 @@ export default function JobsList() {
         onClear={() => setSelectedIds(new Set())}
         onBatchGenerate={handleBatchGenerate}
         onBatchDelete={handleBatchDelete}
+        onBatchExport={handleBatchExport}
         generating={generating}
+        exporting={exporting}
+        hasApproved={selectedIds.size > 0}
       />
     </div>
   );

--- a/apps/root/src/app/fitted/(app)/jobs/JobsListTable.tsx
+++ b/apps/root/src/app/fitted/(app)/jobs/JobsListTable.tsx
@@ -24,14 +24,16 @@ function ScoreBadge({ score }: { score: number }) {
 
 function StatusBadge({ status }: { status: string }) {
   const variant =
-    status === 'applied'
+    status === 'applied' || status === 'resume_ready'
       ? 'success'
       : status === 'saved' || status === 'resume_draft'
         ? 'info'
-        : status === 'rejected'
-          ? 'error'
-          : 'default';
-  return <Badge variant={variant}>{status.replace('_', ' ')}</Badge>;
+        : status === 'interviewing' || status === 'offer'
+          ? 'warning'
+          : status === 'rejected'
+            ? 'error'
+            : 'default';
+  return <Badge variant={variant}>{status.replace(/_/g, ' ')}</Badge>;
 }
 
 function timeAgo(dateStr: string): string {
@@ -222,7 +224,7 @@ export default function JobsListTable({
                           setExpandedId(null);
                           setDeleteKey(k => k + 1);
                         }}
-                        onStatusChange={undefined}
+                        onStatusChange={() => setDeleteKey(k => k + 1)}
                       />
                     </td>
                   </tr>

--- a/apps/root/src/app/fitted/(app)/jobs/ResumeEditor.tsx
+++ b/apps/root/src/app/fitted/(app)/jobs/ResumeEditor.tsx
@@ -1,0 +1,488 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { Badge } from '@danieljoffe.com/shared-ui/Badge';
+import { Modal } from '@danieljoffe.com/shared-ui/Modal';
+import { Spinner } from '@danieljoffe.com/shared-ui/Spinner';
+import { Text } from '@danieljoffe.com/shared-ui/Text';
+import Button from '@/components/Button';
+import { useToast } from '@/state/Toast/ToastProvider';
+import type {
+  LintViolation,
+  TailoredResumePayload,
+  TailoredResumeRecord,
+  TailorResponse,
+} from './types';
+
+interface ResumeEditorProps {
+  jobPostingId: string;
+  companyName: string;
+  jobTitle: string;
+  isOpen: boolean;
+  onClose: () => void;
+  onApproved: () => void;
+}
+
+export default function ResumeEditor({
+  jobPostingId,
+  companyName,
+  jobTitle,
+  isOpen,
+  onClose,
+  onApproved,
+}: ResumeEditorProps) {
+  const [record, setRecord] = useState<TailoredResumeRecord | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [approving, setApproving] = useState(false);
+  const [lintWarnings, setLintWarnings] = useState<LintViolation[]>([]);
+
+  // Editable fields
+  const [summary, setSummary] = useState('');
+  const [skills, setSkills] = useState<string[]>([]);
+  const [newSkill, setNewSkill] = useState('');
+  const [experience, setExperience] = useState<
+    TailoredResumePayload['experience']
+  >([]);
+  const [dirty, setDirty] = useState(false);
+
+  const { toast } = useToast();
+
+  const loadResume = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/jobs/tailor/by-job/${jobPostingId}`);
+      if (!res.ok) {
+        toast({ variant: 'error', title: 'Failed to load resume' });
+        onClose();
+        return;
+      }
+      const data = (await res.json()) as TailoredResumeRecord;
+      setRecord(data);
+      setSummary(data.payload.summary);
+      setSkills([...data.payload.skills]);
+      setExperience(
+        data.payload.experience.map(r => ({
+          ...r,
+          bullets: r.bullets.map(b => ({ ...b })),
+        }))
+      );
+      setDirty(false);
+    } catch {
+      toast({ variant: 'error', title: 'Network error loading resume' });
+      onClose();
+    } finally {
+      setLoading(false);
+    }
+  }, [jobPostingId, onClose, toast]);
+
+  useEffect(() => {
+    if (isOpen) {
+      loadResume();
+    }
+  }, [isOpen, loadResume]);
+
+  function markDirty() {
+    setDirty(true);
+  }
+
+  async function handleSave() {
+    if (!record) return;
+    setSaving(true);
+    setLintWarnings([]);
+    try {
+      const body: Record<string, unknown> = {};
+      if (summary !== record.payload.summary) body['summary'] = summary;
+      if (JSON.stringify(skills) !== JSON.stringify(record.payload.skills)) {
+        body['skills'] = skills;
+      }
+      if (
+        JSON.stringify(experience) !== JSON.stringify(record.payload.experience)
+      ) {
+        body['experience'] = experience;
+      }
+
+      if (Object.keys(body).length === 0) {
+        toast({ variant: 'info', title: 'No changes to save' });
+        setSaving(false);
+        return;
+      }
+
+      const res = await fetch(`/api/jobs/tailor/${record.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+
+      if (res.status === 422) {
+        const err = await res.json();
+        toast({ variant: 'error', title: 'Resume failed ATS lint check' });
+        if (err.detail?.violations) {
+          setLintWarnings(err.detail.violations as LintViolation[]);
+        }
+        return;
+      }
+
+      if (!res.ok) {
+        toast({ variant: 'error', title: 'Failed to save changes' });
+        return;
+      }
+
+      const data = (await res.json()) as TailorResponse;
+      setRecord(data.record);
+      setLintWarnings(data.lint_warnings);
+      setDirty(false);
+      toast({ variant: 'success', title: 'Draft saved' });
+    } catch {
+      toast({ variant: 'error', title: 'Network error saving draft' });
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleApprove() {
+    if (!record) return;
+    /* eslint-disable no-alert -- personal tool, native confirm is fine */
+    if (
+      !window.confirm(
+        'Approve and lock this resume? It cannot be edited after approval.'
+      )
+    )
+      /* eslint-enable no-alert */
+      return;
+
+    setApproving(true);
+    try {
+      const res = await fetch(`/api/jobs/tailor/${record.id}/approve`, {
+        method: 'POST',
+      });
+      if (!res.ok) {
+        toast({ variant: 'error', title: 'Failed to approve resume' });
+        return;
+      }
+      toast({ variant: 'success', title: 'Resume approved' });
+      onApproved();
+      onClose();
+    } catch {
+      toast({ variant: 'error', title: 'Network error approving resume' });
+    } finally {
+      setApproving(false);
+    }
+  }
+
+  async function handleDownload() {
+    if (!record) return;
+    try {
+      const res = await fetch(`/api/jobs/tailor/${record.id}/download`);
+      if (!res.ok) {
+        toast({ variant: 'error', title: 'Download failed' });
+        return;
+      }
+      const blob = await res.blob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `${companyName.replace(/\s+/g, '_')}_resume.docx`;
+      a.click();
+      URL.revokeObjectURL(url);
+    } catch {
+      toast({ variant: 'error', title: 'Network error downloading resume' });
+    }
+  }
+
+  function handleClose() {
+    /* eslint-disable no-alert -- personal tool, native confirm is fine */
+    if (dirty && !window.confirm('You have unsaved changes. Discard them?'))
+      /* eslint-enable no-alert */
+      return;
+    onClose();
+  }
+
+  function removeSkill(index: number) {
+    setSkills(prev => prev.filter((_, i) => i !== index));
+    markDirty();
+  }
+
+  function addSkill() {
+    const trimmed = newSkill.trim();
+    if (!trimmed || skills.includes(trimmed)) return;
+    setSkills(prev => [...prev, trimmed]);
+    setNewSkill('');
+    markDirty();
+  }
+
+  function updateBullet(roleIndex: number, bulletIndex: number, text: string) {
+    setExperience(prev =>
+      prev.map((role, ri) =>
+        ri === roleIndex
+          ? {
+              ...role,
+              bullets: role.bullets.map((b, bi) =>
+                bi === bulletIndex ? { ...b, text } : b
+              ),
+            }
+          : role
+      )
+    );
+    markDirty();
+  }
+
+  function removeBullet(roleIndex: number, bulletIndex: number) {
+    setExperience(prev =>
+      prev.map((role, ri) =>
+        ri === roleIndex
+          ? {
+              ...role,
+              bullets: role.bullets.filter((_, bi) => bi !== bulletIndex),
+            }
+          : role
+      )
+    );
+    markDirty();
+  }
+
+  function addBullet(roleIndex: number) {
+    setExperience(prev =>
+      prev.map((role, ri) =>
+        ri === roleIndex
+          ? {
+              ...role,
+              bullets: [
+                ...role.bullets,
+                { text: '', source_outcome_ref: null },
+              ],
+            }
+          : role
+      )
+    );
+    markDirty();
+  }
+
+  const isApproved =
+    record?.approved_at !== null && record?.approved_at !== undefined;
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={handleClose}
+      title={`Review Resume \u2014 ${companyName} / ${jobTitle}`}
+      size='xl'
+      footer={
+        <div className='flex gap-2 w-full justify-between'>
+          <Button
+            name='download-docx'
+            variant='secondary'
+            size='sm'
+            onClick={handleDownload}
+            disabled={loading}
+          >
+            Download .docx
+          </Button>
+          <div className='flex gap-2'>
+            <Button
+              name='save-draft'
+              variant='outline'
+              size='sm'
+              onClick={handleSave}
+              disabled={saving || loading || isApproved || !dirty}
+            >
+              {saving ? 'Saving...' : 'Save Draft'}
+            </Button>
+            <Button
+              name='approve-resume'
+              variant='primary'
+              size='sm'
+              onClick={handleApprove}
+              disabled={approving || loading || isApproved || dirty}
+            >
+              {approving
+                ? 'Approving...'
+                : isApproved
+                  ? 'Approved'
+                  : 'Approve & Lock'}
+            </Button>
+          </div>
+        </div>
+      }
+    >
+      {loading ? (
+        <div className='flex items-center justify-center py-12'>
+          <Spinner size='lg' />
+        </div>
+      ) : (
+        <div className='space-y-6 max-h-[60vh] overflow-y-auto'>
+          {/* Lint warnings */}
+          {lintWarnings.length > 0 && (
+            <div className='rounded-md bg-warning/10 border border-warning/30 p-3'>
+              <Text variant='caption' className='text-warning mb-1'>
+                ATS Lint Warnings
+              </Text>
+              <ul className='list-disc list-inside space-y-1'>
+                {lintWarnings.map((w, i) => (
+                  <li key={i}>
+                    <Text variant='meta' as='span'>
+                      [{w.code}] {w.message}
+                    </Text>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {isApproved && (
+            <div className='rounded-md bg-success/10 border border-success/30 p-3'>
+              <Text variant='body' className='text-success'>
+                This resume has been approved and is locked for editing.
+              </Text>
+            </div>
+          )}
+
+          {/* Summary */}
+          <div>
+            <Text variant='caption' className='mb-1'>
+              Summary
+            </Text>
+            <textarea
+              className='w-full rounded-md border border-border bg-surface p-3 text-sm font-mono resize-y min-h-[100px]'
+              value={summary}
+              onChange={e => {
+                setSummary(e.target.value);
+                markDirty();
+              }}
+              maxLength={600}
+              disabled={isApproved}
+            />
+            <Text variant='meta' className='text-right'>
+              {summary.length}/600
+            </Text>
+          </div>
+
+          {/* Skills */}
+          <div>
+            <Text variant='caption' className='mb-1'>
+              Skills
+            </Text>
+            <div className='flex flex-wrap gap-2 mb-2'>
+              {skills.map((skill, i) => (
+                <Badge key={`${skill}-${i}`} variant='info' size='sm'>
+                  {skill}
+                  {!isApproved && (
+                    <button
+                      type='button'
+                      onClick={() => removeSkill(i)}
+                      className='ml-1 text-xs opacity-60 hover:opacity-100'
+                      aria-label={`Remove ${skill}`}
+                    >
+                      ×
+                    </button>
+                  )}
+                </Badge>
+              ))}
+            </div>
+            {!isApproved && (
+              <div className='flex gap-2'>
+                <input
+                  type='text'
+                  className='flex-1 rounded-md border border-border bg-surface px-3 py-1.5 text-sm'
+                  value={newSkill}
+                  onChange={e => setNewSkill(e.target.value)}
+                  onKeyDown={e => {
+                    if (e.key === 'Enter') {
+                      e.preventDefault();
+                      addSkill();
+                    }
+                  }}
+                  placeholder='Add skill...'
+                />
+                <Button
+                  name='add-skill'
+                  variant='outline'
+                  size='sm'
+                  onClick={addSkill}
+                >
+                  Add
+                </Button>
+              </div>
+            )}
+          </div>
+
+          {/* Experience */}
+          <div>
+            <Text variant='caption' className='mb-2'>
+              Experience
+            </Text>
+            <div className='space-y-4'>
+              {experience.map((role, ri) => (
+                <div
+                  key={`${role.company}-${role.title}-${ri}`}
+                  className='border border-border rounded-md p-3'
+                >
+                  <div className='flex items-baseline gap-2 mb-2'>
+                    <Text variant='body' className='font-semibold'>
+                      {role.title}
+                    </Text>
+                    <Text variant='meta'>at {role.company}</Text>
+                    <Text variant='meta' className='ml-auto'>
+                      {role.start} — {role.end ?? 'Present'}
+                    </Text>
+                  </div>
+                  <ul className='space-y-2'>
+                    {role.bullets.map((bullet, bi) => (
+                      <li key={bi} className='flex gap-2 items-start'>
+                        <span className='text-text-secondary mt-1.5'>•</span>
+                        <input
+                          type='text'
+                          className='flex-1 rounded border border-border bg-surface px-2 py-1 text-sm'
+                          value={bullet.text}
+                          onChange={e => updateBullet(ri, bi, e.target.value)}
+                          disabled={isApproved}
+                        />
+                        {!isApproved && (
+                          <button
+                            type='button'
+                            onClick={() => removeBullet(ri, bi)}
+                            className='text-error text-xs px-1 hover:opacity-80'
+                            aria-label='Remove bullet'
+                          >
+                            ×
+                          </button>
+                        )}
+                      </li>
+                    ))}
+                  </ul>
+                  {!isApproved && (
+                    <Button
+                      name={`add-bullet-${ri}`}
+                      variant='ghost'
+                      size='sm'
+                      onClick={() => addBullet(ri)}
+                      className='mt-2'
+                    >
+                      + Add bullet
+                    </Button>
+                  )}
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* Education (read-only) */}
+          {record?.payload.education && record.payload.education.length > 0 && (
+            <div>
+              <Text variant='caption' className='mb-1'>
+                Education
+              </Text>
+              {record.payload.education.map((edu, i) => (
+                <div key={i} className='flex gap-2'>
+                  <Text variant='body'>{edu.school}</Text>
+                  {edu.degree && <Text variant='meta'>— {edu.degree}</Text>}
+                  {edu.dates && <Text variant='meta'>({edu.dates})</Text>}
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </Modal>
+  );
+}

--- a/apps/root/src/app/fitted/(app)/jobs/types.ts
+++ b/apps/root/src/app/fitted/(app)/jobs/types.ts
@@ -1,10 +1,13 @@
 export const JOB_STATUSES = [
   'new',
   'saved',
+  'resume_draft',
+  'resume_ready',
   'applied',
+  'interviewing',
+  'offer',
   'rejected',
   'archived',
-  'resume_draft',
 ] as const;
 
 export type JobStatus = (typeof JOB_STATUSES)[number];
@@ -57,4 +60,82 @@ export interface JobAnalysis {
   cost_usd: number;
   latency_ms: number;
   created_at: string;
+}
+
+// ---------------------------------------------------------------------------
+// Resume lifecycle types (#505)
+// ---------------------------------------------------------------------------
+
+export interface TailoredBullet {
+  text: string;
+  source_outcome_ref: string | null;
+}
+
+export interface TailoredRole {
+  company: string;
+  title: string;
+  location: string | null;
+  start: string;
+  end: string | null;
+  bullets: TailoredBullet[];
+  source_role_ref: string;
+}
+
+export interface TailoredEducation {
+  school: string;
+  degree: string | null;
+  dates: string | null;
+}
+
+export interface ContactInfo {
+  name: string;
+  email: string | null;
+  phone: string | null;
+  location: string | null;
+  website: string | null;
+  linkedin: string | null;
+}
+
+export interface TailoredResumePayload {
+  summary: string;
+  contact: ContactInfo;
+  experience: TailoredRole[];
+  skills: string[];
+  education: TailoredEducation[];
+  resume_type: string;
+  jd_snippet: string;
+  preferences_applied: string[];
+}
+
+export interface LintViolation {
+  code: string;
+  message: string;
+  severity: 'error' | 'warning';
+}
+
+export interface TailoredResumeRecord {
+  id: string;
+  user_id: string | null;
+  job_posting_id: string | null;
+  document_type: string;
+  resume_type: string;
+  jd_snapshot: string;
+  jd_snapshot_hash: string;
+  payload: TailoredResumePayload;
+  storage_path: string | null;
+  warnings: string[];
+  model: string | null;
+  input_tokens: number;
+  output_tokens: number;
+  cost_usd: number;
+  latency_ms: number;
+  created_at: string;
+  updated_at: string | null;
+  approved_at: string | null;
+  source_resume_id: string | null;
+}
+
+export interface TailorResponse {
+  record: TailoredResumeRecord;
+  lint_warnings: LintViolation[];
 }

--- a/supabase/migrations/20260425120001_resume_lifecycle.sql
+++ b/supabase/migrations/20260425120001_resume_lifecycle.sql
@@ -1,0 +1,20 @@
+-- ============================================
+-- MIGRATION: Resume lifecycle (#505)
+-- Fixes latent bug: batch.py already writes 'resume_draft' but the
+-- CHECK constraint didn't include it. Also adds new lifecycle statuses
+-- (resume_ready, interviewing, offer) and approval tracking columns.
+-- ============================================
+
+-- Fix CHECK to include resume_draft (latent bug) + add new statuses
+ALTER TABLE job_postings DROP CONSTRAINT IF EXISTS job_postings_status_check;
+ALTER TABLE job_postings ADD CONSTRAINT job_postings_status_check
+  CHECK (status IN ('new', 'saved', 'resume_draft', 'resume_ready',
+                    'applied', 'interviewing', 'offer', 'rejected', 'archived'));
+
+-- Lifecycle columns on tailored_resumes
+ALTER TABLE tailored_resumes
+  ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS approved_at TIMESTAMPTZ;
+
+CREATE INDEX IF NOT EXISTS idx_tailored_resumes_approved
+  ON tailored_resumes(approved_at) WHERE approved_at IS NOT NULL;


### PR DESCRIPTION
## Summary

- **Resume editing**: PATCH endpoint + ResumeEditor modal for editing draft resumes (summary, skills, experience bullets) with re-render and ATS lint validation
- **Approval workflow**: POST approve endpoint locks the resume and transitions job status to `resume_ready`; idempotent
- **Export**: Single .docx download via binary proxy passthrough + bulk .zip export for approved resumes (synchronous, max 20)
- **Status lifecycle fix**: Migration fixes latent CHECK constraint bug (`resume_draft` was written but not in the constraint) and adds `resume_ready`, `interviewing`, `offer` statuses

### Backend
- 4 new endpoints on `/tailor/resumes/`: `GET by-job/{id}`, `POST export-zip`, `PATCH {id}`, `POST {id}/approve`
- 3 persistence helpers: `update_payload`, `approve`, `get_by_job`
- 25 new tests in `test_resume_lifecycle.py` (560 total backend tests pass)

### Frontend
- `ResumeEditor` modal: structured editor with summary textarea, skills chip list, experience bullet editing, save/approve/download
- Binary proxy support (`proxyToFastAPI` `binary` option) for .docx/.zip passthrough
- 5 new proxy routes for the tailor lifecycle endpoints
- Updated `JobDetailPanel` with resume lifecycle section, `BatchActionBar` with export button, `JobsListTable` with new status badge styles

### Migration
- `20260425120001_resume_lifecycle.sql`: fixes `job_postings.status` CHECK, adds `updated_at`/`approved_at` to `tailored_resumes`

## Test plan

- [ ] Backend: `pnpm nx test job-api` — 560 tests pass (25 new)
- [ ] Frontend: `pnpm nx test root -- --testPathPatterns=api/jobs` — 24 tests pass
- [ ] Typecheck: `pnpm tsc --noEmit` — zero errors
- [ ] Manual: Generate resume via batch → status becomes `resume_draft` → "Review Resume" opens editor → edit summary → "Save Draft" → "Approve & Lock" → status becomes `resume_ready` → download .docx
- [ ] Manual: Select multiple approved jobs → "Export Approved (.zip)" downloads zip

Closes #505

🤖 Generated with [Claude Code](https://claude.com/claude-code)