### PR TITLE
refactor: optimize pr-review and skills with manifest-based filtering

### DIFF
--- a/.claude/agents/a11y-reviewer.md
+++ b/.claude/agents/a11y-reviewer.md
@@ -29,6 +29,15 @@ Review changed files for WCAG 2.1 AA compliance issues.
 - `@headlessui/react` is used for accessible components (Disclosure, Dialog, etc.)
 - Pages use `PageContainer` and `MainContent` for consistent landmark structure
 
+## Review Protocol
+
+You receive a file manifest and diff hunks from the orchestrator.
+
+- **Deleted files**: Note if deletion removes an a11y feature (skip link, aria label), but do not read them.
+- **Small changes (diff-only)**: Review the hunk. Read the full file only if you need surrounding context (e.g., to check heading hierarchy or focus management flow).
+- **Larger changes**: Read the full file via `ctx_batch_execute` for files >50 lines.
+- Stay within your assigned file list. You receive only `.tsx` files — no test files, configs, or docs.
+
 ## Output
 
 Report issues with file path, line number, WCAG criterion violated, and fix recommendation.

--- a/.claude/agents/content-reviewer.md
+++ b/.claude/agents/content-reviewer.md
@@ -65,6 +65,15 @@ Review changed MDX content files for metadata completeness, ordering consistency
 - Three content types: `project`, `experience`, `blog`
 - Cover images live in the MDX `metadata.cover` block — no separate thumbnails files
 
+## Review Protocol
+
+You receive a file manifest and diff hunks from the orchestrator.
+
+- **Deleted files**: Check if deletion orphans a content registry entry or breaks pagination links, but do not read the deleted file.
+- **Small changes (diff-only)**: Review the hunk. For metadata field changes, the hunk is usually sufficient.
+- **Larger changes (new posts)**: Read the full MDX file via `ctx_batch_execute` to validate heading hierarchy, structure, and registry integration.
+- Stay within your assigned file list. You receive only `.mdx` content files.
+
 ## Output
 
 Report issues with file path, field name, what's wrong, and how to fix it. Categorize as:

--- a/.claude/agents/e2e-reviewer.md
+++ b/.claude/agents/e2e-reviewer.md
@@ -29,19 +29,23 @@ Review changed files for E2E test coverage, fixture consistency, and Playwright 
 
 ## Existing E2E Specs
 
-Check these for coverage overlap and consistency:
+Auto-discover existing specs rather than relying on a hardcoded list:
 
-- `accessibility.spec.ts` — WCAG checks across pages
-- `navigation.spec.ts` — Desktop/mobile nav, route transitions
-- `contact-form.spec.ts` — Form submission, validation, hCaptcha
-- `dynamic-routes.spec.ts` — Project/experience/blog detail pages
-- `performance.spec.ts` — Core Web Vitals, resource sizes
-- `error-handling.spec.ts` — 404, error boundaries
-- `command-palette.spec.ts` — Keyboard shortcut search
-- `audit-scan.spec.ts`, `audit-report.spec.ts` — Audit tool flows
-- `api-audit.spec.ts`, `api-email.spec.ts` — API endpoint tests
-- `services.spec.ts` — Services page interactions
-- `visual-regression.spec.ts` — Screenshot comparisons (CI-managed)
+```bash
+ls apps/root-e2e/src/*.spec.ts
+```
+
+Cross-reference changed routes against existing specs to identify coverage gaps.
+
+## Review Protocol
+
+You receive a file manifest and diff hunks from the orchestrator.
+
+- **Deleted files**: Check if deletion removes test coverage for an existing route, but do not read them.
+- **Small changes (diff-only)**: Review the hunk. Minor test tweaks are usually clear from the diff.
+- **Larger changes**: Read the full spec file via `ctx_batch_execute` to validate fixture usage, hydration handling, and selector patterns.
+- You receive E2E test files AND the orchestrator's manifest of changed app routes. Use the route list to identify coverage gaps even if the spec files themselves didn't change.
+- Stay within your assigned file list for test quality review. Use the manifest for gap analysis.
 
 ## Output
 

