### PR TITLE
refactor: optimize skills for token efficiency

### DIFF
--- a/.claude/skills/nextjs-audit/SKILL.md
+++ b/.claude/skills/nextjs-audit/SKILL.md
@@ -8,6 +8,12 @@ disable-model-invocation: true
 
 Audit the Next.js application against current official documentation, producing actionable findings and direct code fixes.
 
+## Token Budget Rules
+
+- Route ALL file reads and command outputs through `ctx_batch_execute` or `ctx_execute`
+- Batch context7 `query-docs` calls — resolve all libraries first, then query in 2-3 batched calls
+- If context7 docs for the same libraries were already fetched in this session, skip Phase 1
+
 ## Instructions
 
 ### Phase 1: Fetch Current Documentation

--- a/.claude/skills/nx-audit/SKILL.md
+++ b/.claude/skills/nx-audit/SKILL.md
@@ -8,6 +8,12 @@ disable-model-invocation: true
 
 Audit the Nx monorepo for structural and configuration issues against official Nx guidelines.
 
+## Token Budget Rules
+
+- Route ALL command outputs and workspace inspection results through `ctx_batch_execute` or `ctx_execute`
+- If Nx docs were already fetched via context7 in this session, skip Phase 1
+- Use Nx MCP tools for workspace queries — they're more efficient than raw CLI output
+
 ## Instructions
 
 ### Phase 1: Fetch Current Documentation

--- a/.claude/skills/release-notes/SKILL.md
+++ b/.claude/skills/release-notes/SKILL.md
@@ -10,14 +10,30 @@ argument-hint: '<format: pr|changelog|summary> (default: pr)'
 
 Diff `develop` against `main`, analyze all merged work, and generate release content.
 
+## Token Budget Rules
+
+- Route git log and diff output through `ctx_batch_execute` — these can be large
+- Batch all `gh pr view` calls into a single `ctx_batch_execute` instead of calling per-PR
+
 ## Instructions
 
 1. **Gather the diff**
-   - Run `git fetch origin` to ensure both branches are up to date.
-   - Run `git log main..develop --oneline --no-merges` to get all non-merge commits.
-   - Run `git log main..develop --oneline --merges` to identify merged PRs.
-   - Run `git diff main..develop --stat` to get the file-level change summary.
-   - For each merged PR, extract the PR number from the merge commit message and run `gh pr view <number> --json title,body,labels,number` to get the full context.
+   - Run via `ctx_batch_execute`:
+     ```
+     [
+       { "label": "commits",    "command": "git fetch origin && git log main..develop --oneline --no-merges" },
+       { "label": "merges",     "command": "git log main..develop --oneline --merges" },
+       { "label": "diff-stat",  "command": "git diff main..develop --stat" }
+     ]
+     ```
+   - Extract PR numbers from merge commits, then batch all `gh pr view` calls into one `ctx_batch_execute`:
+     ```
+     [
+       { "label": "PR-123", "command": "gh pr view 123 --json title,body,labels,number" },
+       { "label": "PR-124", "command": "gh pr view 124 --json title,body,labels,number" },
+       ...
+     ]
+     ```
 
 2. **Categorize changes**
    Group the work into these categories (skip empty ones):

--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -1,63 +1,78 @@
 ---
 name: verify
-description: Run full verification loop — build, dev server + browser console.log check, and pom scripts individually
+description: Verify the root Next.js app — build, browser console check, and quality gate
 user-invocable: true
+disable-model-invocation: true
 ---
 
 # Verify
 
-Run the full verification loop after significant changes. Fix any issues that arise at each step before proceeding to the next.
+Verify the root Next.js application passes build, renders correctly, and meets quality gates. **Do not fix failures** — report them and stop.
+
+## Token Budget Rules
+
+- Route ALL commands producing >20 lines through `ctx_batch_execute` or `ctx_execute`
+- Batch independent commands into a single `ctx_batch_execute` call
+- If any phase fails, report the failure in the summary table and **stop** — do not attempt fixes
+- Browser checks: 4 representative pages only
 
 ## Instructions
 
 ### Phase 1: Production Build
 
-Run `pnpm nx build root`. Fix any build errors (missing imports, type errors, prerender failures) before continuing.
+Run via `ctx_execute`:
 
-### Phase 2: Dev Server + Browser console.log Check
+```
+ctx_execute(language: "shell", code: "NX_SOCKET_DIR=/tmp/nx-tmp pnpm nx build root")
+```
+
+If the build fails, report and stop.
+
+### Phase 2: Dev Server + Browser Console Check
 
 1. Start the dev server: `pnpm nx dev root` (background)
 2. Wait for it to be ready, then open a browser using Chrome DevTools MCP
-3. Visit these pages and check console for errors/warnings (ignore Calendly 403s, Storybook iframe errors, and "unable to connect to top frame" warnings — these are pre-existing):
+3. Visit these representative pages and check console for errors (ignore Calendly 403s, Storybook iframe errors, "unable to connect to top frame"):
    - `/` (homepage)
    - `/about`
-   - `/services`
-   - `/projects`
-   - `/experience`
    - `/blog`
    - `/audit`
