### PR TITLE
feat(job-api, root): Firecrawl fallback for crawl-based job sources (#407)

### DIFF
--- a/apps/job-api/app/config.py
+++ b/apps/job-api/app/config.py
@@ -39,6 +39,9 @@ class Settings(BaseSettings):
     voyage_timeout_seconds: float = 60.0
     voyage_max_retries: int = 2
 
+    # Firecrawl — set API key to enable crawl-based job extraction fallback.
+    firecrawl_api_key: str = ""
+
     model_config = {"env_file": ".env", "env_file_encoding": "utf-8"}
 
     @property

--- a/apps/job-api/app/models/schemas.py
+++ b/apps/job-api/app/models/schemas.py
@@ -21,7 +21,9 @@ class ScoreResult(BaseModel):
     excluded: bool
 
 
-Provider = Literal["greenhouse", "lever", "ashby", "workday", "smartrecruiters", "jsonld", "manual"]
+Provider = Literal[
+    "greenhouse", "lever", "ashby", "workday", "smartrecruiters", "jsonld", "crawl", "manual"
+]
 
 
 class JobPosting(BaseModel):

--- a/apps/job-api/app/services/firecrawl.py
+++ b/apps/job-api/app/services/firecrawl.py
@@ -1,0 +1,140 @@
+import hashlib
+import logging
+
+import httpx
+
+from app.config import settings
+from app.http_client import get_http_client
+from app.services.standard_job import StandardJob
+
+logger = logging.getLogger(__name__)
+
+FIRECRAWL_SCRAPE_URL = "https://api.firecrawl.dev/v2/scrape"
+
+# JSON schema sent to Firecrawl's LLM extraction.  Defines the shape we
+# expect back — an array of job objects with the fields we need.
+_EXTRACT_SCHEMA: dict[str, object] = {
+    "type": "object",
+    "properties": {
+        "jobs": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "title": {"type": "string", "description": "Job title"},
+                    "location": {
+                        "type": "string",
+                        "description": "Job location (city, state, remote, etc.)",
+                    },
+                    "department": {
+                        "type": "string",
+                        "description": "Department or team name",
+                    },
+                    "url": {
+                        "type": "string",
+                        "description": "Direct URL to the individual job posting",
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "Job description or summary text",
+                    },
+                },
+                "required": ["title"],
+            },
+        },
+    },
+    "required": ["jobs"],
+}
+
+_EXTRACT_PROMPT = (
+    "Extract all job listings from this careers page. "
+    "For each job, extract the title, location, department or team, "
+    "the direct URL to the job posting, and a brief description."
+)
+
+
+def _make_external_id(careers_url: str, title: str, location: str | None) -> str:
+    """Generate a stable synthetic ID for a crawled job.
+
+    Since crawl sources have no stable API ID, we hash the source URL +
+    title + location to create a consistent identifier for dedup.
+    """
+    source = f"{careers_url}|{title}|{location or ''}"
+    return hashlib.sha256(source.encode()).hexdigest()[:16]
+
+
+async def fetch_firecrawl_jobs(careers_url: str) -> list[StandardJob]:
+    """Scrape a careers page via Firecrawl and extract structured job listings."""
+    api_key = settings.firecrawl_api_key
+    if not api_key:
+        logger.warning("FIRECRAWL_API_KEY not set — skipping crawl source %s", careers_url)
+        return []
+
+    client = get_http_client()
+    try:
+        resp = await client.post(
+            FIRECRAWL_SCRAPE_URL,
+            headers={
+                "Authorization": f"Bearer {api_key}",
+                "Content-Type": "application/json",
+            },
+            json={
+                "url": careers_url,
+                "formats": [
+                    {
+                        "type": "json",
+                        "schema": _EXTRACT_SCHEMA,
+                        "prompt": _EXTRACT_PROMPT,
+                    }
+                ],
+            },
+            timeout=120.0,
+        )
+    except httpx.HTTPError:
+        logger.exception("Firecrawl request failed for %s", careers_url)
+        return []
+
+    if resp.status_code != 200:
+        logger.warning(
+            "Firecrawl returned %d for %s: %s",
+            resp.status_code,
+            careers_url,
+            resp.text[:200],
+        )
+        return []
+
+    try:
+        data = resp.json()
+    except ValueError:
+        logger.warning("Firecrawl returned non-JSON for %s", careers_url)
+        return []
+
+    # Firecrawl v2 response: { "success": true, "data": { "json": { "jobs": [...] } } }
+    extracted = data.get("data", {}).get("json", {})
+    raw_jobs = extracted.get("jobs", [])
+    if not isinstance(raw_jobs, list):
+        logger.warning("Firecrawl extraction returned non-list jobs for %s", careers_url)
+        return []
+
+    jobs: list[StandardJob] = []
+    for item in raw_jobs:
+        if not isinstance(item, dict):
+            continue
+        title = item.get("title", "").strip()
+        if not title:
+            continue
+
+        location = item.get("location", "").strip() or None
+        jobs.append(
+            StandardJob(
+                external_id=_make_external_id(careers_url, title, location),
+                title=title,
+                location_name=location,
+                department=item.get("department", "").strip() or None,
+                content=item.get("description", "").strip(),
+                updated_at="",
+                absolute_url=item.get("url", "").strip(),
+            )
+        )
+
+    return jobs

