### PR TITLE
fix(e2e): use aria-hidden assertion for More sheet close test

### DIFF
--- a/apps/root-e2e/src/navigation.spec.ts
+++ b/apps/root-e2e/src/navigation.spec.ts
@@ -157,8 +157,10 @@ test.describe('mobile navigation', () => {
     // normal Playwright clicks.
     const overlay = page.getByTestId('sheet-overlay');
     await overlay.dispatchEvent('click');
-    // The sheet uses translate-y transition to slide off-screen
-    await expect(sheet).toBeHidden();
+    // The sheet slides off-screen via translate-y-full and sets aria-hidden.
+    // Playwright's toBeHidden() requires display:none or visibility:hidden,
+    // so assert the semantic close state instead.
+    await expect(sheet).toHaveAttribute('aria-hidden', 'true');
   });
 
   test('navigates from More sheet', async ({ page }) => {


### PR DESCRIPTION
## Summary

- Fixes the `closes More sheet on close button click` E2E test that fails across all browsers
- The More sheet hides via `translate-y-full` (CSS transform), which keeps the element rendered off-viewport. Playwright's `toBeHidden()` requires `display:none` or `visibility:hidden`, so it always reported "visible"
- Replaced `toBeHidden()` with `toHaveAttribute('aria-hidden', 'true')`, which is the semantic close state the component already sets correctly

## Test plan

- [x] Verified the failing test now passes locally on Chromium
- [ ] CI should pass all 5 browser variants (chromium, firefox, webkit, Mobile Chrome, Mobile Safari)

🤖 Generated with [Claude Code](https://claude.com/claude-code)