--- a/.claude/agents/nx-reviewer.md
+++ b/.claude/agents/nx-reviewer.md
@@ -25,7 +25,7 @@ Review changed files for Nx monorepo structure, module boundary, and configurati
 - Nx plugins: `@nx/next`, `@nx/jest`, `@nx/playwright`, `@nx/eslint`, `@nx/storybook`
 - Named inputs: `production` excludes test files and config — check new files are properly categorized
 - `neverConnectToCloud: true` — do not recommend Nx Cloud features
-- Yarn workspaces — `package.json` in libs must have correct `name` field matching Nx project name
+- pnpm workspaces — `package.json` in libs must have correct `name` field matching Nx project name
 
 ## Common Issues
 
@@ -34,6 +34,15 @@ Review changed files for Nx monorepo structure, module boundary, and configurati
 - Missing `scope:` or `type:` tags on new projects (needed for module boundary rules)
 - Forgetting to add new project to `nx.json` `targetDefaults` if it needs special config
 - `nx sync` issues from stale TypeScript project references
+
+## Review Protocol
+
+You receive a file manifest and diff hunks from the orchestrator.
+
+- **Deleted files**: Check if deletion leaves stale path aliases in `tsconfig.base.json` or orphaned project references, but do not read deleted files.
+- **Small changes (diff-only)**: Review the hunk. Config changes are usually self-contained in the diff.
+- **Larger changes**: Read the full config file via `ctx_batch_execute` if you need to validate cross-references.
+- Stay within your assigned file list. You receive only config files (`project.json`, `tsconfig*`, `nx.json`, `eslint.config*`, `package.json`).
 
 ## Output
 

--- a/.claude/agents/perf-reviewer.md
+++ b/.claude/agents/perf-reviewer.md
@@ -29,6 +29,15 @@ Review changed files for performance implications in this Next.js 16 + React 19 
 - `next/image` with blurhash placeholders is the standard image pattern
 - Sentry tracing is enabled (avoid adding expensive spans in hot paths)
 
+## Review Protocol
+
+You receive a file manifest and diff hunks from the orchestrator.
+
+- **Deleted files**: Note if deletion affects performance (e.g., removing lazy loading or caching), but do not read them.
+- **Small changes (diff-only)**: Review the hunk. Read the full file only if you need surrounding context (e.g., to check if a new import is already dynamically loaded elsewhere).
+- **Larger changes**: Read the full file via `ctx_batch_execute` for files >50 lines.
+- Stay within your assigned file list. You receive only production `.ts`/`.tsx` files — no test files.
+
 ## Output
 
 Report issues with file path, line number, estimated impact (HIGH/MEDIUM/LOW), and fix recommendation.

--- a/.claude/agents/security-reviewer.md
+++ b/.claude/agents/security-reviewer.md
@@ -1,0 +1,43 @@
+---
+name: security-reviewer
+description: Input validation, auth, SSRF, PII exposure, and API security review
+memory: project
+---
+
+# Security Reviewer
+
+Review changed files for exploitable security vulnerabilities. Report only HIGH-CONFIDENCE findings (>80% exploitable). Skip theoretical issues, DoS, and dependency vulnerabilities.
+
+## What to Check
+
+- **Input validation**: SQL injection, XSS, command injection in user-facing inputs
+- **XSS**: `dangerouslySetInnerHTML` without `isomorphic-dompurify` sanitization
+- **Auth/authz bypasses**: missing or incorrect authentication checks on API routes
+- **Sensitive data exposure**: PII in logs, secrets in responses, credentials in client bundles
+- **SSRF**: URL inputs (especially in audit scan endpoints) without allowlist validation
+- **Rate limiting**: new public endpoints missing rate limiting
+- **PII masking**: form inputs collecting PII must have `data-sentry-mask`
+- **hCaptcha**: form submissions must validate captcha tokens server-side
+- **CSP headers**: changes to `next.config.mjs` must not weaken Content Security Policy
+
+## Project-Specific Patterns
+
+- **Supabase**: browser client must only use anon key, never service role key
+- **Resend**: email sending must validate recipient addresses and sanitize content
+- **Audit API** (`apps/audit-api`): Lighthouse/axe scans must not allow arbitrary URL scanning without auth; SSRF defenses on `/run-scan` URL input
+- **Bot detection** (`botid`): must not be the sole security layer
+- **Public attack surface**: contact form, lead capture, and audit scan endpoints
+- **CSP**: defined in `next.config.mjs` — changes must be reviewed for weakening
+
+## Review Protocol
+
+You receive a file manifest and diff hunks from the orchestrator.
+
+- **Deleted files**: Note if deletion removes a security control, but do not read them.
+- **Small changes (diff-only)**: Review the hunk. Read the full file only if you need surrounding context to assess exploitability.
+- **Larger changes**: Read the full file via `ctx_batch_execute` for files >50 lines.
+- Stay within your assigned file list.
+
+## Output
+
+Report findings with file path, line number, severity (HIGH/MEDIUM), exploit scenario, and fix recommendation. If no vulnerabilities found, state that clearly.