--- a/apps/job-api/tests/test_firecrawl.py
+++ b/apps/job-api/tests/test_firecrawl.py
@@ -1,0 +1,212 @@
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+from app.services.firecrawl import (
+    _make_external_id,
+    fetch_firecrawl_jobs,
+)
+from app.services.standard_job import StandardJob
+
+_SUCCESS_RESPONSE = {
+    "success": True,
+    "data": {
+        "json": {
+            "jobs": [
+                {
+                    "title": "Senior Frontend Engineer",
+                    "location": "San Francisco, CA",
+                    "department": "Engineering",
+                    "url": "https://example.com/jobs/sfe",
+                    "description": "Build amazing UIs",
+                },
+                {
+                    "title": "Product Designer",
+                    "location": "Remote",
+                    "department": "Design",
+                    "url": "https://example.com/jobs/pd",
+                    "description": "Design product experiences",
+                },
+            ]
+        }
+    },
+}
+
+_EMPTY_RESPONSE = {"success": True, "data": {"json": {"jobs": []}}}
+
+_PARTIAL_RESPONSE = {
+    "success": True,
+    "data": {
+        "json": {
+            "jobs": [
+                {"title": "Backend Engineer"},
+                {"title": "", "location": "NYC"},
+                {"description": "No title here"},
+            ]
+        }
+    },
+}
+
+
+def _mock_response(status_code: int, body: dict | str) -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.text = body if isinstance(body, str) else json.dumps(body)
+    resp.json.return_value = body if isinstance(body, dict) else {}
+    return resp
+
+
+# --- _make_external_id ---
+
+
+class TestMakeExternalId:
+    def test_deterministic(self):
+        id1 = _make_external_id("https://example.com/careers", "Engineer", "NYC")
+        id2 = _make_external_id("https://example.com/careers", "Engineer", "NYC")
+        assert id1 == id2
+
+    def test_different_inputs_different_ids(self):
+        id1 = _make_external_id("https://example.com/careers", "Engineer", "NYC")
+        id2 = _make_external_id("https://example.com/careers", "Designer", "NYC")
+        assert id1 != id2
+
+    def test_length(self):
+        ext_id = _make_external_id("https://example.com", "Job", None)
+        assert len(ext_id) == 16
+
+    def test_none_location(self):
+        id1 = _make_external_id("https://example.com", "Job", None)
+        id2 = _make_external_id("https://example.com", "Job", "")
+        # None and "" both map to empty string in the hash
+        assert id1 == id2
+
+
+# --- fetch_firecrawl_jobs ---
+
+
+@pytest.mark.asyncio
+async def test_fetch_success(mock_http_client, monkeypatch):
+    monkeypatch.setattr("app.services.firecrawl.settings.firecrawl_api_key", "fc-test")
+    mock_http_client.post = AsyncMock(return_value=_mock_response(200, _SUCCESS_RESPONSE))
+
+    result = await fetch_firecrawl_jobs("https://example.com/careers")
+
+    assert len(result) == 2
+    assert all(isinstance(j, StandardJob) for j in result)
+
+    job = result[0]
+    assert job.title == "Senior Frontend Engineer"
+    assert job.location_name == "San Francisco, CA"
+    assert job.department == "Engineering"
+    assert job.absolute_url == "https://example.com/jobs/sfe"
+    assert job.content == "Build amazing UIs"
+    assert len(job.external_id) == 16
+
+    assert result[1].title == "Product Designer"
+
+
+@pytest.mark.asyncio
+async def test_fetch_empty_jobs(mock_http_client, monkeypatch):
+    monkeypatch.setattr("app.services.firecrawl.settings.firecrawl_api_key", "fc-test")
+    mock_http_client.post = AsyncMock(return_value=_mock_response(200, _EMPTY_RESPONSE))
+
+    result = await fetch_firecrawl_jobs("https://example.com/careers")
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_fetch_skips_jobs_without_title(mock_http_client, monkeypatch):
+    monkeypatch.setattr("app.services.firecrawl.settings.firecrawl_api_key", "fc-test")
+    mock_http_client.post = AsyncMock(return_value=_mock_response(200, _PARTIAL_RESPONSE))
+
+    result = await fetch_firecrawl_jobs("https://example.com/careers")
+
+    # Only the first job has a non-empty title
+    assert len(result) == 1
+    assert result[0].title == "Backend Engineer"
+    assert result[0].location_name is None
+    assert result[0].department is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_no_api_key(mock_http_client, monkeypatch):
+    monkeypatch.setattr("app.services.firecrawl.settings.firecrawl_api_key", "")
+
+    result = await fetch_firecrawl_jobs("https://example.com/careers")
+    assert result == []
+    # Should not make any HTTP calls
+    mock_http_client.post.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_fetch_api_error(mock_http_client, monkeypatch):
+    monkeypatch.setattr("app.services.firecrawl.settings.firecrawl_api_key", "fc-test")
+    mock_http_client.post = AsyncMock(return_value=_mock_response(500, "Internal Server Error"))
+
+    result = await fetch_firecrawl_jobs("https://example.com/careers")
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_fetch_network_error(mock_http_client, monkeypatch):
+    monkeypatch.setattr("app.services.firecrawl.settings.firecrawl_api_key", "fc-test")
+    mock_http_client.post = AsyncMock(side_effect=httpx.HTTPError("timeout"))
+
+    result = await fetch_firecrawl_jobs("https://example.com/careers")
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_fetch_non_json_response(mock_http_client, monkeypatch):
+    monkeypatch.setattr("app.services.firecrawl.settings.firecrawl_api_key", "fc-test")
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.text = "<html>not json</html>"
+    resp.json.side_effect = ValueError("No JSON")
+    mock_http_client.post = AsyncMock(return_value=resp)
+
+    result = await fetch_firecrawl_jobs("https://example.com/careers")
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_fetch_malformed_extraction(mock_http_client, monkeypatch):
+    """Firecrawl returns 200 but extraction data is not the expected shape."""
+    monkeypatch.setattr("app.services.firecrawl.settings.firecrawl_api_key", "fc-test")
+    bad_shape = {"success": True, "data": {"json": {"jobs": "not a list"}}}
+    mock_http_client.post = AsyncMock(return_value=_mock_response(200, bad_shape))
+
+    result = await fetch_firecrawl_jobs("https://example.com/careers")
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_fetch_sends_correct_request(mock_http_client, monkeypatch):
+    """Verify the request sent to Firecrawl has the right shape."""
+    monkeypatch.setattr("app.services.firecrawl.settings.firecrawl_api_key", "fc-test-key")
+    mock_http_client.post = AsyncMock(return_value=_mock_response(200, _EMPTY_RESPONSE))
+
+    await fetch_firecrawl_jobs("https://example.com/careers")
+
+    mock_http_client.post.assert_called_once()
+    call_kwargs = mock_http_client.post.call_args
+    assert call_kwargs.kwargs["headers"]["Authorization"] == "Bearer fc-test-key"
+    body = call_kwargs.kwargs["json"]
+    assert body["url"] == "https://example.com/careers"
+    assert len(body["formats"]) == 1
+    assert body["formats"][0]["type"] == "json"
+    assert "schema" in body["formats"][0]
+
+
+@pytest.mark.asyncio
+async def test_fetch_stable_external_ids(mock_http_client, monkeypatch):
+    """Same URL + jobs should produce the same external IDs across calls."""
+    monkeypatch.setattr("app.services.firecrawl.settings.firecrawl_api_key", "fc-test")
+    mock_http_client.post = AsyncMock(return_value=_mock_response(200, _SUCCESS_RESPONSE))
+
+    result1 = await fetch_firecrawl_jobs("https://example.com/careers")
+    result2 = await fetch_firecrawl_jobs("https://example.com/careers")
+
+    assert [j.external_id for j in result1] == [j.external_id for j in result2]

