### PR TITLE
feat: split /verify into scoped verify skills per app

### DIFF
--- a/.claude/skills/verify-auditapi/SKILL.md
+++ b/.claude/skills/verify-auditapi/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: verify-auditapi
+description: Verify the audit-api backend and its audit tool frontend workflows
+user-invocable: true
+---
+
+# Verify Audit API
+
+Run targeted verification for the audit-api backend and its audit tool frontend integration. Fix any issues at each step before proceeding.
+
+## Instructions
+
+### Phase 1: Backend Checks
+
+Run these sequentially, fixing failures before proceeding:
+
+1. `pnpm nx lint audit-api`
+2. `pnpm nx typecheck audit-api` (mypy)
+3. `pnpm nx test audit-api`
+
+### Phase 2: TypeScript Typecheck
+
+Run `pnpm tsc --noEmit`. This catches type errors in the Next.js API routes and frontend components that integrate with audit-api.
+
+### Phase 3: Frontend Unit Tests (API route + component subset)
+
+Run the subset of root app tests that cover the audit integration layer:
+
+```bash
+pnpm nx test root -- --testPathPatterns="(api/audit|audit)"
+```
+
+This runs tests matching:
+
+- `apps/root/src/app/api/audit/**`
+- `apps/root/src/app/(public)/audit/**`
+- `apps/root/src/app/tools/admin/audit/**`
+
+### Phase 4: Dev Server + Browser Check
+
+1. Read `TOOLS_ADMIN_PASSWORD` from `apps/root/.env.local` using Grep
+2. Start the dev server: `pnpm nx dev root` (background)
+3. Wait for it to be ready, then open a browser using Chrome DevTools MCP
+
+**Public pages (no auth needed):**
+
+4. Visit these pages and check console for errors/warnings:
+   - `/audit` (scan input form)
+   - `/audit/insights` (public insights dashboard)
+
+**Admin pages (auth needed):**
+
+5. Authenticate by running this in Chrome DevTools `evaluate_script`:
+   ```js
+   await fetch('/api/tools/login', {
+     method: 'POST',
+     headers: { 'Content-Type': 'application/json' },
+     body: JSON.stringify({ password: '<TOOLS_ADMIN_PASSWORD value>' }),
+   });
+   ```
+6. Verify the response status is 200 (the `admin_session` cookie is now set)
+7. Visit admin pages and check console for errors/warnings:
+   - `/tools/admin/audit` (admin dashboard — leads, scans, stats)
+
+**For all pages, verify:**
+
+- No unexpected console errors
+- Page renders without blank screens or loading spinners that never resolve
+- API calls return successfully (check Network tab if needed)
+
+8. Stop the dev server when done
+
+### Phase 5: Report
+
+After all steps pass, report a summary table:
+
+| Step                       | Result |
+| -------------------------- | ------ |
+| lint (audit-api)           | ...    |
+| typecheck (audit-api)      | ...    |
+| test (audit-api)           | ...    |
+| typecheck (tsc)            | ...    |
+| test (root — audit routes) | ...    |
+| console.logs (public)      | ...    |
+| console.logs (admin)       | ...    |
+
+Note any pre-existing warnings separately.
+
+If any fixes were made during verification, commit them before reporting.

