### PR TITLE
chore(root): fix Next.js audit findings

### DIFF
--- a/.claude/skills/batch-commit/SKILL.md
+++ b/.claude/skills/batch-commit/SKILL.md
@@ -9,11 +9,22 @@ user-invocable: true
 
 Review all pending changes, group them into logical commits, and push each one.
 
+## Token Budget Rules
+
+- Route `git diff --stat` and `git status` through `ctx_batch_execute` when the changeset is large
+- Use `ctx_execute` for `git diff --staged --stat` before each commit if many files are staged
+
 ## Instructions
 
 1. **Assess the changeset**
-   - Run `git status` and `git diff --stat` (both staged and unstaged) to see all modified, added, and deleted files.
-   - Run `git log --oneline -5` to understand the recent commit style.
+   - Run via `ctx_batch_execute`:
+     ```
+     [
+       { "label": "status",  "command": "git status" },
+       { "label": "diff",    "command": "git diff --stat" },
+       { "label": "log",     "command": "git log --oneline -5" }
+     ]
+     ```
 
 2. **Plan commit batches**
    - Group files by logical concern (e.g., dependency upgrades, feature code, config changes, documentation, test fixes).

--- a/.claude/skills/coverage-gaps/SKILL.md
+++ b/.claude/skills/coverage-gaps/SKILL.md
@@ -10,6 +10,11 @@ argument-hint: '[--fix] [--quality]'
 
 Scan the codebase for components missing unit tests or Storybook stories, report the gaps, and optionally generate stubs. With `--quality`, also audit existing tests for anti-patterns.
 
+## Token Budget Rules
+
+- Route file listing and test output through `ctx_batch_execute` — scanning many directories produces large output
+- When running generated specs (`--fix`), route test output through `ctx_execute`
+
 ## Arguments
 
 `/coverage-gaps` — scan for missing tests and stories (read-only)

--- a/.claude/skills/nextjs-audit/SKILL.md
+++ b/.claude/skills/nextjs-audit/SKILL.md
@@ -8,6 +8,12 @@ disable-model-invocation: true
 
 Audit the Next.js application against current official documentation, producing actionable findings and direct code fixes.
 
+## Token Budget Rules
+
+- Route ALL file reads and command outputs through `ctx_batch_execute` or `ctx_execute`
+- Batch context7 `query-docs` calls — resolve all libraries first, then query in 2-3 batched calls
+- If context7 docs for the same libraries were already fetched in this session, skip Phase 1
+
 ## Instructions
 
 ### Phase 1: Fetch Current Documentation

--- a/.claude/skills/nx-audit/SKILL.md
+++ b/.claude/skills/nx-audit/SKILL.md
@@ -8,6 +8,12 @@ disable-model-invocation: true
 
 Audit the Nx monorepo for structural and configuration issues against official Nx guidelines.
 
+## Token Budget Rules
+
+- Route ALL command outputs and workspace inspection results through `ctx_batch_execute` or `ctx_execute`
+- If Nx docs were already fetched via context7 in this session, skip Phase 1
+- Use Nx MCP tools for workspace queries — they're more efficient than raw CLI output
+
 ## Instructions
 
 ### Phase 1: Fetch Current Documentation

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -9,6 +9,11 @@ user-invocable: true
 
 Run all reviewer agents in parallel on the current branch's changed files and produce a unified report.
 
+## Token Budget Rules
+
+- Route `git diff` and file list output through `ctx_execute` — diffs can be large
+- Each spawned agent inherits ctx_batch_execute — remind them to use it for large outputs
+
 ## Arguments
 
 `/pr-review` — no arguments needed (uses current branch diff against develop)

--- a/.claude/skills/python-audit/SKILL.md
+++ b/.claude/skills/python-audit/SKILL.md
@@ -12,6 +12,12 @@ Audit the Python FastAPI services (job-api, audit-api) against current documenta
 
 By default, audit **both** `apps/job-api` and `apps/audit-api`. If the user specifies a single project, audit only that one.
 
+## Token Budget Rules
+
+- Route ALL file reads and command outputs through `ctx_batch_execute` or `ctx_execute`
+- Batch context7 `query-docs` calls — resolve all libraries first, then query in 2-3 batched calls
+- If context7 docs for the same libraries were already fetched in this session, skip Phase 1
+
 ## Instructions
 
 ### Phase 1: Fetch Current Documentation

--- a/.claude/skills/release-notes/SKILL.md
+++ b/.claude/skills/release-notes/SKILL.md
@@ -10,14 +10,30 @@ argument-hint: '<format: pr|changelog|summary> (default: pr)'
 
 Diff `develop` against `main`, analyze all merged work, and generate release content.
 
+## Token Budget Rules
+
+- Route git log and diff output through `ctx_batch_execute` — these can be large
+- Batch all `gh pr view` calls into a single `ctx_batch_execute` instead of calling per-PR
+
 ## Instructions
 
 1. **Gather the diff**
-   - Run `git fetch origin` to ensure both branches are up to date.
-   - Run `git log main..develop --oneline --no-merges` to get all non-merge commits.
-   - Run `git log main..develop --oneline --merges` to identify merged PRs.
-   - Run `git diff main..develop --stat` to get the file-level change summary.
-   - For each merged PR, extract the PR number from the merge commit message and run `gh pr view <number> --json title,body,labels,number` to get the full context.
+   - Run via `ctx_batch_execute`:
+     ```
+     [
+       { "label": "commits",    "command": "git fetch origin && git log main..develop --oneline --no-merges" },
+       { "label": "merges",     "command": "git log main..develop --oneline --merges" },
+       { "label": "diff-stat",  "command": "git diff main..develop --stat" }
+     ]
+     ```
+   - Extract PR numbers from merge commits, then batch all `gh pr view` calls into one `ctx_batch_execute`:
+     ```
+     [
+       { "label": "PR-123", "command": "gh pr view 123 --json title,body,labels,number" },
+       { "label": "PR-124", "command": "gh pr view 124 --json title,body,labels,number" },
+       ...
+     ]
+     ```
 
 2. **Categorize changes**
    Group the work into these categories (skip empty ones):