--- a/.claude/skills/batch-commit/SKILL.md
+++ b/.claude/skills/batch-commit/SKILL.md
@@ -26,11 +26,28 @@ Review all pending changes, group them into logical commits, and push each one.
      ]
      ```
 
-2. **Plan commit batches**
-   - Group files by logical concern (e.g., dependency upgrades, feature code, config changes, documentation, test fixes).
-   - Each batch should tell a coherent story — a reviewer should understand the "why" from the commit alone.
-   - Prefer smaller, focused commits over large catch-all commits.
-   - Present the batching plan before executing.
+2. **Classify files and plan commit batches**
+
+   Categorize each changed file to guide grouping:
+
+   | Pattern                                                                  | Category     |
+   | ------------------------------------------------------------------------ | ------------ |
+   | `.claude/`, `CLAUDE.md`                                                  | `skill-meta` |
+   | `*.spec.*`, `*.test.*`, `__tests__/*`                                    | `test`       |
+   | `*.stories.tsx`                                                          | `story`      |
+   | `apps/root-e2e/**`                                                       | `e2e`        |
+   | `project.json`, `tsconfig*`, `nx.json`, `eslint.config*`, `package.json` | `config`     |
+   | `*.mdx` in `data/content/`                                               | `content`    |
+   | `*.md` (docs)                                                            | `docs`       |
+   | `apps/*/src/**`, `libs/*/src/**`                                         | `source`     |
+
+   Group files by logical concern using the categories as hints:
+   - Same-category files that serve one purpose go in one commit (e.g., all skill updates, all test fixes)
+   - Source + its test file go together when the test was written for that source change
+   - Config changes get their own commit unless tightly coupled to a source change
+   - Each batch should tell a coherent story — a reviewer should understand the "why" from the commit alone
+   - Prefer smaller, focused commits over large catch-all commits
+   - Present the batching plan before executing
 
 3. **For each batch, in order:**
    - `git reset HEAD -- .` (only on the first batch if files are already staged, to re-stage selectively).

--- a/.claude/skills/coverage-gaps/SKILL.md
+++ b/.claude/skills/coverage-gaps/SKILL.md
@@ -17,12 +17,25 @@ Scan the codebase for components missing unit tests or Storybook stories, report
 
 ## Arguments
 
-`/coverage-gaps` — scan for missing tests and stories (read-only)
-`/coverage-gaps --fix` — also generate stub files for each gap found
-`/coverage-gaps --quality` — also audit existing test quality (unit + E2E)
-`/coverage-gaps --fix --quality` — both
+- `/coverage-gaps` — scan for missing tests and stories (read-only, full codebase)
+- `/coverage-gaps --changed` — scan only components changed on the current branch (fastest)
+- `/coverage-gaps --fix` — also generate stub files for each gap found
+- `/coverage-gaps --quality` — also audit existing test quality (unit + E2E)
+- `/coverage-gaps --fix --quality` — both
+- Flags combine: `/coverage-gaps --changed --fix`
 
 ## Instructions
+
+### Part 0: Scope detection (if `--changed`)
+
+If `--changed` is passed, narrow the scan to only changed component files:
+
+```bash
+BASE=$(gh pr view --json baseRefName --jq '.baseRefName' 2>/dev/null || echo "develop")
+git diff --name-only origin/${BASE}...HEAD -- '*.tsx' '*.ts' | grep -v '\.spec\.\|\.test\.\|\.stories\.\|__tests__\|__mocks__'
+```
+
+From this list, identify which directories each file belongs to (shared-ui, kit, components, hooks) and only scan those files in Part 1 below. Skip directories with no changed files. This avoids scanning hundreds of files when only a few changed.
 
 ### Part 1: Coverage Scan (always runs)
 

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -1,74 +1,183 @@
 ---
 name: pr-review
-description: Run all reviewer agents (a11y, perf, content, nx, security) in parallel on changed files and summarize findings
+description: Run reviewer agents on changed files with smart filtering, manifest-based routing, and diff-first analysis
 disable-model-invocation: true
 user-invocable: true
 ---
 
 # PR Review
 
-Run all reviewer agents in parallel on the current branch's changed files and produce a unified report.
-
-## Token Budget Rules
-
-- Route `git diff` and file list output through `ctx_execute` — diffs can be large
-- Each spawned agent inherits ctx_batch_execute — remind them to use it for large outputs
+Context-efficient review of the current branch's changed files. Builds a file manifest, filters out noise, and routes only relevant files to each reviewer agent.
 
 ## Arguments
 
-`/pr-review` — no arguments needed (uses current branch diff against develop)
+- `/pr-review` — review all changed files (auto-detects base branch)
+- `/pr-review --only a11y,perf` — run only specified reviewers
+- `/pr-review --skip content,nx` — skip specified reviewers
+- `/pr-review --base main` — override base branch (default: auto-detect)
+- `/pr-review --force` — bypass PR size guardrails
+
+Reviewer names: `a11y`, `perf`, `content`, `nx`, `e2e`, `security`
+
+## Token Budget Rules
+
+- Build the manifest via `ctx_batch_execute` — diffs can be large
+- Pass diff hunks to agents in the prompt — agents only read full files when hunks lack context
+- Agents must use `ctx_batch_execute` for any file reads >50 lines
 
 ## Instructions
 
-1. **Identify changed files:**
+### Step 1: Detect base branch
 
-   ```bash
-   git diff --name-only origin/develop...HEAD
-   ```
+```bash
+gh pr view --json baseRefName --jq '.baseRefName' 2>/dev/null || echo "develop"
+```
 
-2. **Categorize files** to determine which reviewers to run:
-   - **a11y-reviewer**: Any `.tsx` files in `components/`, `libs/shared/ui/`, or `app/`
-   - **perf-reviewer**: Any `.tsx`/`.ts` files touching components, hooks, API routes, or config
-   - **content-reviewer**: Any `.mdx` files in `data/content/`
-   - **nx-reviewer**: Any `project.json`, `tsconfig*.json`, `nx.json`, or workspace config files
-   - **security-reviewer**: Any `.ts`/`.tsx` files in `app/api/`, `lib/`, `proxy.ts`, `middleware.ts`, or files touching env vars, auth, Supabase, or Resend
+Use the result as `BASE_BRANCH`. Override with `--base` if provided. Always `git fetch origin` first.
 
-3. **Launch applicable reviewers in parallel** using the Agent tool:
-   - Pass the list of relevant changed files to each agent
-   - Each agent should read the changed files and apply its review checklist
+### Step 2: Build file manifest
 
-4. **Collect and deduplicate findings** from all agents.
+Run via `ctx_batch_execute`:
 
-5. **Output a unified report:**
+```bash
+git diff --name-status origin/${BASE_BRANCH}...HEAD
+git diff --stat origin/${BASE_BRANCH}...HEAD
+```
 
-   ```markdown
-   ## PR Review Summary
+Parse into a structured manifest. For each file determine:
 
-   **Branch**: <branch-name>
-   **Files changed**: <count>
-   **Reviewers run**: <list>
+| Field             | Values                                                    |
+| ----------------- | --------------------------------------------------------- |
+| **status**        | `A` (added), `M` (modified), `D` (deleted), `R` (renamed) |
+| **lines_changed** | additions + deletions from `--stat`                       |
+| **category**      | See classification table below                            |
 
-   ### Critical (must fix)
+**File classification:**
 
-   - [ ] file:line — description (reviewer)
+| Pattern                                                                  | Category      |
+| ------------------------------------------------------------------------ | ------------- |
+| Status `D` (any path)                                                    | `deleted`     |
+| `*.png`, `*.jpg`, `*.svg`, `*.ico`, `*-snapshots/*`                      | `binary`      |
+| `.claude/`, `CLAUDE.md`                                                  | `skill-meta`  |
+| `*.md` (not `.claude/`, not `.mdx`)                                      | `docs`        |
+| `*.mdx` in `data/content/`                                               | `content-mdx` |
+| `apps/root-e2e/**`                                                       | `e2e-test`    |
+| `*.spec.*`, `*.test.*`, `__tests__/*`, `__mocks__/*`                     | `unit-test`   |
+| `project.json`, `tsconfig*`, `nx.json`, `eslint.config*`, `package.json` | `config`      |
+| `apps/root/src/app/api/**`, `*/middleware.ts`, `*/proxy.ts`              | `api-code`    |
+| `libs/**` (non-test)                                                     | `lib-code`    |
+| `apps/**` (non-test, non-api)                                            | `app-code`    |
 
-   ### Warnings (should fix)
+### Step 3: Apply guardrails
 
-   - [ ] file:line — description (reviewer)
+Count **reviewable files** = total minus `deleted`, `binary`, `skill-meta`, `docs`.
 
-   ### Suggestions (nice to have)
+| Reviewable files | Action                                                                        |
+| ---------------- | ----------------------------------------------------------------------------- |
+| 0                | Report clean — nothing to review. Stop.                                       |
+| 1–30             | Proceed normally.                                                             |
+| 31–80            | Warn the user. Suggest `--only` for focused review. Proceed.                  |
+| >80              | **Refuse** unless `--force`. Print the manifest summary and suggest `--only`. |
 
-   - [ ] file:line — description (reviewer)
+### Step 4: Route files to reviewers
 
-   ### Passed Checks
+Each reviewer gets ONLY its relevant files from the manifest:
 
-   - ✓ description (reviewer)
-   ```
+| Reviewer     | Receives categories                                                         | File filter            |
+| ------------ | --------------------------------------------------------------------------- | ---------------------- |
+| **a11y**     | `app-code`, `lib-code`                                                      | `.tsx` files only      |
+| **perf**     | `app-code`, `lib-code`, `api-code`                                          | `.ts` and `.tsx` files |
+| **content**  | `content-mdx`                                                               | all                    |
+| **nx**       | `config`                                                                    | all                    |
+| **e2e**      | `e2e-test`                                                                  | all                    |
+| **security** | `api-code`, plus `app-code`/`lib-code` touching auth, env, Supabase, Resend | `.ts` and `.tsx` files |
 
-6. If no issues found, report a clean bill of health.
+**Routing rules:**
+
+- Skip any reviewer with 0 matching files.
+- Respect `--only` / `--skip` flags after routing.
+- `unit-test` files are NOT sent to a11y, perf, content, or security reviewers. Only e2e-reviewer receives test files (for coverage gap analysis — it compares test files against routes).
+
+### Step 5: Prepare agent context
+
+For each file in an agent's queue, prepare the diff hunk:
+
+```bash
+git diff origin/${BASE_BRANCH}...HEAD -- <file>
+```
+
+Run all file diffs in a single `ctx_batch_execute` call, then search for each file's hunk.
+
+**Per-file treatment based on change size:**
+
+| Lines changed | Agent receives     | Agent action                                        |
+| ------------- | ------------------ | --------------------------------------------------- |
+| Deleted       | Manifest note only | Note gap/impact, do NOT read                        |
+| < 10 lines    | Diff hunk only     | Review hunk in isolation                            |
+| 10–100 lines  | Diff hunk          | Read full file only if hunk context is insufficient |
+| > 100 lines   | Diff hunk          | Read full file via `ctx_batch_execute`              |
+
+**File budget:** Cap at **15 files per agent**. If a reviewer's queue exceeds 15, prioritize by `lines_changed` (largest first). Note skipped files in the report.
+
+### Step 6: Select agent model
+
+| Reviewer             | Matching files | Model                                      |
+| -------------------- | -------------- | ------------------------------------------ |
+| Any                  | > 10 files     | `sonnet` (faster throughput)               |
+| content, nx          | any count      | `sonnet` (checklist-driven, deterministic) |
+| a11y, perf, security | ≤ 10 files     | default (inherits parent model)            |
+| e2e                  | any count      | `sonnet`                                   |
+
+Override: when `--force` is used, all agents inherit the parent model.
+
+### Step 7: Launch agents in parallel
+
+Spawn each applicable reviewer via the Agent tool with `subagent_type` matching the reviewer name (e.g., `a11y-reviewer`). Include in each agent's prompt:
+
+1. **Manifest summary**: branch, base, total files, reviewable count
+2. **This agent's file list** with diff hunks inline
+3. **Instruction**: "Review ONLY the listed files. For files marked diff-only, review the hunk. Read full files via `ctx_batch_execute` only when the diff lacks sufficient context for your checklist."
+
+### Step 8: Collect and deduplicate
+
+Merge findings from all agents. Deduplicate by `file:line` — if multiple agents flag the same location, merge into one finding noting all reviewers.
+
+### Step 9: Output unified report
+
+```markdown
+## PR Review Summary
+
+**Branch**: <branch> → <base>
+**Files in PR**: <total> | **Reviewed**: <count> | **Skipped**: <count> (deleted/binary/meta/docs)
+**Reviewers run**: <list>
+**Skipped reviewers**: <list with reason>
+
+### Critical (must fix)
+
+- [ ] file:line — description (reviewer)
+
+### Warnings (should fix)
+
+- [ ] file:line — description (reviewer)
+
+### Suggestions (nice to have)
+
+- [ ] file:line — description (reviewer)
+
+### Passed Checks
+
+- ✓ description (reviewer)
+
+### Skipped Files
+
+<count> files not reviewed: <breakdown by reason>
+```
 
 ## Rules
 
-- Only run reviewers that have relevant files to check — skip if no matching files changed.
-- Do not make any code changes — this is read-only analysis.
+- Read-only analysis — no code changes.
 - Group findings by severity, not by reviewer.
+- Deleted files are noted but never read.
+- Binary and snapshot files are always skipped.
+- Test files route to e2e-reviewer only.
+- Skill/meta files (`.claude/`) are always skipped.

--- a/.claude/skills/review-content-style/SKILL.md
+++ b/.claude/skills/review-content-style/SKILL.md
@@ -15,16 +15,28 @@ Scan content against the [Content Style Guide](../../docs/content-style-guide.md
 - Route MDX file reads through `ctx_batch_execute` when scanning multiple files — each file is a section
 - Read the style guide once via `ctx_execute` and search with `ctx_search` for specific rules
 
+## Arguments
+
+- `/review-content-style blog` — scan all blog posts
+- `/review-content-style projects` — scan all project case studies
+- `/review-content-style experience` — scan all experience entries
+- `/review-content-style path/to/file.mdx` — scan a specific file
+- `/review-content-style` — scan all MDX content files
+- `/review-content-style --changed` — scan only MDX files changed on the current branch (fastest)
+
 ## Instructions
 
 1. **Load the style guide**: Read `.claude/docs/content-style-guide.md` to load the full set of rules.
 
 2. **Determine scope**: Based on the argument:
+   - `--changed` → detect base branch via `gh pr view --json baseRefName --jq '.baseRefName' 2>/dev/null || echo "develop"`, then `git diff --name-only origin/${BASE_BRANCH}...HEAD -- '*.mdx'` to get only changed MDX files. If no MDX files changed, report clean and stop.
    - `blog` → scan all files in `apps/root/src/data/content/blog/*.mdx`
    - `projects` → scan all files in `apps/root/src/data/content/projects/*.mdx`
    - `experience` → scan all files in `apps/root/src/data/content/experience/*.mdx`
    - A specific file path → scan that file only
    - No argument → scan all MDX content files across all types
+
+   **Diff-first optimization** (applies to `--changed` mode): For files with < 10 lines changed, review the diff hunk for metadata/punctuation/voice issues before reading the full file. Skip the full read if the hunk covers the changed content entirely.
 
 3. **For each file**, check against every rule in the style guide:
 

--- a/.claude/skills/security-review/SKILL.md
+++ b/.claude/skills/security-review/SKILL.md
@@ -6,38 +6,72 @@ disable-model-invocation: true
 
 # Security Review
 
-Perform a security-focused code review of the changes on the current branch compared to develop (the default PR target).
+Perform a security-focused code review of the changes on the current branch.
 
 ## Token Budget Rules
 
-- Route `git diff` output through `ctx_execute` — branch diffs can be very large
+- Route `git diff` output and file reads through `ctx_batch_execute` — diffs can be very large
 - Use `ctx_search` to find specific patterns in indexed diff output rather than re-reading files
 
 ## Instructions
 
-1. Run via `ctx_execute`:
-   ```
-   ctx_execute(language: "shell", code: "git fetch origin && git diff origin/develop...HEAD")
-   ```
-2. Identify all modified files, focusing on:
-   - API routes (`apps/root/src/app/api/`)
-   - Proxy/middleware (`apps/root/src/proxy.ts`)
-   - Server-side code and data fetching
-   - Environment variable usage
-   - Authentication/authorization logic
-   - Supabase queries and RLS considerations
-   - Email/Resend integrations
-   - CSP and security headers
-3. For each changed file, analyze for:
-   - Input validation vulnerabilities (SQL injection, XSS, command injection)
-   - Authentication/authorization bypasses
-   - Sensitive data exposure (PII logging, secrets in responses)
-   - SSRF in scan service URL handling
-   - Insecure cryptographic patterns
-   - Missing rate limiting on new endpoints
-   - XSS: components must use `isomorphic-dompurify` for user-generated HTML; no `dangerouslySetInnerHTML` without sanitization
-   - PII masking: form inputs collecting PII must have `data-sentry-mask` attribute
-   - hCaptcha: form submissions must validate captcha tokens server-side
+### Step 1: Detect base branch
+
+```bash
+gh pr view --json baseRefName --jq '.baseRefName' 2>/dev/null || echo "develop"
+```
+
+Use the result as `BASE_BRANCH`. Always `git fetch origin` first.
+
+### Step 2: Build file manifest and filter
+
+Run via `ctx_batch_execute`:
+
+```bash
+git diff --name-status origin/${BASE_BRANCH}...HEAD
+git diff --stat origin/${BASE_BRANCH}...HEAD
+```
+
+**Skip these files entirely** — they cannot contain security issues:
+
+- Deleted files (status `D`)
+- Binary files (`*.png`, `*.jpg`, `*.svg`, `*-snapshots/*`)
+- Meta files (`.claude/`, `CLAUDE.md`, `*.md` docs)
+- Test files (`*.spec.*`, `*.test.*`, `__tests__/*`, `__mocks__/*`, `apps/root-e2e/**`)
+- MDX content files (`data/content/**/*.mdx`)
+- Stories (`*.stories.tsx`)
+
+**Prioritize these files** — highest security relevance:
+
+- API routes (`apps/root/src/app/api/`)
+- Proxy/middleware (`proxy.ts`, `middleware.ts`)
+- Server-side code and data fetching
+- Environment variable usage
+- Authentication/authorization logic
+- Supabase queries and RLS considerations
+- Email/Resend integrations
+- CSP and security headers (`next.config.mjs`)
+
+### Step 3: Diff-first review
+
+For each security-relevant file:
+
+- **< 10 lines changed**: Review the diff hunk only. Skip full file read.
+- **10–100 lines changed**: Review the diff hunk. Read full file only if the hunk context is insufficient to assess exploitability.
+- **> 100 lines or new files**: Read the full file via `ctx_batch_execute`.
+
+### Step 4: Analyze for:
+
+- Input validation vulnerabilities (SQL injection, XSS, command injection)
+- Authentication/authorization bypasses
+- Sensitive data exposure (PII logging, secrets in responses)
+- SSRF in scan service URL handling
+- Insecure cryptographic patterns
+- Missing rate limiting on new endpoints
+- XSS: components must use `isomorphic-dompurify` for user-generated HTML; no `dangerouslySetInnerHTML` without sanitization
+- PII masking: form inputs collecting PII must have `data-sentry-mask` attribute
+- hCaptcha: form submissions must validate captcha tokens server-side
+
 4. **Project-specific concerns:**
    - `@supabase/supabase-js` — browser client must only use anon key, never service role key
    - `resend` — email sending must validate recipient addresses and sanitize content

--- a/.claude/skills/storybook-check/SKILL.md
+++ b/.claude/skills/storybook-check/SKILL.md
@@ -20,11 +20,12 @@ Build Storybook for projects affected by current changes and report any broken s
 
 ## Instructions
 
-1. **Identify affected projects with Storybook targets:**
+1. **Detect base branch and identify affected projects:**
 
    ```bash
