### PR TITLE
fix(e2e): resolve strict mode violations in error-handling tests

### DIFF
--- a/apps/root-e2e/src/error-handling.spec.ts
+++ b/apps/root-e2e/src/error-handling.spec.ts
@@ -18,10 +18,7 @@ test.describe('404 Error Page', () => {
     await page.locator('h1, h2').first().waitFor({ state: 'visible' });
 
     await expect(
-      page
-        .getByRole('heading', { name: '404' })
-        .or(page.getByRole('heading', { name: 'Page Not Found' }))
-        .or(page.getByText(/not found/i))
+      page.getByRole('heading', { name: '404', exact: true })
     ).toBeVisible();
   });
 
@@ -101,10 +98,11 @@ test.describe('thank-you page protection', () => {
     await page.locator('form').waitFor({ state: 'visible' });
     await expect(page.getByRole('button', { name: /submit/i })).toBeEnabled();
 
-    // Fill and submit form
-    await fillInput(page.getByLabel(/name/i), VALID_FORM_DATA.name);
-    await fillInput(page.getByLabel(/email/i), VALID_FORM_DATA.email);
-    await fillInput(page.getByLabel(/message/i), VALID_FORM_DATA.message);
+    // Fill and submit form — scope to form to avoid matching nav "Send Email" links
+    const form = page.locator('form');
+    await fillInput(form.getByLabel(/name/i), VALID_FORM_DATA.name);
+    await fillInput(form.getByLabel(/email/i), VALID_FORM_DATA.email);
+    await fillInput(form.getByLabel(/message/i), VALID_FORM_DATA.message);
 
     // Complete hCaptcha verification
     await completeHCaptcha(page);
@@ -131,9 +129,10 @@ test.describe('thank-you page protection', () => {
     await page.locator('form').waitFor({ state: 'visible' });
     await expect(page.getByRole('button', { name: /submit/i })).toBeEnabled();
 
-    await fillInput(page.getByLabel(/name/i), VALID_FORM_DATA.name);
-    await fillInput(page.getByLabel(/email/i), VALID_FORM_DATA.email);
-    await fillInput(page.getByLabel(/message/i), VALID_FORM_DATA.message);
+    const form1 = page.locator('form');
+    await fillInput(form1.getByLabel(/name/i), VALID_FORM_DATA.name);
+    await fillInput(form1.getByLabel(/email/i), VALID_FORM_DATA.email);
+    await fillInput(form1.getByLabel(/message/i), VALID_FORM_DATA.message);
 
     await completeHCaptcha(page);
 
@@ -158,9 +157,10 @@ test.describe('thank-you page protection', () => {
     await page.locator('form').waitFor({ state: 'visible' });
     await expect(page.getByRole('button', { name: /submit/i })).toBeEnabled();
 
-    await fillInput(page.getByLabel(/name/i), VALID_FORM_DATA.name);
-    await fillInput(page.getByLabel(/email/i), VALID_FORM_DATA.email);
-    await fillInput(page.getByLabel(/message/i), VALID_FORM_DATA.message);
+    const form2 = page.locator('form');
+    await fillInput(form2.getByLabel(/name/i), VALID_FORM_DATA.name);
+    await fillInput(form2.getByLabel(/email/i), VALID_FORM_DATA.email);
+    await fillInput(form2.getByLabel(/message/i), VALID_FORM_DATA.message);
 
     await completeHCaptcha(page);
 


### PR DESCRIPTION
## Summary
- **404 test**: The `.or()` locator chain matched both `<h1>404</h1>` and `<h2>Page Not Found</h2>`, causing Playwright strict mode violation. Narrowed to `getByRole('heading', { name: '404', exact: true })`.
- **Form tests**: `getByLabel(/email/i)` matched nav "Send Email" aria-label links alongside the email input (3 elements). Scoped all `getByLabel` calls to the `form` locator.

Fixes CI failures in PR #492.

## Test plan
- [ ] CI e2e passes — both previously-failing tests (`shows 404 for non-existent routes`, `thank-you page accessible after form submission`) should now pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)