### PR TITLE
chore(fitted): WyrdFold migration Phase 0 hardening

### DIFF
--- a/.claude/docs/wyrdfold-migration/PHASES.md
+++ b/.claude/docs/wyrdfold-migration/PHASES.md
@@ -1,0 +1,209 @@
+# WyrdFold Migration — Phased Execution Plan
+
+Companion to the 12 audit docs in this directory. The audits map
+the work; this file orders it.
+
+**App name:** `apps/wyrdfold/` (rebrand to WyrdFold + Pyre theme).
+**Base branch for the migration umbrella:** `feature/fitted` —
+the `/fitted` feature does not exist in `develop` or `main`, so all
+migration work must base on this branch and merge back into it
+before `feature/fitted` itself merges down.
+
+## Phase 0 — Pre-port hardening (on apps/root, before the cut)
+
+Audit doc: `platform-readiness.md` §16, `test-coverage.md` §9 steps 1–3.
+
+The fitted code carries security gaps that must not ride into
+WyrdFold. Land these on `feature/fitted` so they're inherited at
+port time.
+
+- [ ] Add `data-sentry-mask` to Settings identity inputs (name,
+      email, phone, location, linkedin_url, website_url).
+- [ ] Add `data-sentry-mask` to Profile master-document `<textarea>`.
+- [ ] Add `data-sentry-mask` to `_components/ConversationChat*.tsx`
+      input.
+- [ ] Verify shared-ui `<Input>` and `<Textarea>` forward `data-*`
+      attrs. If not, fix in shared-ui first.
+- [ ] Add per-user rate limits (Supabase user_id keyed) on
+      `/api/jobs/[id]/tailor`,
+      `/api/career/experience/derive/stream`, and
+      `/api/career/experience/upload-resume`.
+- [ ] Tier 1 unit tests: profile/types, scoring profile, gap-health
+      (test-coverage.md §5 Tier 1).
+
+**Done when:** Sentry replays no longer leak PII on those forms;
+rate-limit tests pass; Tier 1 specs land green.
+
+## Phase 1 — Workspace foundation (scaffold WyrdFold)
+
+Audit doc: `shared-ui.md`, `platform-readiness.md` §1–§8.
+
+- [ ] Add `pyre-theme.css` sibling to `theme.css` in shared-ui
+      (chartreuse on near-black; see `shared-ui.md` §4 for the
+      token map).
+- [ ] Drop `DarkModeToggle` usage from WyrdFold layout (Pyre is
+      single-theme).
+- [ ] Storybook story exercising `pyre-theme` class.
+- [ ] Generate `apps/wyrdfold/` Nx app (Next.js, App Router,
+      Tailwind, Vitest, Playwright e2e).
+- [ ] Port `next.config.mjs` (security headers, caching, image
+      formats, `optimizePackageImports`, `outputFileTracingIncludes`
+      pruned to WyrdFold's actual OG routes).
+- [ ] Port `proxy.ts` middleware rooted at `/` (no `/fitted` prefix).
+- [ ] Stand up a separate Sentry project for WyrdFold; wire
+      `next.config.mjs` `withSentryConfig` org/project; tunnelRoute
+      `/monitoring`.
+- [ ] Regenerate `.env.example` for the WyrdFold brand.
+- [ ] Mount `ToastProvider` in WyrdFold's root layout.
+
+**Done when:** `apps/wyrdfold/` boots a blank shell at `localhost`
+with Pyre theme, Sentry instrumented, security headers verified.
+
+## Phase 2 — Data foundation (Supabase)
+
+Audit doc: `supabase-schema.md`.
+
+- [ ] Decide rename mapping (supabase-schema.md §8) — sign-off
+      required before mass code changes.
+- [ ] Apply rename-pass migration to current Supabase; validate
+      app still works under renames.
+- [ ] Stand up `wyrdfold-prod` Supabase project.
+- [ ] Schema-only dump from current Supabase → seed
+      `00000000000001_init.sql` in `wyrdfold-prod`.
+- [ ] Port functions, triggers, RPCs (supabase-schema.md §3).
+- [ ] Port RLS policies (supabase-schema.md §4).
+- [ ] Port storage buckets (supabase-schema.md §5).
+- [ ] Regenerate types into `apps/wyrdfold/src/lib/supabase/types.ts`.
+
+**Done when:** WyrdFold's Supabase project boots with the same
+schema (renamed); types regenerate cleanly; a smoke query against
+each table succeeds.
+
+## Phase 3 — Backend port
+
+Audit doc: `job-api.md`.
+
+ADR choice: **fork now, library later** (job-api.md §10).
+
+- [ ] Generate `apps/wyrdfold-api/` (FastAPI, mirror `apps/job-api`
+      structure).
+- [ ] Port routers, services, models with renamed identifiers.
+- [ ] Wire to `wyrdfold-prod` Supabase + new env vars
+      (`WYRDFOLD_API_URL`, `WYRDFOLD_API_KEY`, etc.).
+- [ ] Wire Sentry to the new project (gap called out in
+      job-api.md §7).
+- [ ] Add per-user token-budget guards (defense-in-depth; tracked
+      in `platform-readiness.md` §5 backstop).
+- [ ] Port pytest suite (job-api.md §8).
+- [ ] Deploy to staging; smoke-test endpoints.
+
+**Done when:** `wyrdfold-api` answers a `/health` ping in staging,
+routers/services tests pass, Sentry receives a test event.
+
+## Phase 4 — Next.js BFF routes
+
+Audit doc: `api-routes.md`.
+
+- [ ] Port the 16+ BFF routes from `apps/root/src/app/api/` to
+      `apps/wyrdfold/src/app/api/`.
+- [ ] Rewire `proxyToFastAPI` helper to point at
+      `WYRDFOLD_API_URL` / `WYRDFOLD_API_KEY`.
+- [ ] Auth gating uses WyrdFold's Supabase session (no
+      `adminSession` cookie path — that's audit-tool only).
+- [ ] Sentry breadcrumbs preserved (`captureApiError`).
+- [ ] Rate limits applied per Phase 0 plan.
+- [ ] Audit/leads/contact/unsubscribe routes **stay on apps/root** —
+      do not port (api-routes.md §8).
+
+**Done when:** WyrdFold BFF routes proxy to `wyrdfold-api` and
+return 200 for an authenticated session.
+
+## Phase 5 — Surface ports (dependency order)
+
+Audit docs (in order): `auth-onboarding.md`, `profile-settings.md`,
+`targets.md`, `jobs.md`, `insights.md`.
+
+Each surface is one PR (or sub-PR) merged into the migration umbrella.
+
+### 5a. Auth + onboarding (auth-onboarding.md)
+
+- [ ] Port `login/`, `onboarding/`, `(app)/layout.tsx`.
+- [ ] Strip `/fitted/` prefixes from hardcoded paths
+      (auth-onboarding.md §4) — root-relative URLs only.
+- [ ] Update layout metadata to `WyrdFold` template + new
+      description.
+- [ ] Port `_components/ConversationChat*.tsx`.
+
+### 5b. Profile + Settings (profile-settings.md)
+
+- [ ] Port profile master-document editor.
+- [ ] Port settings (identity + email notifications + threshold).
+- [ ] PII masking already in place from Phase 0.
+
+### 5c. Targets (targets.md)
+
+- [ ] Port `targets/` route group (list + detail + ScoringProfile
+      editor + reference JDs).
+- [ ] Port pending-target flow.
+
+### 5d. Jobs (jobs.md)
+
+- [ ] Port `jobs/` list (table + mobile) + filters + tabs.
+- [ ] Port `jobs/[id]/` detail (panel + score breakdown +
+      lock/unlock + delete).
+- [ ] Port `jobs/[id]/(resume|cover-letter)/` review pages.
+
+### 5e. Insights (insights.md)
+
+- [ ] Move `apps/root/src/hooks/useInsights.ts` into
+      `apps/wyrdfold/src/app/(app)/insights/useInsights.ts`.
+- [ ] Delete `useInsights` from `apps/root` (resolves the one
+      reverse-coupling, dependency-coupling.md §2).
+- [ ] Port chart components (Recharts lazy-loaded; preserve
+      `dynamic({ssr: false})`).
+- [ ] Pyre-tune Recharts palette (test-coverage.md a11y note).
+
+**Done when:** WyrdFold serves all five surfaces from
+`wyrdfold-api`, all data renders, screenshots match Fitted parity.
+
+## Phase 6 — E2E + cutover
+
+Audit doc: `test-coverage.md` §9 steps 4–5.
+
+- [ ] Port + adapt the 6 fitted E2E specs (login, onboarding,
+      profile, jobs, settings, insights) into
+      `apps/wyrdfold-e2e/`.
+- [ ] Run a baseline Lighthouse against staging WyrdFold.
+- [ ] axe sweep on Pyre theme (contrast verification).
+- [ ] Coordinate cutover plan — `/fitted/*` on `apps/root` either
+      deletes, redirects to `wyrdfold.com`, or freezes (epic #564 §4).
+- [ ] Strip `/fitted/*` from `apps/root/src/proxy.ts` after
+      cutover.
+
+**Done when:** WyrdFold passes all 6 E2E specs in CI, Lighthouse
+≥ 90, axe clean; cutover plan signed off.
+
+## Cross-cutting reference
+
+`dependency-coupling.md` is the meta-inventory. Every phase touches
+its tables — keep it open.
+
+## Branching strategy
+
+| Branch                                | Base             | Merges into      |
+| ------------------------------------- | ---------------- | ---------------- |
+| `feature/fitted`                      | `develop`        | `develop`        |
+| `chore/wyrdfold-phase-0-hardening`    | `feature/fitted` | `feature/fitted` |
+| `feature/wyrdfold-phase-1-foundation` | `feature/fitted` | `feature/fitted` |
+| `feature/wyrdfold-phase-2-supabase`   | `feature/fitted` | `feature/fitted` |
+| `feature/wyrdfold-phase-3-api`        | `feature/fitted` | `feature/fitted` |
+| `feature/wyrdfold-phase-4-bff`        | `feature/fitted` | `feature/fitted` |
+| `feature/wyrdfold-phase-5a-auth`      | `feature/fitted` | `feature/fitted` |
+| `feature/wyrdfold-phase-5b-profile`   | `feature/fitted` | `feature/fitted` |
+| `feature/wyrdfold-phase-5c-targets`   | `feature/fitted` | `feature/fitted` |
+| `feature/wyrdfold-phase-5d-jobs`      | `feature/fitted` | `feature/fitted` |
+| `feature/wyrdfold-phase-5e-insights`  | `feature/fitted` | `feature/fitted` |
+| `feature/wyrdfold-phase-6-e2e`        | `feature/fitted` | `feature/fitted` |
+
+Each phase's PR description should link the matching audit doc(s)
+in this directory.

--- a/apps/root/src/app/api/career/experience/derive/stream/route.ts
+++ b/apps/root/src/app/api/career/experience/derive/stream/route.ts
@@ -1,13 +1,18 @@
 import { NextResponse } from 'next/server';
-import {
-  proxyStreamingToFastAPI,
-  verifyJobsAccess,
-} from '@/app/api/jobs/proxy';
+import { proxyStreamingToFastAPI, getJobsAccess } from '@/app/api/jobs/proxy';
+import { checkDeriveRateLimit, tooManyRequests } from '@/lib/llmRateLimit';
 
 export async function POST(request: Request) {
-  if (!(await verifyJobsAccess())) {
+  const access = await getJobsAccess();
+  if (!access) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
+
+  if (access.kind === 'user') {
+    const blocked = tooManyRequests(checkDeriveRateLimit(access.userId));
+    if (blocked) return blocked;
+  }
+
   return proxyStreamingToFastAPI('/experience/derive/stream', request, {
     method: 'POST',
   });

--- a/apps/root/src/app/api/career/experience/upload-resume/route.ts
+++ b/apps/root/src/app/api/career/experience/upload-resume/route.ts
@@ -1,14 +1,22 @@
 import { type NextRequest, NextResponse } from 'next/server';
 import {
-  verifyJobsAccess,
+  getJobsAccess,
   proxyMultipartToFastAPI,
   LLM_TIMEOUT_MS,
 } from '@/app/api/jobs/proxy';
+import { checkUploadRateLimit, tooManyRequests } from '@/lib/llmRateLimit';
 
 export async function POST(request: NextRequest) {
-  if (!(await verifyJobsAccess())) {
+  const access = await getJobsAccess();
+  if (!access) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
+
+  if (access.kind === 'user') {
+    const blocked = tooManyRequests(checkUploadRateLimit(access.userId));
+    if (blocked) return blocked;
+  }
+
   const autoDerives =
     request.nextUrl.searchParams.get('auto_derive') === 'true';
   return proxyMultipartToFastAPI('/experience/upload-resume', request, {

--- a/apps/root/src/app/api/jobs/proxy.ts
+++ b/apps/root/src/app/api/jobs/proxy.ts
@@ -6,20 +6,37 @@ const JOB_API_URL = process.env['JOB_API_URL'] ?? '';
 const JOB_API_KEY = process.env['JOB_API_KEY'] ?? '';
 
 /**
- * Verify access: accepts either an admin session cookie (admin dashboard)
- * or a valid Supabase session (Fitted app via magic link).
+ * Caller identity, used by `getJobsAccess` so route handlers can key
+ * per-user rate limits on `userId` for the Fitted/magic-link path
+ * (admin sessions are infrastructure-class and skip user rate limits).
  */
-export async function verifyJobsAccess(): Promise<boolean> {
+export type JobsAccess = { kind: 'admin' } | { kind: 'user'; userId: string };
+
+/**
+ * Resolve caller identity. Admin session takes precedence (single
+ * operator); otherwise resolves the Supabase user. Returns `null` if
+ * neither is present.
+ */
+export async function getJobsAccess(): Promise<JobsAccess | null> {
   const adminSession = await readAdminSession();
-  if (adminSession !== null) return true;
+  if (adminSession !== null) return { kind: 'admin' };
 
   try {
     const supabase = await createAuthServerClient();
     const { data } = await supabase.auth.getUser();
-    return data.user !== null;
+    if (data.user !== null) return { kind: 'user', userId: data.user.id };
+    return null;
   } catch {
-    return false;
+    return null;
   }
+}
+
+/**
+ * Verify access: accepts either an admin session cookie (admin dashboard)
+ * or a valid Supabase session (Fitted app via magic link).
+ */
+export async function verifyJobsAccess(): Promise<boolean> {
+  return (await getJobsAccess()) !== null;
 }
 
 /** Default upstream timeout in milliseconds. */

--- a/apps/root/src/app/api/jobs/tailor/batch/route.ts
+++ b/apps/root/src/app/api/jobs/tailor/batch/route.ts
@@ -1,13 +1,20 @@
 import { NextResponse } from 'next/server';
 import {
-  verifyJobsAccess,
+  getJobsAccess,
   proxyToFastAPI,
   LLM_TIMEOUT_MS,
 } from '@/app/api/jobs/proxy';
+import { checkTailorRateLimit, tooManyRequests } from '@/lib/llmRateLimit';
 
 export async function POST(request: Request) {
-  if (!(await verifyJobsAccess())) {
+  const access = await getJobsAccess();
+  if (!access) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  if (access.kind === 'user') {
+    const blocked = tooManyRequests(checkTailorRateLimit(access.userId));
+    if (blocked) return blocked;
   }
 
   const body = await request.json();

--- a/apps/root/src/app/api/jobs/tailor/cover-letter/route.ts
+++ b/apps/root/src/app/api/jobs/tailor/cover-letter/route.ts
@@ -1,10 +1,11 @@
 import { type NextRequest, NextResponse } from 'next/server';
 import {
-  verifyJobsAccess,
+  getJobsAccess,
   proxyToFastAPI,
   LLM_TIMEOUT_MS,
 } from '@/app/api/jobs/proxy';
 import { createServerSupabaseClient } from '@/lib/supabase/server';
+import { checkTailorRateLimit, tooManyRequests } from '@/lib/llmRateLimit';
 
 /** Naive HTML tag stripper — enough for JD text extraction. */
 function stripHtml(html: string): string {
@@ -15,8 +16,14 @@ function stripHtml(html: string): string {
 }
 
 export async function POST(request: NextRequest) {
-  if (!(await verifyJobsAccess())) {
+  const access = await getJobsAccess();
+  if (!access) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  if (access.kind === 'user') {
+    const blocked = tooManyRequests(checkTailorRateLimit(access.userId));
+    if (blocked) return blocked;
   }
 
   const body = (await request.json()) as Record<string, unknown>;

--- a/apps/root/src/app/api/jobs/tailor/resume/route.ts
+++ b/apps/root/src/app/api/jobs/tailor/resume/route.ts
@@ -1,13 +1,20 @@
 import { NextResponse } from 'next/server';
 import {
-  verifyJobsAccess,
+  getJobsAccess,
   proxyToFastAPI,
   LLM_TIMEOUT_MS,
 } from '@/app/api/jobs/proxy';
+import { checkTailorRateLimit, tooManyRequests } from '@/lib/llmRateLimit';
 
 export async function POST(request: Request) {
-  if (!(await verifyJobsAccess())) {
+  const access = await getJobsAccess();
+  if (!access) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  if (access.kind === 'user') {
+    const blocked = tooManyRequests(checkTailorRateLimit(access.userId));
+    if (blocked) return blocked;
   }
 
   const body = await request.json();

--- a/apps/root/src/app/fitted/(app)/jobs/[id]/cover-letter/CoverLetterReviewPage.tsx
+++ b/apps/root/src/app/fitted/(app)/jobs/[id]/cover-letter/CoverLetterReviewPage.tsx
@@ -631,6 +631,7 @@ export default function CoverLetterReviewPage({
           }}
           disabled={isApproved || regenerating || approving || unapproving}
           spellCheck
+          data-sentry-mask
         />
         <div className='flex items-center justify-between gap-2'>
           <Text

--- a/apps/root/src/app/fitted/(app)/jobs/[id]/resume/ResumeReviewPage.tsx
+++ b/apps/root/src/app/fitted/(app)/jobs/[id]/resume/ResumeReviewPage.tsx
@@ -647,6 +647,7 @@ export default function ResumeReviewPage({
           }}
           disabled={isApproved || readapting || approving || unapproving}
           spellCheck
+          data-sentry-mask
         />
         <div className='flex items-center justify-between gap-2'>
           <Text

--- a/apps/root/src/app/fitted/(app)/profile/ProfilePage.tsx
+++ b/apps/root/src/app/fitted/(app)/profile/ProfilePage.tsx
@@ -556,6 +556,7 @@ export default function ProfilePage() {
             onChange={e => setDraft(e.target.value)}
             className='min-h-[300px] w-full rounded-md border border-border bg-surface-primary p-3 font-mono text-sm text-text-primary focus:border-brand focus:outline-none focus:ring-1 focus:ring-brand'
             placeholder='Paste or type your master experience document here...'
+            data-sentry-mask
           />
         </CardContent>
       </Card>

--- a/apps/root/src/app/fitted/(app)/profile/__tests__/types.spec.ts
+++ b/apps/root/src/app/fitted/(app)/profile/__tests__/types.spec.ts
@@ -1,0 +1,91 @@
+import {
+  GAP_KIND_LABELS,
+  GAP_KIND_WEIGHTS,
+  hasOptimized,
+  hasProse,
+  type OptimizedDoc,
+  type OptimizedResponse,
+  type ProseDoc,
+  type ProseResponse,
+} from '../types';
+
+const PROSE: ProseDoc = {
+  id: 'p1',
+  user_id: 'u1',
+  version: 1,
+  content: '...',
+  created_at: '2026-04-30T00:00:00.000Z',
+};
+
+const OPTIMIZED: OptimizedDoc = {
+  id: 'o1',
+  user_id: 'u1',
+  prose_doc_id: 'p1',
+  version: 1,
+  payload: { summary: null, roles: [], skills: [], outcomes: [] },
+  markdown_view: null,
+  source: 'llm',
+  created_at: '2026-04-30T00:00:00.000Z',
+};
+
+describe('hasProse', () => {
+  it('narrows the record case', () => {
+    const value: ProseResponse = PROSE;
+    expect(hasProse(value)).toBe(true);
+    if (hasProse(value)) {
+      expect(value.id).toBe('p1');
+    }
+  });
+
+  it('rejects the empty `{ prose: null }` shape', () => {
+    const value: ProseResponse = { prose: null };
+    expect(hasProse(value)).toBe(false);
+  });
+});
+
+describe('hasOptimized', () => {
+  it('narrows the record case', () => {
+    const value: OptimizedResponse = OPTIMIZED;
+    expect(hasOptimized(value)).toBe(true);
+    if (hasOptimized(value)) {
+      expect(value.payload.roles).toEqual([]);
+    }
+  });
+
+  it('rejects the empty `{ optimized: null }` shape', () => {
+    const value: OptimizedResponse = { optimized: null };
+    expect(hasOptimized(value)).toBe(false);
+  });
+});
+
+describe('GAP_KIND_WEIGHTS / GAP_KIND_LABELS', () => {
+  // Both maps must agree on keys — a missing label or weight would render
+  // the gap with a fallback string and zero weight, masking real issues.
+  it('every weight has a matching label', () => {
+    for (const kind of Object.keys(GAP_KIND_WEIGHTS)) {
+      expect(GAP_KIND_LABELS[kind]).toBeDefined();
+    }
+  });
+
+  it('every label has a matching weight', () => {
+    for (const kind of Object.keys(GAP_KIND_LABELS)) {
+      expect(GAP_KIND_WEIGHTS[kind]).toBeDefined();
+    }
+  });
+
+  it('weights are non-negative', () => {
+    for (const w of Object.values(GAP_KIND_WEIGHTS)) {
+      expect(w).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  it('outcome.missing_metric is a high-priority (>=3) gap', () => {
+    expect(GAP_KIND_WEIGHTS['outcome.missing_metric']).toBeGreaterThanOrEqual(
+      3
+    );
+  });
+
+  it('content.empty has zero weight (sentinel, not a scorable gap)', () => {
+    expect(GAP_KIND_WEIGHTS['content.empty']).toBe(0);
+  });
+});

--- a/apps/root/src/app/fitted/(app)/settings/SettingsPage.tsx
+++ b/apps/root/src/app/fitted/(app)/settings/SettingsPage.tsx
@@ -453,6 +453,7 @@ export default function SettingsPage() {
               placeholder='Full name'
               autoComplete='name'
               required
+              data-sentry-mask
             />
             <Input
               label='Email'
@@ -462,6 +463,7 @@ export default function SettingsPage() {
               placeholder='name@example.com'
               autoComplete='email'
               inputMode='email'
+              data-sentry-mask
             />
             <Input
               label='Phone'
@@ -471,6 +473,7 @@ export default function SettingsPage() {
               placeholder='+1 555 555 5555'
               autoComplete='tel'
               inputMode='tel'
+              data-sentry-mask
             />
             <Input
               label='Location'
@@ -478,6 +481,7 @@ export default function SettingsPage() {
               onChange={e => setIdentityLocation(e.target.value)}
               placeholder='City, State'
               autoComplete='address-level2'
+              data-sentry-mask
             />
             <Input
               label='LinkedIn URL'
@@ -487,6 +491,7 @@ export default function SettingsPage() {
               placeholder='https://linkedin.com/in/username'
               autoComplete='url'
               inputMode='url'
+              data-sentry-mask
             />
             <Input
               label='Website'
@@ -496,6 +501,7 @@ export default function SettingsPage() {
               placeholder='https://example.com'
               autoComplete='url'
               inputMode='url'
+              data-sentry-mask
             />
           </div>
         </CardContent>

--- a/apps/root/src/app/fitted/(app)/targets/__tests__/types.spec.ts
+++ b/apps/root/src/app/fitted/(app)/targets/__tests__/types.spec.ts
@@ -1,0 +1,38 @@
+import { emptyScoringProfile } from '../types';
+
+describe('emptyScoringProfile', () => {
+  it('returns an empty categories map', () => {
+    const profile = emptyScoringProfile();
+    expect(profile.categories).toEqual({});
+  });
+
+  it('seeds seniority with null level + empty signals', () => {
+    const profile = emptyScoringProfile();
+    expect(profile.seniority).toEqual({ level: null, signals: [] });
+  });
+
+  it('seeds the domain profile with weight 0.5', () => {
+    const profile = emptyScoringProfile();
+    expect(profile.domain.weight).toBe(0.5);
+    expect(profile.domain.signals).toEqual([]);
+  });
+
+  // The negative weight is intentionally large and negative — a positive or
+  // small value would let "negative" keywords *boost* a job's score, which
+  // defeats the whole point of the negative bucket.
+  it('seeds the negative profile with weight -10', () => {
+    const profile = emptyScoringProfile();
+    expect(profile.negative.weight).toBe(-10);
+    expect(profile.negative.keywords).toEqual([]);
+  });
+
+  it('returns a fresh object on each call (no shared references)', () => {
+    const a = emptyScoringProfile();
+    const b = emptyScoringProfile();
+    expect(a).not.toBe(b);
+    expect(a.categories).not.toBe(b.categories);
+    expect(a.seniority.signals).not.toBe(b.seniority.signals);
+    expect(a.domain.signals).not.toBe(b.domain.signals);
+    expect(a.negative.keywords).not.toBe(b.negative.keywords);
+  });
+});

--- a/apps/root/src/app/fitted/_components/ConversationChat.tsx
+++ b/apps/root/src/app/fitted/_components/ConversationChat.tsx
@@ -263,6 +263,7 @@ export default function ConversationChat({
               rows={2}
               className='flex-1 resize-none'
               aria-label='Your response'
+              data-sentry-mask
             />
             <div className='flex flex-col gap-1'>
               <Button

--- a/apps/root/src/lib/llmRateLimit.ts
+++ b/apps/root/src/lib/llmRateLimit.ts
@@ -1,0 +1,53 @@
+import { NextResponse } from 'next/server';
+import { createRateLimiter } from './rateLimit';
+
+// Per-user limits sized for LLM cost on a personal-use tool. Numbers
+// are generous for legitimate authenticated use but tight enough to
+// stop runaway loops and bound bills if a credential leaks.
+//
+// Keys are Supabase user_ids (not IPs) — multiple users can share an
+// IP, and a single user across devices should still hit one budget.
+
+const HOUR_MS = 60 * 60 * 1_000;
+
+const tailorLimiter = createRateLimiter({
+  maxRequests: 30,
+  windowMs: HOUR_MS,
+});
+
+const deriveLimiter = createRateLimiter({
+  maxRequests: 20,
+  windowMs: HOUR_MS,
+});
+
+const uploadLimiter = createRateLimiter({
+  maxRequests: 10,
+  windowMs: HOUR_MS,
+});
+
+export const checkTailorRateLimit = tailorLimiter.check;
+export const checkDeriveRateLimit = deriveLimiter.check;
+export const checkUploadRateLimit = uploadLimiter.check;
+
+export const resetTailorRateLimit = tailorLimiter.reset;
+export const resetDeriveRateLimit = deriveLimiter.reset;
+export const resetUploadRateLimit = uploadLimiter.reset;
+
+/**
+ * Build a 429 response from a blocked rate-limit result. Returns
+ * `null` when the request is within budget so callers can early-exit
+ * with one expression: `return tooManyRequests(rate) ?? handler();`.
+ */
+export function tooManyRequests(
+  rate: { blocked: boolean; retryAfterSeconds: number },
+  message = 'Too many requests'
+): NextResponse | null {
+  if (!rate.blocked) return null;
+  return NextResponse.json(
+    { error: message },
+    {
+      status: 429,
+      headers: { 'Retry-After': String(rate.retryAfterSeconds) },
+    }
+  );
+}


### PR DESCRIPTION
## Summary

Phase 0 of the WyrdFold migration: harden the current `/fitted` code on `apps/root` *before* the cut so audit-flagged gaps don't ride into the new app. Targets `feature/fitted` because that's where the feature lives.

Four commits, three concerns:

- **0a — Sentry-replay PII masking** (`d6a0a82e`): adds `data-sentry-mask` to identity Inputs (Settings: name/email/phone/location/linkedin/website), the master-document Textarea (Profile), the onboarding chat Textarea (ConversationChat), and the Resume + Cover-Letter review Textareas. With 10% replay sampling in prod, free-text and identity fields would otherwise leak into Sentry.
- **0b — per-user LLM rate limits** (`d4520cfc`): new `lib/llmRateLimit.ts` (tailor 30/h, derive 20/h, upload 10/h) keyed on Supabase `user_id`, plus a `tooManyRequests()` 429 helper. Extends `api/jobs/proxy.ts` with `getJobsAccess()` returning a `{admin} | {user, userId}` discriminated union; `verifyJobsAccess()` becomes a thin boolean wrapper so existing routes don't break. Applied to `/api/jobs/tailor/{resume,cover-letter,batch}`, `/api/career/experience/derive/stream`, `/api/career/experience/upload-resume`. Admin sessions bypass the limit (single operator, infrastructure-class).
- **0c — Tier-1 unit tests** (`50e8fdbe`): 14 specs across `profile/__tests__/types.spec.ts` (hasOptimized/hasProse type guards + GAP_KIND_LABELS↔WEIGHTS parity) and `targets/__tests__/types.spec.ts` (`emptyScoringProfile()` shape including the intentional `negative.weight = -10`). Brings Fitted from 1 spec → 3.

Plus `893a7058` documents the 6-phase migration plan in `.claude/docs/wyrdfold-migration/PHASES.md`.

## Why these three

Per the audit docs:
- `platform-readiness.md §5` — only public-page IP-keyed rate limits exist; LLM routes are unbounded per user
- `pii-and-privacy-review.md` — Sentry replay sampling without input masking is the highest-severity privacy gap
- `test-coverage.md §5` — Fitted has 1 spec across 70 source files; load-bearing pure functions are the cheapest signal

## Test plan

- [x] `pnpm tsc --noEmit` clean
- [x] `pnpm nx lint root` — 0 errors (26 pre-existing warnings in unrelated files)
- [x] `pnpm nx test root` on the 2 new spec files — 14/14 pass
- [ ] Manual verification: trigger 31 tailor calls in <1h with a non-admin session; expect 429 with `Retry-After` on the 31st
- [ ] Manual verification: open a Sentry replay session locally and confirm masked fields render as `***` in the player

🤖 Generated with [Claude Code](https://claude.com/claude-code)