### PR TITLE
feat(shared-ui): WyrdFold Phase 1a — pyre theme (chartreuse on near-black)

### DIFF
--- a/libs/shared/ui/.storybook/preview.ts
+++ b/libs/shared/ui/.storybook/preview.ts
@@ -9,6 +9,7 @@ const preview: Preview = {
       themes: {
         light: '',
         dark: 'dark',
+        pyre: 'pyre dark',
       },
       defaultTheme: 'dark',
     }),

--- a/libs/shared/ui/package.json
+++ b/libs/shared/ui/package.json
@@ -29,7 +29,8 @@
       "types": "./dist/lib/types.d.ts",
       "default": "./src/lib/types.ts"
     },
-    "./styles/indigo-theme.css": "./src/styles/indigo-theme.css"
+    "./styles/indigo-theme.css": "./src/styles/indigo-theme.css",
+    "./styles/pyre-theme.css": "./src/styles/pyre-theme.css"
   },
   "dependencies": {
     "clsx": "^2.1.0",

--- a/libs/shared/ui/src/lib/PyreThemePreview.stories.tsx
+++ b/libs/shared/ui/src/lib/PyreThemePreview.stories.tsx
@@ -1,0 +1,136 @@
+/**
+ * Pyre theme preview — renders a representative subset of components so
+ * the chartreuse + near-black palette can be eyeballed and a11y-checked
+ * in Storybook before WyrdFold consumes it.
+ *
+ * The `pyre` theme is registered in `.storybook/preview.ts`
+ * (`withThemeByClassName`) and toggles a `.pyre dark` class on the body.
+ * Switch via the Storybook toolbar.
+ */
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Button } from './Button';
+import { Card, CardContent, CardHeader, CardTitle } from './Card';
+import { StatsCard } from './StatsCard';
+import { Badge } from './Badge';
+import { Alert } from './Alert';
+
+function PyrePreview() {
+  return (
+    <div className='bg-surface text-text-primary min-h-screen p-8 space-y-8'>
+      <header className='space-y-2'>
+        <h1 className='text-text-primary'>Pyre theme preview</h1>
+        <p className='text-text-secondary max-w-2xl'>
+          Chartreuse on near-black. Toggle the theme via the Storybook toolbar
+          to compare with indigo. This story exists for visual QA and jest-axe
+          contrast verification.
+        </p>
+      </header>
+
+      <section className='space-y-4'>
+        <h2 className='text-text-primary'>Buttons</h2>
+        <div className='flex flex-wrap gap-3'>
+          <Button name='primary'>Primary</Button>
+          <Button name='secondary' variant='secondary'>
+            Secondary
+          </Button>
+          <Button name='outline' variant='outline'>
+            Outline
+          </Button>
+          <Button name='bare' variant='bare'>
+            Bare
+          </Button>
+          <Button name='disabled' disabled>
+            Disabled
+          </Button>
+        </div>
+      </section>
+
+      <section className='space-y-4'>
+        <h2 className='text-text-primary'>Stats</h2>
+        <div className='grid grid-cols-1 md:grid-cols-3 gap-4'>
+          <StatsCard
+            title='Total applications'
+            value='128'
+            change={12.5}
+            changeLabel='vs last month'
+          />
+          <StatsCard
+            title='Interview rate'
+            value='24%'
+            change={-3.1}
+            changeLabel='vs last month'
+          />
+          <StatsCard title='Avg fit score' value='72' />
+        </div>
+      </section>
+
+      <section className='space-y-4'>
+        <h2 className='text-text-primary'>Cards + badges</h2>
+        <div className='grid grid-cols-1 md:grid-cols-2 gap-4'>
+          <Card>
+            <CardHeader>
+              <CardTitle>Senior Frontend Engineer</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className='flex flex-wrap gap-2'>
+                <Badge variant='success'>Applied</Badge>
+                <Badge variant='warning'>High priority</Badge>
+                <Badge variant='error'>Stale</Badge>
+                <Badge>React</Badge>
+                <Badge>TypeScript</Badge>
+              </div>
+            </CardContent>
+          </Card>
+          <Card elevated>
+            <CardHeader>
+              <CardTitle>Elevated surface</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className='text-text-secondary'>
+                Elevated surface variant — slightly lighter than base surface in
+                dark themes.
+              </p>
+            </CardContent>
+          </Card>
+        </div>
+      </section>
+
+      <section className='space-y-4'>
+        <h2 className='text-text-primary'>Alerts</h2>
+        <div className='space-y-3'>
+          <Alert variant='success' title='Saved'>
+            Your changes were persisted.
+          </Alert>
+          <Alert variant='warning' title='Heads up'>
+            Token costs are approaching the monthly cap.
+          </Alert>
+          <Alert variant='error' title='Could not load'>
+            Job API returned 503. Retry in a moment.
+          </Alert>
+          <Alert variant='info' title='New version available'>
+            A newer resume version exists for this target.
+          </Alert>
+        </div>
+      </section>
+    </div>
+  );
+}
+
+const meta = {
+  title: 'Theme/Pyre Preview',
+  component: PyrePreview,
+  parameters: {
+    layout: 'fullscreen',
+  },
+} satisfies Meta<typeof PyrePreview>;
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Pyre: Story = {
+  globals: { theme: 'pyre' },
+};
+
+export const Indigo: Story = {
+  globals: { theme: 'dark' },
+};