--- a/.claude/skills/verify-jobapi/SKILL.md
+++ b/.claude/skills/verify-jobapi/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: verify-jobapi
+description: Verify the job-api backend and its Fitted frontend workflows
+user-invocable: true
+---
+
+# Verify Job API
+
+Run targeted verification for the job-api backend and its Fitted frontend integration. Fix any issues at each step before proceeding.
+
+## Instructions
+
+### Phase 1: Backend Checks
+
+Run these sequentially, fixing failures before proceeding:
+
+1. `pnpm nx lint job-api`
+2. `pnpm nx mypy job-api`
+3. `pnpm nx test job-api`
+
+### Phase 2: TypeScript Typecheck
+
+Run `pnpm tsc --noEmit`. This catches type errors in the Next.js API routes and frontend components that integrate with job-api.
+
+### Phase 3: Frontend Unit Tests (API route subset)
+
+Run the subset of root app tests that cover the job-api integration layer:
+
+```bash
+pnpm nx test root -- --testPathPatterns="(api/(jobs|career|targets)|fitted)"
+```
+
+This runs tests matching:
+
+- `apps/root/src/app/api/jobs/**`
+- `apps/root/src/app/api/career/**`
+- `apps/root/src/app/api/targets/**`
+- `apps/root/src/app/fitted/**`
+
+### Phase 4: Dev Server + Authenticated Browser Check
+
+1. Read `TOOLS_ADMIN_PASSWORD` from `apps/root/.env.local` using Grep
+2. Start the dev server: `pnpm nx dev root` (background)
+3. Wait for it to be ready, then open a browser using Chrome DevTools MCP
+4. Navigate to `http://localhost:3000`
+5. Authenticate by running this in Chrome DevTools `evaluate_script`:
+   ```js
+   await fetch('/api/tools/login', {
+     method: 'POST',
+     headers: { 'Content-Type': 'application/json' },
+     body: JSON.stringify({ password: '<TOOLS_ADMIN_PASSWORD value>' }),
+   });
+   ```
+6. Verify the response status is 200 (the `admin_session` cookie is now set)
+7. Visit these Fitted pages and check console for errors/warnings:
+   - `/fitted` (dashboard)
+   - `/fitted/jobs` (job listings)
+   - `/fitted/targets` (target roles)
+   - `/fitted/profile` (experience profile)
+   - `/fitted/insights` (analytics dashboard)
+8. For each page, verify:
+   - No unexpected console errors
+   - Page renders without blank screens or loading spinners that never resolve
+   - API calls return successfully (check Network tab if needed)
+9. Stop the dev server when done
+
+### Phase 5: Report
+
+After all steps pass, report a summary table:
+
+| Step                     | Result |
+| ------------------------ | ------ |
+| lint (job-api)           | ...    |
+| mypy (job-api)           | ...    |
+| test (job-api)           | ...    |
+| typecheck                | ...    |
+| test (root — job routes) | ...    |
+| console.logs (Fitted)    | ...    |
+
+Note any pre-existing warnings separately.
+
+If any fixes were made during verification, commit them before reporting.

--- a/.claude/skills/verify-root/SKILL.md
+++ b/.claude/skills/verify-root/SKILL.md
@@ -1,12 +1,12 @@
 ---
-name: verify
-description: Run full verification loop — build, dev server + browser console.log check, and pom scripts individually
+name: verify-root
+description: Verify the root Next.js app — build, dev server + browser console check, and POM scripts
 user-invocable: true
 ---
 
-# Verify
+# Verify Root
 
-Run the full verification loop after significant changes. Fix any issues that arise at each step before proceeding to the next.
+Run the full verification loop for the root Next.js application (portfolio/public site) after significant changes. Fix any issues that arise at each step before proceeding to the next.
 
 ## Instructions
 

