### PR TITLE
feat(wyrdfold): phase 1c — Sentry wiring and env contract

### DIFF
--- a/apps/wyrdfold/.env.example
+++ b/apps/wyrdfold/.env.example
@@ -1,0 +1,14 @@
+# Environment variables for WyrdFold (Next.js admin app)
+
+# Supabase (auth + storage)
+NEXT_PUBLIC_SUPABASE_URL=your-supabase-url
+NEXT_PUBLIC_SUPABASE_ANON_ID=your-anon-key
+SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+
+# Sentry — separate project from root (see sentry.config.ts)
+NEXT_PUBLIC_SENTRY_CONFIG_ID=your-wyrdfold-sentry-dsn
+SENTRY_AUTH_TOKEN=your-sentry-cli-token
+
+# Job API (BFF target — wired in Phase 4)
+JOB_API_URL=http://localhost:8000
+JOB_API_TOKEN=your-shared-secret

--- a/apps/wyrdfold/next-env.d.ts
+++ b/apps/wyrdfold/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/wyrdfold/next.config.mjs
+++ b/apps/wyrdfold/next.config.mjs
@@ -135,4 +135,27 @@ const nextConfig = {
 
 const plugins = [withNx];
 
-export default composePlugins(...plugins)(nextConfig);
+const { withSentryConfig } = await import('@sentry/nextjs');
+
+const nextConfigWithPlugins = composePlugins(...plugins)(nextConfig);
+
+// Skip Sentry config in CI/test to keep build deterministic and avoid
+// uploading source maps during PR checks.
+const finalConfig =
+  isCI || isTest
+    ? nextConfigWithPlugins
+    : withSentryConfig(nextConfigWithPlugins, {
+        org: 'testing-b1',
+        project: 'wyrdfold',
+
+        silent: !isCI,
+        widenClientFileUpload: true,
+        tunnelRoute: '/monitoring',
+
+        webpack: {
+          treeshake: { removeDebugLogging: true },
+          automaticVercelMonitors: true,
+        },
+      });
+
+export default finalConfig;

--- a/apps/wyrdfold/src/instrumentation-client.ts
+++ b/apps/wyrdfold/src/instrumentation-client.ts
@@ -1,0 +1,69 @@
+import * as Sentry from '@sentry/nextjs';
+import { sentryEnabled } from '@/lib/sentry.config';
+import { publicEnv } from '@/lib/public.env';
+import { isProduction } from '@/utils/helpers';
+
+if (sentryEnabled) {
+  Sentry.init({
+    dsn: publicEnv.NEXT_PUBLIC_SENTRY_CONFIG_ID as string,
+    environment: publicEnv.NEXT_PUBLIC_NODE_ENV,
+    tracesSampleRate: isProduction() ? 0.1 : 1.0,
+    sampleRate: 1.0,
+    enableLogs: true,
+
+    // Heavy integrations are deferred below to avoid blocking LCP
+    integrations: [],
+
+    replaysSessionSampleRate: isProduction() ? 0.1 : 0,
+    replaysOnErrorSampleRate: 1.0,
+
+    ignoreErrors: [
+      /extensions\//i,
+      /^chrome-extension:\/\//,
+      /^moz-extension:\/\//,
+      'Network request failed',
+      'Failed to fetch',
+      'Load failed',
+      'ResizeObserver loop limit exceeded',
+      'ResizeObserver loop completed with undelivered notifications',
+    ],
+
+    beforeSend(event) {
+      if (typeof window !== 'undefined') {
+        event.tags = {
+          ...event.tags,
+          'page.url': window.location.pathname,
+          'page.referrer': document.referrer || 'direct',
+        };
+      }
+      return event;
+    },
+
+    debug: false,
+  });
+
+  if (typeof window !== 'undefined') {
+    const loadDeferredIntegrations = () => {
+      Sentry.addIntegration(Sentry.browserTracingIntegration());
+      // maskAllText: true is critical for WyrdFold — resume content,
+      // job descriptions, and tailoring prompts contain PII and secrets
+      // that must not leak into Sentry replay payloads.
+      Sentry.addIntegration(
+        Sentry.replayIntegration({
+          maskAllText: true,
+          blockAllMedia: true,
+        })
+      );
+    };
+
+    if ('requestIdleCallback' in window) {
+      window.requestIdleCallback(loadDeferredIntegrations);
+    } else {
+      setTimeout(loadDeferredIntegrations, 0);
+    }
+  }
+}
+
+export const onRouterTransitionStart = sentryEnabled
+  ? Sentry.captureRouterTransitionStart
+  : undefined;

--- a/apps/wyrdfold/src/instrumentation.ts
+++ b/apps/wyrdfold/src/instrumentation.ts
@@ -1,0 +1,13 @@
+import * as Sentry from '@sentry/nextjs';
+
+export async function register() {
+  if (process.env.NEXT_RUNTIME === 'nodejs') {
+    await import('./sentry.server.config');
+  }
+
+  if (process.env.NEXT_RUNTIME === 'edge') {
+    await import('./sentry.edge.config');
+  }
+}
+
+export const onRequestError = Sentry.captureRequestError;

--- a/apps/wyrdfold/src/lib/public.env.ts
+++ b/apps/wyrdfold/src/lib/public.env.ts
@@ -1,0 +1,7 @@
+const NEXT_PUBLIC_SENTRY_CONFIG_ID = process.env.NEXT_PUBLIC_SENTRY_CONFIG_ID;
+const NEXT_PUBLIC_NODE_ENV = process.env.NODE_ENV ?? 'development';
+
+export const publicEnv = {
+  NEXT_PUBLIC_SENTRY_CONFIG_ID,
+  NEXT_PUBLIC_NODE_ENV,
+};

--- a/apps/wyrdfold/src/lib/sentry.config.ts
+++ b/apps/wyrdfold/src/lib/sentry.config.ts
@@ -1,0 +1,15 @@
+import type * as Sentry from '@sentry/nextjs';
+import { publicEnv } from '@/lib/public.env';
+import { isProduction } from '@/utils/helpers';
+
+export const sentryEnabled = !!publicEnv.NEXT_PUBLIC_SENTRY_CONFIG_ID;
+
+export const sharedSentryConfig: Parameters<typeof Sentry.init>[0] = {
+  dsn: publicEnv.NEXT_PUBLIC_SENTRY_CONFIG_ID as string,
+  environment: publicEnv.NEXT_PUBLIC_NODE_ENV,
+  tracesSampleRate: isProduction() ? 0.1 : 1.0,
+  sampleRate: 1.0,
+  enableLogs: true,
+  ignoreErrors: ['NEXT_NOT_FOUND', 'NEXT_REDIRECT'],
+  debug: false,
+};

--- a/apps/wyrdfold/src/sentry.edge.config.ts
+++ b/apps/wyrdfold/src/sentry.edge.config.ts
@@ -1,0 +1,12 @@
+import * as Sentry from '@sentry/nextjs';
+import { sentryEnabled, sharedSentryConfig } from '@/lib/sentry.config';
+
+if (sentryEnabled) {
+  Sentry.init({
+    ...sharedSentryConfig,
+    beforeSend(event) {
+      event.tags = { ...event.tags, runtime: 'edge' };
+      return event;
+    },
+  });
+}

--- a/apps/wyrdfold/src/sentry.server.config.ts
+++ b/apps/wyrdfold/src/sentry.server.config.ts
@@ -1,0 +1,12 @@
+import * as Sentry from '@sentry/nextjs';
+import { sentryEnabled, sharedSentryConfig } from '@/lib/sentry.config';
+
+if (sentryEnabled) {
+  Sentry.init({
+    ...sharedSentryConfig,
+    beforeSend(event) {
+      event.tags = { ...event.tags, runtime: 'nodejs' };
+      return event;
+    },
+  });
+}


### PR DESCRIPTION
## Summary

- Wires `@sentry/nextjs` for server, edge, and client runtimes — separate Sentry project (`testing-b1/wyrdfold`) so error volume and replay quotas stay isolated from the marketing site.
- Replay sampling matches root prod (10% session, 100% error) but with `maskAllText: true` and `blockAllMedia: true`. Resume content, job descriptions, and tailoring prompts contain PII and trade secrets that must not leak into Sentry payloads.
- `withSentryConfig` skipped in CI/test, same as root, to keep PR build output deterministic and avoid source-map uploads on every push.
- Adds `apps/wyrdfold/.env.example` documenting the env contract: Supabase auth, Sentry DSN, future Job API URL/token (Phase 4).

## Test plan

- [x] `pnpm tsc --noEmit -p apps/wyrdfold/tsconfig.json` — clean
- [x] `pnpm nx run-many -t lint,test -p wyrdfold` — pass
- [x] `pnpm nx build wyrdfold` (CI=true) — clean
- [x] `pnpm nx build wyrdfold` (CI unset, Sentry plugin engaged) — clean
- [ ] Live Sentry verification deferred until DSN is provisioned in Vercel project settings

## Out of scope

- Provisioning the actual Sentry project + DSN (manual step in Sentry UI)
- Vercel env var wiring (manual step before Phase 5 cutover)

🤖 Generated with [Claude Code](https://claude.com/claude-code)