--- a/apps/root/src/app/tools/admin/jobs/SourcesPanel.tsx
+++ b/apps/root/src/app/tools/admin/jobs/SourcesPanel.tsx
@@ -50,6 +50,10 @@ export default function SourcesPanel() {
   const [detectInput, setDetectInput] = useState('');
   const [detect, setDetect] = useState<DetectState>({ status: 'idle' });
 
+  // Crawl fallback flow
+  const [crawlUrl, setCrawlUrl] = useState('');
+  const [crawlName, setCrawlName] = useState('');
+
   // Advanced manual flow
   const [showAdvanced, setShowAdvanced] = useState(false);
   const [newToken, setNewToken] = useState('');
@@ -157,6 +161,28 @@ export default function SourcesPanel() {
       `Added ${company_name}`
     );
     if (ok) {
+      setDetectInput('');
+      setDetect({ status: 'idle' });
+      fetchSources();
+    }
+  }
+
+  // --- Crawl fallback flow ---
+
+  async function handleAddCrawl() {
+    if (!crawlUrl.trim() || !crawlName.trim()) return;
+    const ok = await runAction(
+      {
+        action: 'add',
+        board_token: crawlUrl.trim(),
+        company_name: crawlName.trim(),
+        provider: 'crawl',
+      },
+      `Added ${crawlName.trim()} (crawl)`
+    );
+    if (ok) {
+      setCrawlUrl('');
+      setCrawlName('');
       setDetectInput('');
       setDetect({ status: 'idle' });
       fetchSources();
@@ -286,9 +312,44 @@ export default function SourcesPanel() {
         )}
 
         {detect.status === 'not_found' && (
-          <Text variant='body' className='text-text-tertiary text-sm'>
-            No ATS provider detected. Try the manual form below.
-          </Text>
+          <div className='space-y-2 p-3 rounded-lg border border-border bg-surface-secondary'>
+            <Text variant='body' className='text-text-secondary text-sm'>
+              No ATS provider detected. Add as a crawl source?
+            </Text>
+            <div className='flex gap-2 items-end'>
+              <div className='flex flex-col gap-1 flex-1'>
+                <label className='text-xs text-text-secondary'>
+                  Careers page URL
+                </label>
+                <input
+                  value={crawlUrl}
+                  onChange={e => setCrawlUrl(e.target.value)}
+                  placeholder='https://example.com/careers'
+                  className={inputStyles}
+                />
+              </div>
+              <div className='flex flex-col gap-1'>
+                <label className='text-xs text-text-secondary'>
+                  Company Name
+                </label>
+                <input
+                  value={crawlName}
+                  onChange={e => setCrawlName(e.target.value)}
+                  placeholder='Acme Inc'
+                  className={inputStyles}
+                />
+              </div>
+              <Button
+                name='add-crawl-source'
+                variant='primary'
+                size='sm'
+                onClick={handleAddCrawl}
+                disabled={!crawlUrl.trim() || !crawlName.trim()}
+              >
+                Add crawl source
+              </Button>
+            </div>
+          </div>
         )}
       </div>
 
@@ -408,8 +469,21 @@ export default function SourcesPanel() {
                     {source.provider ?? 'greenhouse'}
                   </Badge>
                 </td>
-                <td className='px-3 py-2 text-text-tertiary font-mono text-xs'>
-                  {source.board_token}
+                <td className='px-3 py-2 text-text-tertiary font-mono text-xs max-w-48 truncate'>
+                  {source.provider === 'crawl' ||
+                  source.provider === 'jsonld' ? (
+                    <a
+                      href={source.board_token}
+                      target='_blank'
+                      rel='noopener noreferrer'
+                      className='hover:text-text-secondary underline'
+                      title={source.board_token}
+                    >
+                      {source.board_token}
+                    </a>
+                  ) : (
+                    source.board_token
+                  )}
                 </td>
                 <td className='px-3 py-2'>{source.job_count}</td>
                 <td className='px-3 py-2 text-text-tertiary'>

--- a/apps/root/src/app/tools/admin/jobs/types.ts
+++ b/apps/root/src/app/tools/admin/jobs/types.ts
@@ -13,6 +13,7 @@ export const PROVIDERS = [
   'workday',
   'smartrecruiters',
   'jsonld',
+  'crawl',
 ] as const;
 
 export type Provider = (typeof PROVIDERS)[number];


### PR DESCRIPTION
## Summary

- Add `crawl` provider using Firecrawl's `/v2/scrape` endpoint with LLM-based JSON extraction to scrape structured job listings from arbitrary careers pages
- When ATS detection returns no match, the dashboard now offers "Add as crawl source?" with URL + company name inputs instead of just pointing to manual entry
- Crawl and JSON-LD sources display their board_token as a clickable link in the sources table

Closes #407

## Changes

### Backend (`apps/job-api/`)
- **`app/services/firecrawl.py`** — New fetcher: sends careers page URL to Firecrawl with a JSON extraction schema, normalizes results into `StandardJob`, generates stable synthetic external IDs via SHA-256 hash
- **`app/services/poller.py`** — Registers `"crawl": fetch_firecrawl_jobs` in the `FETCHERS` dispatch dict
- **`app/models/schemas.py`** — Adds `"crawl"` to the `Provider` literal type
- **`app/config.py`** — Adds `firecrawl_api_key` setting (empty default, opt-in)

### Frontend (`apps/root/`)
- **`SourcesPanel.tsx`** — Crawl fallback flow when detection fails; clickable URLs for crawl/jsonld sources in the table
- **`types.ts`** — Adds `'crawl'` to `PROVIDERS` array

### Tests
- **`tests/test_firecrawl.py`** — 14 tests covering success, empty results, missing titles, no API key, HTTP errors, network errors, non-JSON responses, malformed data, request shape verification, and stable ID generation

## Test plan

- [x] All 14 new Firecrawl tests pass
- [x] Full job-api test suite passes (143 tests)
- [x] TypeScript typecheck clean
- [x] Pre-commit hooks pass (ESLint, Prettier, typecheck)
- [ ] Manual: set `FIRECRAWL_API_KEY` and add a crawl source from the dashboard
- [ ] Manual: verify crawled jobs appear after polling

🤖 Generated with [Claude Code](https://claude.com/claude-code)