### PR TITLE
release: audit page tweaks (drop defaults, hide home GridBg)

### DIFF
--- a/apps/root/src/app/(public)/audit/ScanHero.tsx
+++ b/apps/root/src/app/(public)/audit/ScanHero.tsx
@@ -20,7 +20,6 @@ export default function ScanHero({
   return (
     <Section
       aria-labelledby='audit-hero-heading'
-      background='alt'
       overflow='hidden'
       center
       padding='lg'

--- a/apps/root/src/app/(public)/audit/URLInputForm.tsx
+++ b/apps/root/src/app/(public)/audit/URLInputForm.tsx
@@ -198,7 +198,6 @@ export default function URLInputForm() {
           <Button
             type='submit'
             name='audit-submit'
-            size='md'
             disabled={state.phase === 'submitting'}
             className='w-full'
           >
@@ -220,7 +219,6 @@ export default function URLInputForm() {
             type='button'
             name='retry-scan'
             variant='bare'
-            size='sm'
             onClick={() => setState({ phase: 'idle' })}
             className='block mt-2 text-sm font-medium underline hover:no-underline'
           >

--- a/apps/root/src/app/(public)/audit/compare/ComparisonHeader.tsx
+++ b/apps/root/src/app/(public)/audit/compare/ComparisonHeader.tsx
@@ -69,7 +69,6 @@ export default function ComparisonHeader({
   return (
     <Section
       aria-labelledby='comparison-header-heading'
-      background='alt'
       overflow='hidden'
       center
     >

--- a/apps/root/src/app/(public)/audit/compare/CoreWebVitalsDelta.tsx
+++ b/apps/root/src/app/(public)/audit/compare/CoreWebVitalsDelta.tsx
@@ -96,12 +96,7 @@ export default function CoreWebVitalsDelta({
   ];
 
   return (
-    <Section
-      aria-labelledby='cwv-delta-heading'
-      background='alt'
-      overflow='hidden'
-      center
-    >
+    <Section aria-labelledby='cwv-delta-heading' overflow='hidden' center>
       <Heading variant='section' as='h2' id='cwv-delta-heading'>
         Core Web Vitals
       </Heading>

--- a/apps/root/src/app/(public)/audit/insights/HeroStats.tsx
+++ b/apps/root/src/app/(public)/audit/insights/HeroStats.tsx
@@ -20,11 +20,7 @@ export default function HeroStats({ data }: HeroStatsProps) {
   const scoreColor = getScoreColor(data.avgOverallScore);
 
   return (
-    <Section
-      aria-labelledby='insights-hero-heading'
-      background='alt'
-      padding='lg'
-    >
+    <Section aria-labelledby='insights-hero-heading' padding='lg'>
       <div className='text-center mb-12'>
         <Heading variant='hero' as='h1' id='insights-hero-heading'>
           Audit Insights

--- a/apps/root/src/app/(public)/audit/insights/InsightsCTA.tsx
+++ b/apps/root/src/app/(public)/audit/insights/InsightsCTA.tsx
@@ -15,7 +15,6 @@ export default function InsightsCTA({
   return (
     <Section
       aria-labelledby='insights-cta-heading'
-      background='alt'
       padding='lg'
       className='text-center'
     >

--- a/apps/root/src/app/(public)/audit/insights/TrendsChart.tsx
+++ b/apps/root/src/app/(public)/audit/insights/TrendsChart.tsx
@@ -33,7 +33,7 @@ export default function TrendsChart({ data }: TrendsChartProps) {
   const hasData = chartData.length > 0;
 
   return (
-    <Section aria-labelledby='trends-heading' background='alt'>
+    <Section aria-labelledby='trends-heading'>
       <Heading variant='section' as='h2' id='trends-heading'>
         Scores Over Time
       </Heading>

--- a/apps/root/src/app/(public)/audit/insights/ViolationsSection.tsx
+++ b/apps/root/src/app/(public)/audit/insights/ViolationsSection.tsx
@@ -127,7 +127,7 @@ export default function ViolationsSection({
   const [expanded, setExpanded] = useState(false);
 
   return (
-    <Section aria-labelledby='violations-heading' background='alt'>
+    <Section aria-labelledby='violations-heading'>
       <Heading variant='section' as='h2' id='violations-heading'>
         Top Violations
       </Heading>

--- a/apps/root/src/app/(public)/audit/loading.tsx
+++ b/apps/root/src/app/(public)/audit/loading.tsx
@@ -5,13 +5,7 @@ import { Section } from '@danieljoffe.com/shared-ui/Section';
 export default function Loading() {
   return (
     <PageLayout>
-      <Section
-        background='alt'
-        overflow='hidden'
-        center
-        padding='lg'
-        className='text-center'
-      >
+      <Section overflow='hidden' center padding='lg' className='text-center'>
         <div className='flex flex-col gap-6 items-center'>
           {/* Heading */}
           <div className='space-y-3 w-full'>

--- a/apps/root/src/app/(public)/audit/r/[id]/CTASection.tsx
+++ b/apps/root/src/app/(public)/audit/r/[id]/CTASection.tsx
@@ -7,7 +7,6 @@ export default function CTASection() {
   return (
     <Section
       aria-labelledby='cta-heading'
-      background='alt'
       center
       overflow='hidden'
       padding='lg'

--- a/apps/root/src/app/(public)/audit/r/[id]/CalendlyButton.tsx
+++ b/apps/root/src/app/(public)/audit/r/[id]/CalendlyButton.tsx
@@ -10,7 +10,6 @@ export default function CalendlyButton() {
       as='link'
       href={CALENDLY_URL}
       variant='primary'
-      size='md'
       name='calendly-discovery-call'
       onClick={() => analytics.auditCalendlyClicked()}
     >

--- a/apps/root/src/app/(public)/audit/r/[id]/CoreWebVitals.tsx
+++ b/apps/root/src/app/(public)/audit/r/[id]/CoreWebVitals.tsx
@@ -102,12 +102,7 @@ export default function CoreWebVitals({
   ];
 
   return (
-    <Section
-      aria-labelledby='core-web-vitals-heading'
-      background='alt'
-      overflow='hidden'
-      center
-    >
+    <Section aria-labelledby='core-web-vitals-heading' overflow='hidden' center>
       <Heading variant='section' as='h2' id='core-web-vitals-heading'>
         Core Web Vitals
       </Heading>

--- a/apps/root/src/app/(public)/audit/r/[id]/ReportHeader.tsx
+++ b/apps/root/src/app/(public)/audit/r/[id]/ReportHeader.tsx
@@ -31,12 +31,7 @@ export default function ReportHeader({
   const grade = gradeOverall ? GRADE_MAP[gradeOverall] : null;
 
   return (
-    <Section
-      background='alt'
-      center
-      overflow='hidden'
-      aria-labelledby='report-header-heading'
-    >
+    <Section center overflow='hidden' aria-labelledby='report-header-heading'>
       <div className='flex items-center justify-between'>
         <Link
           href='/audit'

--- a/apps/root/src/app/(public)/audit/r/[id]/ScanFailed.tsx
+++ b/apps/root/src/app/(public)/audit/r/[id]/ScanFailed.tsx
@@ -14,7 +14,6 @@ export default function ScanFailed({ url, errorMessage }: ScanFailedProps) {
   return (
     <Section
       aria-labelledby='scan-failed-heading'
-      background='alt'
       overflow='hidden'
       center
       padding='lg'

--- a/apps/root/src/app/(public)/audit/r/[id]/ScanPending.tsx
+++ b/apps/root/src/app/(public)/audit/r/[id]/ScanPending.tsx
@@ -83,7 +83,6 @@ export default function ScanPending({
     return (
       <Section
         aria-labelledby='scan-failed-heading'
-        background='alt'
         overflow='hidden'
         center
         padding='lg'
@@ -113,7 +112,7 @@ export default function ScanPending({
   }
 
   return (
-    <Section background='alt' overflow='hidden' center padding='lg'>
+    <Section overflow='hidden' center padding='lg'>
       <div className='flex flex-col gap-6 items-center max-w-md mx-auto'>
         <ScanProgress url={url} device={device} />
       </div>

--- a/apps/root/src/app/(public)/page.tsx
+++ b/apps/root/src/app/(public)/page.tsx
@@ -9,7 +9,7 @@ import {
   Layers,
 } from 'lucide-react';
 import { CTACard } from '@danieljoffe.com/shared-ui/CTACard';
-import { GridBg } from '@danieljoffe.com/shared-ui/GridBg';
+// import { GridBg } from '@danieljoffe.com/shared-ui/GridBg';
 import { PageLayout } from '@danieljoffe.com/shared-ui/PageLayout';
 import { Section } from '@danieljoffe.com/shared-ui/Section';
 import { SectionLabel } from '@danieljoffe.com/shared-ui/SectionLabel';
@@ -49,7 +49,7 @@ export default function Index() {
           HERO
           ══════════════════════════════════ */}
       <Section padding='none'>
-        <GridBg />
+        {/* <GridBg /> */}
         <div className='relative space-y-6'>
           <div className='flex flex-wrap items-center gap-x-5 gap-y-2 text-sm text-text-tertiary'>
             <span className='flex items-center gap-1.5'>


### PR DESCRIPTION
## Summary

Release `develop` → `main`. One commit ahead:

- `fa1b4fc` chore(audit): drop default Section/Button props + comment out GridBg on home

## Diff scope

Audit page surface only — no API, schema, or shared-ui changes:

- `apps/root/src/app/(public)/audit/**` — defaults dropped on `Section` / `Button` usages
- `apps/root/src/app/(public)/page.tsx` — `GridBg` commented out on home

## Branch sync

`develop` topology was 1 merge commit behind `main` (#492 merge), but content diff `develop...main` is empty. No `main → develop` sync needed; release is clean.

## Test plan

- [ ] CI green on `ci-preview.yml` (release validation pipeline)
- [ ] Lighthouse passes on home + audit pages
- [ ] Manual smoke: home renders without GridBg, audit pages render without default Section/Button regressions
- [ ] No console errors on home or `/audit`

---
_Generated by [Claude Code](https://claude.ai/code/session_01QGwwJd8pvahGTF3xZ8h7xp)_