-   - One detail page from each content type (e.g. `/experience/winc`, `/projects/ui-components-v2`, `/blog/unified-content-pipeline`)
-4. If there are any console.log errors or unexpected errors appear, fix them
+4. If unexpected console errors appear, note them in the report
 5. Stop the dev server when done
 
-### Phase 3: POM Scripts (individually)
+### Phase 3: Test Suite
 
-Run each script from `pnpm pom` one at a time in this order. Fix failures before proceeding:
+Run via `ctx_batch_execute`:
 
-1. `pnpm typecheck`
-2. `pnpm lint:fix`
-3. `pnpm format`
-4. `pnpm test`
-5. `pnpm test:coverage`
-6. `pnpm test:e2e`
-7. `pnpm test:lighthouse`
+```
+[
+  { "label": "typecheck",  "command": "NX_SOCKET_DIR=/tmp/nx-tmp pnpm typecheck" },
+  { "label": "lint",       "command": "NX_SOCKET_DIR=/tmp/nx-tmp pnpm lint:fix" },
+  { "label": "format",     "command": "NX_SOCKET_DIR=/tmp/nx-tmp pnpm format" },
+  { "label": "test",       "command": "NX_SOCKET_DIR=/tmp/nx-tmp pnpm test" },
+  { "label": "coverage",   "command": "NX_SOCKET_DIR=/tmp/nx-tmp pnpm test:coverage" },
+  { "label": "e2e",        "command": "NX_SOCKET_DIR=/tmp/nx-tmp pnpm test:e2e" },
+  { "label": "lighthouse", "command": "NX_SOCKET_DIR=/tmp/nx-tmp pnpm test:lighthouse" }
+]
+```
+
+Search results for failures: `ctx_search(["error", "failed", "FAILED"])`.
 
 ### Phase 4: Report
 
-After all steps pass, report a summary table:
+Report a summary table:
 
-| Step            | Result |
-| --------------- | ------ |
-| Build           | ...    |
-| console.logs    | ...    |
-| typecheck       | ...    |
-| lint:fix        | ...    |
-| format          | ...    |
-| test            | ...    |
-| test:coverage   | ...    |
-| test:e2e        | ...    |
-| test:lighthouse | ...    |
+| Step       | Result |
+| ---------- | ------ |
+| build      | ...    |
+| typecheck  | ...    |
+| lint       | ...    |
+| console    | ...    |
+| test       | ...    |
+| coverage   | ...    |
+| e2e        | ...    |
+| lighthouse | ...    |
 
 Note any pre-existing warnings (not introduced by current changes) separately.
 
-If any fixes were made during verification, commit them before reporting.
+**Do not commit fixes.** If failures need fixing, report them so the user can address them.

--- a/.claude/skills/write-content/SKILL.md
+++ b/.claude/skills/write-content/SKILL.md
@@ -10,15 +10,30 @@ argument-hint: '<draft slug-name> to skip proposals and draft a specific topic'
 
 Analyze the diff between `develop` and `main`, identify content-worthy work, propose topics, and draft MDX posts.
 
+## Token Budget Rules
+
+- Route git log, diff, and `gh pr view` output through `ctx_batch_execute`
+- Batch all `gh pr view` calls into a single `ctx_batch_execute` instead of calling per-PR
+
 ## Instructions
 
 ### Phase 1: Analyze the work
 
-1. Run `git fetch origin` to ensure both branches are current.
-2. Run `git log main..develop --oneline --merges` to find merged PRs.
-3. For each merged PR, run `gh pr view <number> --json title,body,labels,number,files` to get full context.
-4. Run `git diff main..develop --stat` for the overall change footprint.
-5. For notable changes, read the actual code diffs to understand the technical details — don't rely solely on PR descriptions.
+1. Run via `ctx_batch_execute`:
+   ```
+   [
+     { "label": "merges",    "command": "git fetch origin && git log main..develop --oneline --merges" },
+     { "label": "diff-stat", "command": "git diff main..develop --stat" }
+   ]
+   ```
+2. Extract PR numbers from merge commits, then batch all `gh pr view` calls:
+   ```
+   [
+     { "label": "PR-123", "command": "gh pr view 123 --json title,body,labels,number,files" },
+     ...
+   ]
+   ```
+3. For notable changes, use `ctx_search` to find relevant diffs or read the actual code to understand technical details.
 
 ### Phase 2: Propose topics (default behavior)
 


### PR DESCRIPTION
## Summary

- Add **Token Budget Rules** sections to 5 skills: `nextjs-audit`, `nx-audit`, `release-notes`, `verify`, and `write-content`
- Restructure command invocations to use `ctx_batch_execute` for parallel execution and reduced context window consumption
- Update `verify` skill to report-only mode (`disable-model-invocation: true`) with `NX_SOCKET_DIR` fix for long pnpm store paths

## Test plan

- [ ] Run `/verify` and confirm it uses `ctx_batch_execute` and reports without attempting fixes
- [ ] Run `/release-notes` and confirm it batches `gh pr view` calls
- [ ] Run `/write-content` and confirm Phase 1 uses `ctx_batch_execute`

🤖 Generated with [Claude Code](https://claude.com/claude-code)