-   pnpm nx show projects --affected --base=origin/develop --type=lib
-   pnpm nx show projects --affected --base=origin/develop --type=app
+   BASE=$(gh pr view --json baseRefName --jq '.baseRefName' 2>/dev/null || echo "develop")
+   pnpm nx show projects --affected --base=origin/${BASE} --type=lib
+   pnpm nx show projects --affected --base=origin/${BASE} --type=app
    ```
 
    Cross-reference with projects that have a `build-storybook` target.


### PR DESCRIPTION
## Summary

- **Rewrote pr-review skill** with 9-step optimized pipeline: auto base branch detection, file manifest pre-filtering (skip deleted/binary/meta/test files), diff-first review strategy, per-agent file budgets (cap 15), model tiering (sonnet for checklist agents, inherit for judgment agents), and `--only`/`--skip`/`--base`/`--force` CLI flags
- **Created security-reviewer agent** — input validation, auth, SSRF, PII exposure, CSP, Supabase/Resend patterns (was referenced in pr-review but never existed)
- **Added review protocol to all 5 existing agents** (a11y, perf, content, nx, e2e) — diff-first instructions, manifest awareness, file budget compliance. Fixed nx-reviewer "Yarn" → "pnpm" reference. Replaced e2e-reviewer hardcoded spec list with auto-discovery.
- **Applied same optimization patterns to 5 related skills**:
  - `security-review`: manifest filtering, diff-first, base branch detection
  - `coverage-gaps`: `--changed` flag to scan only branch-changed components
  - `review-content-style`: `--changed` flag for branch-scoped MDX review
  - `storybook-check`: auto base branch detection (was hardcoded `origin/develop`)
  - `batch-commit`: file categorization table for smarter commit grouping

### Context savings on a 97-file PR like #492

| Optimization | Impact |
|---|---|
| Skip deleted files (30 in #492) | ~31% fewer reads |
| Skip binary/snapshots (9 PNGs) | ~9% fewer reads |
| Skip meta files (.claude/skills) | ~10% fewer reads |
| Route tests to e2e-reviewer only | ~15% fewer cross-agent reads |
| Diff-only for small changes (<10 lines) | ~10% context savings |
| File budget cap (15/agent) | Prevents context blowout |

## Test plan

- [ ] Run `/pr-review --only perf` on a small branch to verify manifest building and agent routing
- [ ] Run `/coverage-gaps --changed` to verify branch-scoped scanning
- [ ] Run `/review-content-style --changed` on a branch with MDX changes
- [ ] Verify `security-reviewer` agent loads when spawned by pr-review

🤖 Generated with [Claude Code](https://claude.com/claude-code)