--- a/libs/shared/ui/src/styles/preview.scss
+++ b/libs/shared/ui/src/styles/preview.scss
@@ -1,3 +1,4 @@
 @use 'tailwindcss';
 @import './indigo-theme.css';
+@import './pyre-storybook-preview.css';
 @source "../**/*.{js,ts,jsx,tsx}";

--- a/libs/shared/ui/src/styles/pyre-storybook-preview.css
+++ b/libs/shared/ui/src/styles/pyre-storybook-preview.css
@@ -1,0 +1,50 @@
+/**
+ * Pyre overrides scoped to the `.pyre` class — for Storybook only.
+ *
+ * The production Pyre file (pyre-theme.css) registers its tokens via
+ * `@theme {}` at :root, which would clobber indigo's defaults in the
+ * Storybook preview where both palettes coexist. This file scopes the
+ * same token *values* under `.pyre` so the storybook decorator can flip
+ * between palettes by toggling a class on <body>.
+ *
+ * Values must stay in lockstep with pyre-theme.css's @theme block.
+ * If you change one, change both.
+ */
+.pyre {
+  --color-brand-50: oklch(0.97 0.05 127);
+  --color-brand-100: oklch(0.93 0.1 127);
+  --color-brand-200: oklch(0.87 0.16 127);
+  --color-brand-300: oklch(0.78 0.22 127);
+  --color-brand-400: oklch(0.72 0.26 127);
+  --color-brand-500: oklch(0.67 0.28 127);
+  --color-brand-600: oklch(0.6 0.26 127);
+  --color-brand-700: oklch(0.5 0.22 127);
+  --color-brand-800: oklch(0.4 0.17 127);
+  --color-brand-900: oklch(0.3 0.12 127);
+  --color-brand-950: oklch(0.2 0.08 127);
+
+  --color-surface: oklch(0.1 0.01 270);
+  --color-surface-secondary: oklch(0.13 0.01 270);
+  --color-surface-tertiary: oklch(0.16 0.01 270);
+  --color-surface-elevated: oklch(0.13 0.01 270);
+  --color-surface-overlay: rgba(0, 0, 0, 0.7);
+
+  --color-border: oklch(0.22 0.01 270);
+  --color-border-secondary: oklch(0.3 0.01 270);
+  --color-border-focus: oklch(0.67 0.28 127);
+
+  --color-text-primary: oklch(0.96 0.01 90);
+  --color-text-secondary: oklch(0.75 0.02 90);
+  --color-text-tertiary: oklch(0.6 0.02 90);
+  --color-text-inverse: oklch(0.1 0.01 270);
+  --color-text-brand: oklch(0.78 0.22 127);
+
+  --color-success: oklch(0.72 0.2 145);
+  --color-success-light: oklch(0.25 0.05 145);
+  --color-warning: oklch(0.78 0.18 70);
+  --color-warning-light: oklch(0.28 0.05 70);
+  --color-error: oklch(0.65 0.22 25);
+  --color-error-light: oklch(0.25 0.05 25);
+  --color-info: oklch(0.7 0.2 230);
+  --color-info-light: oklch(0.25 0.05 230);
+}

