### PR TITLE
feat(fitted): complete onboarding-to-targets pipeline

### DIFF
--- a/apps/job-api/app/models/targets.py
+++ b/apps/job-api/app/models/targets.py
@@ -96,3 +96,20 @@ class ReferenceJDAdd(BaseModel):
 
     jd_text: str = Field(min_length=50, max_length=100_000)
     jd_url: str | None = None
+
+
+# ---- Suggestion shapes (LLM output) ----------------------------------------
+
+
+class TargetSuggestion(BaseModel):
+    """A single suggested target derived from the user's experience profile."""
+
+    label: str = Field(min_length=1, max_length=200)
+    description: str = Field(max_length=500)
+    core_skills: list[str] = Field(default_factory=list)
+
+
+class TargetSuggestions(BaseModel):
+    """LLM response containing 2-3 suggested targets."""
+
+    suggestions: list[TargetSuggestion] = Field(default_factory=list)

--- a/apps/job-api/app/routers/jobs.py
+++ b/apps/job-api/app/routers/jobs.py
@@ -219,8 +219,8 @@ async def add_manual_job(
             needs_manual_fields=True,
         )
 
-    # Generate external_id from URL
-    external_id = hashlib.sha256(final_url.encode()).hexdigest()[:16]
+    # Generate external_id from URL — must be numeric (bigint column)
+    external_id = str(int(hashlib.sha256(final_url.encode()).hexdigest()[:15], 16))
 
     # Score the job
     score_result = score_job(title, description_html, keyword_config)

--- a/apps/job-api/app/routers/targets.py
+++ b/apps/job-api/app/routers/targets.py
@@ -5,6 +5,9 @@ triggers LLM-powered profile derivation and merges the result into the
 target's composite scoring profile.
 """
 
+import logging
+from typing import Any, cast
+
 from fastapi import APIRouter, Depends, HTTPException
 from supabase import Client
 
@@ -15,14 +18,23 @@ from app.models.targets import (
     ScoringProfile,
     TargetCreate,
     TargetReferenceJD,
+    TargetSuggestions,
     TargetUpdate,
 )
+from app.services.experience import optimized
 from app.services.llm import cost_log
 from app.services.llm.client import LLMClient
+from app.services.scoring import strip_html
 from app.services.targets import crud
 from app.services.targets.derive_profile import DEFAULT_PURPOSE, derive_profile_from_jd
 from app.services.targets.merge import merge_profiles
+from app.services.targets.suggest import (
+    DEFAULT_PURPOSE as SUGGEST_PURPOSE,
+    suggest_targets,
+)
 from app.services.validate import validate_job_url
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(
     prefix="/targets",
@@ -48,6 +60,27 @@ async def list_targets(
 ) -> dict[str, list[JobTarget]]:
     targets = crud.list_all(supabase, user_id=None)
     return {"targets": targets}
+
+
+@router.post("/suggest")
+async def suggest(
+    supabase: Client = Depends(get_supabase),
+    llm: LLMClient = Depends(get_llm_client),
+) -> TargetSuggestions:
+    """Suggest 2-3 targets from the user's OptimizedDoc."""
+    doc = optimized.get_latest(supabase, user_id=None)
+    if doc is None:
+        raise HTTPException(status_code=404, detail="No experience profile found")
+
+    suggestions, result = await suggest_targets(llm, payload=doc.payload)
+    cost_log.record(
+        supabase,
+        user_id=None,
+        purpose=SUGGEST_PURPOSE,
+        result=result,
+        metadata={},
+    )
+    return suggestions
 
 
 @router.get("/active")
