### PR TITLE
feat(root): onboarding flow — three paths for new users (#507)

### DIFF
--- a/apps/root/src/app/api/career/experience/conversation/next-probe/route.ts
+++ b/apps/root/src/app/api/career/experience/conversation/next-probe/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from 'next/server';
+import { verifyJobsAccess, proxyToFastAPI } from '@/app/api/jobs/proxy';
+
+export async function GET() {
+  if (!(await verifyJobsAccess())) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  return proxyToFastAPI('/experience/conversation/next-probe');
+}

--- a/apps/root/src/app/api/career/experience/conversation/turn/route.ts
+++ b/apps/root/src/app/api/career/experience/conversation/turn/route.ts
@@ -1,0 +1,13 @@
+import { type NextRequest, NextResponse } from 'next/server';
+import { verifyJobsAccess, proxyToFastAPI } from '@/app/api/jobs/proxy';
+
+export async function POST(request: NextRequest) {
+  if (!(await verifyJobsAccess())) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const body = await request.json();
+  return proxyToFastAPI('/experience/conversation/turn', {
+    method: 'POST',
+    body,
+  });
+}

--- a/apps/root/src/app/api/career/experience/derive/route.ts
+++ b/apps/root/src/app/api/career/experience/derive/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from 'next/server';
+import { verifyJobsAccess, proxyToFastAPI } from '@/app/api/jobs/proxy';
+
+export async function POST() {
+  if (!(await verifyJobsAccess())) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  return proxyToFastAPI('/experience/derive', { method: 'POST' });
+}

--- a/apps/root/src/app/api/career/experience/upload-resume/route.ts
+++ b/apps/root/src/app/api/career/experience/upload-resume/route.ts
@@ -1,0 +1,14 @@
+import { type NextRequest, NextResponse } from 'next/server';
+import {
+  verifyJobsAccess,
+  proxyMultipartToFastAPI,
+} from '@/app/api/jobs/proxy';
+
+export async function POST(request: NextRequest) {
+  if (!(await verifyJobsAccess())) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  return proxyMultipartToFastAPI('/experience/upload-resume', request, {
+    searchParams: request.nextUrl.searchParams,
+  });
+}

--- a/apps/root/src/app/api/jobs/manual/route.ts
+++ b/apps/root/src/app/api/jobs/manual/route.ts
@@ -1,0 +1,10 @@
+import { type NextRequest, NextResponse } from 'next/server';
+import { verifyJobsAccess, proxyToFastAPI } from '@/app/api/jobs/proxy';
+
+export async function POST(request: NextRequest) {
+  if (!(await verifyJobsAccess())) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const body = await request.json();
+  return proxyToFastAPI('/jobs/manual', { method: 'POST', body });
+}

--- a/apps/root/src/app/api/jobs/proxy.ts
+++ b/apps/root/src/app/api/jobs/proxy.ts
@@ -92,3 +92,64 @@ export async function proxyToFastAPI(
     );
   }
 }
+
+/**
+ * Forward a multipart/form-data request to the FastAPI backend.
+ *
+ * Unlike `proxyToFastAPI` (which JSON-serializes the body), this passes
+ * the raw request body through so the multipart boundary is preserved.
+ */
+export async function proxyMultipartToFastAPI(
+  path: string,
+  request: Request,
+  options: { searchParams?: URLSearchParams } = {}
+): Promise<NextResponse> {
+  const { searchParams } = options;
+  const qs = searchParams ? `?${searchParams.toString()}` : '';
+  const url = `${JOB_API_URL}${path}${qs}`;
+
+  const sessionToken = await readAdminSessionToken();
+  const contentType = request.headers.get('Content-Type') ?? '';
+
+  try {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'x-api-key': JOB_API_KEY,
+        'Content-Type': contentType,
+        ...(sessionToken ? { Authorization: `Bearer ${sessionToken}` } : {}),
+      },
+      body: request.body,
+      // @ts-expect-error -- Node fetch supports duplex for streaming request bodies
+      duplex: 'half',
+    });
+
+    const rawBody = await res.text();
+    try {
+      return NextResponse.json(JSON.parse(rawBody), { status: res.status });
+    } catch {
+      return NextResponse.json(
+        {
+          error: 'Upstream returned non-JSON',
+          upstreamStatus: res.status,
+          ...(process.env.NODE_ENV !== 'production'
+            ? { bodyPreview: rawBody.slice(0, 300) }
+            : {}),
+        },
+        { status: 502 }
+      );
+    }
+  } catch (err) {
+    const detail =
+      process.env.NODE_ENV !== 'production' && err instanceof Error
+        ? {
+            message: err.message,
+            cause: err.cause ? String(err.cause) : undefined,
+          }
+        : undefined;
+    return NextResponse.json(
+      { error: 'Job API unavailable', ...(detail ? { detail } : {}) },
+      { status: 503 }
+    );
+  }
+}