--- a/libs/shared/ui/src/styles/pyre-theme.css
+++ b/libs/shared/ui/src/styles/pyre-theme.css
@@ -1,0 +1,279 @@
+/**
+ * Pyre — chartreuse on near-black, intrinsically dark.
+ *
+ * Standalone replacement for indigo-theme.css. WyrdFold imports this
+ * file once at the app root; every shared-ui component reskins via
+ * the same semantic token names. No light/dark switch — Pyre is one
+ * palette.
+ *
+ * Token *names* mirror indigo-theme.css exactly so the two themes are
+ * drop-in-compatible. Token *values* differ.
+ *
+ * Color decisions (placeholders pending final brand tuning):
+ *   brand   = chartreuse, oklch hue 127, peak chroma at L≈0.67
+ *   surface = near-black, oklch hue 270 with minimal chroma
+ *   text    = near-white at L≈0.96 over surface (≥ 14:1 contrast)
+ *
+ * For Storybook coexistence with indigo, see pyre-storybook-preview.css —
+ * that file scopes Pyre tokens under a `.pyre` class so the indigo theme
+ * can stay the default at :root.
+ */
+@theme {
+  /* Radius scale */
+  --radius-xs: 0.25rem;
+  --radius-sm: 0.375rem;
+  --radius-md: 0.5rem;
+  --radius-lg: 0.75rem;
+  --radius-xl: 1rem;
+  --radius-full: 9999px;
+
+  /* Fonts — actual families injected by next/font via CSS variables at runtime */
+  --font-sans: ui-sans-serif, system-ui, sans-serif;
+  --font-mono: ui-monospace, monospace;
+
+  /* Shadows — heavier opacity values for the dark surface */
+  --shadow-xs: 0 1px 2px rgba(0, 0, 0, 0.2);
+  --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.3), 0 1px 2px rgba(0, 0, 0, 0.2);
+  --shadow-md:
+    0 4px 6px -1px rgba(0, 0, 0, 0.3), 0 2px 4px -2px rgba(0, 0, 0, 0.2);
+  --shadow-lg:
+    0 10px 15px -3px rgba(0, 0, 0, 0.4), 0 4px 6px -4px rgba(0, 0, 0, 0.2);
+  --shadow-xl:
+    0 20px 25px -5px rgba(0, 0, 0, 0.4), 0 8px 10px -6px rgba(0, 0, 0, 0.2);
+
+  /* Animation */
+  --animate-fade-in: fade-in 0.2s ease-out;
+  --animate-slide-up: slide-up 0.2s ease-out;
+  --animate-slide-down: slide-down 0.15s ease-out;
+  --animate-slide-out-down: slide-out-down 0.15s ease-in forwards;
+  --animate-scale-in: scale-in 0.15s ease-out;
+
+  /* Colors — Brand (chartreuse, oklch hue 127) */
+  --color-brand-50: oklch(0.97 0.05 127);
+  --color-brand-100: oklch(0.93 0.1 127);
+  --color-brand-200: oklch(0.87 0.16 127);
+  --color-brand-300: oklch(0.78 0.22 127);
+  --color-brand-400: oklch(0.72 0.26 127);
+  --color-brand-500: oklch(0.67 0.28 127);
+  --color-brand-600: oklch(0.6 0.26 127);
+  --color-brand-700: oklch(0.5 0.22 127);
+  --color-brand-800: oklch(0.4 0.17 127);
+  --color-brand-900: oklch(0.3 0.12 127);
+  --color-brand-950: oklch(0.2 0.08 127);
+
+  /* Semantic Colors — Surface (near-black, hue 270) */
+  --color-surface: oklch(0.1 0.01 270);
+  --color-surface-secondary: oklch(0.13 0.01 270);
+  --color-surface-tertiary: oklch(0.16 0.01 270);
+  --color-surface-elevated: oklch(0.13 0.01 270);
+  --color-surface-overlay: rgba(0, 0, 0, 0.7);
+
+  /* Semantic Colors — Border */
+  --color-border: oklch(0.22 0.01 270);
+  --color-border-secondary: oklch(0.3 0.01 270);
+  --color-border-focus: oklch(0.67 0.28 127);
+
+  /* Semantic Colors — Text */
+  --color-text-primary: oklch(0.96 0.01 90);
+  --color-text-secondary: oklch(0.75 0.02 90);
+  --color-text-tertiary: oklch(0.6 0.02 90);
+  --color-text-inverse: oklch(0.1 0.01 270);
+  --color-text-brand: oklch(0.78 0.22 127);
+
+  /* Semantic Colors — Status (semantic hues, dimmed chroma for dark surface) */
+  --color-success: oklch(0.72 0.2 145);
+  --color-success-light: oklch(0.25 0.05 145);
+  --color-warning: oklch(0.78 0.18 70);
+  --color-warning-light: oklch(0.28 0.05 70);
+  --color-error: oklch(0.65 0.22 25);
+  --color-error-light: oklch(0.25 0.05 25);
+  --color-info: oklch(0.7 0.2 230);
+  --color-info-light: oklch(0.25 0.05 230);
+}
+
+@keyframes fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes slide-up {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes slide-down {
+  from {
+    opacity: 0;
+    transform: translateY(-8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes slide-out-down {
+  from {
+    opacity: 1;
+    transform: translateY(0);
+  }
+  to {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+}
+
+@keyframes scale-in {
+  from {
+    opacity: 0;
+    transform: scale(0.95);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+/* Base styles */
+@layer base {
+  * {
+    @apply border-border outline-border-focus/50;
+  }
+
+  html {
+    font-size: 16px;
+  }
+
+  body {
+    @apply bg-surface text-text-primary antialiased;
+    font-family: var(--font-sans);
+    font-size: 16px;
+    line-height: 1.65;
+    font-weight: 400;
+  }
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    font-family: var(--font-sans);
+    font-weight: 600;
+    color: inherit;
+    text-wrap: balance;
+    margin: 0;
+    letter-spacing: -0.025em;
+  }
+
+  h1 {
+    font-size: 2.25rem;
+    line-height: 1.1;
+  }
+
+  h2 {
+    font-size: 1.75rem;
+    line-height: 1.2;
+  }
+
+  h3 {
+    font-size: 1.375rem;
+    line-height: 1.25;
+  }
+
+  h4 {
+    font-size: 1.125rem;
+    line-height: 1.3;
+  }
+
+  h5 {
+    font-size: 1rem;
+    line-height: 1.5;
+    font-weight: 500;
+  }
+
+  h6 {
+    font-size: 0.875rem;
+    line-height: 1.5;
+    font-weight: 500;
+  }
+
+  :is(h1, h2, h3, h4, h5, h6):first-child {
+    margin-top: 0;
+  }
+
+  p {
+    margin-bottom: 0.5em;
+  }
+  p:last-child {
+    margin-bottom: 0;
+  }
+
+  code:not([data-theme]) {
+    font-family: var(--font-mono);
+    font-size: 0.875rem;
+    line-height: 1.5;
+    @apply bg-brand-950 text-brand-300 rounded px-1.5 py-0.5;
+  }
+
+  ul:not(.prose ul),
+  ol:not(.prose ol) {
+    list-style: none;
+  }
+
+  table {
+    width: 100%;
+    border-collapse: collapse;
+  }
+
+  th,
+  td {
+    text-align: left;
+    padding: 0.25rem 0.75rem;
+  }
+
+  th:first-child,
+  td:first-child {
+    padding-left: 0;
+  }
+
+  th:last-child,
+  td:last-child {
+    padding-right: 0;
+  }
+}
+
+::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+::-webkit-scrollbar-thumb {
+  background: var(--color-border-secondary);
+  border-radius: 3px;
+}
+::-webkit-scrollbar-thumb:hover {
+  background: var(--color-text-tertiary);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}


### PR DESCRIPTION
## Summary

Phase 1a of the WyrdFold migration: author the **Pyre theme** in `libs/shared/ui` — the only blocker the `shared-ui.md` audit identified for WyrdFold consumption. With this in place, every shared-ui component reskins automatically when WyrdFold imports `pyre-theme.css`.

- **`pyre-theme.css`** — standalone `@theme {}` for WyrdFold. Same semantic token names as `indigo-theme.css`, different values:
  - Brand: chartreuse, oklch hue 127, peak chroma at L≈0.67
  - Surface: near-black, oklch hue 270 with minimal chroma (L≈0.10)
  - Text: near-white at L≈0.96 (≥14:1 contrast over surface)
  - Status hues kept semantic (red/amber/green/blue) but chroma dimmed for the dark surface
- **`pyre-storybook-preview.css`** — same values scoped under `.pyre` so Storybook can preview both palettes without indigo's `:root` `@theme` getting clobbered.
- **`PyreThemePreview.stories.tsx`** — renders Buttons / StatsCard / Card / Badge / Alert for visual QA + jest-axe contrast verification.
- **`preview.ts`** — registers a `pyre` theme variant (`'pyre dark'` class) in `withThemeByClassName`.
- **`package.json`** — exports `./styles/pyre-theme.css`.

## Why dark-only

`shared-ui.md §4`: \"Pyre is intrinsically a dark theme (chartreuse-on-near-black). WyrdFold can ship Pyre as the `:root` palette and skip the `html.dark` override entirely.\" v1 ships dark-only; a Pyre Bright variant is deferred until brand maturity.

## Why not extend ThemeProvider

`shared-ui.md §4`: \"Adding a `palette` prop would couple the React layer to WyrdFold's brand, which violates the lib's no-product-knowledge rule. CSS imports on the consumer side keep all branding in the consumer.\"

## Test plan

- [x] `pnpm nx test shared-ui` — 47 suites / 752 tests pass (jest-axe runs across the suite, including the new story)
- [x] `pnpm nx build shared-ui` — clean (vite + dts emit succeed)
- [x] `pnpm tsc --noEmit` — clean
- [ ] Manual: open Storybook, switch the toolbar theme to **Pyre**, eyeball the new \"Theme/Pyre Preview\" story
- [ ] Manual: verify WCAG AA contrast on chartreuse-on-near-black at the chosen `oklch(0.67 0.28 127)` mid-tone (likely fine but worth a meter check)

## Follow-ups (not in this PR)

- Final brand swatch tuning (chartreuse hue/chroma + near-black) once a Figma file lands. The current values are tuned to the audit doc's recommended ranges.
- Phase 1b (`feature/wyrdfold-phase-1b-foundation`) will scaffold `apps/wyrdfold/` and import this theme.

🤖 Generated with [Claude Code](https://claude.com/claude-code)