@@ -103,6 +136,86 @@ async def delete_target(
     if not deleted:
         raise HTTPException(status_code=404, detail="Target not found")
     return {"deleted": True}
+
+
+# ---- Create from job posting -----------------------------------------------
+
+
+@router.post("/from-posting/{posting_id}")
+async def create_target_from_posting(
+    posting_id: str,
+    supabase: Client = Depends(get_supabase),
+    llm: LLMClient = Depends(get_llm_client),
+) -> JobTarget:
+    """Create a target from an existing job posting.
+
+    Reads the posting's title and description, creates a target, derives a
+    scoring profile from the description via LLM, stores the JD as a
+    reference, and activates the target.
+    """
+    resp = (
+        supabase.table("job_postings")
+        .select("id, title, description_html, absolute_url")
+        .eq("id", posting_id)
+        .execute()
+    )
+    rows = cast(list[dict[str, Any]], resp.data or [])
+    if not rows:
+        raise HTTPException(status_code=404, detail="Job posting not found")
+
+    posting = rows[0]
+    title = posting.get("title") or "Untitled Role"
+    description_html: str = posting.get("description_html") or ""
+    absolute_url: str | None = posting.get("absolute_url")
+
+    # Create the target
+    target = crud.create(
+        supabase, user_id=None, payload=TargetCreate(label=title)
+    )
+
+    # Derive scoring profile from description if substantial
+    jd_text = strip_html(description_html)
+    if len(jd_text) >= 50:
+        try:
+            extracted_profile, result = await derive_profile_from_jd(
+                llm, jd_text=jd_text
+            )
+            cost_log.record(
+                supabase,
+                user_id=None,
+                purpose=DEFAULT_PURPOSE,
+                result=result,
+                metadata={
+                    "target_id": target.id,
+                    "posting_id": posting_id,
+                    "jd_url": absolute_url or "",
+                },
+            )
+
+            crud.add_reference_jd(
+                supabase,
+                target_id=target.id,
+                jd_text=jd_text,
+                jd_url=absolute_url,
+                extracted_profile=extracted_profile,
+            )
+
+            # Update target with the derived profile
+            crud.update(
+                supabase,
+                target.id,
+                TargetUpdate(scoring_profile=extracted_profile),
+            )
+        except Exception:
+            logger.exception(
+                "Profile derivation failed for posting %s", posting_id
+            )
+
+    # Activate the target
+    activated = crud.set_active(
+        supabase, user_id=None, target_id=target.id
+    )
+    return activated or target
 
 
 # ---- Reference JDs ---------------------------------------------------------

--- a/apps/job-api/app/services/insights.py
+++ b/apps/job-api/app/services/insights.py
@@ -9,8 +9,13 @@ from __future__ import annotations
 
 from collections import Counter, defaultdict
 from datetime import date, datetime, timedelta
+from typing import Any, cast
 
 from supabase import Client
+
+# Supabase .execute().data is typed as list[JSON] (a broad union).
+# In practice every row is a dict — this alias makes casts readable.
+Row = dict[str, Any]
 
 from app.models.insights import (
     CostBucket,
@@ -62,20 +67,20 @@ def compute_pipeline(supabase: Client, since: datetime | None) -> PipelineInsigh
     q = supabase.table("job_postings").select("id, status, created_at")
     if since:
         q = q.gte("created_at", since.isoformat())
-    postings = q.execute().data or []
+    postings = cast(list[Row], q.execute().data or [])
 
     # Fetch status log for response-time calculation
     sq = supabase.table("job_status_log").select("posting_id, old_status, new_status, created_at")
     if since:
         sq = sq.gte("created_at", since.isoformat())
-    status_logs = sq.execute().data or []
+    status_logs = cast(list[Row], sq.execute().data or [])
 
     # Fetch tailored resumes for velocity
     rq = supabase.table("tailored_resumes").select("job_posting_id, created_at")
     if since:
         rq = rq.gte("created_at", since.isoformat())
     rq = rq.eq("document_type", "resume")
-    resumes = rq.execute().data or []
+    resumes = cast(list[Row], rq.execute().data or [])
 
     # --- Funnel counts ---
     status_counts: Counter[str] = Counter()
@@ -145,17 +150,17 @@ def compute_pipeline(supabase: Client, since: datetime | None) -> PipelineInsigh
 
 def compute_targets(supabase: Client, since: datetime | None) -> TargetInsights:
     # Fetch all targets for labels
-    targets_data = supabase.table("job_targets").select("id, label").execute().data or []
+    targets_data = cast(list[Row], supabase.table("job_targets").select("id, label").execute().data or [])
     target_labels = {t["id"]: t["label"] for t in targets_data}
 
     # Fetch postings with target + score + status
     q = supabase.table("job_postings").select("id, target_id, score, status, created_at")
     if since:
         q = q.gte("created_at", since.isoformat())
-    postings = q.execute().data or []
+    postings = cast(list[Row], q.execute().data or [])
 
     # --- Per-target aggregation ---
-    target_jobs: defaultdict[str, list[dict]] = defaultdict(list)
+    target_jobs: defaultdict[str, list[Row]] = defaultdict(list)
     all_scores: list[int] = []
     for p in postings:
         score = p.get("score") or 0
@@ -243,20 +248,20 @@ def compute_skills_cost(supabase: Client, since: datetime | None) -> SkillsCostI
     aq = supabase.table("job_analyses").select("scorecard, created_at")
     if since:
         aq = aq.gte("created_at", since.isoformat())
-    analyses = aq.execute().data or []
+    analyses = cast(list[Row], aq.execute().data or [])
 
     # Fetch LLM cost log
     cq = supabase.table("llm_cost_log").select("purpose, cost_usd, created_at")
     if since:
         cq = cq.gte("created_at", since.isoformat())
-    cost_logs = cq.execute().data or []
+    cost_logs = cast(list[Row], cq.execute().data or [])
 
     # Fetch tailored resumes for per-resume cost
     rq = supabase.table("tailored_resumes").select("cost_usd, created_at")
     if since:
         rq = rq.gte("created_at", since.isoformat())
     rq = rq.eq("document_type", "resume")
-    resume_costs = rq.execute().data or []
+    resume_costs = cast(list[Row], rq.execute().data or [])
 
     # --- Skill frequencies ---
     matched_counts: Counter[str] = Counter()

--- a/apps/job-api/app/services/targets/suggest.py
+++ b/apps/job-api/app/services/targets/suggest.py
@@ -1,0 +1,106 @@
+"""Suggest job targets from the user's OptimizedDoc via LLM.
+
+Given the user's structured experience (roles, skills, outcomes), the LLM
+suggests 2-3 concrete role targets. Each suggestion includes a label,
+short description, and core skills — enough to create a useful target
+immediately. Detailed scoring profiles come later via reference JDs.
+"""
+
+from app.models.experience import OptimizedPayload
+from app.models.llm import LLMResult, Message, ModelId
+from app.models.targets import TargetSuggestions
+from app.services.llm.client import LLMClient, complete_json
+
+DEFAULT_MODEL: ModelId = "claude-sonnet-4-6"
+DEFAULT_PURPOSE = "target.suggest"
+
+SYSTEM_PROMPT = """\
+You are a career advisor. Given a user's structured experience profile \
+(roles, skills, outcomes), suggest 2-3 job targets they should pursue.
+
+Return JSON matching this exact schema:
+
+{
+  "suggestions": [
+    {
+      "label": "Senior Frontend Engineer",
+      "description": "Frontend-focused roles at mid-to-large companies \
+leveraging your React and TypeScript expertise.",
+      "core_skills": ["React", "TypeScript", "CSS", "Testing"]
+    }
+  ]
+}
+
+Rules:
+- Suggest 2-3 targets. Each should be a distinct career direction.
+- "label" is a concise role title (e.g., "Staff Full-Stack Engineer", \
+"Engineering Manager", "Senior DevOps Engineer").
+- "description" is 1-2 sentences explaining why this target fits and what \
+kinds of companies/teams to look for.
+- "core_skills" lists 3-6 skills from the user's profile most relevant to \
+this target. Use canonical names (React not reactjs, TypeScript not TS).
+- Base suggestions ONLY on the user's actual experience. Do not invent \
+skills or roles they haven't held.
+- Vary seniority or function across suggestions when the experience supports \
+it (e.g., IC vs management, frontend vs full-stack).
+- Return ONLY the JSON object. No prose, no markdown, no code fences."""
+
+
+def _build_user_message(payload: OptimizedPayload) -> str:
+    """Serialize the OptimizedPayload into a compact text summary for the LLM."""
+    parts: list[str] = []
+
+    if payload.summary:
+        parts.append(f"Summary: {payload.summary}")
+
+    if payload.roles:
+        role_lines = []
+        for r in payload.roles:
+            line = f"- {r.title} at {r.company} ({r.start}–{r.end or 'present'})"
+            if r.skills:
+                line += f" | Skills: {', '.join(r.skills)}"
+            role_lines.append(line)
+        parts.append("Roles:\n" + "\n".join(role_lines))
+
+    if payload.skills:
+        skill_lines = []
+        for s in payload.skills:
+            line = s.name
+            if s.years:
+                line += f" ({s.years}y)"
+            skill_lines.append(line)
+        parts.append("Skills: " + ", ".join(skill_lines))
+
+    if payload.outcomes:
+        outcome_lines = []
+        for o in payload.outcomes:
+            line = f"- {o.description}"
+            if o.metric and o.value:
+                line += f" ({o.metric}: {o.value})"
+            outcome_lines.append(line)
+        parts.append("Key outcomes:\n" + "\n".join(outcome_lines[:10]))
+
+    return "\n\n".join(parts) if parts else "No experience data available."
+
+
+async def suggest_targets(
+    llm: LLMClient,
+    *,
+    payload: OptimizedPayload,
+    model: ModelId = DEFAULT_MODEL,
+    purpose: str = DEFAULT_PURPOSE,
+) -> tuple[TargetSuggestions, LLMResult]:
+    """Suggest targets from an OptimizedPayload.
+
+    Returns (suggestions, result) so callers can log cost.
+    """
+    user_message = _build_user_message(payload)
+    return await complete_json(
+        llm,
+        model=model,
+        system=SYSTEM_PROMPT,
+        messages=[Message(role="user", content=user_message)],
+        schema=TargetSuggestions,
+        purpose=purpose,
+        cache_system=True,
+    )

--- a/apps/job-api/tests/test_manual_job.py
+++ b/apps/job-api/tests/test_manual_job.py
@@ -190,7 +190,7 @@ class TestManualJobEndpoint:
         import hashlib
 
         url = "https://example.com/jobs/same"
-        expected_id = hashlib.sha256(url.encode()).hexdigest()[:16]
+        expected_id = str(int(hashlib.sha256(url.encode()).hexdigest()[:15], 16))
 
         mock_http_client.get = AsyncMock(
             return_value=_mock_response(text=JSONLD_HTML, url=url)

--- a/apps/root-e2e/src/error-handling.spec.ts
+++ b/apps/root-e2e/src/error-handling.spec.ts
@@ -18,10 +18,7 @@ test.describe('404 Error Page', () => {
     await page.locator('h1, h2').first().waitFor({ state: 'visible' });
 
     await expect(
-      page
-        .getByRole('heading', { name: '404' })
-        .or(page.getByRole('heading', { name: 'Page Not Found' }))
-        .or(page.getByText(/not found/i))
+      page.getByRole('heading', { name: '404', exact: true })
     ).toBeVisible();
   });
 
@@ -101,10 +98,11 @@ test.describe('thank-you page protection', () => {
     await page.locator('form').waitFor({ state: 'visible' });
     await expect(page.getByRole('button', { name: /submit/i })).toBeEnabled();
 
-    // Fill and submit form
-    await fillInput(page.getByLabel(/name/i), VALID_FORM_DATA.name);
-    await fillInput(page.getByLabel(/email/i), VALID_FORM_DATA.email);
-    await fillInput(page.getByLabel(/message/i), VALID_FORM_DATA.message);
+    // Fill and submit form — scope to form to avoid matching nav "Send Email" links
+    const form = page.locator('form');
+    await fillInput(form.getByLabel(/name/i), VALID_FORM_DATA.name);
+    await fillInput(form.getByLabel(/email/i), VALID_FORM_DATA.email);
+    await fillInput(form.getByLabel(/message/i), VALID_FORM_DATA.message);
 
     // Complete hCaptcha verification
     await completeHCaptcha(page);
@@ -131,9 +129,10 @@ test.describe('thank-you page protection', () => {
     await page.locator('form').waitFor({ state: 'visible' });
     await expect(page.getByRole('button', { name: /submit/i })).toBeEnabled();
 
-    await fillInput(page.getByLabel(/name/i), VALID_FORM_DATA.name);
-    await fillInput(page.getByLabel(/email/i), VALID_FORM_DATA.email);
-    await fillInput(page.getByLabel(/message/i), VALID_FORM_DATA.message);
+    const form1 = page.locator('form');
+    await fillInput(form1.getByLabel(/name/i), VALID_FORM_DATA.name);
+    await fillInput(form1.getByLabel(/email/i), VALID_FORM_DATA.email);
+    await fillInput(form1.getByLabel(/message/i), VALID_FORM_DATA.message);
 
     await completeHCaptcha(page);
 
@@ -158,9 +157,10 @@ test.describe('thank-you page protection', () => {
     await page.locator('form').waitFor({ state: 'visible' });
     await expect(page.getByRole('button', { name: /submit/i })).toBeEnabled();
 
-    await fillInput(page.getByLabel(/name/i), VALID_FORM_DATA.name);
-    await fillInput(page.getByLabel(/email/i), VALID_FORM_DATA.email);
-    await fillInput(page.getByLabel(/message/i), VALID_FORM_DATA.message);
+    const form2 = page.locator('form');
+    await fillInput(form2.getByLabel(/name/i), VALID_FORM_DATA.name);
+    await fillInput(form2.getByLabel(/email/i), VALID_FORM_DATA.email);
+    await fillInput(form2.getByLabel(/message/i), VALID_FORM_DATA.message);
 
     await completeHCaptcha(page);
 

--- a/apps/root-e2e/src/navigation.spec.ts
+++ b/apps/root-e2e/src/navigation.spec.ts
@@ -157,8 +157,10 @@ test.describe('mobile navigation', () => {
     // normal Playwright clicks.
     const overlay = page.getByTestId('sheet-overlay');
     await overlay.dispatchEvent('click');
-    // The sheet uses translate-y transition to slide off-screen
-    await expect(sheet).toBeHidden();
+    // The sheet slides off-screen via translate-y-full and sets aria-hidden.
+    // Playwright's toBeHidden() requires display:none or visibility:hidden,
+    // so assert the semantic close state instead.
+    await expect(sheet).toHaveAttribute('aria-hidden', 'true');
   });
 
   test('navigates from More sheet', async ({ page }) => {

--- a/apps/root/src/app/api/career/experience/upload-resume/route.ts
+++ b/apps/root/src/app/api/career/experience/upload-resume/route.ts
@@ -2,13 +2,17 @@ import { type NextRequest, NextResponse } from 'next/server';
 import {
   verifyJobsAccess,
   proxyMultipartToFastAPI,
+  LLM_TIMEOUT_MS,
 } from '@/app/api/jobs/proxy';
 
 export async function POST(request: NextRequest) {
   if (!(await verifyJobsAccess())) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
+  const autoDerives =
+    request.nextUrl.searchParams.get('auto_derive') === 'true';
   return proxyMultipartToFastAPI('/experience/upload-resume', request, {
     searchParams: request.nextUrl.searchParams,
+    timeoutMs: autoDerives ? LLM_TIMEOUT_MS : undefined,
   });
 }

--- a/apps/root/src/app/api/targets/from-posting/[id]/route.ts
+++ b/apps/root/src/app/api/targets/from-posting/[id]/route.ts
@@ -1,0 +1,20 @@
+import { type NextRequest, NextResponse } from 'next/server';
+import {
+  verifyJobsAccess,
+  proxyToFastAPI,
+  LLM_TIMEOUT_MS,
+} from '@/app/api/jobs/proxy';
+
+export async function POST(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  if (!(await verifyJobsAccess())) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const { id } = await params;
+  return proxyToFastAPI(`/targets/from-posting/${id}`, {
+    method: 'POST',
+    timeoutMs: LLM_TIMEOUT_MS,
+  });
+}

--- a/apps/root/src/app/api/targets/suggest/route.ts
+++ b/apps/root/src/app/api/targets/suggest/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from 'next/server';
+import {
+  verifyJobsAccess,
+  proxyToFastAPI,
+  LLM_TIMEOUT_MS,
+} from '@/app/api/jobs/proxy';
+
+export async function POST() {
+  if (!(await verifyJobsAccess())) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  return proxyToFastAPI('/targets/suggest', {
+    method: 'POST',
+    timeoutMs: LLM_TIMEOUT_MS,
+  });
+}

--- a/apps/root/src/app/fitted/(app)/jobs/JobsList.tsx
+++ b/apps/root/src/app/fitted/(app)/jobs/JobsList.tsx
@@ -16,7 +16,11 @@ const INITIAL_FILTERS: JobsFilterState = {
 
 const BATCH_POLL_INTERVAL = 3000;
 
-export default function JobsList() {
+interface JobsListProps {
+  targetId: string | undefined;
+}
+
+export default function JobsList({ targetId }: JobsListProps) {
   const [filters, setFilters] = useState<JobsFilterState>(INITIAL_FILTERS);
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [refreshKey, setRefreshKey] = useState(0);
@@ -196,6 +200,7 @@ export default function JobsList() {
         selectedIds={selectedIds}
         onSelectionChange={setSelectedIds}
         refreshKey={refreshKey}
+        targetId={targetId}
       />
 
       <BatchActionBar

--- a/apps/root/src/app/fitted/(app)/jobs/JobsListTable.tsx
+++ b/apps/root/src/app/fitted/(app)/jobs/JobsListTable.tsx
@@ -15,6 +15,7 @@ interface JobsListTableProps {
   selectedIds: Set<string>;
   onSelectionChange: (ids: Set<string>) => void;
   refreshKey: number;
+  targetId: string | undefined;
 }
 
 function ScoreBadge({ score }: { score: number }) {
@@ -56,19 +57,21 @@ export default function JobsListTable({
   selectedIds,
   onSelectionChange,
   refreshKey,
+  targetId,
 }: JobsListTableProps) {
   const [expandedId, setExpandedId] = useState<string | null>(null);
   const [deleteKey, setDeleteKey] = useState(0);
 
   const extraParams = useMemo(() => {
     const params: Record<string, string> = {};
+    if (targetId) params.target_id = targetId;
     if (filters.minScore) params.min_score = filters.minScore;
     if (filters.status) params.status = filters.status;
     if (filters.search) params.search = filters.search;
     const combined = refreshKey + deleteKey;
     if (combined) params._r = String(combined);
     return params;
-  }, [filters, refreshKey, deleteKey]);
+  }, [targetId, filters, refreshKey, deleteKey]);
 
   const {
     data: postings,

--- a/apps/root/src/app/fitted/(app)/jobs/page.tsx
+++ b/apps/root/src/app/fitted/(app)/jobs/page.tsx
@@ -5,6 +5,14 @@ export const metadata: Metadata = {
   title: 'Jobs',
 };
 
-export default function FittedJobsPage() {
-  return <JobsList />;
+export default async function FittedJobsPage({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const params = await searchParams;
+  const targetId =
+    typeof params.target === 'string' ? params.target : undefined;
+
+  return <JobsList targetId={targetId} />;
 }

--- a/apps/root/src/app/fitted/(app)/targets/TargetCard.tsx
+++ b/apps/root/src/app/fitted/(app)/targets/TargetCard.tsx
@@ -12,6 +12,7 @@ interface TargetCardProps {
   target: JobTarget;
   onActivate: (id: string) => void;
   onDelete: (id: string) => void;
+  onViewJobs: (id: string) => void;
 }
 
 function countKeywords(target: JobTarget): number {
@@ -25,6 +26,7 @@ export default function TargetCard({
   target,
   onActivate,
   onDelete,
+  onViewJobs,
 }: TargetCardProps) {
   const categoryCount = Object.keys(target.scoring_profile.categories).length;
   const keywordCount = countKeywords(target);
@@ -67,6 +69,14 @@ export default function TargetCard({
         </Text>
 
         <div className='flex items-center gap-2 pt-1'>
+          <Button
+            name={`target-view-jobs-${target.id}`}
+            variant='primary'
+            size='sm'
+            onClick={() => onViewJobs(target.id)}
+          >
+            View Jobs
+          </Button>
           {!target.is_active && (
             <Button
               name={`target-activate-${target.id}`}

--- a/apps/root/src/app/fitted/(app)/targets/TargetsList.tsx
+++ b/apps/root/src/app/fitted/(app)/targets/TargetsList.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
 import { Plus } from 'lucide-react';
 import { Heading } from '@danieljoffe.com/shared-ui/Heading';
 import { Text } from '@danieljoffe.com/shared-ui/Text';
@@ -17,13 +18,14 @@ export default function TargetsList() {
   const [loading, setLoading] = useState(true);
   const [modalOpen, setModalOpen] = useState(false);
   const { toast } = useToast();
+  const router = useRouter();
 
   const fetchTargets = useCallback(async () => {
     try {
       const res = await fetch('/api/targets');
       if (!res.ok) throw new Error('Failed to fetch targets');
-      const data = (await res.json()) as JobTarget[];
-      setTargets(data);
+      const { targets } = (await res.json()) as { targets: JobTarget[] };
+      setTargets(targets);
     } catch {
       toast({ variant: 'error', title: 'Failed to load targets' });
     } finally {
@@ -67,6 +69,13 @@ export default function TargetsList() {
       }
     },
     [toast, fetchTargets]
+  );
+
+  const handleViewJobs = useCallback(
+    (id: string) => {
+      router.push(`/fitted/jobs?target=${id}`);
+    },
+    [router]
   );
 
   const handleCreated = useCallback(() => {
@@ -125,6 +134,7 @@ export default function TargetsList() {
               target={target}
               onActivate={handleActivate}
               onDelete={handleDelete}
+              onViewJobs={handleViewJobs}
             />
           ))}
         </div>

--- a/apps/root/src/app/fitted/onboarding/CompletionScreen.tsx
+++ b/apps/root/src/app/fitted/onboarding/CompletionScreen.tsx
@@ -19,22 +19,22 @@ export default function CompletionScreen() {
               You&apos;re all set!
             </Heading>
             <Text variant='body' className='mt-2 text-text-secondary'>
-              Your account is ready. Head to the dashboard to start tracking
-              jobs and generating tailored resumes.
+              Your account is ready. Head to your targets to start tracking jobs
+              and generating tailored resumes.
             </Text>
           </div>
         </div>
       </Card>
 
       <Button
-        name='onboarding-go-to-dashboard'
+        name='onboarding-go-to-targets'
         as='link'
-        href='/fitted'
+        href='/fitted/targets'
         variant='primary'
         size='lg'
         className='w-full justify-center'
       >
-        <span>Go to Dashboard</span>
+        <span>Go to Targets</span>
         <ArrowRight className='size-4' aria-hidden />
       </Button>
     </div>

--- a/apps/root/src/app/fitted/onboarding/JobUrlInput.tsx
+++ b/apps/root/src/app/fitted/onboarding/JobUrlInput.tsx
@@ -10,8 +10,13 @@ import { Spinner } from '@danieljoffe.com/shared-ui/Spinner';
 import { Alert } from '@danieljoffe.com/shared-ui/Alert';
 import Button from '@/components/Button';
 
+export interface JobData {
+  postingId: string;
+  title: string | null;
+}
+
 interface JobUrlInputProps {
-  onComplete: () => void;
+  onComplete: (data?: JobData) => void;
   onSkip: () => void;
 }
 
@@ -71,7 +76,10 @@ export default function JobUrlInput({ onComplete, onSkip }: JobUrlInputProps) {
           posting_id: data.posting_id,
         });
 
-        timerRef.current = setTimeout(onComplete, 1500);
+        const jobData = data.posting_id
+          ? { postingId: data.posting_id, title: data.extracted?.title ?? null }
+          : undefined;
+        timerRef.current = setTimeout(() => onComplete(jobData), 1500);
       } catch (err) {
         setError(
           err instanceof Error

--- a/apps/root/src/app/fitted/onboarding/OnboardingWizard.tsx
+++ b/apps/root/src/app/fitted/onboarding/OnboardingWizard.tsx
@@ -7,7 +7,7 @@ import { Text } from '@danieljoffe.com/shared-ui/Text';
 import { Heading } from '@danieljoffe.com/shared-ui/Heading';
 import PathChooser from './PathChooser';
 import ResumeUploader from './ResumeUploader';
-import JobUrlInput from './JobUrlInput';
+import JobUrlInput, { type JobData } from './JobUrlInput';
 import TargetSuggestions from './TargetSuggestions';
 import ConversationChat from './ConversationChat';
 import CompletionScreen from './CompletionScreen';
@@ -23,7 +23,7 @@ type Step =
   | 'completion';
 
 const STEPS_BY_PATH: Record<OnboardingPath, Step[]> = {
-  A: ['path-chooser', 'upload-resume', 'add-job', 'completion'],
+  A: ['path-chooser', 'upload-resume', 'add-job', 'pick-targets', 'completion'],
   B: ['path-chooser', 'upload-resume', 'pick-targets', 'completion'],
   C: ['path-chooser', 'conversation', 'pick-targets', 'completion'],
 };
@@ -32,6 +32,7 @@ export default function OnboardingWizard() {
   const router = useRouter();
   const [currentStep, setCurrentStep] = useState<Step>('path-chooser');
   const [selectedPath, setSelectedPath] = useState<OnboardingPath | null>(null);
+  const [jobData, setJobData] = useState<JobData | null>(null);
   const stepRef = useRef<HTMLDivElement>(null);
 
   const steps = selectedPath ? STEPS_BY_PATH[selectedPath] : ['path-chooser'];
@@ -59,7 +60,7 @@ export default function OnboardingWizard() {
   }, []);
 
   const handleSkip = useCallback(() => {
-    router.push('/fitted');
+    router.push('/fitted/targets');
   }, [router]);
 
   return (
@@ -103,10 +104,20 @@ export default function OnboardingWizard() {
             <ResumeUploader onComplete={goNext} onSkip={handleSkip} />
           )}
           {currentStep === 'add-job' && (
-            <JobUrlInput onComplete={goNext} onSkip={handleSkip} />
+            <JobUrlInput
+              onComplete={data => {
+                if (data) setJobData(data);
+                goNext();
+              }}
+              onSkip={handleSkip}
+            />
           )}
           {currentStep === 'pick-targets' && (
-            <TargetSuggestions onComplete={goNext} onSkip={handleSkip} />
+            <TargetSuggestions
+              onComplete={goNext}
+              onSkip={handleSkip}
+              jobData={jobData}
+            />
           )}
           {currentStep === 'conversation' && (
             <ConversationChat onComplete={goNext} onSkip={handleSkip} />

--- a/apps/root/src/app/fitted/onboarding/TargetSuggestions.tsx
+++ b/apps/root/src/app/fitted/onboarding/TargetSuggestions.tsx
@@ -1,68 +1,192 @@
 'use client';
 
-import { useEffect, useState, useCallback } from 'react';
-import { Target, ArrowRight } from 'lucide-react';
+import { useEffect, useState, useCallback, useRef } from 'react';
+import { CheckCircle, Target } from 'lucide-react';
 import { Card } from '@danieljoffe.com/shared-ui/Card';
 import { Text } from '@danieljoffe.com/shared-ui/Text';
 import { Heading } from '@danieljoffe.com/shared-ui/Heading';
 import { Spinner } from '@danieljoffe.com/shared-ui/Spinner';
 import { Alert } from '@danieljoffe.com/shared-ui/Alert';
 import Button from '@/components/Button';
+import { cn } from '@/lib/cn';
+import type { JobData } from './JobUrlInput';
 
 interface TargetSuggestionsProps {
   onComplete: () => void;
   onSkip: () => void;
+  jobData?: JobData | null;
 }
 
-interface OptimizedSkill {
-  name: string;
-  proficiency: string;
+interface Suggestion {
+  label: string;
+  description: string;
+  core_skills: string[];
 }
 
 export default function TargetSuggestions({
   onComplete,
   onSkip,
+  jobData,
 }: TargetSuggestionsProps) {
   const [loading, setLoading] = useState(true);
-  const [skills, setSkills] = useState<string[]>([]);
   const [error, setError] = useState<string | null>(null);
+  const [createdLabel, setCreatedLabel] = useState<string | null>(null);
+  const [suggestions, setSuggestions] = useState<Suggestion[]>([]);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [creating, setCreating] = useState(false);
+  const [createdCount, setCreatedCount] = useState(0);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, []);
+
+  // Path A: auto-create target from job posting
+  useEffect(() => {
+    if (!jobData) return;
     let cancelled = false;
 
-    async function fetchSkills() {
+    async function createFromPosting() {
       try {
-        const res = await fetch('/api/career/experience/optimized');
-        if (!res.ok) {
-          // No master doc yet — that's fine, show generic message
-          setSkills([]);
-          return;
-        }
-        const data = (await res.json()) as {
-          payload?: { skills?: OptimizedSkill[] };
-        };
-        if (!cancelled && data.payload?.skills) {
-          setSkills(
-            data.payload.skills.slice(0, 8).map((s: OptimizedSkill) => s.name)
-          );
+        const res = await fetch(
+          `/api/targets/from-posting/${jobData.postingId}`,
+          { method: 'POST' }
+        );
+        if (!res.ok) throw new Error('Failed to create target');
+        const data = (await res.json()) as { label: string };
+        if (!cancelled) {
+          setCreatedLabel(data.label);
+          timerRef.current = setTimeout(onComplete, 2000);
         }
       } catch {
-        if (!cancelled) setError('Could not load your profile.');
+        if (!cancelled) {
+          setError(
+            'Could not auto-create target. You can create one manually.'
+          );
+        }
       } finally {
         if (!cancelled) setLoading(false);
       }
     }
 
-    fetchSkills();
+    createFromPosting();
     return () => {
       cancelled = true;
     };
+  }, [jobData, onComplete]);
+
+  // Paths B/C: fetch suggestions from LLM
+  useEffect(() => {
+    if (jobData) return;
+    let cancelled = false;
+
+    async function fetchSuggestions() {
+      try {
+        const res = await fetch('/api/targets/suggest', { method: 'POST' });
+        if (!res.ok) throw new Error('Failed to load suggestions');
+        const data = (await res.json()) as {
+          suggestions: Suggestion[];
+        };
+        if (!cancelled && data.suggestions?.length > 0) {
+          setSuggestions(data.suggestions);
+          // Pre-select all suggestions
+          setSelected(new Set(data.suggestions.map(s => s.label)));
+        }
+      } catch {
+        if (!cancelled)
+          setError(
+            'Could not generate suggestions. You can create targets manually.'
+          );
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+
+    fetchSuggestions();
+    return () => {
+      cancelled = true;
+    };
+  }, [jobData]);
+
+  const toggleSelection = useCallback((label: string) => {
+    setSelected(prev => {
+      const next = new Set(prev);
+      if (next.has(label)) {
+        next.delete(label);
+      } else {
+        next.add(label);
+      }
+      return next;
+    });
   }, []);
 
-  const handleGoToTargets = useCallback(() => {
-    onComplete();
-  }, [onComplete]);
+  const handleCreateSelected = useCallback(async () => {
+    if (selected.size === 0) {
+      onComplete();
+      return;
+    }
 
+    setCreating(true);
+    let created = 0;
+
+    for (const suggestion of suggestions) {
+      if (!selected.has(suggestion.label)) continue;
+      try {
+        const res = await fetch('/api/targets', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ label: suggestion.label }),
+        });
+        if (res.ok) created++;
+      } catch {
+        // Continue creating remaining targets
+      }
+    }
+
+    setCreatedCount(created);
+    setCreating(false);
+    timerRef.current = setTimeout(onComplete, 1500);
+  }, [selected, suggestions, onComplete]);
+
+  // Path A: auto-creation in progress or completed
+  if (jobData) {
+    if (loading) {
+      return (
+        <div className='flex flex-col items-center gap-4 py-12'>
+          <Spinner size='lg' aria-label='Creating target' />
+          <Text variant='body' className='text-text-secondary'>
+            Setting up a target from your job posting...
+          </Text>
+        </div>
+      );
+    }
+
+    if (createdLabel) {
+      return (
+        <div className='flex flex-col items-center gap-6'>
+          <Card padding='lg' className='w-full text-center'>
+            <div className='flex flex-col items-center gap-3 py-4'>
+              <CheckCircle className='size-12 text-success' aria-hidden />
+              <div>
+                <Text variant='body' className='font-medium'>
+                  Target created
+                </Text>
+                <Text variant='caption' className='mt-1 text-text-secondary'>
+                  {createdLabel}
+                </Text>
+              </div>
+            </div>
+          </Card>
+        </div>
+      );
+    }
+
+    // Error fallback — show manual flow below
+  }
+
+  // Paths B/C: suggestions or manual prompt
   if (loading) {
     return (
       <div className='flex flex-col items-center gap-4 py-12'>
@@ -74,6 +198,147 @@ export default function TargetSuggestions({
     );
   }
 
+  // Post-creation success
+  if (createdCount > 0) {
+    return (
+      <div className='flex flex-col items-center gap-6'>
+        <Card padding='lg' className='w-full text-center'>
+          <div className='flex flex-col items-center gap-3 py-4'>
+            <CheckCircle className='size-12 text-success' aria-hidden />
+            <div>
+              <Text variant='body' className='font-medium'>
+                {createdCount === 1
+                  ? '1 target created'
+                  : `${createdCount} targets created`}
+              </Text>
+            </div>
+          </div>
+        </Card>
+      </div>
+    );
+  }
+
+  // Suggestions available — show selectable cards
+  if (suggestions.length > 0) {
+    return (
+      <div className='flex flex-col gap-6'>
+        <div className='text-center'>
+          <Heading variant='cardTitle' as='h2'>
+            Suggested targets
+          </Heading>
+          <Text variant='caption' className='mt-1 text-text-secondary'>
+            Based on your experience, we suggest these role targets. Select the
+            ones you&apos;d like to track.
+          </Text>
+        </div>
+
+        <div className='flex flex-col gap-3'>
+          {suggestions.map(suggestion => {
+            const isSelected = selected.has(suggestion.label);
+            return (
+              <Card
+                key={suggestion.label}
+                padding='lg'
+                className={cn(
+                  'cursor-pointer transition-colors',
+                  isSelected
+                    ? 'border-brand-500 bg-brand-500/5'
+                    : 'hover:border-border-hover'
+                )}
+                onClick={() => toggleSelection(suggestion.label)}
+                role='checkbox'
+                aria-checked={isSelected}
+                tabIndex={0}
+                aria-label={suggestion.label}
+                onKeyDown={e => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    toggleSelection(suggestion.label);
+                  }
+                }}
+              >
+                <div className='flex items-start gap-4'>
+                  <div
+                    className={cn(
+                      'mt-0.5 flex size-5 shrink-0 items-center justify-center rounded border-2 transition-colors',
+                      isSelected
+                        ? 'border-brand-500 bg-brand-500'
+                        : 'border-border'
+                    )}
+                  >
+                    {isSelected && (
+                      <CheckCircle
+                        className='size-3.5 text-white'
+                        aria-hidden
+                      />
+                    )}
+                  </div>
+                  <div className='flex-1'>
+                    <Text variant='body' className='font-medium'>
+                      {suggestion.label}
+                    </Text>
+                    <Text
+                      variant='caption'
+                      className='mt-0.5 text-text-secondary'
+                    >
+                      {suggestion.description}
+                    </Text>
+                    {suggestion.core_skills.length > 0 && (
+                      <div className='mt-2 flex flex-wrap gap-1.5'>
+                        {suggestion.core_skills.map(skill => (
+                          <span
+                            key={skill}
+                            className='rounded-full bg-surface-tertiary px-2.5 py-0.5 text-xs text-text-secondary'
+                          >
+                            {skill}
+                          </span>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                </div>
+              </Card>
+            );
+          })}
+        </div>
+
+        {error && <Alert variant='error'>{error}</Alert>}
+
+        <div className='flex items-center justify-between'>
+          <Button
+            name='onboarding-skip-targets'
+            variant='ghost'
+            size='sm'
+            onClick={onSkip}
+          >
+            Skip for now
+          </Button>
+          <Button
+            name='onboarding-create-targets'
+            variant='primary'
+            size='sm'
+            onClick={handleCreateSelected}
+            disabled={creating}
+          >
+            {creating ? (
+              <>
+                <Spinner size='sm' aria-label='Creating targets' />
+                <span>Creating...</span>
+              </>
+            ) : selected.size === 0 ? (
+              'Continue without targets'
+            ) : selected.size === 1 ? (
+              'Create 1 target'
+            ) : (
+              `Create ${selected.size} targets`
+            )}
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  // No suggestions (error or empty OptimizedDoc) — fallback to manual prompt
   return (
     <div className='flex flex-col gap-6'>
       <div className='text-center'>
@@ -86,37 +351,19 @@ export default function TargetSuggestions({
         </Text>
       </div>
 
-      {skills.length > 0 && (
-        <Card padding='lg'>
-          <Text variant='caption' className='mb-3 text-text-secondary'>
-            Based on your experience, you might target roles involving:
-          </Text>
-          <div className='flex flex-wrap gap-2'>
-            {skills.map(skill => (
-              <span
-                key={skill}
-                className='rounded-full bg-surface-tertiary px-3 py-1 text-sm text-text-secondary'
-              >
-                {skill}
-              </span>
-            ))}
-          </div>
-        </Card>
-      )}
-
       {error && <Alert variant='error'>{error}</Alert>}
 
       <Card
         padding='lg'
         className='cursor-pointer transition-colors hover:border-brand-500'
-        onClick={handleGoToTargets}
+        onClick={onComplete}
         role='button'
         tabIndex={0}
         aria-label='Create your first target'
         onKeyDown={e => {
           if (e.key === 'Enter' || e.key === ' ') {
             e.preventDefault();
-            handleGoToTargets();
+            onComplete();
           }
         }}
       >
@@ -132,7 +379,6 @@ export default function TargetSuggestions({
               Define a role type, and we&apos;ll score and track matching jobs.
             </Text>
           </div>
-          <ArrowRight className='size-5 text-text-tertiary' aria-hidden />
         </div>
       </Card>
 


### PR DESCRIPTION
## Summary

- Fix the broken onboarding flow so all 3 paths (A: resume+job, B: resume-only, C: conversation) end with targets created and the user lands on `/fitted/targets`
- **Path A**: auto-creates a target from the job posting (with LLM-derived scoring profile) via new `POST /targets/from-posting/{id}` endpoint
- **Paths B/C**: LLM-powered target suggestions from the user's OptimizedDoc via new `POST /targets/suggest` endpoint, shown as selectable cards with batch creation
- Add "View Jobs" button on target cards → navigates to `/fitted/jobs?target={id}` with target-specific scoring from the backend
- Fix upload-resume 503 timeout (30s → 120s when `auto_derive=true`)
- Fix bigint type mismatch for manual job `external_id`
- Fix 105 pre-existing mypy errors in `insights.py` (cast Supabase JSON rows)

## Test plan

- [ ] Path A: Upload resume → Add job URL → Target auto-created from posting → Lands on `/fitted/targets`
- [ ] Path B: Upload resume → Target suggestions shown → Select/deselect → Create targets → Lands on `/fitted/targets`
- [ ] Path C: Conversation → Target suggestions shown → Create targets → Lands on `/fitted/targets`
- [ ] "Skip for now" at any step → Lands on `/fitted/targets`
- [ ] Click "View Jobs" on a target card → Navigates to `/fitted/jobs?target={id}` with target-specific scores
- [ ] Resume upload with `auto_derive=true` completes without 503

🤖 Generated with [Claude Code](https://claude.com/claude-code)