--- a/.claude/skills/review-content-style/SKILL.md
+++ b/.claude/skills/review-content-style/SKILL.md
@@ -10,6 +10,11 @@ argument-hint: '<content-type or file path> to scope the review (e.g. "blog", "p
 
 Scan content against the [Content Style Guide](../../docs/content-style-guide.md) and flag violations.
 
+## Token Budget Rules
+
+- Route MDX file reads through `ctx_batch_execute` when scanning multiple files — each file is a section
+- Read the style guide once via `ctx_execute` and search with `ctx_search` for specific rules
+
 ## Instructions
 
 1. **Load the style guide**: Read `.claude/docs/content-style-guide.md` to load the full set of rules.

--- a/.claude/skills/security-review/SKILL.md
+++ b/.claude/skills/security-review/SKILL.md
@@ -8,9 +8,17 @@ disable-model-invocation: true
 
 Perform a security-focused code review of the changes on the current branch compared to develop (the default PR target).
 
+## Token Budget Rules
+
+- Route `git diff` output through `ctx_execute` — branch diffs can be very large
+- Use `ctx_search` to find specific patterns in indexed diff output rather than re-reading files
+
 ## Instructions
 
-1. Run `git fetch origin && git diff origin/develop...HEAD` to get all changes on the current branch
+1. Run via `ctx_execute`:
+   ```
+   ctx_execute(language: "shell", code: "git fetch origin && git diff origin/develop...HEAD")
+   ```
 2. Identify all modified files, focusing on:
    - API routes (`apps/root/src/app/api/`)
    - Proxy/middleware (`apps/root/src/proxy.ts`)

--- a/.claude/skills/storybook-check/SKILL.md
+++ b/.claude/skills/storybook-check/SKILL.md
@@ -9,6 +9,11 @@ user-invocable: true
 
 Build Storybook for projects affected by current changes and report any broken stories.
 
+## Token Budget Rules
+
+- Route Storybook build output through `ctx_execute` — builds produce verbose output
+- Route `nx show projects` through `ctx_batch_execute`
+
 ## Arguments
 
 `/storybook-check` — no arguments needed (detects affected projects automatically)

--- a/.claude/skills/verify-auditapi/SKILL.md
+++ b/.claude/skills/verify-auditapi/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: verify-auditapi
+description: Verify the audit-api backend and its audit tool frontend workflows
+user-invocable: true
+---
+
+# Verify Audit API
+
+Run targeted verification for the audit-api backend and its audit tool frontend integration. Fix any issues at each step before proceeding.
+
+## Instructions
+
+### Phase 1: Backend Checks
+
+Run these sequentially, fixing failures before proceeding:
+
+1. `pnpm nx lint audit-api`
+2. `pnpm nx typecheck audit-api` (mypy)
+3. `pnpm nx test audit-api`
+
+### Phase 2: TypeScript Typecheck
+
+Run `pnpm tsc --noEmit`. This catches type errors in the Next.js API routes and frontend components that integrate with audit-api.
+
+### Phase 3: Frontend Unit Tests (API route + component subset)
+
+Run the subset of root app tests that cover the audit integration layer:
+
+```bash
+pnpm nx test root -- --testPathPatterns="(api/audit|audit)"
+```
+
+This runs tests matching:
+
+- `apps/root/src/app/api/audit/**`
+- `apps/root/src/app/(public)/audit/**`
+- `apps/root/src/app/tools/admin/audit/**`
+
+### Phase 4: Dev Server + Browser Check
+
+1. Read `TOOLS_ADMIN_PASSWORD` from `apps/root/.env.local` using Grep
+2. Start the dev server: `pnpm nx dev root` (background)
+3. Wait for it to be ready, then open a browser using Chrome DevTools MCP
+
+**Public pages (no auth needed):**
+
+4. Visit these pages and check console for errors/warnings:
+   - `/audit` (scan input form)
+   - `/audit/insights` (public insights dashboard)
+
+**Admin pages (auth needed):**
+
+5. Authenticate by running this in Chrome DevTools `evaluate_script`:
+   ```js
+   await fetch('/api/tools/login', {
+     method: 'POST',
+     headers: { 'Content-Type': 'application/json' },
+     body: JSON.stringify({ password: '<TOOLS_ADMIN_PASSWORD value>' }),
+   });
+   ```
+6. Verify the response status is 200 (the `admin_session` cookie is now set)
+7. Visit admin pages and check console for errors/warnings:
+   - `/tools/admin/audit` (admin dashboard — leads, scans, stats)
+
+**For all pages, verify:**
+
+- No unexpected console errors
+- Page renders without blank screens or loading spinners that never resolve
+- API calls return successfully (check Network tab if needed)
+
+8. Stop the dev server when done
+
+### Phase 5: Report
+
+After all steps pass, report a summary table:
+
+| Step                       | Result |
+| -------------------------- | ------ |
+| lint (audit-api)           | ...    |
+| typecheck (audit-api)      | ...    |
+| test (audit-api)           | ...    |
+| typecheck (tsc)            | ...    |
+| test (root — audit routes) | ...    |
+| console.logs (public)      | ...    |
+| console.logs (admin)       | ...    |
+
+Note any pre-existing warnings separately.
+
+If any fixes were made during verification, commit them before reporting.

--- a/.claude/skills/verify-auditapi/SKILL.md
+++ b/.claude/skills/verify-auditapi/SKILL.md
@@ -2,41 +2,48 @@
 name: verify-auditapi
 description: Verify the audit-api backend and its audit tool frontend workflows
 user-invocable: true
+disable-model-invocation: true
 ---
 
 # Verify Audit API
 
