### PR TITLE
chore(nx): fix audit findings — caching, naming, config

### DIFF
--- a/apps/audit-api/project.json
+++ b/apps/audit-api/project.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "name": "audit-api",
   "sourceRoot": "apps/audit-api",
   "projectType": "application",
@@ -24,7 +25,7 @@
     "lint": {
       "executor": "nx:run-commands",
       "cache": true,
-      "inputs": ["default"],
+      "inputs": ["default", "{projectRoot}/pyproject.toml"],
       "options": {
         "command": "uv run --package audit-api ruff check .",
         "cwd": "apps/audit-api"

--- a/apps/job-api/project.json
+++ b/apps/job-api/project.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "name": "job-api",
   "sourceRoot": "apps/job-api",
   "projectType": "application",
@@ -24,13 +25,13 @@
     "lint": {
       "executor": "nx:run-commands",
       "cache": true,
-      "inputs": ["default"],
+      "inputs": ["default", "{projectRoot}/pyproject.toml"],
       "options": {
         "command": "uv run --package job-api ruff check .",
         "cwd": "apps/job-api"
       }
     },
-    "mypy": {
+    "typecheck": {
       "executor": "nx:run-commands",
       "cache": true,
       "inputs": ["default", "^production"],

--- a/apps/root/project.json
+++ b/apps/root/project.json
@@ -7,12 +7,23 @@
   "targets": {
     "generate-search-index": {
       "command": "tsx scripts/generate-search-index.ts",
+      "cache": true,
+      "inputs": [
+        "{projectRoot}/src/data/content/**/*.mdx",
+        "{workspaceRoot}/scripts/generate-search-index.ts"
+      ],
+      "outputs": ["{projectRoot}/src/data/generated/searchIndex.json"],
       "options": {
         "cwd": "{workspaceRoot}"
       }
     },
     "validate-content": {
       "command": "tsx scripts/validate-content.ts",
+      "cache": true,
+      "inputs": [
+        "{projectRoot}/src/data/content/**/*.mdx",
+        "{workspaceRoot}/scripts/validate-content.ts"
+      ],
       "options": {
         "cwd": "{workspaceRoot}"
       }

--- a/nx.json
+++ b/nx.json
@@ -10,6 +10,7 @@
       "!{projectRoot}/**/?(*.)+(spec|test).[jt]s?(x)?(.snap)",
       "!{projectRoot}/tsconfig.spec.json",
       "!{projectRoot}/jest.config.[jt]s",
+      "!{projectRoot}/vitest.config.[jt]s",
       "!{projectRoot}/src/test-setup.[jt]s",
       "!{projectRoot}/test-setup.[jt]s",
       "!{projectRoot}/**/*.md",


### PR DESCRIPTION
## Summary

Fixes all actionable findings from the Nx monorepo audit:

- **Cache `generate-search-index` and `validate-content`** (HIGH) — both are in the critical path of `build` and `test` but had no caching. Now cached with proper MDX content inputs and output paths, so they skip reruns when content hasn't changed.
- **Rename job-api `mypy` → `typecheck`** (MEDIUM) — audit-api already uses `typecheck`; now `nx affected -t typecheck` covers both Python projects uniformly.
- **Override Python lint inputs** (MEDIUM) — Python projects inherited the global ESLint config as a lint input despite using `ruff`. Now scoped to `pyproject.toml` only.
- **Exclude `vitest.config` from production namedInput** (LOW) — `jest.config` was excluded but `vitest.config` wasn't, causing unnecessary cache invalidation for shared-ui builds.
- **Add `$schema` to Python project.json files** (LOW) — IDE validation/autocompletion for Nx config.

Two findings are deferred:
- Nx Cloud re-enable — waiting for May 1 credit reset
- Python CI through Nx runner — blocked on Nx Cloud (no benefit without remote cache)

## Test plan

- [x] `pnpm tsc --noEmit` passes
- [x] `nx show project` confirms cached targets, renamed typecheck, and correct lint inputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)