### PR TITLE
feat(job-api, root): insights dashboard — pipeline, targets, skills, cost (#512)

### DIFF
--- a/apps/job-api/app/main.py
+++ b/apps/job-api/app/main.py
@@ -7,7 +7,7 @@ from starlette.types import Receive, Scope, Send
 
 from app.config import settings
 from app.http_client import close_http_client
-from app.routers import analysis, experience, jobs, poll, sources, status, tailor, targets
+from app.routers import analysis, experience, insights, jobs, poll, sources, status, tailor, targets
 from app.supabase_pool import close_supabase, init_supabase
 
 if not settings.allowed_hosts_list:
@@ -51,6 +51,7 @@ app.add_middleware(
 
 app.include_router(analysis.router)
 app.include_router(experience.router)
+app.include_router(insights.router)
 app.include_router(jobs.router)
 app.include_router(poll.router)
 app.include_router(sources.router)

--- a/apps/job-api/app/models/insights.py
+++ b/apps/job-api/app/models/insights.py
@@ -1,0 +1,90 @@
+"""Pydantic response models for insights endpoints (#512)."""
+
+from __future__ import annotations
+
+from datetime import date
+
+from pydantic import BaseModel
+
+
+# ── Pipeline endpoint ────────────────────────────────────────────────────────
+
+
+class WeeklyCount(BaseModel):
+    week_start: date
+    resumes_generated: int
+    applications_submitted: int
+
+
+class FunnelStage(BaseModel):
+    stage: str
+    count: int
+
+
+class PipelineInsights(BaseModel):
+    total_applications: int
+    total_interviews: int
+    total_offers: int
+    response_rate: float | None
+    avg_days_to_response: float | None
+    velocity: list[WeeklyCount]
+    funnel: list[FunnelStage]
+
+
+# ── Targets endpoint ─────────────────────────────────────────────────────────
+
+
+class TargetComparison(BaseModel):
+    target_id: str
+    target_label: str
+    job_count: int
+    avg_score: float
+    applied_count: int
+    interview_count: int
+    conversion_rate: float | None
+
+
+class ScoreBucket(BaseModel):
+    bucket: str
+    count: int
+
+
+class ScoreTrendPoint(BaseModel):
+    week_start: date
+    avg_score: float
+
+
+class TargetInsights(BaseModel):
+    targets: list[TargetComparison]
+    score_distribution: list[ScoreBucket]
+    score_trend: list[ScoreTrendPoint]
+
+
+# ── Skills + Cost endpoint ───────────────────────────────────────────────────
+
+
+class SkillFrequency(BaseModel):
+    skill: str
+    matched_count: int
+    missing_count: int
+
+
+class CostBucket(BaseModel):
+    week_start: date
+    total_cost: float
+    resume_count: int
+
+
+class PurposeCost(BaseModel):
+    purpose: str
+    total_cost: float
+    call_count: int
+
+
+class SkillsCostInsights(BaseModel):
+    top_skills: list[SkillFrequency]
+    top_missing: list[str]
+    cost_over_time: list[CostBucket]
+    cost_by_purpose: list[PurposeCost]
+    total_cost: float
+    avg_cost_per_resume: float | None

--- a/apps/job-api/app/routers/insights.py
+++ b/apps/job-api/app/routers/insights.py
@@ -1,0 +1,59 @@
+"""Insights router (#512).
+
+Three GET endpoints return pre-aggregated analytics for the insights
+dashboard.  Each accepts a ``?period=`` query param (7d/30d/90d/all)
+and delegates to the corresponding service function.
+"""
+
+from datetime import UTC, datetime, timedelta
+
+from fastapi import APIRouter, Depends, Query
+from supabase import Client
+
+from app.dependencies import get_supabase, verify_api_key_or_session
+from app.models.insights import PipelineInsights, SkillsCostInsights, TargetInsights
+from app.services.insights import compute_pipeline, compute_skills_cost, compute_targets
+
+router = APIRouter(
+    prefix="/insights",
+    tags=["insights"],
+    dependencies=[Depends(verify_api_key_or_session)],
+)
+
+_PERIOD_DAYS: dict[str, int | None] = {
+    "7d": 7,
+    "30d": 30,
+    "90d": 90,
+    "all": None,
+}
+
+
+def _since(period: str) -> datetime | None:
+    days = _PERIOD_DAYS.get(period)
+    if days is None:
+        return None
+    return datetime.now(UTC) - timedelta(days=days)
+
+
+@router.get("/pipeline")
+async def pipeline_insights(
+    period: str = Query("30d", pattern=r"^(7d|30d|90d|all)$"),
+    supabase: Client = Depends(get_supabase),
+) -> PipelineInsights:
+    return compute_pipeline(supabase, _since(period))
+
+
+@router.get("/targets")
+async def target_insights(
+    period: str = Query("30d", pattern=r"^(7d|30d|90d|all)$"),
+    supabase: Client = Depends(get_supabase),
+) -> TargetInsights:
+    return compute_targets(supabase, _since(period))
+
+
+@router.get("/skills-cost")
+async def skills_cost_insights(
+    period: str = Query("30d", pattern=r"^(7d|30d|90d|all)$"),
+    supabase: Client = Depends(get_supabase),
+) -> SkillsCostInsights:
+    return compute_skills_cost(supabase, _since(period))

--- a/apps/job-api/app/services/insights.py
+++ b/apps/job-api/app/services/insights.py
@@ -1,0 +1,347 @@
+"""Aggregation logic for the insights dashboard (#512).
+
+Each compute function fetches filtered rows from Supabase and aggregates
+in Python.  Supabase REST has no GROUP BY, but at personal-tool scale
+(hundreds to low thousands of rows) this is efficient.
+"""
+
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+from datetime import UTC, date, datetime, timedelta
+
+from supabase import Client
+
+from app.models.insights import (
+    CostBucket,
+    FunnelStage,
+    PipelineInsights,
+    PurposeCost,
+    ScoreBucket,
+    ScoreTrendPoint,
+    SkillFrequency,
+    SkillsCostInsights,
+    TargetComparison,
+    TargetInsights,
+    WeeklyCount,
+)
+
+# Funnel stage ordering (used for consistent display)
+FUNNEL_ORDER = [
+    "new",
+    "saved",
+    "resume_draft",
+    "resume_ready",
+    "applied",
+    "interviewing",
+    "offer",
+]
+
+APPLIED_STATUSES = {"applied", "interviewing", "offer"}
+
+
+def _iso_week_start(dt: datetime | date) -> date:
+    """Return the Monday of the ISO week containing *dt*."""
+    if isinstance(dt, datetime):
+        d = dt.date()
+    else:
+        d = dt
+    return d - timedelta(days=d.weekday())
+
+
+def _parse_dt(value: str) -> datetime:
+    """Parse an ISO timestamp from Supabase (may include tz offset)."""
+    return datetime.fromisoformat(value)
+
+
+# ── Pipeline ─────────────────────────────────────────────────────────────────
+
+
+def compute_pipeline(supabase: Client, since: datetime | None) -> PipelineInsights:
+    # Fetch job postings
+    q = supabase.table("job_postings").select("id, status, created_at")
+    if since:
+        q = q.gte("created_at", since.isoformat())
+    postings = q.execute().data or []
+
+    # Fetch status log for response-time calculation
+    sq = supabase.table("job_status_log").select("posting_id, old_status, new_status, created_at")
+    if since:
+        sq = sq.gte("created_at", since.isoformat())
+    status_logs = sq.execute().data or []
+
+    # Fetch tailored resumes for velocity
+    rq = supabase.table("tailored_resumes").select("job_posting_id, created_at")
+    if since:
+        rq = rq.gte("created_at", since.isoformat())
+    rq = rq.eq("document_type", "resume")
+    resumes = rq.execute().data or []
+
+    # --- Funnel counts ---
+    status_counts: Counter[str] = Counter()
+    for p in postings:
+        status_counts[p["status"]] += 1
+
+    funnel = [FunnelStage(stage=s, count=status_counts.get(s, 0)) for s in FUNNEL_ORDER]
+
+    # --- Top-line KPIs ---
+    total_applications = sum(status_counts.get(s, 0) for s in APPLIED_STATUSES)
+    total_interviews = status_counts.get("interviewing", 0) + status_counts.get("offer", 0)
+    total_offers = status_counts.get("offer", 0)
+    response_rate = (total_interviews / total_applications) if total_applications > 0 else None
+
+    # --- Avg days from applied → interviewing ---
+    applied_times: dict[str, datetime] = {}
+    interview_times: dict[str, datetime] = {}
+    for log in status_logs:
+        posting_id = log["posting_id"]
+        ts = _parse_dt(log["created_at"])
+        if log["new_status"] == "applied" and posting_id not in applied_times:
+            applied_times[posting_id] = ts
+        if log["new_status"] == "interviewing" and posting_id not in interview_times:
+            interview_times[posting_id] = ts
+
+    response_days: list[float] = []
+    for pid, interview_ts in interview_times.items():
+        if pid in applied_times:
+            delta = (interview_ts - applied_times[pid]).total_seconds() / 86400
+            if delta >= 0:
+                response_days.append(delta)
+    avg_days = (sum(response_days) / len(response_days)) if response_days else None
+
+    # --- Weekly velocity ---
+    week_resumes: Counter[date] = Counter()
+    for r in resumes:
+        week_resumes[_iso_week_start(_parse_dt(r["created_at"]))] += 1
+
+    week_apps: Counter[date] = Counter()
+    for log in status_logs:
+        if log["new_status"] in APPLIED_STATUSES and log["old_status"] not in APPLIED_STATUSES:
+            week_apps[_iso_week_start(_parse_dt(log["created_at"]))] += 1
+
+    all_weeks = sorted(set(week_resumes.keys()) | set(week_apps.keys()))
+    velocity = [
+        WeeklyCount(
+            week_start=w,
+            resumes_generated=week_resumes.get(w, 0),
+            applications_submitted=week_apps.get(w, 0),
+        )
+        for w in all_weeks
+    ]
+
+    return PipelineInsights(
+        total_applications=total_applications,
+        total_interviews=total_interviews,
+        total_offers=total_offers,
+        response_rate=round(response_rate, 3) if response_rate is not None else None,
+        avg_days_to_response=round(avg_days, 1) if avg_days is not None else None,
+        velocity=velocity,
+        funnel=funnel,
+    )
+
+
+# ── Targets ──────────────────────────────────────────────────────────────────
+
+
+def compute_targets(supabase: Client, since: datetime | None) -> TargetInsights:
+    # Fetch all targets for labels
+    targets_data = supabase.table("job_targets").select("id, label").execute().data or []
+    target_labels = {t["id"]: t["label"] for t in targets_data}
+
+    # Fetch postings with target + score + status
+    q = supabase.table("job_postings").select("id, target_id, score, status, created_at")
+    if since:
+        q = q.gte("created_at", since.isoformat())
+    postings = q.execute().data or []
+
+    # --- Per-target aggregation ---
+    target_jobs: defaultdict[str, list[dict]] = defaultdict(list)
+    all_scores: list[int] = []
+    for p in postings:
+        score = p.get("score") or 0
+        all_scores.append(score)
+        tid = p.get("target_id")
+        if tid and tid in target_labels:
+            target_jobs[tid].append(p)
+
+    comparisons: list[TargetComparison] = []
+    for tid, label in target_labels.items():
+        jobs = target_jobs.get(tid, [])
+        if not jobs:
+            comparisons.append(
+                TargetComparison(
+                    target_id=tid,
+                    target_label=label,
+                    job_count=0,
+                    avg_score=0.0,
+                    applied_count=0,
+                    interview_count=0,
+                    conversion_rate=None,
+                )
+            )
+            continue
+        scores = [j.get("score", 0) or 0 for j in jobs]
+        applied = sum(1 for j in jobs if j["status"] in APPLIED_STATUSES)
+        interviews = sum(
+            1 for j in jobs if j["status"] in {"interviewing", "offer"}
+        )
+        comparisons.append(
+            TargetComparison(
+                target_id=tid,
+                target_label=label,
+                job_count=len(jobs),
+                avg_score=round(sum(scores) / len(scores), 1),
+                applied_count=applied,
+                interview_count=interviews,
+                conversion_rate=round(interviews / applied, 3) if applied > 0 else None,
+            )
+        )
+
+    # --- Score distribution ---
+    bucket_counts: Counter[str] = Counter()
+    for s in all_scores:
+        clamped = max(0, min(s, 100))
+        bucket_idx = min(clamped // 10, 9)
+        lo = bucket_idx * 10
+        hi = lo + 10 if lo < 90 else 100
+        bucket_counts[f"{lo}-{hi}"] += 1
+
+    buckets = [
+        ScoreBucket(bucket=f"{lo}-{lo + 10 if lo < 90 else 100}", count=bucket_counts.get(f"{lo}-{lo + 10 if lo < 90 else 100}", 0))
+        for lo in range(0, 100, 10)
+    ]
+
+    # --- Score trend by week ---
+    week_scores: defaultdict[date, list[int]] = defaultdict(list)
+    for p in postings:
+        score = p.get("score") or 0
+        week_scores[_iso_week_start(_parse_dt(p["created_at"]))].append(score)
+
+    score_trend = sorted(
+        [
+            ScoreTrendPoint(week_start=w, avg_score=round(sum(ss) / len(ss), 1))
+            for w, ss in week_scores.items()
+        ],
+        key=lambda x: x.week_start,
+    )
+
+    return TargetInsights(
+        targets=comparisons,
+        score_distribution=buckets,
+        score_trend=score_trend,
+    )
+
+
+# ── Skills + Cost ────────────────────────────────────────────────────────────
+
+
+def compute_skills_cost(supabase: Client, since: datetime | None) -> SkillsCostInsights:
+    # Fetch analyses for skill extraction
+    aq = supabase.table("job_analyses").select("scorecard, created_at")
+    if since:
+        aq = aq.gte("created_at", since.isoformat())
+    analyses = aq.execute().data or []
+
+    # Fetch LLM cost log
+    cq = supabase.table("llm_cost_log").select("purpose, cost_usd, created_at")
+    if since:
+        cq = cq.gte("created_at", since.isoformat())
+    cost_logs = cq.execute().data or []
+
+    # Fetch tailored resumes for per-resume cost
+    rq = supabase.table("tailored_resumes").select("cost_usd, created_at")
+    if since:
+        rq = rq.gte("created_at", since.isoformat())
+    rq = rq.eq("document_type", "resume")
+    resume_costs = rq.execute().data or []
+
+    # --- Skill frequencies ---
+    matched_counts: Counter[str] = Counter()
+    missing_counts: Counter[str] = Counter()
+
+    for a in analyses:
+        scorecard = a.get("scorecard")
+        if not isinstance(scorecard, dict):
+            continue
+        for sm in scorecard.get("skills_matched", []):
+            if isinstance(sm, dict) and sm.get("name"):
+                if sm.get("matched"):
+                    matched_counts[sm["name"]] += 1
+                else:
+                    missing_counts[sm["name"]] += 1
+        for skill_name in scorecard.get("skills_missing", []):
+            if isinstance(skill_name, str):
+                missing_counts[skill_name] += 1
+
+    # Combine and rank by total frequency
+    all_skills = set(matched_counts.keys()) | set(missing_counts.keys())
+    skill_freqs = sorted(
+        [
+            SkillFrequency(
+                skill=s,
+                matched_count=matched_counts.get(s, 0),
+                missing_count=missing_counts.get(s, 0),
+            )
+            for s in all_skills
+        ],
+        key=lambda x: x.matched_count + x.missing_count,
+        reverse=True,
+    )[:15]
+
+    # Top missing (skills never matched)
+    pure_missing = [
+        s for s, _ in missing_counts.most_common(10) if matched_counts.get(s, 0) == 0
+    ]
+
+    # --- Cost over time ---
+    week_cost: defaultdict[date, float] = defaultdict(float)
+    week_resume_count: Counter[date] = Counter()
+    for rc in resume_costs:
+        w = _iso_week_start(_parse_dt(rc["created_at"]))
+        week_cost[w] += float(rc.get("cost_usd") or 0)
+        week_resume_count[w] += 1
+
+    all_cost_weeks = sorted(set(week_cost.keys()) | set(week_resume_count.keys()))
+    cost_over_time = [
+        CostBucket(
+            week_start=w,
+            total_cost=round(week_cost.get(w, 0), 4),
+            resume_count=week_resume_count.get(w, 0),
+        )
+        for w in all_cost_weeks
+    ]
+
+    # --- Cost by purpose ---
+    purpose_totals: defaultdict[str, float] = defaultdict(float)
+    purpose_counts: Counter[str] = Counter()
+    for cl in cost_logs:
+        purpose = cl.get("purpose", "unknown")
+        purpose_totals[purpose] += float(cl.get("cost_usd") or 0)
+        purpose_counts[purpose] += 1
+
+    cost_by_purpose = sorted(
+        [
+            PurposeCost(
+                purpose=p,
+                total_cost=round(purpose_totals[p], 4),
+                call_count=purpose_counts[p],
+            )
+            for p in purpose_totals
+        ],
+        key=lambda x: x.total_cost,
+        reverse=True,
+    )
+
+    # --- Totals ---
+    total_cost = sum(float(cl.get("cost_usd") or 0) for cl in cost_logs)
+    total_resumes = len(resume_costs)
+    avg_cost_per_resume = (total_cost / total_resumes) if total_resumes > 0 else None
+
+    return SkillsCostInsights(
+        top_skills=skill_freqs,
+        top_missing=pure_missing,
+        cost_over_time=cost_over_time,
+        cost_by_purpose=cost_by_purpose,
+        total_cost=round(total_cost, 4),
+        avg_cost_per_resume=round(avg_cost_per_resume, 4) if avg_cost_per_resume is not None else None,
+    )

--- a/apps/job-api/tests/test_insights.py
+++ b/apps/job-api/tests/test_insights.py
@@ -1,0 +1,282 @@
+"""Tests for insights aggregation logic (#512)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import MagicMock
+
+from app.services.insights import compute_pipeline, compute_skills_cost, compute_targets
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_NOW = datetime.now(UTC)
+_WEEK_AGO = _NOW - timedelta(days=7)
+
+
+def _ts(dt: datetime) -> str:
+    return dt.isoformat()
+
+
+def _mock_supabase(tables: dict[str, list[dict]]) -> MagicMock:
+    """Build a MagicMock that simulates chained Supabase queries.
+
+    *tables* maps table name → list of dicts that .execute().data returns.
+    Every chained method (.select, .eq, .gte, .order, .limit) returns the
+    same mock, so the final .execute() always resolves.
+    """
+    client = MagicMock()
+
+    def table_side_effect(name: str) -> MagicMock:
+        tbl = MagicMock()
+        result = MagicMock()
+        result.data = tables.get(name, [])
+
+        # Every chainable method returns the same table mock
+        for method in ("select", "eq", "gte", "lte", "order", "limit", "neq", "in_"):
+            getattr(tbl, method).return_value = tbl
+        tbl.execute.return_value = result
+        return tbl
+
+    client.table.side_effect = table_side_effect
+    return client
+
+
+# ===========================================================================
+# Pipeline
+# ===========================================================================
+
+
+class TestComputePipeline:
+    def test_basic_funnel_counts(self):
+        postings = [
+            {"id": "1", "status": "new", "created_at": _ts(_NOW)},
+            {"id": "2", "status": "new", "created_at": _ts(_NOW)},
+            {"id": "3", "status": "applied", "created_at": _ts(_NOW)},
+            {"id": "4", "status": "interviewing", "created_at": _ts(_NOW)},
+            {"id": "5", "status": "offer", "created_at": _ts(_NOW)},
+        ]
+        sb = _mock_supabase({"job_postings": postings})
+        result = compute_pipeline(sb, since=None)
+
+        assert result.total_applications == 3  # applied + interviewing + offer
+        assert result.total_interviews == 2  # interviewing + offer
+        assert result.total_offers == 1
+
+        funnel_map = {f.stage: f.count for f in result.funnel}
+        assert funnel_map["new"] == 2
+        assert funnel_map["applied"] == 1
+        assert funnel_map["interviewing"] == 1
+        assert funnel_map["offer"] == 1
+
+    def test_response_rate(self):
+        postings = [
+            {"id": "1", "status": "applied", "created_at": _ts(_NOW)},
+            {"id": "2", "status": "applied", "created_at": _ts(_NOW)},
+            {"id": "3", "status": "interviewing", "created_at": _ts(_NOW)},
+            {"id": "4", "status": "offer", "created_at": _ts(_NOW)},
+        ]
+        sb = _mock_supabase({"job_postings": postings})
+        result = compute_pipeline(sb, since=None)
+
+        # 4 applied-or-beyond, 2 interviewing-or-beyond → 0.5
+        assert result.response_rate == 0.5
+
+    def test_avg_days_to_response(self):
+        logs = [
+            {
+                "posting_id": "1",
+                "old_status": "resume_ready",
+                "new_status": "applied",
+                "created_at": _ts(_NOW - timedelta(days=10)),
+            },
+            {
+                "posting_id": "1",
+                "old_status": "applied",
+                "new_status": "interviewing",
+                "created_at": _ts(_NOW - timedelta(days=4)),
+            },
+        ]
+        postings = [{"id": "1", "status": "interviewing", "created_at": _ts(_NOW)}]
+        sb = _mock_supabase({"job_postings": postings, "job_status_log": logs})
+        result = compute_pipeline(sb, since=None)
+
+        assert result.avg_days_to_response == 6.0
+
+    def test_empty_data(self):
+        sb = _mock_supabase({})
+        result = compute_pipeline(sb, since=None)
+
+        assert result.total_applications == 0
+        assert result.response_rate is None
+        assert result.avg_days_to_response is None
+        assert result.velocity == []
+
+    def test_velocity_grouping(self):
+        resumes = [
+            {"job_posting_id": "1", "created_at": _ts(_NOW)},
+            {"job_posting_id": "2", "created_at": _ts(_NOW - timedelta(days=1))},
+            {"job_posting_id": "3", "created_at": _ts(_NOW - timedelta(days=8))},
+        ]
+        sb = _mock_supabase({"tailored_resumes": resumes})
+        result = compute_pipeline(sb, since=None)
+
+        # Should group into weeks — at least 1 or 2 week buckets
+        assert len(result.velocity) >= 1
+        total_resumes = sum(v.resumes_generated for v in result.velocity)
+        assert total_resumes == 3
+
+
+# ===========================================================================
+# Targets
+# ===========================================================================
+
+
+class TestComputeTargets:
+    def test_basic_target_comparison(self):
+        targets = [
+            {"id": "t1", "label": "Frontend"},
+            {"id": "t2", "label": "Backend"},
+        ]
+        postings = [
+            {"id": "1", "target_id": "t1", "score": 80, "status": "applied", "created_at": _ts(_NOW)},
+            {"id": "2", "target_id": "t1", "score": 60, "status": "new", "created_at": _ts(_NOW)},
+            {"id": "3", "target_id": "t2", "score": 90, "status": "interviewing", "created_at": _ts(_NOW)},
+        ]
+        sb = _mock_supabase({"job_targets": targets, "job_postings": postings})
+        result = compute_targets(sb, since=None)
+
+        assert len(result.targets) == 2
+        fe = next(t for t in result.targets if t.target_label == "Frontend")
+        assert fe.job_count == 2
+        assert fe.avg_score == 70.0
+        assert fe.applied_count == 1
+
+        be = next(t for t in result.targets if t.target_label == "Backend")
+        assert be.job_count == 1
+        assert be.avg_score == 90.0
+
+    def test_score_distribution(self):
+        postings = [
+            {"id": "1", "target_id": None, "score": 15, "status": "new", "created_at": _ts(_NOW)},
+            {"id": "2", "target_id": None, "score": 85, "status": "new", "created_at": _ts(_NOW)},
+            {"id": "3", "target_id": None, "score": 85, "status": "new", "created_at": _ts(_NOW)},
+        ]
+        sb = _mock_supabase({"job_postings": postings})
+        result = compute_targets(sb, since=None)
+
+        bucket_map = {b.bucket: b.count for b in result.score_distribution}
+        assert bucket_map["10-20"] == 1
+        assert bucket_map["80-90"] == 2
+        assert bucket_map["0-10"] == 0
+
+    def test_empty_targets(self):
+        sb = _mock_supabase({})
+        result = compute_targets(sb, since=None)
+
+        assert result.targets == []
+        assert len(result.score_distribution) == 10  # Always 10 buckets
+        assert result.score_trend == []
+
+    def test_score_trend(self):
+        postings = [
+            {"id": "1", "target_id": None, "score": 60, "status": "new", "created_at": _ts(_NOW)},
+            {"id": "2", "target_id": None, "score": 80, "status": "new", "created_at": _ts(_NOW - timedelta(days=8))},
+        ]
+        sb = _mock_supabase({"job_postings": postings})
+        result = compute_targets(sb, since=None)
+
+        # At least 1 week bucket
+        assert len(result.score_trend) >= 1
+
+
+# ===========================================================================
+# Skills + Cost
+# ===========================================================================
+
+
+class TestComputeSkillsCost:
+    def test_basic_skill_frequencies(self):
+        analyses = [
+            {
+                "scorecard": {
+                    "skills_matched": [
+                        {"name": "Python", "matched": True, "confidence": "high", "evidence": ""},
+                        {"name": "React", "matched": False, "confidence": "low", "evidence": ""},
+                    ],
+                    "skills_missing": ["Docker"],
+                },
+                "created_at": _ts(_NOW),
+            },
+            {
+                "scorecard": {
+                    "skills_matched": [
+                        {"name": "Python", "matched": True, "confidence": "high", "evidence": ""},
+                    ],
+                    "skills_missing": ["React", "Docker"],
+                },
+                "created_at": _ts(_NOW),
+            },
+        ]
+        sb = _mock_supabase({"job_analyses": analyses})
+        result = compute_skills_cost(sb, since=None)
+
+        skill_map = {s.skill: s for s in result.top_skills}
+        assert "Python" in skill_map
+        assert skill_map["Python"].matched_count == 2
+        assert skill_map["Python"].missing_count == 0
+
+        # React: 1 unmatched in skills_matched + 1 in skills_missing
+        assert "React" in skill_map
+        assert skill_map["React"].missing_count == 2
+
+        assert "Docker" in skill_map
+        assert skill_map["Docker"].missing_count == 2
+
+        # Docker is never matched → should be in top_missing
+        assert "Docker" in result.top_missing
+
+    def test_cost_over_time(self):
+        resume_costs = [
+            {"cost_usd": "0.0050", "created_at": _ts(_NOW)},
+            {"cost_usd": "0.0030", "created_at": _ts(_NOW - timedelta(days=1))},
+        ]
+        cost_logs = [
+            {"purpose": "tailor", "cost_usd": "0.0080", "created_at": _ts(_NOW)},
+        ]
+        sb = _mock_supabase({
+            "tailored_resumes": resume_costs,
+            "llm_cost_log": cost_logs,
+        })
+        result = compute_skills_cost(sb, since=None)
+
+        assert result.total_cost == 0.008
+        assert result.avg_cost_per_resume is not None
+        assert len(result.cost_over_time) >= 1
+        total_resume_cost = sum(c.total_cost for c in result.cost_over_time)
+        assert total_resume_cost == 0.008
+
+    def test_cost_by_purpose(self):
+        cost_logs = [
+            {"purpose": "tailor", "cost_usd": "0.01", "created_at": _ts(_NOW)},
+            {"purpose": "tailor", "cost_usd": "0.02", "created_at": _ts(_NOW)},
+            {"purpose": "analysis", "cost_usd": "0.005", "created_at": _ts(_NOW)},
+        ]
+        sb = _mock_supabase({"llm_cost_log": cost_logs})
+        result = compute_skills_cost(sb, since=None)
+
+        purpose_map = {p.purpose: p for p in result.cost_by_purpose}
+        assert purpose_map["tailor"].total_cost == 0.03
+        assert purpose_map["tailor"].call_count == 2
+        assert purpose_map["analysis"].total_cost == 0.005
+
+    def test_empty_data(self):
+        sb = _mock_supabase({})
+        result = compute_skills_cost(sb, since=None)
+
+        assert result.top_skills == []
+        assert result.top_missing == []
+        assert result.cost_over_time == []
+        assert result.total_cost == 0.0
+        assert result.avg_cost_per_resume is None

--- a/apps/root/src/app/api/jobs/insights/pipeline/route.ts
+++ b/apps/root/src/app/api/jobs/insights/pipeline/route.ts
@@ -1,0 +1,11 @@
+import { type NextRequest, NextResponse } from 'next/server';
+import { verifyJobsAccess, proxyToFastAPI } from '../../proxy';
+
+export async function GET(request: NextRequest) {
+  if (!(await verifyJobsAccess())) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  return proxyToFastAPI('/insights/pipeline', {
+    searchParams: request.nextUrl.searchParams,
+  });
+}

--- a/apps/root/src/app/api/jobs/insights/skills-cost/route.ts
+++ b/apps/root/src/app/api/jobs/insights/skills-cost/route.ts
@@ -1,0 +1,11 @@
+import { type NextRequest, NextResponse } from 'next/server';
+import { verifyJobsAccess, proxyToFastAPI } from '../../proxy';
+
+export async function GET(request: NextRequest) {
+  if (!(await verifyJobsAccess())) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  return proxyToFastAPI('/insights/skills-cost', {
+    searchParams: request.nextUrl.searchParams,
+  });
+}

--- a/apps/root/src/app/api/jobs/insights/targets/route.ts
+++ b/apps/root/src/app/api/jobs/insights/targets/route.ts
@@ -1,0 +1,11 @@
+import { type NextRequest, NextResponse } from 'next/server';
+import { verifyJobsAccess, proxyToFastAPI } from '../../proxy';
+
+export async function GET(request: NextRequest) {
+  if (!(await verifyJobsAccess())) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  return proxyToFastAPI('/insights/targets', {
+    searchParams: request.nextUrl.searchParams,
+  });
+}

--- a/apps/root/src/app/fitted/(app)/insights/InsightsDashboard.tsx
+++ b/apps/root/src/app/fitted/(app)/insights/InsightsDashboard.tsx
@@ -1,0 +1,216 @@
+'use client';
+
+import { useState } from 'react';
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from '@danieljoffe.com/shared-ui/Card';
+import { Skeleton } from '@danieljoffe.com/shared-ui/Skeleton';
+import { StatsCard } from '@danieljoffe.com/shared-ui/StatsCard';
+import { Text } from '@danieljoffe.com/shared-ui/Text';
+import { useInsights } from '@/hooks/useInsights';
+import CostChart from './charts/CostChart';
+import FunnelChart from './charts/FunnelChart';
+import ScoreDistributionChart from './charts/ScoreDistributionChart';
+import SkillFrequencyChart from './charts/SkillFrequencyChart';
+import TargetComparisonChart from './charts/TargetComparisonChart';
+import VelocityChart from './charts/VelocityChart';
+import type { Period } from './types';
+
+const PERIODS: { id: Period; label: string }[] = [
+  { id: '7d', label: '7d' },
+  { id: '30d', label: '30d' },
+  { id: '90d', label: '90d' },
+  { id: 'all', label: 'All' },
+];
+
+function PeriodFilter({
+  value,
+  onChange,
+}: {
+  value: Period;
+  onChange: (p: Period) => void;
+}) {
+  return (
+    <div className='flex gap-1 p-1 bg-surface-tertiary rounded-lg'>
+      {PERIODS.map(p => (
+        <button
+          key={p.id}
+          type='button'
+          onClick={() => onChange(p.id)}
+          className={[
+            'px-4 py-2 rounded-md text-sm font-medium transition-colors',
+            'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2',
+            value === p.id
+              ? 'bg-surface text-text-primary shadow-sm'
+              : 'text-text-secondary hover:text-text-primary',
+          ].join(' ')}
+        >
+          {p.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function ChartSkeleton() {
+  return <Skeleton variant='rectangular' height={250} />;
+}
+
+function formatPct(value: number | null): string {
+  if (value === null) return '--';
+  return `${Math.round(value * 100)}%`;
+}
+
+function formatDays(value: number | null): string {
+  if (value === null) return '--';
+  return `${value.toFixed(1)}d`;
+}
+
+export default function InsightsDashboard() {
+  const [period, setPeriod] = useState<Period>('30d');
+  const { pipeline, targets, skillsCost, loading, error } = useInsights(period);
+
+  return (
+    <div className='space-y-6'>
+      {/* Period filter */}
+      <PeriodFilter value={period} onChange={setPeriod} />
+
+      {/* Error banner */}
+      {error && (
+        <div className='rounded-md bg-error-light border border-error/30 p-3'>
+          <Text variant='body' className='text-error'>
+            {error}
+          </Text>
+        </div>
+      )}
+
+      {/* KPI cards */}
+      <div className='grid gap-4 grid-cols-2 lg:grid-cols-4'>
+        {loading && !pipeline ? (
+          Array.from({ length: 4 }).map((_, i) => (
+            <Skeleton key={i} variant='rectangular' height={100} />
+          ))
+        ) : (
+          <>
+            <StatsCard
+              title='Applications'
+              value={pipeline?.total_applications ?? 0}
+            />
+            <StatsCard
+              title='Interviews'
+              value={pipeline?.total_interviews ?? 0}
+            />
+            <StatsCard
+              title='Response Rate'
+              value={formatPct(pipeline?.response_rate ?? null)}
+            />
+            <StatsCard
+              title='Avg Days to Response'
+              value={formatDays(pipeline?.avg_days_to_response ?? null)}
+            />
+          </>
+        )}
+      </div>
+
+      {/* Application velocity — full width */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Application Velocity</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {loading && !pipeline ? (
+            <ChartSkeleton />
+          ) : (
+            <VelocityChart data={pipeline?.velocity ?? []} />
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Two-column row: Funnel + Score Distribution */}
+      <div className='grid gap-6 grid-cols-1 lg:grid-cols-2'>
+        <Card>
+          <CardHeader>
+            <CardTitle>Pipeline Funnel</CardTitle>
+          </CardHeader>
+          <CardContent>
+            {loading && !pipeline ? (
+              <ChartSkeleton />
+            ) : (
+              <FunnelChart data={pipeline?.funnel ?? []} />
+            )}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Score Distribution</CardTitle>
+          </CardHeader>
+          <CardContent>
+            {loading && !targets ? (
+              <ChartSkeleton />
+            ) : (
+              <ScoreDistributionChart
+                data={targets?.score_distribution ?? []}
+              />
+            )}
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Two-column row: Target Comparison + Skill Frequency */}
+      <div className='grid gap-6 grid-cols-1 lg:grid-cols-2'>
+        <Card>
+          <CardHeader>
+            <CardTitle>Target Comparison</CardTitle>
+          </CardHeader>
+          <CardContent>
+            {loading && !targets ? (
+              <ChartSkeleton />
+            ) : (
+              <TargetComparisonChart data={targets?.targets ?? []} />
+            )}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Skill Frequency</CardTitle>
+          </CardHeader>
+          <CardContent>
+            {loading && !skillsCost ? (
+              <ChartSkeleton />
+            ) : (
+              <SkillFrequencyChart data={skillsCost?.top_skills ?? []} />
+            )}
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* LLM Cost — full width */}
+      <Card>
+        <CardHeader>
+          <div className='flex items-baseline gap-4'>
+            <CardTitle>LLM Cost</CardTitle>
+            {skillsCost && (
+              <Text variant='meta'>
+                Total: ${skillsCost.total_cost.toFixed(2)}
+                {skillsCost.avg_cost_per_resume !== null &&
+                  ` | Avg/resume: $${skillsCost.avg_cost_per_resume.toFixed(3)}`}
+              </Text>
+            )}
+          </div>
+        </CardHeader>
+        <CardContent>
+          {loading && !skillsCost ? (
+            <ChartSkeleton />
+          ) : (
+            <CostChart data={skillsCost?.cost_over_time ?? []} />
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/root/src/app/fitted/(app)/insights/charts/CostChart.tsx
+++ b/apps/root/src/app/fitted/(app)/insights/charts/CostChart.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import {
+  Area,
+  AreaChart,
+  CartesianGrid,
+  Legend,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+import type { CostBucket } from '../types';
+import { CHART_COLORS } from './colors';
+
+interface CostChartProps {
+  data: CostBucket[];
+}
+
+function formatWeek(value: string) {
+  const d = new Date(value);
+  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+}
+
+function formatCost(value: number) {
+  return `$${value.toFixed(2)}`;
+}
+
+export default function CostChart({ data }: CostChartProps) {
+  if (data.length === 0) {
+    return (
+      <p className='text-sm text-text-secondary py-8 text-center'>
+        No cost data yet
+      </p>
+    );
+  }
+
+  return (
+    <ResponsiveContainer width='100%' height={250}>
+      <AreaChart data={data}>
+        <CartesianGrid strokeDasharray='3 3' stroke={CHART_COLORS.grid} />
+        <XAxis
+          dataKey='week_start'
+          tickFormatter={formatWeek}
+          tick={{ fontSize: 12 }}
+        />
+        <YAxis
+          yAxisId='cost'
+          tickFormatter={formatCost}
+          tick={{ fontSize: 12 }}
+        />
+        <YAxis
+          yAxisId='count'
+          orientation='right'
+          allowDecimals={false}
+          tick={{ fontSize: 12 }}
+        />
+        <Tooltip
+          labelFormatter={formatWeek}
+          formatter={(value: number, name: string) =>
+            name === 'Cost' ? formatCost(value) : value
+          }
+          contentStyle={{ fontSize: 12 }}
+        />
+        <Legend wrapperStyle={{ fontSize: 12 }} />
+        <Area
+          yAxisId='cost'
+          type='monotone'
+          dataKey='total_cost'
+          name='Cost'
+          stroke={CHART_COLORS.warning}
+          fill={CHART_COLORS.warning}
+          fillOpacity={0.2}
+        />
+        <Area
+          yAxisId='count'
+          type='monotone'
+          dataKey='resume_count'
+          name='Resumes'
+          stroke={CHART_COLORS.brand}
+          fill={CHART_COLORS.brand}
+          fillOpacity={0.15}
+        />
+      </AreaChart>
+    </ResponsiveContainer>
+  );
+}

--- a/apps/root/src/app/fitted/(app)/insights/charts/FunnelChart.tsx
+++ b/apps/root/src/app/fitted/(app)/insights/charts/FunnelChart.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Cell,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+import type { FunnelStage } from '../types';
+import { CHART_COLORS } from './colors';
+
+interface FunnelChartProps {
+  data: FunnelStage[];
+}
+
+const STAGE_LABELS: Record<string, string> = {
+  new: 'New',
+  saved: 'Saved',
+  resume_draft: 'Draft',
+  resume_ready: 'Ready',
+  applied: 'Applied',
+  interviewing: 'Interview',
+  offer: 'Offer',
+};
+
+/** Gradient from brand → success across the funnel. */
+const STAGE_COLORS = [
+  CHART_COLORS.brand,
+  CHART_COLORS.brand,
+  CHART_COLORS.info,
+  CHART_COLORS.info,
+  CHART_COLORS.warning,
+  CHART_COLORS.success,
+  CHART_COLORS.success,
+];
+
+export default function FunnelChart({ data }: FunnelChartProps) {
+  if (data.length === 0 || data.every(d => d.count === 0)) {
+    return (
+      <p className='text-sm text-text-secondary py-8 text-center'>
+        No pipeline data yet
+      </p>
+    );
+  }
+
+  const formatted = data.map(d => ({
+    ...d,
+    label: STAGE_LABELS[d.stage] ?? d.stage,
+  }));
+
+  return (
+    <ResponsiveContainer width='100%' height={250}>
+      <BarChart data={formatted} layout='vertical'>
+        <CartesianGrid
+          strokeDasharray='3 3'
+          stroke={CHART_COLORS.grid}
+          horizontal={false}
+        />
+        <XAxis type='number' allowDecimals={false} tick={{ fontSize: 12 }} />
+        <YAxis
+          type='category'
+          dataKey='label'
+          width={70}
+          tick={{ fontSize: 12 }}
+        />
+        <Tooltip contentStyle={{ fontSize: 12 }} />
+        <Bar dataKey='count' name='Jobs' radius={[0, 4, 4, 0]}>
+          {formatted.map((_, i) => (
+            <Cell
+              key={i}
+              fill={STAGE_COLORS[i % STAGE_COLORS.length]}
+              fillOpacity={0.85}
+            />
+          ))}
+        </Bar>
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}

--- a/apps/root/src/app/fitted/(app)/insights/charts/ScoreDistributionChart.tsx
+++ b/apps/root/src/app/fitted/(app)/insights/charts/ScoreDistributionChart.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Cell,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+import type { ScoreBucket } from '../types';
+import { CHART_COLORS } from './colors';
+
+interface ScoreDistributionChartProps {
+  data: ScoreBucket[];
+}
+
+function bucketColor(bucket: string): string {
+  const lo = parseInt(bucket.split('-')[0] ?? '0', 10);
+  if (lo >= 70) return CHART_COLORS.success;
+  if (lo >= 40) return CHART_COLORS.warning;
+  return CHART_COLORS.error;
+}
+
+export default function ScoreDistributionChart({
+  data,
+}: ScoreDistributionChartProps) {
+  if (data.length === 0 || data.every(d => d.count === 0)) {
+    return (
+      <p className='text-sm text-text-secondary py-8 text-center'>
+        No score data yet
+      </p>
+    );
+  }
+
+  return (
+    <ResponsiveContainer width='100%' height={250}>
+      <BarChart data={data}>
+        <CartesianGrid strokeDasharray='3 3' stroke={CHART_COLORS.grid} />
+        <XAxis dataKey='bucket' tick={{ fontSize: 11 }} />
+        <YAxis allowDecimals={false} tick={{ fontSize: 12 }} />
+        <Tooltip contentStyle={{ fontSize: 12 }} />
+        <Bar dataKey='count' name='Jobs' radius={[4, 4, 0, 0]}>
+          {data.map((entry, i) => (
+            <Cell key={i} fill={bucketColor(entry.bucket)} fillOpacity={0.8} />
+          ))}
+        </Bar>
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}

--- a/apps/root/src/app/fitted/(app)/insights/charts/SkillFrequencyChart.tsx
+++ b/apps/root/src/app/fitted/(app)/insights/charts/SkillFrequencyChart.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Legend,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+import type { SkillFrequency } from '../types';
+import { CHART_COLORS } from './colors';
+
+interface SkillFrequencyChartProps {
+  data: SkillFrequency[];
+}
+
+export default function SkillFrequencyChart({
+  data,
+}: SkillFrequencyChartProps) {
+  if (data.length === 0) {
+    return (
+      <p className='text-sm text-text-secondary py-8 text-center'>
+        No skill data yet
+      </p>
+    );
+  }
+
+  return (
+    <ResponsiveContainer width='100%' height={Math.max(250, data.length * 30)}>
+      <BarChart data={data} layout='vertical'>
+        <CartesianGrid
+          strokeDasharray='3 3'
+          stroke={CHART_COLORS.grid}
+          horizontal={false}
+        />
+        <XAxis type='number' allowDecimals={false} tick={{ fontSize: 12 }} />
+        <YAxis
+          type='category'
+          dataKey='skill'
+          width={120}
+          tick={{ fontSize: 11 }}
+        />
+        <Tooltip contentStyle={{ fontSize: 12 }} />
+        <Legend wrapperStyle={{ fontSize: 12 }} />
+        <Bar
+          dataKey='matched_count'
+          name='Matched'
+          stackId='a'
+          fill={CHART_COLORS.success}
+          radius={[0, 0, 0, 0]}
+        />
+        <Bar
+          dataKey='missing_count'
+          name='Missing'
+          stackId='a'
+          fill={CHART_COLORS.error}
+          fillOpacity={0.7}
+          radius={[0, 4, 4, 0]}
+        />
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}

--- a/apps/root/src/app/fitted/(app)/insights/charts/TargetComparisonChart.tsx
+++ b/apps/root/src/app/fitted/(app)/insights/charts/TargetComparisonChart.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Legend,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+import type { TargetComparison } from '../types';
+import { CHART_COLORS } from './colors';
+
+interface TargetComparisonChartProps {
+  data: TargetComparison[];
+}
+
+export default function TargetComparisonChart({
+  data,
+}: TargetComparisonChartProps) {
+  if (data.length === 0) {
+    return (
+      <p className='text-sm text-text-secondary py-8 text-center'>
+        No target data yet
+      </p>
+    );
+  }
+
+  const formatted = data.map(t => ({
+    ...t,
+    conversion_pct:
+      t.conversion_rate !== null ? Math.round(t.conversion_rate * 100) : 0,
+  }));
+
+  return (
+    <ResponsiveContainer width='100%' height={250}>
+      <BarChart data={formatted}>
+        <CartesianGrid strokeDasharray='3 3' stroke={CHART_COLORS.grid} />
+        <XAxis dataKey='target_label' tick={{ fontSize: 12 }} />
+        <YAxis yAxisId='score' tick={{ fontSize: 12 }} />
+        <YAxis
+          yAxisId='pct'
+          orientation='right'
+          tick={{ fontSize: 12 }}
+          unit='%'
+        />
+        <Tooltip contentStyle={{ fontSize: 12 }} />
+        <Legend wrapperStyle={{ fontSize: 12 }} />
+        <Bar
+          yAxisId='score'
+          dataKey='avg_score'
+          name='Avg Score'
+          fill={CHART_COLORS.brand}
+          radius={[4, 4, 0, 0]}
+        />
+        <Bar
+          yAxisId='pct'
+          dataKey='conversion_pct'
+          name='Conversion %'
+          fill={CHART_COLORS.success}
+          radius={[4, 4, 0, 0]}
+        />
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}

--- a/apps/root/src/app/fitted/(app)/insights/charts/VelocityChart.tsx
+++ b/apps/root/src/app/fitted/(app)/insights/charts/VelocityChart.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import {
+  Area,
+  AreaChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+import type { WeeklyCount } from '../types';
+import { CHART_COLORS } from './colors';
+
+interface VelocityChartProps {
+  data: WeeklyCount[];
+}
+
+function formatWeek(value: string) {
+  const d = new Date(value);
+  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+}
+
+export default function VelocityChart({ data }: VelocityChartProps) {
+  if (data.length === 0) {
+    return (
+      <p className='text-sm text-text-secondary py-8 text-center'>
+        No velocity data yet
+      </p>
+    );
+  }
+
+  return (
+    <ResponsiveContainer width='100%' height={250}>
+      <AreaChart data={data}>
+        <CartesianGrid strokeDasharray='3 3' stroke={CHART_COLORS.grid} />
+        <XAxis
+          dataKey='week_start'
+          tickFormatter={formatWeek}
+          tick={{ fontSize: 12 }}
+        />
+        <YAxis allowDecimals={false} tick={{ fontSize: 12 }} />
+        <Tooltip labelFormatter={formatWeek} contentStyle={{ fontSize: 12 }} />
+        <Area
+          type='monotone'
+          dataKey='resumes_generated'
+          name='Resumes'
+          stackId='1'
+          stroke={CHART_COLORS.brand}
+          fill={CHART_COLORS.brand}
+          fillOpacity={0.3}
+        />
+        <Area
+          type='monotone'
+          dataKey='applications_submitted'
+          name='Applications'
+          stackId='1'
+          stroke={CHART_COLORS.success}
+          fill={CHART_COLORS.success}
+          fillOpacity={0.3}
+        />
+      </AreaChart>
+    </ResponsiveContainer>
+  );
+}

--- a/apps/root/src/app/fitted/(app)/insights/charts/colors.ts
+++ b/apps/root/src/app/fitted/(app)/insights/charts/colors.ts
@@ -1,0 +1,28 @@
+/**
+ * Chart color tokens.
+ *
+ * recharts needs explicit color values (not CSS variables), so we duplicate
+ * the brand palette here.  Values sourced from theme.css @theme block.
+ */
+export const CHART_COLORS = {
+  brand: 'oklch(0.54 0.19 250)', // brand-500
+  brandLight: 'oklch(0.68 0.15 250)', // brand-400
+  success: '#10b981',
+  warning: '#f59e0b',
+  error: '#ef4444',
+  info: '#2563eb',
+  muted: '#6b7280', // text-secondary
+  grid: '#e5e7eb', // border
+} as const;
+
+/**
+ * Ordered palette for multi-series charts. Add more as needed.
+ */
+export const SERIES_PALETTE = [
+  CHART_COLORS.brand,
+  CHART_COLORS.success,
+  CHART_COLORS.warning,
+  CHART_COLORS.info,
+  CHART_COLORS.error,
+  CHART_COLORS.brandLight,
+] as const;

--- a/apps/root/src/app/fitted/(app)/insights/loading.tsx
+++ b/apps/root/src/app/fitted/(app)/insights/loading.tsx
@@ -3,16 +3,37 @@ import { Skeleton } from '@danieljoffe.com/shared-ui/Skeleton';
 export default function InsightsLoading() {
   return (
     <div className='flex flex-col gap-6'>
+      {/* Header */}
       <div>
         <Skeleton variant='text' size='lg' className='w-32' />
         <Skeleton variant='text' className='mt-2 w-56' />
       </div>
+
+      {/* Period filter */}
+      <Skeleton variant='rectangular' height={44} className='w-56' />
+
+      {/* KPI cards */}
       <div className='grid gap-4 grid-cols-2 lg:grid-cols-4'>
         {Array.from({ length: 4 }).map((_, i) => (
           <Skeleton key={i} variant='rectangular' height={100} />
         ))}
       </div>
-      <Skeleton variant='rectangular' height={200} />
+
+      {/* Velocity chart */}
+      <Skeleton variant='rectangular' height={300} />
+
+      {/* Two-column charts */}
+      <div className='grid gap-6 grid-cols-1 lg:grid-cols-2'>
+        <Skeleton variant='rectangular' height={300} />
+        <Skeleton variant='rectangular' height={300} />
+      </div>
+      <div className='grid gap-6 grid-cols-1 lg:grid-cols-2'>
+        <Skeleton variant='rectangular' height={300} />
+        <Skeleton variant='rectangular' height={300} />
+      </div>
+
+      {/* Cost chart */}
+      <Skeleton variant='rectangular' height={300} />
     </div>
   );
 }

--- a/apps/root/src/app/fitted/(app)/insights/page.tsx
+++ b/apps/root/src/app/fitted/(app)/insights/page.tsx
@@ -1,24 +1,11 @@
 import type { Metadata } from 'next';
 import { Heading } from '@danieljoffe.com/shared-ui/Heading';
 import { Text } from '@danieljoffe.com/shared-ui/Text';
-import {
-  Card,
-  CardHeader,
-  CardTitle,
-  CardContent,
-} from '@danieljoffe.com/shared-ui/Card';
-import { Skeleton } from '@danieljoffe.com/shared-ui/Skeleton';
+import InsightsDashboard from './InsightsDashboard';
 
 export const metadata: Metadata = {
   title: 'Insights',
 };
-
-const metrics = [
-  'Applications',
-  'Interviews',
-  'Response Rate',
-  'Avg. Time to Hear Back',
-];
 
 export default function FittedInsights() {
   return (
@@ -31,28 +18,7 @@ export default function FittedInsights() {
           Track your job search progress
         </Text>
       </div>
-
-      <div className='grid gap-4 grid-cols-2 lg:grid-cols-4'>
-        {metrics.map(metric => (
-          <Card key={metric}>
-            <CardHeader>
-              <CardTitle className='text-sm'>{metric}</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <Skeleton variant='text' lines={1} size='lg' />
-            </CardContent>
-          </Card>
-        ))}
-      </div>
-
-      <Card>
-        <CardHeader>
-          <CardTitle>Activity Over Time</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <Skeleton variant='rectangular' height={200} />
-        </CardContent>
-      </Card>
+      <InsightsDashboard />
     </div>
   );
 }

--- a/apps/root/src/app/fitted/(app)/insights/types.ts
+++ b/apps/root/src/app/fitted/(app)/insights/types.ts
@@ -1,0 +1,81 @@
+export type Period = '7d' | '30d' | '90d' | 'all';
+
+// ── Pipeline ────────────────────────────────────────────────────────────────
+
+export interface WeeklyCount {
+  week_start: string;
+  resumes_generated: number;
+  applications_submitted: number;
+}
+
+export interface FunnelStage {
+  stage: string;
+  count: number;
+}
+
+export interface PipelineInsights {
+  total_applications: number;
+  total_interviews: number;
+  total_offers: number;
+  response_rate: number | null;
+  avg_days_to_response: number | null;
+  velocity: WeeklyCount[];
+  funnel: FunnelStage[];
+}
+
+// ── Targets ────��──────────────────────────────────���─────────────────────────
+
+export interface TargetComparison {
+  target_id: string;
+  target_label: string;
+  job_count: number;
+  avg_score: number;
+  applied_count: number;
+  interview_count: number;
+  conversion_rate: number | null;
+}
+
+export interface ScoreBucket {
+  bucket: string;
+  count: number;
+}
+
+export interface ScoreTrendPoint {
+  week_start: string;
+  avg_score: number;
+}
+
+export interface TargetInsights {
+  targets: TargetComparison[];
+  score_distribution: ScoreBucket[];
+  score_trend: ScoreTrendPoint[];
+}
+
+// ── Skills + Cost ─────��─────────────────────────────────────────────────────
+
+export interface SkillFrequency {
+  skill: string;
+  matched_count: number;
+  missing_count: number;
+}
+
+export interface CostBucket {
+  week_start: string;
+  total_cost: number;
+  resume_count: number;
+}
+
+export interface PurposeCost {
+  purpose: string;
+  total_cost: number;
+  call_count: number;
+}
+
+export interface SkillsCostInsights {
+  top_skills: SkillFrequency[];
+  top_missing: string[];
+  cost_over_time: CostBucket[];
+  cost_by_purpose: PurposeCost[];
+  total_cost: number;
+  avg_cost_per_resume: number | null;
+}

--- a/apps/root/src/hooks/useInsights.ts
+++ b/apps/root/src/hooks/useInsights.ts
@@ -1,0 +1,116 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import type {
+  Period,
+  PipelineInsights,
+  SkillsCostInsights,
+  TargetInsights,
+} from '@/app/fitted/(app)/insights/types';
+
+interface InsightsState {
+  period: Period;
+  pipeline: PipelineInsights | undefined;
+  targets: TargetInsights | undefined;
+  skillsCost: SkillsCostInsights | undefined;
+  error: string | undefined;
+}
+
+interface InsightsData {
+  pipeline: PipelineInsights | undefined;
+  targets: TargetInsights | undefined;
+  skillsCost: SkillsCostInsights | undefined;
+  loading: boolean;
+  error: string | undefined;
+}
+
+async function fetchJSON<T>(url: string, signal: AbortSignal): Promise<T> {
+  const res = await fetch(url, { signal });
+  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+  return res.json() as Promise<T>;
+}
+
+/**
+ * Fetches all 3 insights endpoints in parallel when the period changes.
+ *
+ * Loading state is derived (not set synchronously inside the effect) to
+ * satisfy the react-hooks/set-state-in-effect lint rule.
+ */
+export function useInsights(period: Period): InsightsData {
+  const [state, setState] = useState<InsightsState>({
+    period,
+    pipeline: undefined,
+    targets: undefined,
+    skillsCost: undefined,
+    error: undefined,
+  });
+  const requestRef = useRef(0);
+
+  // Loading is true when the requested period doesn't match the last fetched one
+  const loading = state.period !== period || state.pipeline === undefined;
+
+  useEffect(() => {
+    const controller = new AbortController();
+    const requestId = ++requestRef.current;
+
+    async function doFetch() {
+      const qs = `?period=${period}`;
+      const results = await Promise.allSettled([
+        fetchJSON<PipelineInsights>(
+          `/api/jobs/insights/pipeline${qs}`,
+          controller.signal
+        ),
+        fetchJSON<TargetInsights>(
+          `/api/jobs/insights/targets${qs}`,
+          controller.signal
+        ),
+        fetchJSON<SkillsCostInsights>(
+          `/api/jobs/insights/skills-cost${qs}`,
+          controller.signal
+        ),
+      ]);
+
+      // Bail if a newer request superseded this one
+      if (requestRef.current !== requestId) return;
+
+      const [pipelineResult, targetsResult, skillsCostResult] = results;
+      const failures = results.filter(r => r.status === 'rejected');
+
+      let error: string | undefined;
+      if (failures.length === results.length) {
+        error = 'Failed to load insights data';
+      } else if (failures.length > 0) {
+        error = 'Some insights data failed to load';
+      }
+
+      setState({
+        period,
+        pipeline:
+          pipelineResult.status === 'fulfilled'
+            ? pipelineResult.value
+            : undefined,
+        targets:
+          targetsResult.status === 'fulfilled'
+            ? targetsResult.value
+            : undefined,
+        skillsCost:
+          skillsCostResult.status === 'fulfilled'
+            ? skillsCostResult.value
+            : undefined,
+        error,
+      });
+    }
+
+    doFetch();
+
+    return () => controller.abort();
+  }, [period]);
+
+  return {
+    pipeline: state.pipeline,
+    targets: state.targets,
+    skillsCost: state.skillsCost,
+    loading,
+    error: state.error,
+  };
+}


### PR DESCRIPTION
## Summary

- **3 new FastAPI endpoints** (`/insights/pipeline`, `/insights/targets`, `/insights/skills-cost`) with `?period=7d|30d|90d|all` filter — aggregates from 6 tables (job_postings, job_status_log, job_analyses, tailored_resumes, job_targets, llm_cost_log) in Python
- **6 recharts v3 chart components** — VelocityChart (stacked area), FunnelChart (horizontal bar), TargetComparisonChart (grouped bar), ScoreDistributionChart (histogram), SkillFrequencyChart (horizontal stacked bar), CostChart (dual-axis area)
- **InsightsDashboard** client component with period pill filter, StatsCards for KPIs (applications, interviews, response rate, avg days to response), and responsive chart grid layout

## Test plan

- [x] `uv run pytest tests/test_insights.py` — 13 tests pass (all 3 compute functions + edge cases)
- [x] `pnpm tsc --noEmit` — zero type errors
- [ ] Manual: dev server renders insights page at `/fitted/insights` with period filter and charts
- [ ] Manual: period toggle re-fetches data and updates all charts
- [ ] Manual: empty state shows placeholder text per chart when no data exists

Closes #512

🤖 Generated with [Claude Code](https://claude.com/claude-code)