--- a/apps/root/src/app/fitted/(app)/page.tsx
+++ b/apps/root/src/app/fitted/(app)/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next';
+import { redirect } from 'next/navigation';
 import { Heading } from '@danieljoffe.com/shared-ui/Heading';
 import { Text } from '@danieljoffe.com/shared-ui/Text';
 import { Card } from '@danieljoffe.com/shared-ui/Card';
@@ -8,11 +9,32 @@ export const metadata: Metadata = {
   title: 'Dashboard',
 };
 
+const JOB_API_URL = process.env['JOB_API_URL'] ?? '';
+const JOB_API_KEY = process.env['JOB_API_KEY'] ?? '';
+
+async function hasMasterDoc(): Promise<boolean> {
+  if (!JOB_API_URL) return false;
+  try {
+    const res = await fetch(`${JOB_API_URL}/experience/optimized`, {
+      headers: { 'x-api-key': JOB_API_KEY },
+      cache: 'no-store',
+    });
+    return res.ok;
+  } catch {
+    // If backend is down, don't block the dashboard
+    return true;
+  }
+}
+
 export default async function FittedDashboard() {
   const supabase = await createAuthServerClient();
   const {
     data: { user },
   } = await supabase.auth.getUser();
+
+  if (user && !(await hasMasterDoc())) {
+    redirect('/fitted/onboarding');
+  }
 
   return (
     <div className='flex flex-col gap-6'>

--- a/apps/root/src/app/fitted/onboarding/CompletionScreen.tsx
+++ b/apps/root/src/app/fitted/onboarding/CompletionScreen.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { CheckCircle, ArrowRight } from 'lucide-react';
+import { Card } from '@danieljoffe.com/shared-ui/Card';
+import { Text } from '@danieljoffe.com/shared-ui/Text';
+import { Heading } from '@danieljoffe.com/shared-ui/Heading';
+import Button from '@/components/Button';
+
+export default function CompletionScreen() {
+  return (
+    <div className='flex flex-col items-center gap-6'>
+      <Card padding='lg' className='w-full text-center'>
+        <div className='flex flex-col items-center gap-4 py-4'>
+          <div className='rounded-full bg-success/10 p-4'>
+            <CheckCircle className='size-12 text-success' aria-hidden />
+          </div>
+          <div>
+            <Heading variant='cardTitle' as='h2'>
+              You&apos;re all set!
+            </Heading>
+            <Text variant='body' className='mt-2 text-text-secondary'>
+              Your account is ready. Head to the dashboard to start tracking
+              jobs and generating tailored resumes.
+            </Text>
+          </div>
+        </div>
+      </Card>
+
+      <Button
+        name='onboarding-go-to-dashboard'
+        as='link'
+        href='/fitted'
+        variant='primary'
+        size='lg'
+        className='w-full justify-center'
+      >
+        <span>Go to Dashboard</span>
+        <ArrowRight className='size-4' aria-hidden />
+      </Button>
+    </div>
+  );
+}

--- a/apps/root/src/app/fitted/onboarding/ConversationChat.tsx
+++ b/apps/root/src/app/fitted/onboarding/ConversationChat.tsx
@@ -1,0 +1,294 @@
+'use client';
+
+import { useState, useCallback, useEffect, useRef } from 'react';
+import { Send } from 'lucide-react';
+import { Card } from '@danieljoffe.com/shared-ui/Card';
+import { Text } from '@danieljoffe.com/shared-ui/Text';
+import { Heading } from '@danieljoffe.com/shared-ui/Heading';
+import { Spinner } from '@danieljoffe.com/shared-ui/Spinner';
+import { Alert } from '@danieljoffe.com/shared-ui/Alert';
+import { Textarea } from '@danieljoffe.com/shared-ui/Textarea';
+import Button from '@/components/Button';
+
+interface ConversationChatProps {
+  onComplete: () => void;
+  onSkip: () => void;
+}
+
+interface Message {
+  role: 'assistant' | 'user';
+  content: string;
+}
+
+export default function ConversationChat({
+  onComplete,
+  onSkip,
+}: ConversationChatProps) {
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [input, setInput] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [sending, setSending] = useState(false);
+  const [deriving, setDeriving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  // Scroll to bottom when messages change
+  useEffect(() => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+    }
+  }, [messages, loading, sending]);
+
+  // Fetch initial probe question
+  useEffect(() => {
+    let cancelled = false;
+
+    async function fetchProbe() {
+      try {
+        const res = await fetch(
+          '/api/career/experience/conversation/next-probe'
+        );
+        if (!res.ok) throw new Error('Failed to load question');
+        const data = (await res.json()) as { question: string };
+        if (!cancelled) {
+          setMessages([{ role: 'assistant', content: data.question }]);
+        }
+      } catch {
+        if (!cancelled)
+          setError('Could not start conversation. Please try again.');
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+
+    fetchProbe();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const handleSend = useCallback(async () => {
+    const trimmed = input.trim();
+    if (!trimmed || sending) return;
+
+    setInput('');
+    setError(null);
+    setSending(true);
+    setMessages(prev => [...prev, { role: 'user', content: trimmed }]);
+
+    try {
+      const res = await fetch('/api/career/experience/conversation/turn', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          conversation_type: 'onboarding',
+          content: trimmed,
+          skipped: false,
+        }),
+      });
+
+      if (!res.ok) throw new Error('Failed to send message');
+
+      const data = (await res.json()) as {
+        assistant_message: string;
+        done: boolean;
+      };
+
+      setMessages(prev => [
+        ...prev,
+        { role: 'assistant', content: data.assistant_message },
+      ]);
+
+      if (data.done) {
+        // Derive master doc from conversation
+        setDeriving(true);
+        const deriveRes = await fetch('/api/career/experience/derive', {
+          method: 'POST',
+        });
+        if (!deriveRes.ok) throw new Error('Failed to build master document');
+        setDeriving(false);
+
+        setTimeout(onComplete, 800);
+      }
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : 'Something went wrong. Try again.'
+      );
+    } finally {
+      setSending(false);
+    }
+  }, [input, sending, onComplete]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Enter' && !e.shiftKey) {
+        e.preventDefault();
+        handleSend();
+      }
+    },
+    [handleSend]
+  );
+
+  const handleSkipQuestion = useCallback(async () => {
+    if (sending) return;
+
+    setError(null);
+    setSending(true);
+
+    try {
+      const res = await fetch('/api/career/experience/conversation/turn', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          conversation_type: 'onboarding',
+          content: '',
+          skipped: true,
+        }),
+      });
+
+      if (!res.ok) throw new Error('Failed to skip question');
+
+      const data = (await res.json()) as {
+        assistant_message: string;
+        done: boolean;
+      };
+
+      setMessages(prev => [
+        ...prev,
+        { role: 'assistant', content: data.assistant_message },
+      ]);
+
+      if (data.done) {
+        setDeriving(true);
+        const deriveRes = await fetch('/api/career/experience/derive', {
+          method: 'POST',
+        });
+        if (!deriveRes.ok) throw new Error('Failed to build master document');
+        setDeriving(false);
+        setTimeout(onComplete, 800);
+      }
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : 'Something went wrong. Try again.'
+      );
+    } finally {
+      setSending(false);
+    }
+  }, [sending, onComplete]);
+
+  return (
+    <div className='flex flex-col gap-4'>
+      <div className='text-center'>
+        <Heading variant='cardTitle' as='h2'>
+          Let&apos;s build your profile
+        </Heading>
+        <Text variant='caption' className='mt-1 text-text-secondary'>
+          Answer a few questions about your experience. Skip any you&apos;d
+          rather not answer.
+        </Text>
+      </div>
+
+      {/* Messages area */}
+      <Card
+        padding='none'
+        className='flex flex-col'
+        style={{ height: '400px' }}
+      >
+        <div ref={scrollRef} className='flex-1 overflow-y-auto p-4'>
+          <div className='flex flex-col gap-3'>
+            {messages.map((msg, i) => (
+              <div
+                key={i}
+                className={
+                  msg.role === 'assistant'
+                    ? 'flex justify-start'
+                    : 'flex justify-end'
+                }
+              >
+                <div
+                  className={[
+                    'max-w-[80%] rounded-lg px-4 py-2.5 text-sm',
+                    msg.role === 'assistant'
+                      ? 'bg-surface-tertiary text-text-primary'
+                      : 'bg-brand-500 text-white',
+                  ].join(' ')}
+                >
+                  {msg.content}
+                </div>
+              </div>
+            ))}
+
+            {(loading || sending) && (
+              <div className='flex justify-start'>
+                <div className='rounded-lg bg-surface-tertiary px-4 py-2.5'>
+                  <Spinner size='sm' aria-label='Thinking' />
+                </div>
+              </div>
+            )}
+
+            {deriving && (
+              <div className='flex justify-start'>
+                <div className='flex items-center gap-2 rounded-lg bg-surface-tertiary px-4 py-2.5 text-sm text-text-secondary'>
+                  <Spinner size='sm' aria-label='Building master document' />
+                  Building your master document...
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* Input area */}
+        <div className='border-t border-border p-3'>
+          <div className='flex gap-2'>
+            <Textarea
+              value={input}
+              onChange={e => setInput(e.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder='Type your answer...'
+              disabled={loading || sending || deriving}
+              rows={2}
+              className='flex-1 resize-none'
+              aria-label='Your response'
+            />
+            <div className='flex flex-col gap-1'>
+              <Button
+                name='onboarding-chat-send'
+                variant='primary'
+                size='sm'
+                iconOnly
+                onClick={handleSend}
+                disabled={!input.trim() || loading || sending || deriving}
+                aria-label='Send message'
+              >
+                <Send className='size-4' />
+              </Button>
+            </div>
+          </div>
+        </div>
+      </Card>
+
+      {error && <Alert variant='error'>{error}</Alert>}
+
+      <div className='flex items-center justify-between'>
+        <Button
+          name='onboarding-skip-question'
+          variant='outline'
+          size='sm'
+          onClick={handleSkipQuestion}
+          disabled={loading || sending || deriving}
+        >
+          Skip this question
+        </Button>
+        <Button
+          name='onboarding-skip-conversation'
+          variant='ghost'
+          size='sm'
+          onClick={onSkip}
+          disabled={sending || deriving}
+        >
+          Skip for now
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/root/src/app/fitted/onboarding/JobUrlInput.tsx
+++ b/apps/root/src/app/fitted/onboarding/JobUrlInput.tsx
@@ -1,0 +1,163 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+import { ExternalLink, CheckCircle, Briefcase } from 'lucide-react';
+import { Card } from '@danieljoffe.com/shared-ui/Card';
+import { Text } from '@danieljoffe.com/shared-ui/Text';
+import { Heading } from '@danieljoffe.com/shared-ui/Heading';
+import { Input } from '@danieljoffe.com/shared-ui/Input';
+import { Spinner } from '@danieljoffe.com/shared-ui/Spinner';
+import { Alert } from '@danieljoffe.com/shared-ui/Alert';
+import Button from '@/components/Button';
+
+interface JobUrlInputProps {
+  onComplete: () => void;
+  onSkip: () => void;
+}
+
+interface ExtractedJob {
+  title: string | null;
+  company_name: string | null;
+  posting_id: string | null;
+}
+
+export default function JobUrlInput({ onComplete, onSkip }: JobUrlInputProps) {
+  const [url, setUrl] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [extracted, setExtracted] = useState<ExtractedJob | null>(null);
+
+  const handleSubmit = useCallback(
+    async (e: React.FormEvent) => {
+      e.preventDefault();
+      const trimmed = url.trim();
+      if (!trimmed) return;
+
+      setError(null);
+      setSubmitting(true);
+
+      try {
+        const res = await fetch('/api/jobs/manual', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ url: trimmed }),
+        });
+
+        if (!res.ok) {
+          const data = await res.json().catch(() => null);
+          throw new Error(
+            (data as Record<string, string> | null)?.detail ??
+              `Failed to add job (${res.status})`
+          );
+        }
+
+        const data = (await res.json()) as {
+          success: boolean;
+          posting_id: string | null;
+          extracted: { title: string | null; company_name: string | null };
+        };
+
+        setExtracted({
+          title: data.extracted?.title ?? null,
+          company_name: data.extracted?.company_name ?? null,
+          posting_id: data.posting_id,
+        });
+
+        setTimeout(onComplete, 1500);
+      } catch (err) {
+        setError(
+          err instanceof Error
+            ? err.message
+            : 'Failed to add job. Please try again.'
+        );
+      } finally {
+        setSubmitting(false);
+      }
+    },
+    [url, onComplete]
+  );
+
+  return (
+    <div className='flex flex-col gap-6'>
+      <div className='text-center'>
+        <Heading variant='cardTitle' as='h2'>
+          Add your first job
+        </Heading>
+        <Text variant='caption' className='mt-1 text-text-secondary'>
+          Paste a job posting URL and we&apos;ll extract the details.
+        </Text>
+      </div>
+
+      {extracted ? (
+        <Card padding='lg'>
+          <div className='flex flex-col items-center gap-3 py-4'>
+            <CheckCircle className='size-12 text-success' aria-hidden />
+            <div className='text-center'>
+              <Text variant='body' className='font-medium'>
+                {extracted.title ?? 'Job added'}
+              </Text>
+              {extracted.company_name && (
+                <Text variant='caption' className='mt-1 text-text-secondary'>
+                  at {extracted.company_name}
+                </Text>
+              )}
+            </div>
+          </div>
+        </Card>
+      ) : (
+        <Card padding='lg'>
+          <form onSubmit={handleSubmit} className='flex flex-col gap-4'>
+            <div className='flex items-center gap-3'>
+              <div className='rounded-lg bg-surface-tertiary p-2'>
+                <Briefcase className='size-5 text-text-secondary' aria-hidden />
+              </div>
+              <div className='flex-1'>
+                <Input
+                  value={url}
+                  onChange={e => setUrl(e.target.value)}
+                  placeholder='https://jobs.example.com/posting/...'
+                  type='url'
+                  disabled={submitting}
+                  aria-label='Job posting URL'
+                />
+              </div>
+            </div>
+            <Button
+              name='onboarding-add-job'
+              variant='primary'
+              type='submit'
+              disabled={!url.trim() || submitting}
+              className='w-full justify-center'
+            >
+              {submitting ? (
+                <>
+                  <Spinner size='sm' aria-label='Adding job' />
+                  <span>Extracting job details...</span>
+                </>
+              ) : (
+                <>
+                  <ExternalLink className='size-4' aria-hidden />
+                  <span>Add job</span>
+                </>
+              )}
+            </Button>
+          </form>
+        </Card>
+      )}
+
+      {error && <Alert variant='error'>{error}</Alert>}
+
+      <div className='text-center'>
+        <Button
+          name='onboarding-skip-job'
+          variant='ghost'
+          size='sm'
+          onClick={onSkip}
+          disabled={submitting}
+        >
+          Skip for now
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/root/src/app/fitted/onboarding/OnboardingWizard.tsx
+++ b/apps/root/src/app/fitted/onboarding/OnboardingWizard.tsx
@@ -1,0 +1,106 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+import { useRouter } from 'next/navigation';
+import { ProgressBar } from '@danieljoffe.com/shared-ui/ProgressBar';
+import { Text } from '@danieljoffe.com/shared-ui/Text';
+import { Heading } from '@danieljoffe.com/shared-ui/Heading';
+import PathChooser from './PathChooser';
+import ResumeUploader from './ResumeUploader';
+import JobUrlInput from './JobUrlInput';
+import TargetSuggestions from './TargetSuggestions';
+import ConversationChat from './ConversationChat';
+import CompletionScreen from './CompletionScreen';
+
+export type OnboardingPath = 'A' | 'B' | 'C';
+
+type Step =
+  | 'path-chooser'
+  | 'upload-resume'
+  | 'add-job'
+  | 'pick-targets'
+  | 'conversation'
+  | 'completion';
+
+const STEPS_BY_PATH: Record<OnboardingPath, Step[]> = {
+  A: ['path-chooser', 'upload-resume', 'add-job', 'completion'],
+  B: ['path-chooser', 'upload-resume', 'pick-targets', 'completion'],
+  C: ['path-chooser', 'conversation', 'pick-targets', 'completion'],
+};
+
+export default function OnboardingWizard() {
+  const router = useRouter();
+  const [currentStep, setCurrentStep] = useState<Step>('path-chooser');
+  const [selectedPath, setSelectedPath] = useState<OnboardingPath | null>(null);
+
+  const steps = selectedPath ? STEPS_BY_PATH[selectedPath] : ['path-chooser'];
+  const stepIndex = steps.indexOf(currentStep);
+  const totalSteps = steps.length;
+
+  const goNext = useCallback(() => {
+    if (!selectedPath) return;
+    const stepsForPath = STEPS_BY_PATH[selectedPath];
+    const idx = stepsForPath.indexOf(currentStep);
+    if (idx < stepsForPath.length - 1) {
+      setCurrentStep(stepsForPath[idx + 1]);
+    }
+  }, [selectedPath, currentStep]);
+
+  const handlePathSelect = useCallback((path: OnboardingPath) => {
+    setSelectedPath(path);
+    const firstStep = STEPS_BY_PATH[path][1];
+    setCurrentStep(firstStep);
+  }, []);
+
+  const handleSkip = useCallback(() => {
+    router.push('/fitted');
+  }, [router]);
+
+  return (
+    <div className='flex min-h-screen items-center justify-center bg-bg px-4 py-12'>
+      <div className='w-full max-w-2xl'>
+        {/* Header */}
+        <div className='mb-8 text-center'>
+          <Heading variant='component' as='h1'>
+            Welcome to Fitted
+          </Heading>
+          <Text variant='body' className='mt-2 text-text-secondary'>
+            {currentStep === 'path-chooser'
+              ? 'How would you like to get started?'
+              : `Step ${stepIndex + 1} of ${totalSteps}`}
+          </Text>
+        </div>
+
+        {/* Progress bar */}
+        {selectedPath && currentStep !== 'completion' && (
+          <div className='mb-8'>
+            <ProgressBar
+              value={stepIndex + 1}
+              max={totalSteps}
+              size='sm'
+              aria-label={`Step ${stepIndex + 1} of ${totalSteps}`}
+            />
+          </div>
+        )}
+
+        {/* Step content */}
+        {currentStep === 'path-chooser' && (
+          <PathChooser onSelect={handlePathSelect} onSkip={handleSkip} />
+        )}
+        {currentStep === 'upload-resume' && (
+          <ResumeUploader onComplete={goNext} onSkip={handleSkip} />
+        )}
+        {currentStep === 'add-job' && (
+          <JobUrlInput onComplete={goNext} onSkip={handleSkip} />
+        )}
+        {currentStep === 'pick-targets' && (
+          <TargetSuggestions onComplete={goNext} onSkip={handleSkip} />
+        )}
+        {currentStep === 'conversation' && (
+          <ConversationChat onComplete={goNext} onSkip={handleSkip} />
+        )}
+        {currentStep === 'completion' && <CompletionScreen />}
+      </div>
+    </div>
+  );
+}

--- a/apps/root/src/app/fitted/onboarding/PathChooser.tsx
+++ b/apps/root/src/app/fitted/onboarding/PathChooser.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import { FileText, Search, MessageCircle } from 'lucide-react';
+import { Card } from '@danieljoffe.com/shared-ui/Card';
+import { Heading } from '@danieljoffe.com/shared-ui/Heading';
+import { Text } from '@danieljoffe.com/shared-ui/Text';
+import Button from '@/components/Button';
+import type { OnboardingPath } from './OnboardingWizard';
+
+interface PathChooserProps {
+  onSelect: (path: OnboardingPath) => void;
+  onSkip: () => void;
+}
+
+const paths: {
+  id: OnboardingPath;
+  icon: typeof FileText;
+  title: string;
+  description: string;
+}[] = [
+  {
+    id: 'A',
+    icon: FileText,
+    title: 'I have a resume and a role in mind',
+    description:
+      'Upload your resume and paste a job URL to get a tailored resume right away.',
+  },
+  {
+    id: 'B',
+    icon: Search,
+    title: "I have a resume but I'm exploring roles",
+    description:
+      'Upload your resume and browse suggested job targets based on your experience.',
+  },
+  {
+    id: 'C',
+    icon: MessageCircle,
+    title: "I'm not sure where to start",
+    description:
+      "Answer a few questions and we'll build your master document from scratch.",
+  },
+];
+
+export default function PathChooser({ onSelect, onSkip }: PathChooserProps) {
+  return (
+    <div className='flex flex-col gap-4'>
+      {paths.map(({ id, icon: Icon, title, description }) => (
+        <button key={id} onClick={() => onSelect(id)} className='text-left'>
+          <Card className='transition-colors hover:border-brand-500 cursor-pointer'>
+            <div className='flex items-start gap-4'>
+              <div className='rounded-lg bg-surface-tertiary p-3'>
+                <Icon className='size-5 text-text-secondary' aria-hidden />
+              </div>
+              <div className='flex-1'>
+                <Heading variant='cardTitle' as='h2'>
+                  {title}
+                </Heading>
+                <Text variant='caption' className='mt-1 text-text-secondary'>
+                  {description}
+                </Text>
+              </div>
+            </div>
+          </Card>
+        </button>
+      ))}
+
+      <div className='mt-4 text-center'>
+        <Button
+          name='onboarding-skip'
+          variant='ghost'
+          size='sm'
+          onClick={onSkip}
+        >
+          Skip for now
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/root/src/app/fitted/onboarding/ResumeUploader.tsx
+++ b/apps/root/src/app/fitted/onboarding/ResumeUploader.tsx
@@ -1,0 +1,195 @@
+'use client';
+
+import { useState, useCallback, useRef } from 'react';
+import { Upload, FileText, CheckCircle } from 'lucide-react';
+import { Card } from '@danieljoffe.com/shared-ui/Card';
+import { Text } from '@danieljoffe.com/shared-ui/Text';
+import { Heading } from '@danieljoffe.com/shared-ui/Heading';
+import { Spinner } from '@danieljoffe.com/shared-ui/Spinner';
+import { Alert } from '@danieljoffe.com/shared-ui/Alert';
+import Button from '@/components/Button';
+import { cn } from '@/lib/cn';
+
+const ACCEPTED_TYPES = [
+  'application/pdf',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+];
+const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB
+
+interface ResumeUploaderProps {
+  onComplete: () => void;
+  onSkip: () => void;
+}
+
+export default function ResumeUploader({
+  onComplete,
+  onSkip,
+}: ResumeUploaderProps) {
+  const [dragOver, setDragOver] = useState(false);
+  const [uploading, setUploading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [uploaded, setUploaded] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const upload = useCallback(
+    async (file: File) => {
+      if (!ACCEPTED_TYPES.includes(file.type)) {
+        setError('Please upload a PDF or DOCX file.');
+        return;
+      }
+      if (file.size > MAX_FILE_SIZE) {
+        setError('File must be under 10 MB.');
+        return;
+      }
+
+      setError(null);
+      setUploading(true);
+
+      try {
+        const formData = new FormData();
+        formData.append('file', file);
+
+        const res = await fetch(
+          '/api/career/experience/upload-resume?auto_derive=true',
+          { method: 'POST', body: formData }
+        );
+
+        if (!res.ok) {
+          const data = await res.json().catch(() => null);
+          throw new Error(
+            (data as Record<string, string> | null)?.detail ??
+              `Upload failed (${res.status})`
+          );
+        }
+
+        setUploaded(true);
+        // Brief delay to show success state before advancing
+        setTimeout(onComplete, 1200);
+      } catch (err) {
+        setError(
+          err instanceof Error
+            ? err.message
+            : 'Upload failed. Please try again.'
+        );
+      } finally {
+        setUploading(false);
+      }
+    },
+    [onComplete]
+  );
+
+  const handleDrop = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault();
+      setDragOver(false);
+      const file = e.dataTransfer.files[0];
+      if (file) upload(file);
+    },
+    [upload]
+  );
+
+  const handleFileChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0];
+      if (file) upload(file);
+    },
+    [upload]
+  );
+
+  return (
+    <div className='flex flex-col gap-6'>
+      <div className='text-center'>
+        <Heading variant='cardTitle' as='h2'>
+          Upload your resume
+        </Heading>
+        <Text variant='caption' className='mt-1 text-text-secondary'>
+          We&apos;ll parse it to build your master experience document.
+        </Text>
+      </div>
+
+      <Card
+        padding='lg'
+        className={cn(
+          'cursor-pointer border-dashed transition-colors',
+          dragOver && 'border-brand-500 bg-brand-500/5',
+          uploaded && 'border-success bg-success/5'
+        )}
+        onClick={() => !uploading && !uploaded && inputRef.current?.click()}
+        onDragOver={e => {
+          e.preventDefault();
+          setDragOver(true);
+        }}
+        onDragLeave={() => setDragOver(false)}
+        onDrop={handleDrop}
+        role='button'
+        tabIndex={0}
+        onKeyDown={e => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            if (!uploading && !uploaded) inputRef.current?.click();
+          }
+        }}
+        aria-label='Upload resume file'
+      >
+        <div className='flex flex-col items-center gap-3 py-4'>
+          {uploading ? (
+            <>
+              <Spinner size='lg' aria-label='Uploading resume' />
+              <Text variant='body' className='text-text-secondary'>
+                Uploading and parsing your resume...
+              </Text>
+            </>
+          ) : uploaded ? (
+            <>
+              <CheckCircle className='size-12 text-success' aria-hidden />
+              <Text variant='body' className='text-success'>
+                Resume uploaded successfully!
+              </Text>
+            </>
+          ) : (
+            <>
+              <div className='rounded-full bg-surface-tertiary p-4'>
+                {dragOver ? (
+                  <FileText className='size-8 text-brand-500' aria-hidden />
+                ) : (
+                  <Upload className='size-8 text-text-tertiary' aria-hidden />
+                )}
+              </div>
+              <div className='text-center'>
+                <Text variant='body'>
+                  Drop your resume here or click to browse
+                </Text>
+                <Text variant='caption' className='mt-1 text-text-tertiary'>
+                  PDF or DOCX, up to 10 MB
+                </Text>
+              </div>
+            </>
+          )}
+        </div>
+      </Card>
+
+      <input
+        ref={inputRef}
+        type='file'
+        accept='.pdf,.docx'
+        onChange={handleFileChange}
+        className='hidden'
+        aria-hidden='true'
+      />
+
+      {error && <Alert variant='error'>{error}</Alert>}
+
+      <div className='text-center'>
+        <Button
+          name='onboarding-skip-upload'
+          variant='ghost'
+          size='sm'
+          onClick={onSkip}
+          disabled={uploading}
+        >
+          Skip for now
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/root/src/app/fitted/onboarding/TargetSuggestions.tsx
+++ b/apps/root/src/app/fitted/onboarding/TargetSuggestions.tsx
@@ -1,0 +1,150 @@
+'use client';
+
+import { useEffect, useState, useCallback } from 'react';
+import { Target, ArrowRight } from 'lucide-react';
+import { Card } from '@danieljoffe.com/shared-ui/Card';
+import { Text } from '@danieljoffe.com/shared-ui/Text';
+import { Heading } from '@danieljoffe.com/shared-ui/Heading';
+import { Spinner } from '@danieljoffe.com/shared-ui/Spinner';
+import { Alert } from '@danieljoffe.com/shared-ui/Alert';
+import Button from '@/components/Button';
+
+interface TargetSuggestionsProps {
+  onComplete: () => void;
+  onSkip: () => void;
+}
+
+interface OptimizedSkill {
+  name: string;
+  proficiency: string;
+}
+
+export default function TargetSuggestions({
+  onComplete,
+  onSkip,
+}: TargetSuggestionsProps) {
+  const [loading, setLoading] = useState(true);
+  const [skills, setSkills] = useState<string[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function fetchSkills() {
+      try {
+        const res = await fetch('/api/career/experience/optimized');
+        if (!res.ok) {
+          // No master doc yet — that's fine, show generic message
+          setSkills([]);
+          return;
+        }
+        const data = (await res.json()) as {
+          payload?: { skills?: OptimizedSkill[] };
+        };
+        if (!cancelled && data.payload?.skills) {
+          setSkills(
+            data.payload.skills.slice(0, 8).map((s: OptimizedSkill) => s.name)
+          );
+        }
+      } catch {
+        if (!cancelled) setError('Could not load your profile.');
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+
+    fetchSkills();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const handleGoToTargets = useCallback(() => {
+    onComplete();
+  }, [onComplete]);
+
+  if (loading) {
+    return (
+      <div className='flex flex-col items-center gap-4 py-12'>
+        <Spinner size='lg' aria-label='Loading suggestions' />
+        <Text variant='body' className='text-text-secondary'>
+          Analyzing your experience...
+        </Text>
+      </div>
+    );
+  }
+
+  return (
+    <div className='flex flex-col gap-6'>
+      <div className='text-center'>
+        <Heading variant='cardTitle' as='h2'>
+          Set up your job targets
+        </Heading>
+        <Text variant='caption' className='mt-1 text-text-secondary'>
+          Targets define the types of roles you&apos;re looking for. Create one
+          to start tracking jobs.
+        </Text>
+      </div>
+
+      {skills.length > 0 && (
+        <Card padding='lg'>
+          <Text variant='caption' className='mb-3 text-text-secondary'>
+            Based on your experience, you might target roles involving:
+          </Text>
+          <div className='flex flex-wrap gap-2'>
+            {skills.map(skill => (
+              <span
+                key={skill}
+                className='rounded-full bg-surface-tertiary px-3 py-1 text-sm text-text-secondary'
+              >
+                {skill}
+              </span>
+            ))}
+          </div>
+        </Card>
+      )}
+
+      {error && <Alert variant='error'>{error}</Alert>}
+
+      <Card
+        padding='lg'
+        className='cursor-pointer transition-colors hover:border-brand-500'
+        onClick={handleGoToTargets}
+        role='button'
+        tabIndex={0}
+        onKeyDown={e => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            handleGoToTargets();
+          }
+        }}
+      >
+        <div className='flex items-center gap-4'>
+          <div className='rounded-lg bg-surface-tertiary p-3'>
+            <Target className='size-5 text-text-secondary' aria-hidden />
+          </div>
+          <div className='flex-1'>
+            <Text variant='body' className='font-medium'>
+              Create your first target
+            </Text>
+            <Text variant='caption' className='mt-0.5 text-text-secondary'>
+              Define a role type, and we&apos;ll score and track matching jobs.
+            </Text>
+          </div>
+          <ArrowRight className='size-5 text-text-tertiary' aria-hidden />
+        </div>
+      </Card>
+
+      <div className='text-center'>
+        <Button
+          name='onboarding-skip-targets'
+          variant='ghost'
+          size='sm'
+          onClick={onSkip}
+        >
+          Skip for now
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/root/src/app/fitted/onboarding/page.tsx
+++ b/apps/root/src/app/fitted/onboarding/page.tsx
@@ -1,0 +1,21 @@
+import type { Metadata } from 'next';
+import { redirect } from 'next/navigation';
+import { createAuthServerClient } from '@/lib/supabase/auth-server';
+import OnboardingWizard from './OnboardingWizard';
+
+export const metadata: Metadata = {
+  title: 'Get Started',
+};
+
+export default async function OnboardingPage() {
+  const supabase = await createAuthServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect('/fitted/login');
+  }
+
+  return <OnboardingWizard />;
+}


### PR DESCRIPTION
## Summary

- Three-option onboarding wizard at `/fitted/onboarding` for bootstrapping new accounts:
  - **Option A** ("resume + role in mind"): upload resume → paste job URL → completion
  - **Option B** ("resume, exploring roles"): upload resume → browse suggested targets → completion
  - **Option C** ("need help"): conversational master doc builder → target suggestions → completion
- 5 new API proxy routes: `upload-resume`, `conversation/turn`, `conversation/next-probe`, `derive`, `manual job`
- New `proxyMultipartToFastAPI()` helper for FormData forwarding (resume upload)
- Dashboard redirects to onboarding when user has no master document

## New files (15)

- `apps/root/src/app/fitted/onboarding/page.tsx` — server page with auth check
- `apps/root/src/app/fitted/onboarding/OnboardingWizard.tsx` — state machine wizard shell
- `apps/root/src/app/fitted/onboarding/PathChooser.tsx` — three option cards + skip
- `apps/root/src/app/fitted/onboarding/ResumeUploader.tsx` — drag-and-drop PDF/DOCX upload
- `apps/root/src/app/fitted/onboarding/JobUrlInput.tsx` — URL paste + job extraction
- `apps/root/src/app/fitted/onboarding/TargetSuggestions.tsx` — skills cloud + target creation CTA
- `apps/root/src/app/fitted/onboarding/ConversationChat.tsx` — chat UI for Option C
- `apps/root/src/app/fitted/onboarding/CompletionScreen.tsx` — success + dashboard link
- 5 proxy route files + multipart helper in `proxy.ts`

## Test plan

- [ ] `pnpm tsc --noEmit` passes
- [ ] `pnpm nx test root` — 1083 tests pass, no regressions
- [ ] Sign in via magic link → redirected to onboarding → choose Option A → upload resume → paste job URL → completion → dashboard
- [ ] Option B flow → upload resume → target suggestions → completion
- [ ] Option C flow → conversation builds master doc → derive → target suggestions → completion
- [ ] Skip at each step → lands on dashboard
- [ ] Return to `/fitted` after completing onboarding → no redirect (master doc exists)

🤖 Generated with [Claude Code](https://claude.com/claude-code)