-Run targeted verification for the audit-api backend and its audit tool frontend integration. Fix any issues at each step before proceeding.
+Verify the audit-api backend and audit tool frontend pass all checks. **Do not fix failures** — report them and stop.
+
+## Token Budget Rules
+
+- Route ALL commands producing >20 lines through `ctx_batch_execute` or `ctx_execute`
+- Batch independent commands into a single `ctx_batch_execute` call
+- If any phase fails, report the failure in the summary table and **stop** — do not attempt fixes
+- Browser checks: 2 public pages + 1 admin page
 
 ## Instructions
 
-### Phase 1: Backend Checks
+### Phase 1: Backend + TypeScript Checks
 
-Run these sequentially, fixing failures before proceeding:
+Run via `ctx_batch_execute` (one call):
 
-1. `pnpm nx lint audit-api`
-2. `pnpm nx typecheck audit-api` (mypy)
-3. `pnpm nx test audit-api`
-
-### Phase 2: TypeScript Typecheck
-
-Run `pnpm tsc --noEmit`. This catches type errors in the Next.js API routes and frontend components that integrate with audit-api.
-
-### Phase 3: Frontend Unit Tests (API route + component subset)
-
-Run the subset of root app tests that cover the audit integration layer:
-
-```bash
-pnpm nx test root -- --testPathPatterns="(api/audit|audit)"
+```
+[
+  { "label": "lint-auditapi",     "command": "pnpm nx lint audit-api" },
+  { "label": "typecheck-auditapi","command": "pnpm nx typecheck audit-api" },
+  { "label": "test-auditapi",     "command": "pnpm nx test audit-api" },
+  { "label": "typecheck-tsc",     "command": "pnpm tsc --noEmit" }
+]
 ```
 
-This runs tests matching:
+Search results for failures: `ctx_search(["error", "failed", "FAILED"])`. If any command failed, report and stop.
 
-- `apps/root/src/app/api/audit/**`
-- `apps/root/src/app/(public)/audit/**`
-- `apps/root/src/app/tools/admin/audit/**`
+### Phase 2: Frontend Unit Tests
 
-### Phase 4: Dev Server + Browser Check
+Run the subset of root app tests covering the audit integration:
+
+```
+ctx_execute(language: "shell", code: "pnpm nx test root -- --testPathPatterns='(api/audit|audit)'")
+```
+
+If tests fail, report and stop.
+
+### Phase 3: Browser Check
 
 1. Read `TOOLS_ADMIN_PASSWORD` from `apps/root/.env.local` using Grep
 2. Start the dev server: `pnpm nx dev root` (background)
@@ -44,13 +51,11 @@ This runs tests matching:
 
 **Public pages (no auth needed):**
 
-4. Visit these pages and check console for errors/warnings:
-   - `/audit` (scan input form)
-   - `/audit/insights` (public insights dashboard)
+4. Visit `/audit` and `/audit/insights`, check console for errors
 
-**Admin pages (auth needed):**
+**Admin page (auth needed):**
 
-5. Authenticate by running this in Chrome DevTools `evaluate_script`:
+5. Authenticate via Chrome DevTools `evaluate_script`:
    ```js
    await fetch('/api/tools/login', {
      method: 'POST',
@@ -58,21 +63,10 @@ This runs tests matching:
      body: JSON.stringify({ password: '<TOOLS_ADMIN_PASSWORD value>' }),
    });
    ```
-6. Verify the response status is 200 (the `admin_session` cookie is now set)
-7. Visit admin pages and check console for errors/warnings:
-   - `/tools/admin/audit` (admin dashboard — leads, scans, stats)
+6. Visit `/tools/admin/audit`, check console for errors
+7. Stop the dev server when done
 
-**For all pages, verify:**
-
-- No unexpected console errors
-- Page renders without blank screens or loading spinners that never resolve
-- API calls return successfully (check Network tab if needed)
-
-8. Stop the dev server when done
-
-### Phase 5: Report
-
-After all steps pass, report a summary table:
+### Phase 4: Report
 
 | Step                       | Result |
 | -------------------------- | ------ |
@@ -81,9 +75,7 @@ After all steps pass, report a summary table:
 | test (audit-api)           | ...    |
 | typecheck (tsc)            | ...    |
 | test (root — audit routes) | ...    |
-| console.logs (public)      | ...    |
-| console.logs (admin)       | ...    |
+| console (public)           | ...    |
+| console (admin)            | ...    |
 
-Note any pre-existing warnings separately.
-
-If any fixes were made during verification, commit them before reporting.
+Note pre-existing warnings separately. **Do not commit fixes.**

--- a/.claude/skills/verify-jobapi/SKILL.md
+++ b/.claude/skills/verify-jobapi/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: verify-jobapi
+description: Verify the job-api backend and its Fitted frontend workflows
+user-invocable: true
+---
+
+# Verify Job API
+
+Run targeted verification for the job-api backend and its Fitted frontend integration. Fix any issues at each step before proceeding.
+
+## Instructions
+
+### Phase 1: Backend Checks
+
+Run these sequentially, fixing failures before proceeding:
+
+1. `pnpm nx lint job-api`
+2. `pnpm nx mypy job-api`
+3. `pnpm nx test job-api`
+
+### Phase 2: TypeScript Typecheck
+
+Run `pnpm tsc --noEmit`. This catches type errors in the Next.js API routes and frontend components that integrate with job-api.
+
+### Phase 3: Frontend Unit Tests (API route subset)
+
+Run the subset of root app tests that cover the job-api integration layer:
+
+```bash
+pnpm nx test root -- --testPathPatterns="(api/(jobs|career|targets)|fitted)"
+```
+
+This runs tests matching:
+
+- `apps/root/src/app/api/jobs/**`
+- `apps/root/src/app/api/career/**`
+- `apps/root/src/app/api/targets/**`
+- `apps/root/src/app/fitted/**`
+
+### Phase 4: Dev Server + Authenticated Browser Check
+
+1. Read `TOOLS_ADMIN_PASSWORD` from `apps/root/.env.local` using Grep
+2. Start the dev server: `pnpm nx dev root` (background)
+3. Wait for it to be ready, then open a browser using Chrome DevTools MCP
+4. Navigate to `http://localhost:3000`
+5. Authenticate by running this in Chrome DevTools `evaluate_script`:
+   ```js
+   await fetch('/api/tools/login', {
+     method: 'POST',
+     headers: { 'Content-Type': 'application/json' },
+     body: JSON.stringify({ password: '<TOOLS_ADMIN_PASSWORD value>' }),
+   });
+   ```
+6. Verify the response status is 200 (the `admin_session` cookie is now set)
+7. Visit these Fitted pages and check console for errors/warnings:
+   - `/fitted` (dashboard)
+   - `/fitted/jobs` (job listings)
+   - `/fitted/targets` (target roles)
+   - `/fitted/profile` (experience profile)
+   - `/fitted/insights` (analytics dashboard)
+8. For each page, verify:
+   - No unexpected console errors
+   - Page renders without blank screens or loading spinners that never resolve
+   - API calls return successfully (check Network tab if needed)
+9. Stop the dev server when done
+
+### Phase 5: Report
+
+After all steps pass, report a summary table:
+
+| Step                     | Result |
+| ------------------------ | ------ |
+| lint (job-api)           | ...    |
+| mypy (job-api)           | ...    |
+| test (job-api)           | ...    |
+| typecheck                | ...    |
+| test (root — job routes) | ...    |
+| console.logs (Fitted)    | ...    |
+
+Note any pre-existing warnings separately.
+
+If any fixes were made during verification, commit them before reporting.

--- a/.claude/skills/verify-jobapi/SKILL.md
+++ b/.claude/skills/verify-jobapi/SKILL.md
@@ -2,48 +2,54 @@
 name: verify-jobapi
 description: Verify the job-api backend and its Fitted frontend workflows
 user-invocable: true
+disable-model-invocation: true
 ---
 
 # Verify Job API
 
-Run targeted verification for the job-api backend and its Fitted frontend integration. Fix any issues at each step before proceeding.
+Verify the job-api backend and Fitted frontend integration pass all checks. **Do not fix failures** — report them and stop.
+
+## Token Budget Rules
+
+- Route ALL commands producing >20 lines through `ctx_batch_execute` or `ctx_execute`
+- Batch independent commands into a single `ctx_batch_execute` call
+- If any phase fails, report the failure in the summary table and **stop** — do not attempt fixes
+- Browser checks: 2 representative pages only
 
 ## Instructions
 
-### Phase 1: Backend Checks
+### Phase 1: Backend + TypeScript Checks
 
-Run these sequentially, fixing failures before proceeding:
+Run via `ctx_batch_execute` (one call):
 
-1. `pnpm nx lint job-api`
-2. `pnpm nx mypy job-api`
-3. `pnpm nx test job-api`
-
-### Phase 2: TypeScript Typecheck
-
-Run `pnpm tsc --noEmit`. This catches type errors in the Next.js API routes and frontend components that integrate with job-api.
-
-### Phase 3: Frontend Unit Tests (API route subset)
-
-Run the subset of root app tests that cover the job-api integration layer:
-
-```bash
-pnpm nx test root -- --testPathPatterns="(api/(jobs|career|targets)|fitted)"
+```
+[
+  { "label": "lint-jobapi",  "command": "pnpm nx lint job-api" },
+  { "label": "mypy-jobapi",  "command": "pnpm nx mypy job-api" },
+  { "label": "test-jobapi",  "command": "pnpm nx test job-api" },
+  { "label": "typecheck",    "command": "pnpm tsc --noEmit" }
+]
 ```
 
-This runs tests matching:
+Search results for failures: `ctx_search(["error", "failed", "FAILED"])`. If any command failed, report and stop.
 
-- `apps/root/src/app/api/jobs/**`
-- `apps/root/src/app/api/career/**`
-- `apps/root/src/app/api/targets/**`
-- `apps/root/src/app/fitted/**`
+### Phase 2: Frontend Unit Tests
 
-### Phase 4: Dev Server + Authenticated Browser Check
+Run the subset of root app tests covering the job-api integration:
+
+```
+ctx_execute(language: "shell", code: "pnpm nx test root -- --testPathPatterns='(api/(jobs|career|targets)|fitted)'")
+```
+
+If tests fail, report and stop.
+
+### Phase 3: Authenticated Browser Check
 
 1. Read `TOOLS_ADMIN_PASSWORD` from `apps/root/.env.local` using Grep
 2. Start the dev server: `pnpm nx dev root` (background)
 3. Wait for it to be ready, then open a browser using Chrome DevTools MCP
 4. Navigate to `http://localhost:3000`
-5. Authenticate by running this in Chrome DevTools `evaluate_script`:
+5. Authenticate via Chrome DevTools `evaluate_script`:
    ```js
    await fetch('/api/tools/login', {
      method: 'POST',
@@ -51,22 +57,14 @@ This runs tests matching:
      body: JSON.stringify({ password: '<TOOLS_ADMIN_PASSWORD value>' }),
    });
    ```
-6. Verify the response status is 200 (the `admin_session` cookie is now set)
-7. Visit these Fitted pages and check console for errors/warnings:
+6. Verify response status is 200
+7. Visit these pages and check console for errors:
    - `/fitted` (dashboard)
    - `/fitted/jobs` (job listings)
-   - `/fitted/targets` (target roles)
-   - `/fitted/profile` (experience profile)
-   - `/fitted/insights` (analytics dashboard)
-8. For each page, verify:
-   - No unexpected console errors
-   - Page renders without blank screens or loading spinners that never resolve
-   - API calls return successfully (check Network tab if needed)
+8. Note any unexpected console errors
 9. Stop the dev server when done
 
-### Phase 5: Report
-
-After all steps pass, report a summary table:
+### Phase 4: Report
 
 | Step                     | Result |
 | ------------------------ | ------ |
@@ -75,8 +73,6 @@ After all steps pass, report a summary table:
 | test (job-api)           | ...    |
 | typecheck                | ...    |
 | test (root — job routes) | ...    |
-| console.logs (Fitted)    | ...    |
+| console (Fitted)         | ...    |
 
-Note any pre-existing warnings separately.
-
-If any fixes were made during verification, commit them before reporting.
+Note pre-existing warnings separately. **Do not commit fixes.**

--- a/.claude/skills/verify-root/SKILL.md
+++ b/.claude/skills/verify-root/SKILL.md
@@ -1,12 +1,12 @@
 ---
-name: verify
-description: Run full verification loop — build, dev server + browser console.log check, and pom scripts individually
+name: verify-root
+description: Verify the root Next.js app — build, dev server + browser console check, and POM scripts
 user-invocable: true
 ---
 
-# Verify
+# Verify Root
 
-Run the full verification loop after significant changes. Fix any issues that arise at each step before proceeding to the next.
+Run the full verification loop for the root Next.js application (portfolio/public site) after significant changes. Fix any issues that arise at each step before proceeding to the next.
 
 ## Instructions
 

--- a/.claude/skills/verify-root/SKILL.md
+++ b/.claude/skills/verify-root/SKILL.md
@@ -1,63 +1,88 @@
 ---
 name: verify-root
-description: Verify the root Next.js app — build, dev server + browser console check, and POM scripts
+description: Verify the root Next.js app — build, browser console check, and quality gate
 user-invocable: true
+disable-model-invocation: true
 ---
 
 # Verify Root
 
-Run the full verification loop for the root Next.js application (portfolio/public site) after significant changes. Fix any issues that arise at each step before proceeding to the next.
+Verify the root Next.js application (portfolio/public site) passes build, renders correctly, and meets quality gates. **Do not fix failures** — report them and stop.
+
+## Token Budget Rules
+
+- Route ALL commands producing >20 lines through `ctx_batch_execute` or `ctx_execute`
+- Batch independent commands into a single `ctx_batch_execute` call
+- If any phase fails, report the failure in the summary table and **stop** — do not attempt fixes
+- Keep browser checks to representative pages only
 
 ## Instructions
 
-### Phase 1: Production Build
+### Phase 1: Build + Static Checks
 
-Run `pnpm nx build root`. Fix any build errors (missing imports, type errors, prerender failures) before continuing.
+Run via `ctx_batch_execute` (all three in one call):
 
-### Phase 2: Dev Server + Browser console.log Check
+```
+[
+  { "label": "build",     "command": "pnpm nx build root" },
+  { "label": "typecheck", "command": "pnpm tsc --noEmit" },
+  { "label": "lint",      "command": "pnpm lint:fix" }
+]
+```
+
+Search results for failures: `ctx_search(["error", "failed"])`. If any command failed, report and stop.
+
+### Phase 2: Browser Console Check
 
 1. Start the dev server: `pnpm nx dev root` (background)
 2. Wait for it to be ready, then open a browser using Chrome DevTools MCP
-3. Visit these pages and check console for errors/warnings (ignore Calendly 403s, Storybook iframe errors, and "unable to connect to top frame" warnings — these are pre-existing):
+3. Visit these representative pages and check console for errors (ignore Calendly 403s, Storybook iframe errors, "unable to connect to top frame"):
    - `/` (homepage)
    - `/about`
-   - `/services`
-   - `/projects`
-   - `/experience`
    - `/blog`
    - `/audit`
-   - One detail page from each content type (e.g. `/experience/winc`, `/projects/ui-components-v2`, `/blog/unified-content-pipeline`)
-4. If there are any console.log errors or unexpected errors appear, fix them
+4. If unexpected console errors appear, note them in the report
 5. Stop the dev server when done
 
-### Phase 3: POM Scripts (individually)
+### Phase 3: Test Suite
 
-Run each script from `pnpm pom` one at a time in this order. Fix failures before proceeding:
+Run via `ctx_batch_execute`:
 
-1. `pnpm typecheck`
-2. `pnpm lint:fix`
-3. `pnpm format`
-4. `pnpm test`
-5. `pnpm test:coverage`
-6. `pnpm test:e2e`
-7. `pnpm test:lighthouse`
+```
+[
+  { "label": "unit-tests",  "command": "pnpm test" },
+  { "label": "coverage",    "command": "pnpm test:coverage" }
+]
+```
 
-### Phase 4: Report
+Search for failures. If tests fail, report and stop.
 
-After all steps pass, report a summary table:
+### Phase 4: E2E + Lighthouse (optional)
 
-| Step            | Result |
-| --------------- | ------ |
-| Build           | ...    |
-| console.logs    | ...    |
-| typecheck       | ...    |
-| lint:fix        | ...    |
-| format          | ...    |
-| test            | ...    |
-| test:coverage   | ...    |
-| test:e2e        | ...    |
-| test:lighthouse | ...    |
+These are slow and often have pre-existing flaky failures. Run only if Phases 1-3 pass cleanly:
+
+```
+[
+  { "label": "e2e",        "command": "pnpm test:e2e" },
+  { "label": "lighthouse", "command": "pnpm test:lighthouse" }
+]
+```
+
+### Phase 5: Report
+
+Report a summary table with pass/fail for each step:
+
+| Step       | Result |
+| ---------- | ------ |
+| build      | ...    |
+| typecheck  | ...    |
+| lint       | ...    |
+| console    | ...    |
+| test       | ...    |
+| coverage   | ...    |
+| e2e        | ...    |
+| lighthouse | ...    |
 
 Note any pre-existing warnings (not introduced by current changes) separately.
 
-If any fixes were made during verification, commit them before reporting.
+**Do not commit fixes.** If failures need fixing, report them so the user can address them.

--- a/.claude/skills/verify-sharedui/SKILL.md
+++ b/.claude/skills/verify-sharedui/SKILL.md
@@ -2,57 +2,62 @@
 name: verify-sharedui
 description: Verify the shared-ui library — build, unit tests, Storybook, and consumer smoke test
 user-invocable: true
+disable-model-invocation: true
 ---
 
 # Verify Shared UI
 
-Run targeted verification for the shared-ui component library. Fix any issues at each step before proceeding.
+Verify the shared-ui component library passes all checks. **Do not fix failures** — report them and stop.
+
+## Token Budget Rules
+
+- Route ALL commands producing >20 lines through `ctx_batch_execute` or `ctx_execute`
+- Batch independent commands into a single `ctx_batch_execute` call
+- If any phase fails, report the failure in the summary table and **stop** — do not attempt fixes
+- No visual browser checks — interaction tests cover rendering
 
 ## Instructions
 
-### Phase 1: Lint + Typecheck
+### Phase 1: Static Checks + Unit Tests
 
-Run these sequentially, fixing failures before proceeding:
+Run via `ctx_batch_execute` (one call):
 
-1. `pnpm nx lint @danieljoffe.com/shared-ui`
-2. `pnpm nx typecheck @danieljoffe.com/shared-ui`
+```
+[
+  { "label": "lint",      "command": "pnpm nx lint @danieljoffe.com/shared-ui" },
+  { "label": "typecheck", "command": "pnpm nx typecheck @danieljoffe.com/shared-ui" },
+  { "label": "test",      "command": "pnpm nx test @danieljoffe.com/shared-ui" }
+]
+```
 
-### Phase 2: Unit Tests (Jest)
+Search results for failures: `ctx_search(["error", "failed", "FAILED"])`. If any command failed, report and stop.
 
-Run `pnpm nx test @danieljoffe.com/shared-ui`. These are the Jest-based spec files in `libs/shared/ui/src/`.
+### Phase 2: Storybook Build + Interaction Tests
 
-### Phase 3: Storybook Build + Interaction Tests
+Run via `ctx_batch_execute`:
 
-1. Build Storybook: `pnpm nx build-storybook @danieljoffe.com/shared-ui`
-   - Fix any build errors before continuing
-2. Run Storybook interaction tests (Vitest + Playwright): `pnpm nx test-storybook @danieljoffe.com/shared-ui`
-   - These run `play` functions from stories in a headless browser
+```
+[
+  { "label": "build-storybook", "command": "pnpm nx build-storybook @danieljoffe.com/shared-ui" },
+  { "label": "test-storybook",  "command": "pnpm nx test-storybook @danieljoffe.com/shared-ui" }
+]
+```
 
-### Phase 4: Visual Storybook Check
+Note: `test-storybook` runs Vitest + Playwright in headless browser, executing `play` functions from stories. This covers both interaction logic and rendering — no separate visual browser check needed.
 
-1. Start Storybook: `pnpm nx storybook @danieljoffe.com/shared-ui` (background)
-2. Wait for it to be ready, then open a browser using Chrome DevTools MCP
-3. Navigate to Storybook (typically `http://localhost:6006`)
-4. Spot-check a few component stories for rendering issues:
-   - A layout component (e.g., Grid, Stack, Container)
-   - A form component (e.g., Input, Select, Checkbox)
-   - A feedback component (e.g., Alert, Toast, Modal)
-5. Check console for errors/warnings
-6. Stop Storybook when done
+If build-storybook fails, report and stop (test-storybook depends on it).
 
-### Phase 5: Consumer Smoke Test
+### Phase 3: Consumer Smoke Test
 
-Verify the root app (primary consumer) still builds with the shared-ui changes:
+Verify the root app (primary consumer) still builds:
 
-```bash
-pnpm nx build root
+```
+ctx_execute(language: "shell", code: "pnpm nx build root")
 ```
 
 This catches breaking export changes, missing components, or type mismatches at the integration boundary.
 
-### Phase 6: Report
-
-After all steps pass, report a summary table:
+### Phase 4: Report
 
 | Step                  | Result |
 | --------------------- | ------ |
@@ -61,9 +66,6 @@ After all steps pass, report a summary table:
 | test (shared-ui)      | ...    |
 | build-storybook       | ...    |
 | test-storybook        | ...    |
-| visual check          | ...    |
 | consumer build (root) | ...    |
 
-Note any pre-existing warnings separately.
-
-If any fixes were made during verification, commit them before reporting.
+Note pre-existing warnings separately. **Do not commit fixes.**

--- a/.claude/skills/verify-sharedui/SKILL.md
+++ b/.claude/skills/verify-sharedui/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: verify-sharedui
+description: Verify the shared-ui library — build, unit tests, Storybook, and consumer smoke test
+user-invocable: true
+---
+
+# Verify Shared UI
+
+Run targeted verification for the shared-ui component library. Fix any issues at each step before proceeding.
+
+## Instructions
+
+### Phase 1: Lint + Typecheck
+
+Run these sequentially, fixing failures before proceeding:
+
+1. `pnpm nx lint @danieljoffe.com/shared-ui`
+2. `pnpm nx typecheck @danieljoffe.com/shared-ui`
+
+### Phase 2: Unit Tests (Jest)
+
+Run `pnpm nx test @danieljoffe.com/shared-ui`. These are the Jest-based spec files in `libs/shared/ui/src/`.
+
+### Phase 3: Storybook Build + Interaction Tests
+
+1. Build Storybook: `pnpm nx build-storybook @danieljoffe.com/shared-ui`
+   - Fix any build errors before continuing
+2. Run Storybook interaction tests (Vitest + Playwright): `pnpm nx test-storybook @danieljoffe.com/shared-ui`
+   - These run `play` functions from stories in a headless browser
+
+### Phase 4: Visual Storybook Check
+
+1. Start Storybook: `pnpm nx storybook @danieljoffe.com/shared-ui` (background)
+2. Wait for it to be ready, then open a browser using Chrome DevTools MCP
+3. Navigate to Storybook (typically `http://localhost:6006`)
+4. Spot-check a few component stories for rendering issues:
+   - A layout component (e.g., Grid, Stack, Container)
+   - A form component (e.g., Input, Select, Checkbox)
+   - A feedback component (e.g., Alert, Toast, Modal)
+5. Check console for errors/warnings
+6. Stop Storybook when done
+
+### Phase 5: Consumer Smoke Test
+
+Verify the root app (primary consumer) still builds with the shared-ui changes:
+
+```bash
+pnpm nx build root
+```
+
+This catches breaking export changes, missing components, or type mismatches at the integration boundary.
+
+### Phase 6: Report
+
+After all steps pass, report a summary table:
+
+| Step                  | Result |
+| --------------------- | ------ |
+| lint (shared-ui)      | ...    |
+| typecheck (shared-ui) | ...    |
+| test (shared-ui)      | ...    |
+| build-storybook       | ...    |
+| test-storybook        | ...    |
+| visual check          | ...    |
+| consumer build (root) | ...    |
+
+Note any pre-existing warnings separately.
+
+If any fixes were made during verification, commit them before reporting.

--- a/.claude/skills/write-content/SKILL.md
+++ b/.claude/skills/write-content/SKILL.md
@@ -10,15 +10,30 @@ argument-hint: '<draft slug-name> to skip proposals and draft a specific topic'
 
 Analyze the diff between `develop` and `main`, identify content-worthy work, propose topics, and draft MDX posts.
 
+## Token Budget Rules
+
+- Route git log, diff, and `gh pr view` output through `ctx_batch_execute`
+- Batch all `gh pr view` calls into a single `ctx_batch_execute` instead of calling per-PR
+
 ## Instructions
 
 ### Phase 1: Analyze the work
 
-1. Run `git fetch origin` to ensure both branches are current.
-2. Run `git log main..develop --oneline --merges` to find merged PRs.
-3. For each merged PR, run `gh pr view <number> --json title,body,labels,number,files` to get full context.
-4. Run `git diff main..develop --stat` for the overall change footprint.
-5. For notable changes, read the actual code diffs to understand the technical details — don't rely solely on PR descriptions.
+1. Run via `ctx_batch_execute`:
+   ```
+   [
+     { "label": "merges",    "command": "git fetch origin && git log main..develop --oneline --merges" },
+     { "label": "diff-stat", "command": "git diff main..develop --stat" }
+   ]
+   ```
+2. Extract PR numbers from merge commits, then batch all `gh pr view` calls:
+   ```
+   [
+     { "label": "PR-123", "command": "gh pr view 123 --json title,body,labels,number,files" },
+     ...
+   ]
+   ```
+3. For notable changes, use `ctx_search` to find relevant diffs or read the actual code to understand technical details.
 
 ### Phase 2: Propose topics (default behavior)
 

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ node_modules
 /.sass-cache
 /connect.lock
 coverage
+.coverage
 /libpeerconnection.log
 npm-debug.log
 yarn-error.log

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,10 @@ For in-depth reference, see these docs (loaded on demand):
 The workspace includes Claude Code skills and agents for common workflows:
 
 - **Skills** (`.claude/skills/`): Task-specific workflows invocable via `/skill-name`
-  - `/verify` — full verification loop (build, test, lint, e2e, Lighthouse)
+  - `/verify-root` — verify root Next.js app (build, browser console check, full POM suite)
+  - `/verify-jobapi` — verify job-api backend + Fitted frontend workflows
+  - `/verify-auditapi` — verify audit-api backend + audit tool frontend workflows
+  - `/verify-sharedui` — verify shared-ui library (build, tests, Storybook, consumer smoke test)
   - `/gen-test` — generate unit tests following project conventions
   - `/coverage-gaps` — scan for missing tests and stories
   - `/pr-review` — orchestrate all reviewers in parallel

--- a/apps/root/next.config.mjs
+++ b/apps/root/next.config.mjs
@@ -63,9 +63,7 @@ const nextConfig = {
   devIndicators: false,
   // Performance optimizations
   experimental: {
-    // Disable fetch caching across HMR refreshes so dev always shows fresh data
-    serverComponentsHmrCache: false,
-    optimizePackageImports: ['@sentry/nextjs', 'yup', 'schema-dts'],
+    optimizePackageImports: ['yup', 'schema-dts'],
     // Disable in CI/test
     webpackBuildWorker: !isTest && !isCI,
   },

--- a/apps/root/src/app/api/audit/scan/route.test.ts
+++ b/apps/root/src/app/api/audit/scan/route.test.ts
@@ -4,6 +4,18 @@
 import { NextRequest } from 'next/server';
 import { POST } from './route';
 
+// Mock next/server's after() to execute callbacks immediately in tests
+const afterCallbacks: Array<() => Promise<void>> = [];
+jest.mock('next/server', () => {
+  const actual = jest.requireActual('next/server');
+  return {
+    ...actual,
+    after: (cb: () => Promise<void>) => {
+      afterCallbacks.push(cb);
+    },
+  };
+});
+
 // Mock Supabase
 const mockSelect = jest.fn();
 const mockInsert = jest.fn();
@@ -40,6 +52,7 @@ function createRequest(body: Record<string, unknown>, ip = '1.2.3.4') {
 describe('POST /api/audit/scan', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    afterCallbacks.length = 0;
     global.fetch = jest.fn().mockResolvedValue(new Response('ok'));
     process.env['SCAN_SERVICE_URL'] = 'http://scan-service:3001';
     process.env['SCAN_SERVICE_API_KEY'] = 'test-key';
@@ -336,8 +349,8 @@ describe('POST /api/audit/scan', () => {
     const res = await POST(req);
     expect(res.status).toBe(200);
 
-    // Wait for fire-and-forget fetch().then() to settle
-    await new Promise(resolve => setImmediate(resolve));
+    // Flush after() callbacks captured by the mock
+    for (const cb of afterCallbacks) await cb();
 
     expect(mockUpdate).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/apps/root/src/app/api/audit/scan/route.ts
+++ b/apps/root/src/app/api/audit/scan/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { after, NextRequest, NextResponse } from 'next/server';
 import { checkBotId } from 'botid/server';
 import {
   isValidUrl,
@@ -31,22 +31,22 @@ async function markScanFailed(
     .eq('id', scanId);
 }
 
-function fireScan(
+async function fireScan(
   serviceUrl: string,
   apiKey: string,
   payload: { scan_id: string; url: string; device_mode: string },
   supabase: any
 ) {
-  fetch(`${serviceUrl}/run-scan`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'x-api-key': apiKey,
-    },
-    body: JSON.stringify(payload),
-  })
-    .then(async res => {
-      if (res.ok) return;
+  try {
+    const res = await fetch(`${serviceUrl}/run-scan`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': apiKey,
+      },
+      body: JSON.stringify(payload),
+    });
+    if (!res.ok) {
       const message = `Scan service returned HTTP ${res.status}`;
       await markScanFailed(supabase, payload.scan_id, message);
       captureApiError(
@@ -56,24 +56,24 @@ function fireScan(
         res.status,
         { scanId: payload.scan_id }
       );
-    })
-    .catch(async (fetchError: unknown) => {
-      await markScanFailed(
-        supabase,
-        payload.scan_id,
-        'Failed to reach scan service'
-      );
+    }
+  } catch (fetchError: unknown) {
+    await markScanFailed(
+      supabase,
+      payload.scan_id,
+      'Failed to reach scan service'
+    );
 
-      captureApiError(
-        fetchError instanceof Error
-          ? fetchError
-          : new Error('Scan service fetch failed'),
-        '/api/audit/scan',
-        'POST',
-        500,
-        { scanId: payload.scan_id }
-      );
-    });
+    captureApiError(
+      fetchError instanceof Error
+        ? fetchError
+        : new Error('Scan service fetch failed'),
+      '/api/audit/scan',
+      'POST',
+      500,
+      { scanId: payload.scan_id }
+    );
+  }
 }
 
 export async function POST(request: NextRequest) {
@@ -234,22 +234,24 @@ export async function POST(request: NextRequest) {
         .update({ paired_scan_id: mobileScan.id })
         .eq('id', desktopScan.id);
 
-      fireScan(
-        scanServiceUrl,
-        scanServiceApiKey,
-        { scan_id: mobileScan.id, url: normalized, device_mode: 'mobile' },
-        supabase
-      );
-      fireScan(
-        scanServiceUrl,
-        scanServiceApiKey,
-        {
-          scan_id: desktopScan.id,
-          url: normalized,
-          device_mode: 'desktop',
-        },
-        supabase
-      );
+      after(async () => {
+        await fireScan(
+          scanServiceUrl,
+          scanServiceApiKey,
+          { scan_id: mobileScan.id, url: normalized, device_mode: 'mobile' },
+          supabase
+        );
+        await fireScan(
+          scanServiceUrl,
+          scanServiceApiKey,
+          {
+            scan_id: desktopScan.id,
+            url: normalized,
+            device_mode: 'desktop',
+          },
+          supabase
+        );
+      });
 
       return NextResponse.json({
         scan_id: mobileScan.id,
@@ -277,12 +279,14 @@ export async function POST(request: NextRequest) {
       throw new Error(insertError?.message || 'Failed to create scan');
     }
 
-    fireScan(
-      scanServiceUrl,
-      scanServiceApiKey,
-      { scan_id: newScan.id, url: normalized, device_mode: device },
-      supabase
-    );
+    after(async () => {
+      await fireScan(
+        scanServiceUrl,
+        scanServiceApiKey,
+        { scan_id: newScan.id, url: normalized, device_mode: device },
+        supabase
+      );
+    });
 
     return NextResponse.json({
       scan_id: newScan.id,

--- a/apps/root/src/app/layout.tsx
+++ b/apps/root/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata, Viewport } from 'next';
+import * as Sentry from '@sentry/nextjs';
 import { Inter, JetBrains_Mono } from 'next/font/google';
 import { rootMetadata } from '@/data/metadata/root';
 import { WithChildren } from '@/types/base';
@@ -20,7 +21,15 @@ const jetbrainsMono = JetBrains_Mono({
   display: 'swap',
 });
 
-export const metadata: Metadata = rootMetadata;
+export function generateMetadata(): Metadata {
+  return {
+    ...rootMetadata,
+    other: {
+      ...rootMetadata.other,
+      ...Sentry.getTraceData(),
+    },
+  };
+}
 export const viewport: Viewport = {
   width: 'device-width',
   initialScale: 1,


### PR DESCRIPTION
## Summary
- Convert fire-and-forget `fireScan` calls to `after()` API for reliable post-response work in serverless (prevents silent failures when the function is GC'd before promises settle)
- Add Sentry distributed tracing to root layout metadata via `generateMetadata()` + `Sentry.getTraceData()`
- Remove graduated `serverComponentsHmrCache` experimental flag and redundant `@sentry/nextjs` from `optimizePackageImports` (Sentry's `treeshake.removeDebugLogging` handles this)

## Test plan
- [x] `pnpm tsc --noEmit` passes
- [x] `route.test.ts` — all 10 tests pass (added `after()` mock that captures callbacks for flush-and-assert pattern)
- [ ] Verify scan service fires correctly in staging (after() runs post-response)
- [ ] Verify Sentry traces propagate from root layout to downstream services

🤖 Generated with [Claude Code](https://claude.com/claude-code)