--- a/.claude/skills/verify-sharedui/SKILL.md
+++ b/.claude/skills/verify-sharedui/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: verify-sharedui
+description: Verify the shared-ui library — build, unit tests, Storybook, and consumer smoke test
+user-invocable: true
+---
+
+# Verify Shared UI
+
+Run targeted verification for the shared-ui component library. Fix any issues at each step before proceeding.
+
+## Instructions
+
+### Phase 1: Lint + Typecheck
+
+Run these sequentially, fixing failures before proceeding:
+
+1. `pnpm nx lint @danieljoffe.com/shared-ui`
+2. `pnpm nx typecheck @danieljoffe.com/shared-ui`
+
+### Phase 2: Unit Tests (Jest)
+
+Run `pnpm nx test @danieljoffe.com/shared-ui`. These are the Jest-based spec files in `libs/shared/ui/src/`.
+
+### Phase 3: Storybook Build + Interaction Tests
+
+1. Build Storybook: `pnpm nx build-storybook @danieljoffe.com/shared-ui`
+   - Fix any build errors before continuing
+2. Run Storybook interaction tests (Vitest + Playwright): `pnpm nx test-storybook @danieljoffe.com/shared-ui`
+   - These run `play` functions from stories in a headless browser
+
+### Phase 4: Visual Storybook Check
+
+1. Start Storybook: `pnpm nx storybook @danieljoffe.com/shared-ui` (background)
+2. Wait for it to be ready, then open a browser using Chrome DevTools MCP
+3. Navigate to Storybook (typically `http://localhost:6006`)
+4. Spot-check a few component stories for rendering issues:
+   - A layout component (e.g., Grid, Stack, Container)
+   - A form component (e.g., Input, Select, Checkbox)
+   - A feedback component (e.g., Alert, Toast, Modal)
+5. Check console for errors/warnings
+6. Stop Storybook when done
+
+### Phase 5: Consumer Smoke Test
+
+Verify the root app (primary consumer) still builds with the shared-ui changes:
+
+```bash
+pnpm nx build root
+```
+
+This catches breaking export changes, missing components, or type mismatches at the integration boundary.
+
+### Phase 6: Report
+
+After all steps pass, report a summary table:
+
+| Step                  | Result |
+| --------------------- | ------ |
+| lint (shared-ui)      | ...    |
+| typecheck (shared-ui) | ...    |
+| test (shared-ui)      | ...    |
+| build-storybook       | ...    |
+| test-storybook        | ...    |
+| visual check          | ...    |
+| consumer build (root) | ...    |
+
+Note any pre-existing warnings separately.
+
+If any fixes were made during verification, commit them before reporting.

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ node_modules
 /.sass-cache
 /connect.lock
 coverage
+.coverage
 /libpeerconnection.log
 npm-debug.log
 yarn-error.log

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,10 @@ For in-depth reference, see these docs (loaded on demand):
 The workspace includes Claude Code skills and agents for common workflows:
 
 - **Skills** (`.claude/skills/`): Task-specific workflows invocable via `/skill-name`
-  - `/verify` — full verification loop (build, test, lint, e2e, Lighthouse)
+  - `/verify-root` — verify root Next.js app (build, browser console check, full POM suite)
+  - `/verify-jobapi` — verify job-api backend + Fitted frontend workflows
+  - `/verify-auditapi` — verify audit-api backend + audit tool frontend workflows
+  - `/verify-sharedui` — verify shared-ui library (build, tests, Storybook, consumer smoke test)
   - `/gen-test` — generate unit tests following project conventions
   - `/coverage-gaps` — scan for missing tests and stories
   - `/pr-review` — orchestrate all reviewers in parallel


### PR DESCRIPTION
## Summary

- Replaces the monolithic `/verify` skill with four targeted verification skills scoped to each app/library
- `/verify-root` — root Next.js app (build, browser console check, full POM suite)
- `/verify-jobapi` — job-api backend (lint, mypy, pytest) + Fitted frontend browser check with admin auth
- `/verify-auditapi` — audit-api backend (lint, mypy, pytest) + audit tool public + admin pages
- `/verify-sharedui` — shared-ui library (Jest, Storybook build + interaction tests, visual check, consumer build smoke test)
- Each API skill runs the relevant subset of root app unit tests (`--testPathPatterns`) for the integration seam
- Auth for protected pages uses the existing `POST /api/tools/login` admin endpoint to set a session cookie
- Also adds `.coverage` to `.gitignore` (pytest artifact from verify runs)

## Test plan

- [x] Ran `/verify-auditapi` — all phases pass, admin auth works via `apps/root/.env.local`
- [x] Ran `/verify-sharedui` — all phases pass (39 pre-existing Storybook interaction test failures noted)
- [x] Ran `/verify-jobapi` — backend + test phases pass, auth partially tested
- [x] Ran `/verify-root` — build + browser + POM phases pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)