### PR TITLE
feat(wyrdfold): rip the bandaid — rename jobs schema (Phase 2)

### DIFF
--- a/apps/job-api/app/models/analysis.py
+++ b/apps/job-api/app/models/analysis.py
@@ -2,7 +2,7 @@
 
 The LLM grades the user's OptimizedPayload against a job description,
 producing a structured scorecard and one-line recommendation. Results
-are cached in the `job_analyses` table.
+are cached in the `analyses` table.
 """
 
 from datetime import datetime
@@ -36,7 +36,7 @@ class JobAnalysis(BaseModel):
 
 
 class JobAnalysisRecord(BaseModel):
-    """DB read shape for job_analyses rows."""
+    """DB read shape for analyses rows."""
 
     id: str
     job_posting_id: str

--- a/apps/job-api/app/models/batch.py
+++ b/apps/job-api/app/models/batch.py
@@ -20,7 +20,7 @@ class BatchItem(BaseModel):
 
 
 class BatchJob(BaseModel):
-    """DB read shape for batch_jobs rows."""
+    """DB read shape for batch_runs rows."""
 
     id: str
     user_id: str | None

--- a/apps/job-api/app/models/embeddings.py
+++ b/apps/job-api/app/models/embeddings.py
@@ -1,7 +1,7 @@
 """Pydantic models for the embeddings layer (#185 P2b).
 
 Embeddings are conceptually different from LLM completions but share
-the same cost-tracking surface (llm_cost_log). The model column there
+the same cost-tracking surface (llm_costs). The model column there
 holds either a Claude ID or a Voyage ID — disambiguated at the call
 site, opaque at the read layer.
 """

--- a/apps/job-api/app/models/llm.py
+++ b/apps/job-api/app/models/llm.py
@@ -60,7 +60,7 @@ LLMStreamEvent = LLMStreamDelta | LLMStreamFinal
 
 
 class LLMCallRecord(BaseModel):
-    """Read shape for llm_cost_log rows.
+    """Read shape for llm_costs rows.
 
     Covers both LLM completions and embedding calls. The `model` column
     holds either a Claude ID (ModelId) or a Voyage ID (EmbeddingModelId);

--- a/apps/job-api/app/models/schemas.py
+++ b/apps/job-api/app/models/schemas.py
@@ -121,7 +121,7 @@ ScoringStatus = Literal["stage1", "stage2", "complete"]
 
 
 class JobTargetScore(BaseModel):
-    """DB read shape for job_target_scores rows."""
+    """DB read shape for scores rows."""
 
     id: str
     job_posting_id: str

--- a/apps/job-api/app/models/tailor.py
+++ b/apps/job-api/app/models/tailor.py
@@ -180,7 +180,7 @@ class CoverLetterRequest(BaseModel):
 
 
 class TailoredResumeRecord(BaseModel):
-    """Read shape for a tailored_resumes row.
+    """Read shape for a documents row.
 
     `payload` is stored as JSONB; its shape depends on `document_type`:
     - `"resume"` -> parseable as `TailoredResume`

--- a/apps/job-api/app/models/targets.py
+++ b/apps/job-api/app/models/targets.py
@@ -36,7 +36,7 @@ class NegativeProfile(BaseModel):
 
 
 class ScoringProfile(BaseModel):
-    """Per-target scoring profile. Stored as JSONB in job_targets.scoring_profile."""
+    """Per-target scoring profile. Stored as JSONB in targets.scoring_profile."""
 
     categories: dict[str, CategoryProfile] = Field(default_factory=dict)
     seniority: SeniorityProfile = Field(default_factory=SeniorityProfile)

--- a/apps/job-api/app/routers/analysis.py
+++ b/apps/job-api/app/routers/analysis.py
@@ -59,7 +59,7 @@ async def create_analysis(
 
     # 4. Fetch job posting (existence + description in one round-trip)
     resp = (
-        supabase.table("job_postings")
+        supabase.table("jobs")
         .select("id, description_html")
         .eq("id", job_id)
         .limit(1)

--- a/apps/job-api/app/routers/experience.py
+++ b/apps/job-api/app/routers/experience.py
@@ -42,6 +42,7 @@ from app.models.experience import (
     ResumeUploadResponse,
     TurnAppend,
 )
+from app.models.llm import Message
 from app.services.conversation import orchestrator
 from app.services.embeddings.client import EmbeddingsClient
 from app.services.experience import (
@@ -58,7 +59,6 @@ from app.services.experience import (
 from app.services.ingest import merge_into_prose, parse_resume
 from app.services.ingest.parse import ParseError
 from app.services.ingest.storage import upload_file
-from app.models.llm import Message
 from app.services.llm import cost_log
 from app.services.llm.client import LLMClient, strip_markdown_fence
 
@@ -235,7 +235,7 @@ async def upload_resume(
         "file_size_bytes": len(file_bytes),
         "warnings": warnings,
     }
-    supabase.table("resume_uploads").insert(upload_row).execute()
+    supabase.table("uploaded_resumes").insert(upload_row).execute()
 
     # Optional: auto-derive
     optimized_doc_id: str | None = None

--- a/apps/job-api/app/routers/jobs.py
+++ b/apps/job-api/app/routers/jobs.py
@@ -115,7 +115,7 @@ def _list_jobs_for_target_two_query(
     """Fallback: two-query pattern with pagination pushed to the scores layer."""
     sort_col = "score" if sort == "score" else sort
     ts_query = (
-        supabase.table("job_target_scores")
+        supabase.table("scores")
         .select("job_posting_id, score, score_breakdown, scoring_status", count=CountMethod.exact)
         .eq("target_id", target_id)
         .eq("excluded", False)
@@ -145,7 +145,7 @@ def _list_jobs_for_target_two_query(
         total = None  # will be computed after posting-level filters
 
     jp_query = (
-        supabase.table("job_postings")
+        supabase.table("jobs")
         .select(_JP_SELECT_COLS)
         .in_("id", page_ids)
     )
@@ -282,8 +282,8 @@ def list_jobs(
         job_list_cache.set(cache_key, result)
         return result
 
-    # Global view — query job_postings directly with global scores
-    query = supabase.table("job_postings").select(
+    # Global view — query jobs directly with global scores
+    query = supabase.table("jobs").select(
         _JP_SELECT_COLS,
         count=CountMethod.exact,
     )
@@ -413,7 +413,7 @@ async def add_manual_job(
     if not salary and description_html:
         salary = extract_salary_from_text(strip_html(description_html))
 
-    # Upsert into job_postings (score starts at 0, updated by target pipeline)
+    # Upsert into jobs (score starts at 0, updated by target pipeline)
     row: dict[str, Any] = {
         "external_id": external_id,
         "source_id": MANUAL_SOURCE_ID,
@@ -430,7 +430,7 @@ async def add_manual_job(
     }
 
     resp_db = (
-        supabase.table("job_postings")
+        supabase.table("jobs")
         .upsert(row, on_conflict="source_id,external_id")
         .execute()
     )
@@ -510,7 +510,7 @@ async def backfill_salary(
     """One-off: extract salary from description_html for jobs missing salary_text.
 
     Per batch of 500, extract salaries in Python then write all rows in a
-    single `bulk_update_job_salaries` RPC — turns ~N row-by-row UPDATEs
+    single `bulk_update_salaries` RPC — turns ~N row-by-row UPDATEs
     into one statement per batch.
     """
     batch_size = 500
@@ -519,7 +519,7 @@ async def backfill_salary(
 
     while True:
         resp = (
-            supabase.table("job_postings")
+            supabase.table("jobs")
             .select("id, description_html")
             .is_("salary_text", "null")
             .range(offset, offset + batch_size - 1)
@@ -540,7 +540,7 @@ async def backfill_salary(
 
         if updates:
             supabase.rpc(
-                "bulk_update_job_salaries", {"p_updates": updates}
+                "bulk_update_salaries", {"p_updates": updates}
             ).execute()
             updated += len(updates)
 
@@ -558,7 +558,7 @@ async def get_job(
     supabase: Client = Depends(get_supabase),
 ) -> dict[str, Any]:
     resp = (
-        supabase.table("job_postings")
+        supabase.table("jobs")
         .select(_JP_SELECT_COLS)
         .eq("id", posting_id)
         .limit(1)
@@ -579,7 +579,7 @@ async def delete_job(
     supabase: Client = Depends(get_supabase),
 ) -> dict[str, Any]:
     resp = (
-        supabase.table("job_postings")
+        supabase.table("jobs")
         .delete()
         .eq("id", posting_id)
         .execute()

--- a/apps/job-api/app/routers/sources.py
+++ b/apps/job-api/app/routers/sources.py
@@ -20,7 +20,7 @@ router = APIRouter(
 
 @router.get("")
 async def list_sources(supabase: Client = Depends(get_supabase)) -> dict[str, Any]:
-    resp = supabase.table("job_sources").select("*").order("company_name").execute()
+    resp = supabase.table("sources").select("*").order("company_name").execute()
     return {"sources": resp.data or []}
 
 
@@ -33,7 +33,7 @@ async def manage_source(
         if not body.company_name:
             raise HTTPException(status_code=422, detail="company_name required for add")
         resp = (
-            supabase.table("job_sources")
+            supabase.table("sources")
             .upsert(
                 {
                     "board_token": body.board_token,
@@ -47,12 +47,12 @@ async def manage_source(
         return {"success": True, "source": resp.data[0] if resp.data else None}
 
     elif body.action == "remove":
-        supabase.table("job_sources").delete().eq("board_token", body.board_token).execute()
+        supabase.table("sources").delete().eq("board_token", body.board_token).execute()
         return {"success": True}
 
     elif body.action == "toggle":
         current = (
-            supabase.table("job_sources")
+            supabase.table("sources")
             .select("enabled")
             .eq("board_token", body.board_token)
             .single()
@@ -61,7 +61,7 @@ async def manage_source(
         if current.data:
             row = cast(dict[str, Any], current.data)
             new_enabled = not row["enabled"]
-            supabase.table("job_sources").update({"enabled": new_enabled}).eq(
+            supabase.table("sources").update({"enabled": new_enabled}).eq(
                 "board_token", body.board_token
             ).execute()
             return {"success": True, "enabled": new_enabled}
@@ -107,7 +107,7 @@ async def detect_provider(
 
 @router.post("/seed")
 async def seed_sources(supabase: Client = Depends(get_supabase)) -> dict[str, Any]:
-    supabase.table("job_sources").upsert(
+    supabase.table("sources").upsert(
         list(COMPANY_SEED), on_conflict="board_token"
     ).execute()
     return {"success": True, "seeded": len(COMPANY_SEED)}

--- a/apps/job-api/app/routers/status.py
+++ b/apps/job-api/app/routers/status.py
@@ -21,7 +21,7 @@ async def get_status_history(
     supabase: Client = Depends(get_supabase),
 ) -> dict[str, Any]:
     result = (
-        supabase.table("job_status_log")
+        supabase.table("status_log")
         .select("id, old_status, new_status, note, created_at")
         .eq("posting_id", posting_id)
         .order("created_at", desc=True)
@@ -38,7 +38,7 @@ async def update_status(
     supabase: Client = Depends(get_supabase),
 ) -> dict[str, Any]:
     current = (
-        supabase.table("job_postings")
+        supabase.table("jobs")
         .select("status")
         .eq("id", posting_id)
         .single()
@@ -50,7 +50,7 @@ async def update_status(
     row = cast(dict[str, Any], current.data)
     old_status = row["status"]
 
-    supabase.table("job_status_log").insert(
+    supabase.table("status_log").insert(
         {
             "posting_id": posting_id,
             "old_status": old_status,
@@ -59,7 +59,7 @@ async def update_status(
         }
     ).execute()
 
-    supabase.table("job_postings").update(
+    supabase.table("jobs").update(
         {
             "status": body.status,
             "updated_at": datetime.now(UTC).isoformat(),

--- a/apps/job-api/app/routers/tailor.py
+++ b/apps/job-api/app/routers/tailor.py
@@ -42,7 +42,6 @@ from app.models.tailor import (
     TailorResponse,
 )
 from app.services.ats_lint import lint_markdown
-from app.services.ats_lint.linter import lint_docx
 from app.services.batch import create_batch, get_batch, process_batch
 from app.services.docx.pandoc_render import (
     PandocNotInstalled,
@@ -109,7 +108,7 @@ async def create_tailored_resume(
     # Reuse check (#504): skip pipeline if a similar resume exists in the target
     if not body.force_fresh and body.job_posting_id:
         jp_resp = (
-            supabase.table("job_postings")
+            supabase.table("jobs")
             .select("target_id")
             .eq("id", body.job_posting_id)
             .execute()
@@ -118,7 +117,7 @@ async def create_tailored_resume(
             target_id = cast(dict[str, Any], jp_resp.data[0]).get("target_id")
             if target_id:
                 target_resp = (
-                    supabase.table("job_targets")
+                    supabase.table("targets")
                     .select("scoring_profile")
                     .eq("id", target_id)
                     .execute()
@@ -260,7 +259,7 @@ async def create_tailored_cover_letter(
 
 
 @router.get("/resumes")
-async def list_tailored_resumes(
+async def list_documents(
     limit: int = 50,
     supabase: Client = Depends(get_supabase),
 ) -> dict[str, list[TailoredResumeRecord]]:
@@ -451,7 +450,7 @@ async def approve_tailored_resume(
     # Resume approval also advances the linked job posting to resume_ready;
     # cover letters don't drive job status.
     if row.document_type == "resume" and row.job_posting_id:
-        supabase.table("job_postings").update(
+        supabase.table("jobs").update(
             {"status": "resume_ready"}
         ).eq("id", row.job_posting_id).execute()
 
@@ -476,7 +475,7 @@ async def unapprove_tailored_resume(
     # Mirror the approve side: resume unlock walks the linked job back to
     # resume_draft so the lifecycle stays in sync.
     if row.document_type == "resume" and row.job_posting_id:
-        supabase.table("job_postings").update(
+        supabase.table("jobs").update(
             {"status": "resume_draft"}
         ).eq("id", row.job_posting_id).execute()
 
@@ -618,7 +617,7 @@ async def create_batch_resumes(
     postings: list[dict[str, Any]] = []
     for jid in body.job_posting_ids:
         resp = (
-            supabase.table("job_postings")
+            supabase.table("jobs")
             .select("id, title, description_html, target_id")
             .eq("id", jid)
             .execute()
@@ -650,7 +649,7 @@ async def create_batch_resumes(
         batch_id=batch.id,
         user_id=None,
         optimized=current_optimized,
-        job_postings=postings,
+        jobs=postings,
         contact=contact,
         preferences=prefs_payload,
         resume_type=body.resume_type or "generic",

--- a/apps/job-api/app/routers/targets.py
+++ b/apps/job-api/app/routers/targets.py
@@ -19,6 +19,7 @@ from app.dependencies import (
     get_supabase,
     verify_api_key_or_session,
 )
+from app.http_client import get_http_client
 from app.models.schemas import PollResult
 from app.models.targets import (
     CreateOrLinkResult,
@@ -34,7 +35,6 @@ from app.models.targets import (
     UserTarget,
     UserTargetWithTarget,
 )
-from app.http_client import get_http_client
 from app.services.experience import optimized
 from app.services.extract import (
     ExtractionResult,
@@ -449,7 +449,7 @@ async def get_target_status(
         raise HTTPException(status_code=404, detail="Target not found")
 
     count_resp = (
-        supabase.table("job_target_scores")
+        supabase.table("scores")
         .select("id", count=CountMethod.exact)
         .eq("target_id", target_id)
         .execute()
@@ -489,7 +489,7 @@ async def create_target_from_posting(
     reference, and activates the target.
     """
     resp = (
-        supabase.table("job_postings")
+        supabase.table("jobs")
         .select("id, title, description_html, absolute_url")
         .eq("id", posting_id)
         .execute()

--- a/apps/job-api/app/services/analysis/persistence.py
+++ b/apps/job-api/app/services/analysis/persistence.py
@@ -1,4 +1,4 @@
-"""Cache CRUD for job_analyses table.
+"""Cache CRUD for analyses table.
 
 The cache key is (job_posting_id, target_id, optimized_doc_id) so that
 re-deriving the master doc or switching targets naturally invalidates
@@ -15,7 +15,7 @@ from supabase import Client
 from app.models.analysis import JobAnalysis, JobAnalysisRecord
 from app.models.llm import LLMResult
 
-TABLE = "job_analyses"
+TABLE = "analyses"
 
 
 def get_cached(
@@ -58,7 +58,7 @@ def persist(
     analysis: JobAnalysis,
     llm_result: LLMResult,
 ) -> JobAnalysisRecord:
-    """Insert one job_analyses row."""
+    """Insert one analyses row."""
     row: dict[str, Any] = {
         "job_posting_id": job_posting_id,
         "target_id": target_id,
@@ -73,5 +73,5 @@ def persist(
     resp = supabase.table(TABLE).insert(row).execute()
     rows = cast(list[dict[str, Any]], resp.data or [])
     if not rows:
-        raise RuntimeError("Failed to insert job_analyses row")
+        raise RuntimeError("Failed to insert analyses row")
     return JobAnalysisRecord.model_validate(rows[0])

--- a/apps/job-api/app/services/batch.py
+++ b/apps/job-api/app/services/batch.py
@@ -1,7 +1,7 @@
 """Batch resume generation service (#503).
 
 Processes multiple job postings sequentially through the existing
-`run_tailor_pipeline`. Progress is tracked in the `batch_jobs` table
+`run_tailor_pipeline`. Progress is tracked in the `batch_runs` table
 so the frontend can poll for status.
 
 #504 adds a reuse check: before generating a fresh resume, check if
@@ -27,7 +27,7 @@ from app.services.tailor.reuse import (
     find_reusable_resume,
 )
 
-TABLE = "batch_jobs"
+TABLE = "batch_runs"
 
 
 # ---------------------------------------------------------------------------
@@ -41,7 +41,7 @@ def create_batch(
     user_id: str | None,
     job_posting_ids: list[str],
 ) -> BatchJob:
-    """Insert a new batch_jobs row with all items pending."""
+    """Insert a new batch_runs row with all items pending."""
     items = [
         BatchItem(job_posting_id=jid).model_dump(mode="json")
         for jid in job_posting_ids
@@ -101,7 +101,7 @@ async def process_batch(
     batch_id: str,
     user_id: str | None,
     optimized: OptimizedDoc,
-    job_postings: list[dict[str, Any]],
+    jobs: list[dict[str, Any]],
     contact: ContactInfo,
     preferences: PreferencesPayload | None,
     resume_type: ResumeType,
@@ -130,7 +130,7 @@ async def process_batch(
     scoring_keywords: set[str] | None = None
     if target_id and not force_fresh:
         target_resp = (
-            supabase.table("job_targets")
+            supabase.table("targets")
             .select("scoring_profile")
             .eq("id", target_id)
             .execute()
@@ -144,7 +144,7 @@ async def process_batch(
 
     _update_batch(supabase, batch_id, status="processing")
 
-    for i, posting in enumerate(job_postings):
+    for i, posting in enumerate(jobs):
         job_posting_id = posting["id"]
         description_html = posting.get("description_html", "") or ""
 

--- a/apps/job-api/app/services/experience/chunks.py
+++ b/apps/job-api/app/services/experience/chunks.py
@@ -118,7 +118,7 @@ async def upsert_for_optimized(
     """Generate, embed, and persist chunks for an optimized doc.
 
     Idempotent: deletes any existing chunks for this doc_id before insert.
-    Records embedding cost in llm_cost_log under `purpose`.
+    Records embedding cost in llm_costs under `purpose`.
     """
     inputs = chunks_for_optimized(optimized.payload)
     _delete_existing(supabase, optimized.id)

--- a/apps/job-api/app/services/extract.py
+++ b/apps/job-api/app/services/extract.py
@@ -14,7 +14,7 @@ from bs4 import BeautifulSoup
 from pydantic import BaseModel
 
 from app.services.jsonld import (
-    _extract_job_postings,
+    _extract_jobs,
     _format_salary,
     _get_location,
     _get_str,
@@ -83,7 +83,7 @@ def _company_from_domain(url: str) -> str:
 
 def _extract_from_jsonld(html: str) -> ExtractionResult | None:
     """Tier 1: Extract job metadata from JSON-LD structured data."""
-    postings = _extract_job_postings(html)
+    postings = _extract_jobs(html)
     if not postings:
         return None
 

--- a/apps/job-api/app/services/insights.py
+++ b/apps/job-api/app/services/insights.py
@@ -67,7 +67,7 @@ def _parse_dt(value: str) -> datetime:
 def _fetch_postings_window(
     supabase: Client, since: datetime | None, until: datetime | None
 ) -> list[Row]:
-    q = supabase.table("job_postings").select("id, status, created_at")
+    q = supabase.table("jobs").select("id, status, created_at")
     if since:
         q = q.gte("created_at", since.isoformat())
     if until:
@@ -78,7 +78,7 @@ def _fetch_postings_window(
 def _fetch_status_logs_window(
     supabase: Client, since: datetime | None, until: datetime | None
 ) -> list[Row]:
-    sq = supabase.table("job_status_log").select(
+    sq = supabase.table("status_log").select(
         "posting_id, old_status, new_status, created_at"
     )
     if since:
@@ -141,7 +141,7 @@ def compute_pipeline(
     status_logs = _fetch_status_logs_window(supabase, since, None)
 
     # Fetch tailored resumes for velocity (current window only)
-    rq = supabase.table("tailored_resumes").select("job_posting_id, created_at")
+    rq = supabase.table("documents").select("job_posting_id, created_at")
     if since:
         rq = rq.gte("created_at", since.isoformat())
     rq = rq.eq("document_type", "resume")
@@ -203,12 +203,12 @@ def compute_targets(supabase: Client, since: datetime | None) -> TargetInsights:
     # Fetch all targets for labels
     targets_data = cast(
         list[Row],
-        supabase.table("job_targets").select("id, label").execute().data or [],
+        supabase.table("targets").select("id, label").execute().data or [],
     )
     target_labels = {t["id"]: t["label"] for t in targets_data}
 
     # Fetch postings with target + score + status
-    q = supabase.table("job_postings").select("id, target_id, score, status, created_at")
+    q = supabase.table("jobs").select("id, target_id, score, status, created_at")
     if since:
         q = q.gte("created_at", since.isoformat())
     postings = cast(list[Row], q.execute().data or [])
@@ -301,7 +301,7 @@ def compute_targets(supabase: Client, since: datetime | None) -> TargetInsights:
 
 def compute_skills_cost(supabase: Client, since: datetime | None) -> SkillsCostInsights:
     # Fetch analyses for skill extraction
-    aq = supabase.table("job_analyses").select("job_posting_id, scorecard, created_at")
+    aq = supabase.table("analyses").select("job_posting_id, scorecard, created_at")
     if since:
         aq = aq.gte("created_at", since.isoformat())
     analyses = cast(list[Row], aq.execute().data or [])
@@ -309,7 +309,7 @@ def compute_skills_cost(supabase: Client, since: datetime | None) -> SkillsCostI
     # Fetch posting scores so we can rank skill gaps by impact (sum of
     # llm_score across jobs missing the skill). Postings without a score
     # contribute to missing_count but not priority_score.
-    pq = supabase.table("job_postings").select("id, llm_score")
+    pq = supabase.table("jobs").select("id, llm_score")
     if since:
         pq = pq.gte("created_at", since.isoformat())
     posting_rows = cast(list[Row], pq.execute().data or [])
@@ -320,13 +320,13 @@ def compute_skills_cost(supabase: Client, since: datetime | None) -> SkillsCostI
             posting_scores[str(p["id"])] = float(score)
 
     # Fetch LLM cost log
-    cq = supabase.table("llm_cost_log").select("purpose, cost_usd, created_at")
+    cq = supabase.table("llm_costs").select("purpose, cost_usd, created_at")
     if since:
         cq = cq.gte("created_at", since.isoformat())
     cost_logs = cast(list[Row], cq.execute().data or [])
 
     # Fetch tailored resumes for per-resume cost
-    rq = supabase.table("tailored_resumes").select("cost_usd, created_at")
+    rq = supabase.table("documents").select("cost_usd, created_at")
     if since:
         rq = rq.gte("created_at", since.isoformat())
     rq = rq.eq("document_type", "resume")

--- a/apps/job-api/app/services/jsonld.py
+++ b/apps/job-api/app/services/jsonld.py
@@ -34,7 +34,7 @@ class _JsonLdExtractor(HTMLParser):
             self.blocks.append(self._buf)
 
 
-def _extract_job_postings(html: str) -> list[dict[str, object]]:
+def _extract_jobs(html: str) -> list[dict[str, object]]:
     """Parse HTML for JSON-LD blocks and return all JobPosting objects."""
     parser = _JsonLdExtractor()
     parser.feed(html)
@@ -151,7 +151,7 @@ async def fetch_jsonld_jobs(careers_url: str) -> list[StandardJob]:
     except httpx.HTTPError:
         return []
 
-    postings = _extract_job_postings(resp.text)
+    postings = _extract_jobs(resp.text)
 
     jobs: list[StandardJob] = []
     for posting in postings:

--- a/apps/job-api/app/services/llm/cost_log.py
+++ b/apps/job-api/app/services/llm/cost_log.py
@@ -17,14 +17,14 @@ from supabase import Client
 from app.models.embeddings import EmbeddingResult
 from app.models.llm import LLMCallRecord, LLMResult
 
-TABLE = "llm_cost_log"
+TABLE = "llm_costs"
 
 
 def _insert_row(supabase: Client, row: dict[str, Any]) -> LLMCallRecord:
     resp = supabase.table(TABLE).insert(row).execute()
     rows = cast(list[dict[str, Any]], resp.data or [])
     if not rows:
-        raise RuntimeError("Failed to insert llm_cost_log row")
+        raise RuntimeError("Failed to insert llm_costs row")
     return LLMCallRecord.model_validate(rows[0])
 
 

--- a/apps/job-api/app/services/notify.py
+++ b/apps/job-api/app/services/notify.py
@@ -6,12 +6,12 @@ Email flow:
     poller.py  (FastAPI)  ──POST──▶  /api/email/job-alert  (Next.js)
          │                                       │
          │                                       └─ renders React Email, sends via Resend
-         └─ writes job_notification_sent (dedup, channel='email')
+         └─ writes notifications_sent (dedup, channel='email')
 
 SMS flow:
     poller.py  (FastAPI)  ──Twilio SDK──▶  Twilio API
          │
-         └─ writes job_notification_sent (dedup, channel='sms')
+         └─ writes notifications_sent (dedup, channel='sms')
 
 At-most-once semantics: a dedup row is claimed via upsert-with-
 ignore_duplicates BEFORE the send. If the claim wins, we send; if the
@@ -97,7 +97,7 @@ async def _try_send_one(
     job_id = job["id"]
 
     claim = await asyncio.to_thread(
-        lambda: supabase.table("job_notification_sent")
+        lambda: supabase.table("notifications_sent")
         .upsert(
             {
                 "user_profile_id": profile_id,
@@ -125,7 +125,7 @@ async def _try_send_one(
 
     if resend_id:
         await asyncio.to_thread(
-            lambda: supabase.table("job_notification_sent")
+            lambda: supabase.table("notifications_sent")
             .update({"external_id": resend_id})
             .eq("id", claim_id)
             .execute()
@@ -214,7 +214,7 @@ async def _sms_count_today(supabase: Client, profile_id: str) -> int:
     """Count SMS notifications sent today for a profile."""
     today = datetime.now(UTC).strftime("%Y-%m-%dT00:00:00+00:00")
     resp = await asyncio.to_thread(
-        lambda: supabase.table("job_notification_sent")
+        lambda: supabase.table("notifications_sent")
         .select("id", count="exact")  # type: ignore[arg-type]
         .eq("user_profile_id", profile_id)
         .eq("channel", "sms")
@@ -247,7 +247,7 @@ async def _try_send_sms(
 
     # Claim dedup row
     claim = await asyncio.to_thread(
-        lambda: supabase.table("job_notification_sent")
+        lambda: supabase.table("notifications_sent")
         .upsert(
             {
                 "user_profile_id": profile_id,
@@ -286,7 +286,7 @@ async def _try_send_sms(
 
     if twilio_sid:
         await asyncio.to_thread(
-            lambda: supabase.table("job_notification_sent")
+            lambda: supabase.table("notifications_sent")
             .update({"external_id": twilio_sid})
             .eq("id", claim_id)
             .execute()

--- a/apps/job-api/app/services/poller.py
+++ b/apps/job-api/app/services/poller.py
@@ -252,7 +252,7 @@ async def _run_llm_scoring_for_row(
     # Fetch the current global score (average of target stage-2 scores)
     try:
         score_resp = await asyncio.to_thread(
-            supabase.table("job_postings")
+            supabase.table("jobs")
             .select("score")
             .eq("id", job_id)
             .single()
@@ -284,7 +284,7 @@ async def _run_llm_scoring_for_row(
             llm_score = scorecard_to_numeric(cached.scorecard)
             blended = blend_scores(current_score, llm_score)
             await asyncio.to_thread(
-                supabase.table("job_postings")
+                supabase.table("jobs")
                 .update(
                     {
                         "score": blended,
@@ -328,9 +328,9 @@ async def _run_llm_scoring_for_row(
         llm_score = scorecard_to_numeric(analysis.scorecard)
         blended = blend_scores(current_score, llm_score)
 
-        # Update the job_postings row with LLM score data
+        # Update the jobs row with LLM score data
         await asyncio.to_thread(
-            supabase.table("job_postings")
+            supabase.table("jobs")
             .update(
                 {
                     "score": blended,
@@ -430,7 +430,7 @@ async def _poll_one_source(
 
         # Upsert new/updated jobs AND fetch existing rows in parallel.
         existing_query = (
-            supabase.table("job_postings")
+            supabase.table("jobs")
             .select("id, external_id")
             .eq("source_id", source_id)
             .not_.in_("status", ["saved", "applied", "archived"])
@@ -438,7 +438,7 @@ async def _poll_one_source(
 
         new_rows: list[dict[str, Any]] = []
         if rows_to_upsert:
-            upsert_query = supabase.table("job_postings").upsert(
+            upsert_query = supabase.table("jobs").upsert(
                 rows_to_upsert, on_conflict="source_id,external_id"
             )
             upsert_resp, existing_resp = await asyncio.gather(
@@ -572,7 +572,7 @@ async def _poll_one_source(
 
         # Archive stale jobs AND update last_polled_at in parallel
         last_polled_query = (
-            supabase.table("job_sources")
+            supabase.table("sources")
             .update(
                 {
                     "last_polled_at": datetime.now(UTC).isoformat(),
@@ -584,7 +584,7 @@ async def _poll_one_source(
 
         if stale_ids:
             archive_query = (
-                supabase.table("job_postings")
+                supabase.table("jobs")
                 .update({"status": "archived", "updated_at": datetime.now(UTC).isoformat()})
                 .in_("id", stale_ids)
             )
@@ -619,7 +619,7 @@ async def _poll_one_source(
 
 
 async def poll_all_sources(supabase: Client) -> PollResult:
-    sources_query = supabase.table("job_sources").select("*").eq("enabled", True)
+    sources_query = supabase.table("sources").select("*").eq("enabled", True)
     sources_resp = await asyncio.to_thread(sources_query.execute)
     sources = sources_resp.data or []
 
@@ -708,7 +708,7 @@ async def _poll_one_source_for_target(
 
         if rows_to_upsert:
             upsert_resp = await asyncio.to_thread(
-                supabase.table("job_postings")
+                supabase.table("jobs")
                 .upsert(rows_to_upsert, on_conflict="source_id,external_id")
                 .execute
             )
@@ -809,7 +809,7 @@ async def poll_sources_for_target(supabase: Client, target: JobTarget) -> PollRe
             errors=["Target has no search keywords"],
         )
 
-    sources_query = supabase.table("job_sources").select("*").eq("enabled", True)
+    sources_query = supabase.table("sources").select("*").eq("enabled", True)
     sources_resp = await asyncio.to_thread(sources_query.execute)
     sources = sources_resp.data or []
 

--- a/apps/job-api/app/services/scoring.py
+++ b/apps/job-api/app/services/scoring.py
@@ -165,7 +165,7 @@ def _count_keyword_occurrences(keyword: str, text_lower: str) -> int:
 # ---- Target-based scoring (#495) -------------------------------------------
 
 # Map dynamic category names to existing ScoreBreakdown fields.
-# Pragmatic for v1: avoids migrating job_postings.score_breakdown.
+# Pragmatic for v1: avoids migrating jobs.score_breakdown.
 _CATEGORY_TO_FIELD: dict[str, str] = {
     "core_skills": "technologies",
     "secondary_skills": "domain_skills",

--- a/apps/job-api/app/services/tailor/__init__.py
+++ b/apps/job-api/app/services/tailor/__init__.py
@@ -8,7 +8,7 @@ front of an employer.
 Layout:
 - tailor.py       — LLM synthesis + trace validation (P3a)
 - prompts.py      — TAILOR_SYSTEM (P3a)
-- persistence.py  — tailored_resumes CRUD + Supabase Storage (P3d)
+- persistence.py  — documents CRUD + Supabase Storage (P3d)
 - pipeline.py     — end-to-end orchestration (P3d)
 - reuse.py        — resume reuse within targets (#504)
 """

--- a/apps/job-api/app/services/tailor/persistence.py
+++ b/apps/job-api/app/services/tailor/persistence.py
@@ -1,4 +1,4 @@
-"""Persistence + Supabase Storage for tailored_resumes.
+"""Persistence + Supabase Storage for documents.
 
 The pipeline produces a TailoredResume or TailoredCoverLetter + `.docx`
 bytes + cost metadata. This module handles:
@@ -33,7 +33,7 @@ from app.models.tailor import (
 from app.services.docx.pandoc_render import md_payload_hash
 from app.services.tailor import versions
 
-TABLE = "tailored_resumes"
+TABLE = "documents"
 STORAGE_BUCKET = "tailored-resumes"
 DOCX_CONTENT_TYPE = (
     "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
@@ -81,7 +81,7 @@ def insert_row(
     resp = supabase.table(TABLE).insert(row).execute()
     rows = cast(list[dict[str, Any]], resp.data or [])
     if not rows:
-        raise RuntimeError("Failed to insert tailored_resumes row")
+        raise RuntimeError("Failed to insert documents row")
     record = TailoredResumeRecord.model_validate(rows[0])
     # F3-H: capture the initial payload as version 1.
     versions.record(
@@ -106,7 +106,7 @@ def persist(
     llm_result: LLMResult,
     storage_path: str | None,
 ) -> TailoredResumeRecord:
-    """Insert one tailored_resumes row for a resume."""
+    """Insert one documents row for a resume."""
     row: dict[str, Any] = {
         "user_id": user_id,
         "job_posting_id": job_posting_id,
@@ -140,7 +140,7 @@ def persist_cover_letter(
     llm_result: LLMResult,
     storage_path: str | None,
 ) -> TailoredResumeRecord:
-    """Insert one tailored_resumes row for a cover letter.
+    """Insert one documents row for a cover letter.
 
     `resume_type` is set to 'generic' since the column is NOT NULL; it's
     ignored on reads when `document_type == 'cover_letter'`.
@@ -202,7 +202,7 @@ def update_payload(
     resp = supabase.table(TABLE).update(updates).eq("id", resume_id).execute()
     rows = cast(list[dict[str, Any]], resp.data or [])
     if not rows:
-        raise RuntimeError(f"Failed to update tailored_resumes row {resume_id}")
+        raise RuntimeError(f"Failed to update documents row {resume_id}")
     return TailoredResumeRecord.model_validate(rows[0])
 
 
@@ -235,7 +235,7 @@ def update_payload_md(
     resp = supabase.table(TABLE).update(updates).eq("id", resume_id).execute()
     rows = cast(list[dict[str, Any]], resp.data or [])
     if not rows:
-        raise RuntimeError(f"Failed to update tailored_resumes row {resume_id}")
+        raise RuntimeError(f"Failed to update documents row {resume_id}")
     return TailoredResumeRecord.model_validate(rows[0])
 
 
@@ -268,7 +268,7 @@ def mark_job_resume_draft(supabase: Client, job_posting_id: str) -> None:
     update. We unconditionally set the status because re-generation
     supersedes any prior draft/approval.
     """
-    supabase.table("job_postings").update(
+    supabase.table("jobs").update(
         {
             "status": "resume_draft",
             "updated_at": datetime.now(UTC).isoformat(),
@@ -281,7 +281,7 @@ def approve(supabase: Client, resume_id: str) -> TailoredResumeRecord:
     resp = supabase.table(TABLE).update({"approved_at": "now()"}).eq("id", resume_id).execute()
     rows = cast(list[dict[str, Any]], resp.data or [])
     if not rows:
-        raise RuntimeError(f"Failed to approve tailored_resumes row {resume_id}")
+        raise RuntimeError(f"Failed to approve documents row {resume_id}")
     return TailoredResumeRecord.model_validate(rows[0])
 
 
@@ -290,7 +290,7 @@ def unapprove(supabase: Client, resume_id: str) -> TailoredResumeRecord:
     resp = supabase.table(TABLE).update({"approved_at": None}).eq("id", resume_id).execute()
     rows = cast(list[dict[str, Any]], resp.data or [])
     if not rows:
-        raise RuntimeError(f"Failed to unapprove tailored_resumes row {resume_id}")
+        raise RuntimeError(f"Failed to unapprove documents row {resume_id}")
     return TailoredResumeRecord.model_validate(rows[0])
 
 

--- a/apps/job-api/app/services/tailor/reuse.py
+++ b/apps/job-api/app/services/tailor/reuse.py
@@ -67,12 +67,12 @@ def find_reusable_resume(
 ) -> TailoredResumeRecord | None:
     """Find an existing resume in the same target similar enough to reuse.
 
-    Queries tailored_resumes for jobs sharing the same target_id.
+    Queries documents for jobs sharing the same target_id.
     Returns the best match above SIMILARITY_THRESHOLD, or None.
     """
     # Get job_posting_ids in this target
     jp_resp = (
-        supabase.table("job_postings")
+        supabase.table("jobs")
         .select("id")
         .eq("target_id", target_id)
         .execute()
@@ -83,7 +83,7 @@ def find_reusable_resume(
 
     # Get recent resumes for those job postings
     resp = (
-        supabase.table("tailored_resumes")
+        supabase.table("documents")
         .select("*")
         .in_("job_posting_id", jp_ids)
         .eq("document_type", "resume")
@@ -114,7 +114,7 @@ def clone_resume_for_job(
     job_description: str,
     user_id: str | None,
 ) -> TailoredResumeRecord:
-    """Create a new tailored_resumes row that clones an existing resume.
+    """Create a new documents row that clones an existing resume.
 
     Same payload, same storage_path (docx), linked to a different
     job_posting. source_resume_id tracks the lineage. Zero LLM cost.

--- a/apps/job-api/app/services/tailor/tailor.py
+++ b/apps/job-api/app/services/tailor/tailor.py
@@ -2,7 +2,7 @@
 
 Pure function. No DB. No docx. No retrieval (the optimized doc is small
 enough to pass in full). Cost logging happens at the router layer, which
-also persists the result to `tailored_resumes` and kicks off rendering.
+also persists the result to `documents` and kicks off rendering.
 
 Post-generation, `validate_trace_refs()` checks that every role and
 bullet carries a source ref that actually exists in the OptimizedPayload.

--- a/apps/job-api/app/services/tailor/versions.py
+++ b/apps/job-api/app/services/tailor/versions.py
@@ -1,6 +1,6 @@
 """Resume payload version history (F3-H).
 
-Every `update_payload()` writes a snapshot row into `tailored_resume_versions`
+Every `update_payload()` writes a snapshot row into `document_versions`
 before mutating the live payload. We cap free-tier history at 5 most recent
 versions — older snapshots get pruned. The cap is enforced in Python rather
 than via a Postgres trigger so it's easy to test, easy to lift per user, and
@@ -15,7 +15,7 @@ from typing import Any, Literal, cast
 from pydantic import BaseModel
 from supabase import Client
 
-VERSIONS_TABLE = "tailored_resume_versions"
+VERSIONS_TABLE = "document_versions"
 
 VersionSource = Literal["initial", "user_edit", "llm_adapt"]
 
@@ -71,7 +71,7 @@ def checkpoint(supabase: Client, resume_id: str) -> bool:
     minutes of typing.
     """
     resume_resp = (
-        supabase.table("tailored_resumes")
+        supabase.table("documents")
         .select("payload, payload_md")
         .eq("id", resume_id)
         .single()

--- a/apps/job-api/app/services/target_scoring.py
+++ b/apps/job-api/app/services/target_scoring.py
@@ -5,8 +5,8 @@ Three-stage scoring pipeline:
   Stage 2: Full JD match (async, after stage 1 passes)
   Stage 3: LLM analysis (async, for top stage-2 scores)
 
-Stores target-specific scores in `job_target_scores`. The global score
-on `job_postings` = average across active targets (updated after each stage).
+Stores target-specific scores in `scores`. The global score
+on `jobs` = average across active targets (updated after each stage).
 
 Consumers:
 - Poller: stage 1 title scoring during poll, stage 2+3 async after
@@ -30,7 +30,7 @@ from app.services.scoring import score_job_with_profile, score_title_against_pro
 
 logger = logging.getLogger(__name__)
 
-TABLE = "job_target_scores"
+TABLE = "scores"
 
 
 def _parse_score(row: dict[str, Any]) -> JobTargetScore:
@@ -84,7 +84,7 @@ def _upsert_score(
     )
     rows = cast(list[dict[str, Any]], resp.data or [])
     if not rows:
-        raise RuntimeError("Failed to upsert job_target_scores row")
+        raise RuntimeError("Failed to upsert scores row")
     return _parse_score(rows[0])
 
 
@@ -155,7 +155,7 @@ def score_and_upsert(
 def bulk_score_for_target(supabase: Client, target: JobTarget) -> int:
     """Re-score stale jobs for this target. Returns count scored.
 
-    Only fetches jobs with existing ``job_target_scores`` rows whose
+    Only fetches jobs with existing ``scores`` rows whose
     ``scored_profile_version`` is less than the target's current
     ``profile_version`` (lazy re-scoring). Used by the re-score endpoint
     when a target's profile changes.
@@ -190,7 +190,7 @@ def bulk_score_for_target(supabase: Client, target: JobTarget) -> int:
     for i in range(0, len(all_job_ids), batch_size):
         batch_ids = all_job_ids[i : i + batch_size]
         resp = (
-            supabase.table("job_postings")
+            supabase.table("jobs")
             .select("id, title, description_html")
             .in_("id", batch_ids)
             .execute()
@@ -251,7 +251,7 @@ def get_target_scores(
 
 
 def update_global_score(supabase: Client, job_posting_id: str) -> None:
-    """Recompute job_postings.score as average of active-target scores.
+    """Recompute jobs.score as average of active-target scores.
 
     Called after any stage updates a target score. Uses a single query
     to average all non-excluded target scores for this job.
@@ -269,7 +269,7 @@ def update_global_score(supabase: Client, job_posting_id: str) -> None:
     scores = [r["score"] for r in rows if not r.get("excluded", False)]
     avg_score = round(sum(scores) / len(scores)) if scores else 0
 
-    supabase.table("job_postings").update({"score": avg_score}).eq(
+    supabase.table("jobs").update({"score": avg_score}).eq(
         "id", job_posting_id
     ).execute()
 
@@ -280,11 +280,11 @@ _BATCH_CHUNK_SIZE = 100
 def batch_update_global_scores(
     supabase: Client, job_posting_ids: list[str]
 ) -> None:
-    """Recompute job_postings.score for many jobs in fewer DB round-trips.
+    """Recompute jobs.score for many jobs in fewer DB round-trips.
 
     Fetches all target scores for the given IDs in one query (chunked to
     avoid URL length limits), computes averages in Python, then writes
-    every new score in a single `bulk_update_job_scores` RPC instead of
+    every new score in a single `bulk_update_scores` RPC instead of
     one UPDATE per job.
     """
     if not job_posting_ids:
@@ -321,7 +321,7 @@ def batch_update_global_scores(
         for job_id in unique_ids
     ]
     if updates:
-        supabase.rpc("bulk_update_job_scores", {"p_updates": updates}).execute()
+        supabase.rpc("bulk_update_scores", {"p_updates": updates}).execute()
 
 
 def mark_complete(supabase: Client, job_posting_id: str) -> None:

--- a/apps/job-api/app/services/targets/crud.py
+++ b/apps/job-api/app/services/targets/crud.py
@@ -20,9 +20,9 @@ from app.models.targets import (
     UserTargetWithTarget,
 )
 
-TARGETS_TABLE = "job_targets"
+TARGETS_TABLE = "targets"
 USER_TARGETS_TABLE = "user_targets"
-REF_JDS_TABLE = "target_reference_jds"
+REF_JDS_TABLE = "reference_jds"
 
 
 def _parse_target(row: dict[str, Any]) -> JobTarget:
@@ -84,7 +84,7 @@ def create(supabase: Client, payload: TargetCreate) -> JobTarget:
     resp = supabase.table(TARGETS_TABLE).insert(row).execute()
     rows = cast(list[dict[str, Any]], resp.data or [])
     if not rows:
-        raise RuntimeError("Failed to insert job_targets row")
+        raise RuntimeError("Failed to insert targets row")
     return _parse_target(rows[0])
 
 
@@ -110,7 +110,7 @@ def list_all(supabase: Client) -> list[JobTarget]:
 def get_active(supabase: Client) -> list[JobTarget]:
     """Return all globally active targets (active for any user).
 
-    The trigger on user_targets maintains job_targets.is_active, so this
+    The trigger on user_targets maintains targets.is_active, so this
     query works without joining user_targets.
     """
     resp = (
@@ -157,7 +157,7 @@ def delete(supabase: Client, target_id: str) -> bool:
 
 
 def set_active(supabase: Client, target_id: str) -> JobTarget | None:
-    """Directly set job_targets.is_active = True.
+    """Directly set targets.is_active = True.
 
     Prefer link_user_to_target() for multi-user flows — the DB trigger
     will keep is_active in sync. This is kept for single-user / system use.
@@ -173,7 +173,7 @@ def set_active(supabase: Client, target_id: str) -> JobTarget | None:
 
 
 def set_inactive(supabase: Client, target_id: str) -> JobTarget | None:
-    """Directly set job_targets.is_active = False.
+    """Directly set targets.is_active = False.
 
     Prefer unlink/deactivate via user_targets for multi-user flows.
     """
@@ -301,7 +301,7 @@ def link_user_to_target(
     fit_score: int | None = None,
     fit_score_reasoning: str | None = None,
 ) -> UserTarget:
-    """Link a user to a target (upsert). The DB trigger syncs job_targets.is_active."""
+    """Link a user to a target (upsert). The DB trigger syncs targets.is_active."""
     row: dict[str, Any] = {
         "user_id": user_id,
         "target_id": target_id,
@@ -369,7 +369,7 @@ def list_user_targets(supabase: Client, user_id: str) -> list[UserTarget]:
 def set_user_target_active(
     supabase: Client, user_id: str, target_id: str
 ) -> UserTarget | None:
-    """Activate a user's link to a target. The DB trigger syncs job_targets.is_active."""
+    """Activate a user's link to a target. The DB trigger syncs targets.is_active."""
     resp = (
         supabase.table(USER_TARGETS_TABLE)
         .update({"is_active": True, "updated_at": datetime.now(UTC).isoformat()})
@@ -384,7 +384,7 @@ def set_user_target_active(
 def set_user_target_inactive(
     supabase: Client, user_id: str, target_id: str
 ) -> UserTarget | None:
-    """Deactivate a user's link to a target. The DB trigger syncs job_targets.is_active."""
+    """Deactivate a user's link to a target. The DB trigger syncs targets.is_active."""
     resp = (
         supabase.table(USER_TARGETS_TABLE)
         .update({"is_active": False, "updated_at": datetime.now(UTC).isoformat()})
@@ -415,7 +415,7 @@ def add_reference_jd(
     resp = supabase.table(REF_JDS_TABLE).insert(row).execute()
     rows = cast(list[dict[str, Any]], resp.data or [])
     if not rows:
-        raise RuntimeError("Failed to insert target_reference_jds row")
+        raise RuntimeError("Failed to insert reference_jds row")
     return _parse_ref_jd(rows[0])
 
 

--- a/apps/job-api/app/services/validate.py
+++ b/apps/job-api/app/services/validate.py
@@ -9,7 +9,7 @@ from urllib.parse import urlparse
 
 import httpx
 
-from app.services.jsonld import _extract_job_postings
+from app.services.jsonld import _extract_jobs
 
 # ---------------------------------------------------------------------------
 # Layer 1 — URL format validation
@@ -111,7 +111,7 @@ def _verify_content(html: str) -> tuple[bool, list[str]]:
     Returns (is_job_page, warnings). Never hard-rejects.
     """
     # Tier 1: JSON-LD (gold standard)
-    if _extract_job_postings(html):
+    if _extract_jobs(html):
         return True, []
 
     # Tier 2: HTML heuristics

--- a/apps/job-api/scripts/backfill_payload_md.py
+++ b/apps/job-api/scripts/backfill_payload_md.py
@@ -1,4 +1,4 @@
-"""Backfill payload_md for tailored_resumes rows that predate the markdown pivot.
+"""Backfill payload_md for documents rows that predate the markdown pivot.
 
 Markdown is now the source of truth for the editor and the pandoc-rendered
 .docx. Older rows have only the structured `payload` JSONB. This script
@@ -30,7 +30,7 @@ from app.supabase_pool import get_supabase_pool, init_supabase
 logging.basicConfig(level=logging.INFO, format="%(message)s")
 logger = logging.getLogger("backfill_payload_md")
 
-TABLE = "tailored_resumes"
+TABLE = "documents"
 
 
 def _serialize(row: dict[str, Any]) -> str:

--- a/apps/job-api/tests/test_batch.py
+++ b/apps/job-api/tests/test_batch.py
@@ -237,7 +237,7 @@ class TestBatchProcessing:
                 batch_id="batch-1",
                 user_id=None,
                 optimized=_OPTIMIZED,
-                job_postings=[{"id": "job-1", "description_html": "<p>JD</p>"}],
+                jobs=[{"id": "job-1", "description_html": "<p>JD</p>"}],
                 contact=_CONTACT,
                 preferences=None,
                 resume_type="generic",
@@ -274,7 +274,7 @@ class TestBatchProcessing:
                 batch_id="batch-1",
                 user_id=None,
                 optimized=_OPTIMIZED,
-                job_postings=[{"id": "job-1", "description_html": "<p>JD</p>"}],
+                jobs=[{"id": "job-1", "description_html": "<p>JD</p>"}],
                 contact=_CONTACT,
                 preferences=None,
                 resume_type="generic",
@@ -300,7 +300,7 @@ class TestBatchProcessing:
                 batch_id="batch-1",
                 user_id=None,
                 optimized=_OPTIMIZED,
-                job_postings=[{"id": "job-1", "description_html": "<p>JD</p>"}],
+                jobs=[{"id": "job-1", "description_html": "<p>JD</p>"}],
                 contact=_CONTACT,
                 preferences=None,
                 resume_type="generic",
@@ -322,7 +322,7 @@ class TestBatchProcessing:
             batch_id="nonexistent",
             user_id=None,
             optimized=_OPTIMIZED,
-            job_postings=[],
+            jobs=[],
             contact=_CONTACT,
             preferences=None,
             resume_type="generic",
@@ -360,7 +360,7 @@ class TestBatchProcessing:
                 batch_id="batch-1",
                 user_id=None,
                 optimized=_OPTIMIZED,
-                job_postings=[
+                jobs=[
                     {"id": "job-1", "description_html": "<p>JD1</p>"},
                     {"id": "job-2", "description_html": "<p>JD2</p>"},
                 ],
@@ -401,7 +401,7 @@ class TestBatchProcessing:
                 batch_id="batch-1",
                 user_id=None,
                 optimized=_OPTIMIZED,
-                job_postings=[{"id": "job-1", "description_html": "<p>JD</p>"}],
+                jobs=[{"id": "job-1", "description_html": "<p>JD</p>"}],
                 contact=_CONTACT,
                 preferences=None,
                 resume_type="generic",
@@ -478,7 +478,7 @@ class TestBatchEndpoint:
         from app.routers import tailor as tailor_router
 
         supabase = MagicMock()
-        # Mock job_postings lookup
+        # Mock jobs lookup
         _set_mock_data(supabase, [
             {"id": "job-1", "title": "SWE", "description_html": "<p>JD</p>"}
         ])

--- a/apps/job-api/tests/test_consolidate.py
+++ b/apps/job-api/tests/test_consolidate.py
@@ -18,7 +18,6 @@ from app.services.experience.consolidate import (
 )
 from app.services.llm.mock import MockLLMClient
 
-
 # ---------------------------------------------------------------------------
 # Service: consolidate_prose
 # ---------------------------------------------------------------------------

--- a/apps/job-api/tests/test_derive.py
+++ b/apps/job-api/tests/test_derive.py
@@ -251,7 +251,7 @@ def _parse_sse(raw: bytes) -> list[tuple[str, dict[str, Any]]]:
 
 
 async def _drain(streaming_response: object) -> bytes:
-    body_iterator = getattr(streaming_response, "body_iterator")
+    body_iterator = streaming_response.body_iterator
     chunks: list[bytes] = []
     async for chunk in body_iterator:
         chunks.append(chunk if isinstance(chunk, bytes) else chunk.encode("utf-8"))

--- a/apps/job-api/tests/test_ingest.py
+++ b/apps/job-api/tests/test_ingest.py
@@ -8,6 +8,8 @@ import pytest
 
 from app.services.ingest.merge import (
     DEFAULT_PURPOSE as MERGE_PURPOSE,
+)
+from app.services.ingest.merge import (
     MIN_PRESERVATION_RATIO,
     merge_into_prose,
 )

--- a/apps/job-api/tests/test_insights.py
+++ b/apps/job-api/tests/test_insights.py
@@ -57,7 +57,7 @@ class TestComputePipeline:
             {"id": "4", "status": "interviewing", "created_at": _ts(_NOW)},
             {"id": "5", "status": "offer", "created_at": _ts(_NOW)},
         ]
-        sb = _mock_supabase({"job_postings": postings})
+        sb = _mock_supabase({"jobs": postings})
         result = compute_pipeline(sb, since=None)
 
         assert result.total_applications == 3  # applied + interviewing + offer
@@ -77,7 +77,7 @@ class TestComputePipeline:
             {"id": "3", "status": "interviewing", "created_at": _ts(_NOW)},
             {"id": "4", "status": "offer", "created_at": _ts(_NOW)},
         ]
-        sb = _mock_supabase({"job_postings": postings})
+        sb = _mock_supabase({"jobs": postings})
         result = compute_pipeline(sb, since=None)
 
         # 4 applied-or-beyond, 2 interviewing-or-beyond → 0.5
@@ -99,7 +99,7 @@ class TestComputePipeline:
             },
         ]
         postings = [{"id": "1", "status": "interviewing", "created_at": _ts(_NOW)}]
-        sb = _mock_supabase({"job_postings": postings, "job_status_log": logs})
+        sb = _mock_supabase({"jobs": postings, "status_log": logs})
         result = compute_pipeline(sb, since=None)
 
         assert result.avg_days_to_response == 6.0
@@ -119,7 +119,7 @@ class TestComputePipeline:
             {"job_posting_id": "2", "created_at": _ts(_NOW - timedelta(days=1))},
             {"job_posting_id": "3", "created_at": _ts(_NOW - timedelta(days=8))},
         ]
-        sb = _mock_supabase({"tailored_resumes": resumes})
+        sb = _mock_supabase({"documents": resumes})
         result = compute_pipeline(sb, since=None)
 
         # Should group into weeks — at least 1 or 2 week buckets
@@ -140,7 +140,7 @@ class TestComputePipeline:
             {"id": "1", "status": "applied", "created_at": _ts(_NOW)},
             {"id": "2", "status": "interviewing", "created_at": _ts(_NOW)},
         ]
-        sb = _mock_supabase({"job_postings": postings})
+        sb = _mock_supabase({"jobs": postings})
         prior_until = _NOW - timedelta(days=30)
         prior_since = _NOW - timedelta(days=60)
         result = compute_pipeline(
@@ -169,7 +169,7 @@ class TestComputeTargets:
             {"id": "2", "target_id": "t1", "score": 60, "status": "new", "created_at": _ts(_NOW)},
             {"id": "3", "target_id": "t2", "score": 90, "status": "interviewing", "created_at": _ts(_NOW)},
         ]
-        sb = _mock_supabase({"job_targets": targets, "job_postings": postings})
+        sb = _mock_supabase({"targets": targets, "jobs": postings})
         result = compute_targets(sb, since=None)
 
         assert len(result.targets) == 2
@@ -192,7 +192,7 @@ class TestComputeTargets:
             {"id": "1", "target_id": "t1", "score": 80, "status": "new", "created_at": _ts(_NOW)},
             {"id": "2", "target_id": "t2", "score": 70, "status": "new", "created_at": _ts(_NOW)},
         ]
-        sb = _mock_supabase({"job_targets": targets, "job_postings": postings})
+        sb = _mock_supabase({"targets": targets, "jobs": postings})
         result = compute_targets(sb, since=None)
 
         labels = {t.target_label for t in result.targets}
@@ -206,7 +206,7 @@ class TestComputeTargets:
             {"id": "2", "target_id": None, "score": None, "status": "new", "created_at": _ts(_NOW)},
             {"id": "3", "target_id": None, "score": 5, "status": "new", "created_at": _ts(_NOW)},
         ]
-        sb = _mock_supabase({"job_postings": postings})
+        sb = _mock_supabase({"jobs": postings})
         result = compute_targets(sb, since=None)
 
         assert result.unscored_count == 2
@@ -220,7 +220,7 @@ class TestComputeTargets:
             {"id": "2", "target_id": None, "score": 85, "status": "new", "created_at": _ts(_NOW)},
             {"id": "3", "target_id": None, "score": 85, "status": "new", "created_at": _ts(_NOW)},
         ]
-        sb = _mock_supabase({"job_postings": postings})
+        sb = _mock_supabase({"jobs": postings})
         result = compute_targets(sb, since=None)
 
         bucket_map = {b.bucket: b.count for b in result.score_distribution}
@@ -242,7 +242,7 @@ class TestComputeTargets:
             {"id": "1", "target_id": None, "score": 60, "status": "new", "created_at": _ts(_NOW)},
             {"id": "2", "target_id": None, "score": 80, "status": "new", "created_at": _ts(_NOW - timedelta(days=8))},
         ]
-        sb = _mock_supabase({"job_postings": postings})
+        sb = _mock_supabase({"jobs": postings})
         result = compute_targets(sb, since=None)
 
         # At least 1 week bucket
@@ -277,7 +277,7 @@ class TestComputeSkillsCost:
                 "created_at": _ts(_NOW),
             },
         ]
-        sb = _mock_supabase({"job_analyses": analyses})
+        sb = _mock_supabase({"analyses": analyses})
         result = compute_skills_cost(sb, since=None)
 
         skill_map = {s.skill: s for s in result.top_skills}
@@ -330,7 +330,7 @@ class TestComputeSkillsCost:
             {"id": "low-1", "llm_score": 30.0, "created_at": _ts(_NOW)},
             {"id": "low-2", "llm_score": 30.0, "created_at": _ts(_NOW)},
         ]
-        sb = _mock_supabase({"job_analyses": analyses, "job_postings": postings})
+        sb = _mock_supabase({"analyses": analyses, "jobs": postings})
         result = compute_skills_cost(sb, since=None)
 
         skills = [m.skill for m in result.top_missing]
@@ -359,7 +359,7 @@ class TestComputeSkillsCost:
         ]
         # postings with no llm_score
         postings = [{"id": "p1", "llm_score": None, "created_at": _ts(_NOW)}]
-        sb = _mock_supabase({"job_analyses": analyses, "job_postings": postings})
+        sb = _mock_supabase({"analyses": analyses, "jobs": postings})
         result = compute_skills_cost(sb, since=None)
 
         by_skill = {m.skill: m for m in result.top_missing}
@@ -378,8 +378,8 @@ class TestComputeSkillsCost:
             {"purpose": "tailor", "cost_usd": "0.0080", "created_at": _ts(_NOW)},
         ]
         sb = _mock_supabase({
-            "tailored_resumes": resume_costs,
-            "llm_cost_log": cost_logs,
+            "documents": resume_costs,
+            "llm_costs": cost_logs,
         })
         result = compute_skills_cost(sb, since=None)
 
@@ -395,7 +395,7 @@ class TestComputeSkillsCost:
             {"purpose": "tailor", "cost_usd": "0.02", "created_at": _ts(_NOW)},
             {"purpose": "analysis", "cost_usd": "0.005", "created_at": _ts(_NOW)},
         ]
-        sb = _mock_supabase({"llm_cost_log": cost_logs})
+        sb = _mock_supabase({"llm_costs": cost_logs})
         result = compute_skills_cost(sb, since=None)
 
         purpose_map = {p.purpose: p for p in result.cost_by_purpose}

--- a/apps/job-api/tests/test_jsonld.py
+++ b/apps/job-api/tests/test_jsonld.py
@@ -3,7 +3,7 @@ from unittest.mock import AsyncMock, MagicMock
 import httpx
 import pytest
 
-from app.services.jsonld import _extract_job_postings, fetch_jsonld_jobs
+from app.services.jsonld import _extract_jobs, fetch_jsonld_jobs
 from app.services.standard_job import StandardJob
 
 _SINGLE_POSTING_HTML = """
@@ -103,31 +103,31 @@ _ARRAY_FORMAT_HTML = """
 """
 
 
-# --- _extract_job_postings unit tests ---
+# --- _extract_jobs unit tests ---
 
 
 class TestExtractJobPostings:
     def test_single_posting(self):
-        postings = _extract_job_postings(_SINGLE_POSTING_HTML)
+        postings = _extract_jobs(_SINGLE_POSTING_HTML)
         assert len(postings) == 1
         assert postings[0]["title"] == "Frontend Engineer"
 
     def test_graph_format(self):
-        postings = _extract_job_postings(_GRAPH_HTML)
+        postings = _extract_jobs(_GRAPH_HTML)
         assert len(postings) == 1
         assert postings[0]["jobTitle"] == "Designer"
 
     def test_no_jsonld(self):
-        postings = _extract_job_postings(_NO_JSONLD_HTML)
+        postings = _extract_jobs(_NO_JSONLD_HTML)
         assert postings == []
 
     def test_array_format(self):
-        postings = _extract_job_postings(_ARRAY_FORMAT_HTML)
+        postings = _extract_jobs(_ARRAY_FORMAT_HTML)
         assert len(postings) == 2
 
     def test_invalid_json_skipped(self):
         html = '<script type="application/ld+json">not valid json</script>'
-        postings = _extract_job_postings(html)
+        postings = _extract_jobs(html)
         assert postings == []
 
 

--- a/apps/job-api/tests/test_notify.py
+++ b/apps/job-api/tests/test_notify.py
@@ -21,9 +21,9 @@ def _build_supabase_mock(
 ) -> MagicMock:
     """Returns a MagicMock that answers:
     - table('user_profiles').select(...).eq(...).is_(...).execute()  → profiles
-    - table('job_notification_sent').upsert(...).execute()           → claim_response
-    - table('job_notification_sent').update(...).eq(...).execute()   → ok
-    - table('job_notification_sent').select(..., count=...).eq(...)  → count stub
+    - table('notifications_sent').upsert(...).execute()           → claim_response
+    - table('notifications_sent').update(...).eq(...).execute()   → ok
+    - table('notifications_sent').select(..., count=...).eq(...)  → count stub
     """
     profiles_chain = MagicMock()
     profiles_chain.select.return_value = profiles_chain
@@ -46,7 +46,7 @@ def _build_supabase_mock(
     count_chain.gte.return_value = count_chain
     count_chain.execute.return_value = _ExecuteStub([], count=0)
 
-    # Track calls to job_notification_sent to route between claim/update/count
+    # Track calls to notifications_sent to route between claim/update/count
     notif_calls: dict[str, int] = {"n": 0}
 
     def _notif_table(_name: str) -> MagicMock:
@@ -58,7 +58,7 @@ def _build_supabase_mock(
     def _table(name: str) -> MagicMock:
         if name == "user_profiles":
             return profiles_chain
-        if name == "job_notification_sent":
+        if name == "notifications_sent":
             return _notif_table(name)
         raise AssertionError(f"Unexpected table: {name}")
 
@@ -109,7 +109,7 @@ def _build_sms_supabase_mock(
     def _table(name: str) -> MagicMock:
         if name == "user_profiles":
             return profiles_chain
-        if name == "job_notification_sent":
+        if name == "notifications_sent":
             return _notif_table(name)
         raise AssertionError(f"Unexpected table: {name}")
 

--- a/apps/job-api/tests/test_resume_lifecycle.py
+++ b/apps/job-api/tests/test_resume_lifecycle.py
@@ -126,7 +126,7 @@ class TestPersistenceHelpers:
 
         result = update_payload(supabase, "rec-1", {"summary": "Updated"})
         assert result.id == "rec-1"
-        supabase.table.assert_called_with("tailored_resumes")
+        supabase.table.assert_called_with("documents")
 
     def test_update_payload_with_storage_path(self) -> None:
         from app.services.tailor.persistence import update_payload
@@ -212,7 +212,7 @@ class TestPersistenceHelpers:
         supabase = MagicMock()
         mark_job_resume_draft(supabase, "job-42")
 
-        supabase.table.assert_called_with("job_postings")
+        supabase.table.assert_called_with("jobs")
         update_call = supabase.table.return_value.update.call_args
         payload = update_call[0][0]
         assert payload["status"] == "resume_draft"
@@ -228,7 +228,7 @@ class TestPersistenceHelpers:
 
 
 class TestSingleResumeStatusBump:
-    """POST /tailor/resume must advance job_postings.status to 'resume_draft'
+    """POST /tailor/resume must advance jobs.status to 'resume_draft'
     after a successful generation. Without this the JobDetailPanel never
     shows the 'Review Resume' button — the resume exists in the DB but is
     invisible to the user.
@@ -294,7 +294,7 @@ class TestSingleResumeStatusBump:
     @pytest.mark.asyncio
     async def test_no_status_bump_when_job_posting_id_missing(self) -> None:
         """One-off generations without a linked job (e.g. preview from a JD
-        paste) should not touch any job_postings row."""
+        paste) should not touch any jobs row."""
         from app.models.tailor import TailorRequest
         from app.routers import tailor as tailor_router
         from app.services.tailor import PipelineSuccess
@@ -505,7 +505,7 @@ class TestApproveResume:
 
         assert result.approved_at is not None
         # Verify job status was updated to resume_ready
-        supabase.table.assert_any_call("job_postings")
+        supabase.table.assert_any_call("jobs")
 
     @pytest.mark.asyncio
     async def test_approve_idempotent(self) -> None:
@@ -568,9 +568,9 @@ class TestApproveResume:
             )
 
         assert result.approved_at is not None
-        # No job_postings.update — cover letters don't drive job status.
+        # No jobs.update — cover letters don't drive job status.
         for call in supabase.table.call_args_list:
-            assert call.args[0] != "job_postings"
+            assert call.args[0] != "jobs"
 
 
 # ---------------------------------------------------------------------------
@@ -746,8 +746,8 @@ class TestCheckpointEndpoint:
 
     @pytest.mark.asyncio
     async def test_no_body_snapshots_current_state(self) -> None:
-        from app.routers import tailor as tailor_router
         from app.models.tailor import ResumeCheckpointRequest
+        from app.routers import tailor as tailor_router
 
         supabase = MagicMock()
         record = _make_record(payload_md=_GOOD_MD)
@@ -774,8 +774,8 @@ class TestCheckpointEndpoint:
 
     @pytest.mark.asyncio
     async def test_body_with_markdown_saves_then_checkpoints(self) -> None:
-        from app.routers import tailor as tailor_router
         from app.models.tailor import ResumeCheckpointRequest
+        from app.routers import tailor as tailor_router
 
         supabase = MagicMock()
         record = _make_record(payload_md="old md")
@@ -805,8 +805,8 @@ class TestCheckpointEndpoint:
     async def test_body_with_invalid_markdown_returns_422(self) -> None:
         from fastapi import HTTPException
 
-        from app.routers import tailor as tailor_router
         from app.models.tailor import ResumeCheckpointRequest
+        from app.routers import tailor as tailor_router
 
         supabase = MagicMock()
         record = _make_record()
@@ -831,8 +831,8 @@ class TestCheckpointEndpoint:
 
     @pytest.mark.asyncio
     async def test_approved_resume_skips_checkpoint(self) -> None:
-        from app.routers import tailor as tailor_router
         from app.models.tailor import ResumeCheckpointRequest
+        from app.routers import tailor as tailor_router
 
         supabase = MagicMock()
         record = _make_record(approved_at=_NOW)
@@ -856,8 +856,8 @@ class TestCheckpointEndpoint:
     async def test_not_found_returns_404(self) -> None:
         from fastapi import HTTPException
 
-        from app.routers import tailor as tailor_router
         from app.models.tailor import ResumeCheckpointRequest
+        from app.routers import tailor as tailor_router
 
         supabase = MagicMock()
 

--- a/apps/job-api/tests/test_reuse.py
+++ b/apps/job-api/tests/test_reuse.py
@@ -148,16 +148,16 @@ def test_find_reusable_resume_no_jobs_in_target() -> None:
 def test_find_reusable_resume_no_resumes() -> None:
     supabase = MagicMock()
 
-    # First call: job_postings query returns IDs
+    # First call: jobs query returns IDs
     jp_mock = MagicMock()
     jp_mock.select.return_value.eq.return_value.execute.return_value.data = [{"id": "jp-1"}]
 
-    # Second call: tailored_resumes query returns empty
+    # Second call: documents query returns empty
     tr_mock = MagicMock()
     tr_chain = tr_mock.select.return_value.in_.return_value.eq.return_value.order.return_value
     tr_chain.limit.return_value.execute.return_value.data = []
 
-    supabase.table.side_effect = lambda name: jp_mock if name == "job_postings" else tr_mock
+    supabase.table.side_effect = lambda name: jp_mock if name == "jobs" else tr_mock
 
     result = find_reusable_resume(
         supabase,
@@ -182,7 +182,7 @@ def test_find_reusable_resume_below_threshold() -> None:
     tr_chain = tr_mock.select.return_value.in_.return_value.eq.return_value.order.return_value
     tr_chain.limit.return_value.execute.return_value.data = [resume_row]
 
-    supabase.table.side_effect = lambda name: jp_mock if name == "job_postings" else tr_mock
+    supabase.table.side_effect = lambda name: jp_mock if name == "jobs" else tr_mock
 
     result = find_reusable_resume(
         supabase,
@@ -207,7 +207,7 @@ def test_find_reusable_resume_above_threshold() -> None:
     tr_chain = tr_mock.select.return_value.in_.return_value.eq.return_value.order.return_value
     tr_chain.limit.return_value.execute.return_value.data = [resume_row]
 
-    supabase.table.side_effect = lambda name: jp_mock if name == "job_postings" else tr_mock
+    supabase.table.side_effect = lambda name: jp_mock if name == "jobs" else tr_mock
 
     kws = {"react", "typescript", "graphql", "node.js"}
     result = find_reusable_resume(
@@ -286,8 +286,8 @@ def test_clone_resume_carries_markdown_and_cache_hash() -> None:
         user_id=None,
     )
 
-    # `insert_row` writes to `tailored_resumes` first and then to the
-    # versions table — find the tailored_resumes call and assert against it.
+    # `insert_row` writes to `documents` first and then to the
+    # versions table — find the documents call and assert against it.
     inserts = supabase.table.return_value.insert.call_args_list
     main_insert = next(
         call[0][0] for call in inserts if "jd_snapshot" in call[0][0]

--- a/apps/job-api/tests/test_routers_sources.py
+++ b/apps/job-api/tests/test_routers_sources.py
@@ -45,7 +45,7 @@ def test_sources_add_calls_upsert(client_factory):
     )
     assert r.status_code == 200
     assert r.json()["success"] is True
-    sb.table.assert_any_call("job_sources")
+    sb.table.assert_any_call("sources")
     sb.table.return_value.upsert.assert_called_once()
     args, kwargs = sb.table.return_value.upsert.call_args
     assert args[0] == {"board_token": "foo", "company_name": "Foo", "provider": "greenhouse"}

--- a/apps/job-api/tests/test_routers_status.py
+++ b/apps/job-api/tests/test_routers_status.py
@@ -15,7 +15,7 @@ class _Resp:
 
 def _build_supabase(posting_data: dict[str, Any] | None) -> MagicMock:
     sb = MagicMock()
-    # .table("job_postings").select("status").eq("id", id).single().execute()
+    # .table("jobs").select("status").eq("id", id).single().execute()
     select_chain = sb.table.return_value.select.return_value.eq.return_value.single
     select_chain.return_value.execute.return_value = _Resp(posting_data)
     # insert, update, and delete are chain-called; default MagicMock return is fine

--- a/apps/job-api/tests/test_tailor_pipeline.py
+++ b/apps/job-api/tests/test_tailor_pipeline.py
@@ -248,7 +248,7 @@ async def test_lint_failure_does_not_persist(
 
     assert isinstance(result, PipelineLintFailure)
     assert any(v.code == "no_tables" for v in result.lint.errors)
-    # No insert call for tailored_resumes.
+    # No insert call for documents.
     supabase.table.return_value.insert.assert_not_called()
 
 

--- a/apps/job-api/tests/test_tailor_versions.py
+++ b/apps/job-api/tests/test_tailor_versions.py
@@ -21,27 +21,27 @@ class _RecordingChain:
         self.inserts: list[dict[str, Any]] = []
         self.deletes_in_ids: list[list[str]] = []
 
-    def select(self, *_: Any, **__: Any) -> "_RecordingChain":
+    def select(self, *_: Any, **__: Any) -> _RecordingChain:
         return self
 
-    def insert(self, row: dict[str, Any]) -> "_RecordingChain":
+    def insert(self, row: dict[str, Any]) -> _RecordingChain:
         self.inserts.append(row)
         return self
 
-    def delete(self) -> "_RecordingChain":
+    def delete(self) -> _RecordingChain:
         return self
 
-    def in_(self, _col: str, ids: list[str]) -> "_RecordingChain":
+    def in_(self, _col: str, ids: list[str]) -> _RecordingChain:
         self.deletes_in_ids.append(ids)
         return self
 
-    def eq(self, *_: Any, **__: Any) -> "_RecordingChain":
+    def eq(self, *_: Any, **__: Any) -> _RecordingChain:
         return self
 
-    def order(self, *_: Any, **__: Any) -> "_RecordingChain":
+    def order(self, *_: Any, **__: Any) -> _RecordingChain:
         return self
 
-    def limit(self, *_: Any, **__: Any) -> "_RecordingChain":
+    def limit(self, *_: Any, **__: Any) -> _RecordingChain:
         return self
 
     def execute(self) -> _ExecuteStub:
@@ -110,8 +110,8 @@ def _checkpoint_supabase(
     """Builds a supabase mock with separate chains for the two tables the
     checkpoint() flow touches.
 
-    - tailored_resumes select returns {payload, payload_md}.
-    - tailored_resume_versions: insert calls land in `inserts`; the
+    - documents select returns {payload, payload_md}.
+    - document_versions: insert calls land in `inserts`; the
       last-version select (with `.limit(1)`) returns `last_versions`;
       the prune select (no `.limit`) also returns `last_versions` so
       prune behavior is deterministic.
@@ -121,12 +121,12 @@ def _checkpoint_supabase(
 
     def table_factory(name: str) -> MagicMock:
         chain = MagicMock()
-        if name == "tailored_resumes":
+        if name == "documents":
             chain.select.return_value.eq.return_value.single.return_value.execute.return_value.data = (
                 resume_row
             )
             return chain
-        assert name == "tailored_resume_versions"
+        assert name == "document_versions"
 
         def insert_capturing(row: dict[str, Any]) -> MagicMock:
             inserts.append(row)

--- a/apps/job-api/tests/test_target_scoring.py
+++ b/apps/job-api/tests/test_target_scoring.py
@@ -96,7 +96,7 @@ def _make_supabase_mock(
     supabase.table.return_value.select.return_value.eq.return_value.execute.return_value.data = (
         select_data or []
     )
-    # For bulk_score_for_target: range query on job_postings
+    # For bulk_score_for_target: range query on jobs
     supabase.table.return_value.select.return_value.range.return_value.execute.return_value.data = (
         select_data or []
     )
@@ -124,7 +124,7 @@ def test_score_and_upsert_calls_upsert_with_correct_shape() -> None:
     assert result.job_posting_id == "job-1"
     assert result.target_id == "target-1"
     # Verify upsert was called on the right table
-    supabase.table.assert_any_call("job_target_scores")
+    supabase.table.assert_any_call("scores")
 
 
 def test_score_and_upsert_raises_on_empty_response() -> None:
@@ -241,7 +241,7 @@ def test_get_target_scores_returns_empty_dict_when_no_scores() -> None:
 def test_list_jobs_without_target_returns_global_view(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Global view queries job_postings directly with global scores."""
+    """Global view queries jobs directly with global scores."""
     from fastapi.testclient import TestClient
 
     from app.dependencies import get_supabase, verify_api_key_or_session
@@ -326,7 +326,7 @@ def test_list_jobs_with_target_overlays_target_score(
 
     supabase = MagicMock()
     supabase.table.side_effect = (
-        lambda name: ts_mock if name == "job_target_scores" else jp_mock
+        lambda name: ts_mock if name == "scores" else jp_mock
     )
 
     app.dependency_overrides[get_supabase] = lambda: supabase

--- a/apps/job-api/tests/test_targets_from_input.py
+++ b/apps/job-api/tests/test_targets_from_input.py
@@ -30,7 +30,6 @@ from app.services.llm import cost_log
 from app.services.targets import crud, from_input
 from app.services.targets.fit_score import FitScoreResult
 
-
 # ---- Helpers ----------------------------------------------------------------
 
 

--- a/apps/job-api/tests/test_targets_user_links.py
+++ b/apps/job-api/tests/test_targets_user_links.py
@@ -2,7 +2,7 @@
 
 Covers:
   1. set_user_target_inactive deactivates via user_targets (so the trigger
-     can sync job_targets.is_active).
+     can sync targets.is_active).
   2. FitScoreResult tolerates reasoning strings up to 1500 chars (the LLM
      occasionally exceeds the original 500 cap, which caused 502s).
 """

--- a/apps/root/src/app/api/jobs/tailor/cover-letter/route.ts
+++ b/apps/root/src/app/api/jobs/tailor/cover-letter/route.ts
@@ -28,12 +28,12 @@ export async function POST(request: NextRequest) {
 
   const body = (await request.json()) as Record<string, unknown>;
 
-  // If job_description is missing or empty, fetch from job_postings table
+  // If job_description is missing or empty, fetch from jobs table
   if (!body['job_description'] && body['job_posting_id']) {
     const supabase = createServerSupabaseClient();
     if (supabase) {
       const { data } = await supabase
-        .from('job_postings')
+        .from('jobs')
         .select('description_html')
         .eq('id', body['job_posting_id'] as string)
         .single();

--- a/apps/wyrdfold/src/lib/supabase/types.ts
+++ b/apps/wyrdfold/src/lib/supabase/types.ts
@@ -1,0 +1,26 @@
+// Placeholder. Regenerate from the wyrdfold schema once the rename-pass
+// migration is applied:
+//
+//   pnpm supabase gen types typescript --project-id <project-id> \
+//     > apps/wyrdfold/src/lib/supabase/types.ts
+//
+// Until then, BFF routes and surface ports import this empty Database type
+// just so server clients stay typed at the call site.
+
+export type Json =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: Json | undefined }
+  | Json[];
+
+export interface Database {
+  public: {
+    Tables: Record<string, never>;
+    Views: Record<string, never>;
+    Functions: Record<string, never>;
+    Enums: Record<string, never>;
+    CompositeTypes: Record<string, never>;
+  };
+}

--- a/libs/shared/audit/src/lib/database.types.ts
+++ b/libs/shared/audit/src/lib/database.types.ts
@@ -39,6 +39,221 @@ export type Database = {
   };
   public: {
     Tables: {
+      analyses: {
+        Row: {
+          cost_usd: number;
+          created_at: string;
+          id: string;
+          job_posting_id: string;
+          latency_ms: number;
+          model: string;
+          optimized_doc_id: string | null;
+          recommendation: string;
+          scorecard: Json;
+          target_id: string;
+          user_id: string | null;
+        };
+        Insert: {
+          cost_usd?: number;
+          created_at?: string;
+          id?: string;
+          job_posting_id: string;
+          latency_ms?: number;
+          model: string;
+          optimized_doc_id?: string | null;
+          recommendation: string;
+          scorecard: Json;
+          target_id: string;
+          user_id?: string | null;
+        };
+        Update: {
+          cost_usd?: number;
+          created_at?: string;
+          id?: string;
+          job_posting_id?: string;
+          latency_ms?: number;
+          model?: string;
+          optimized_doc_id?: string | null;
+          recommendation?: string;
+          scorecard?: Json;
+          target_id?: string;
+          user_id?: string | null;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'job_analyses_job_posting_id_fkey';
+            columns: ['job_posting_id'];
+            isOneToOne: false;
+            referencedRelation: 'jobs';
+            referencedColumns: ['id'];
+          },
+          {
+            foreignKeyName: 'job_analyses_target_id_fkey';
+            columns: ['target_id'];
+            isOneToOne: false;
+            referencedRelation: 'targets';
+            referencedColumns: ['id'];
+          },
+        ];
+      };
+      batch_runs: {
+        Row: {
+          completed: number;
+          created_at: string;
+          failed: number;
+          id: string;
+          items: Json;
+          status: string;
+          total: number;
+          updated_at: string;
+          user_id: string | null;
+        };
+        Insert: {
+          completed?: number;
+          created_at?: string;
+          failed?: number;
+          id?: string;
+          items?: Json;
+          status?: string;
+          total: number;
+          updated_at?: string;
+          user_id?: string | null;
+        };
+        Update: {
+          completed?: number;
+          created_at?: string;
+          failed?: number;
+          id?: string;
+          items?: Json;
+          status?: string;
+          total?: number;
+          updated_at?: string;
+          user_id?: string | null;
+        };
+        Relationships: [];
+      };
+      document_versions: {
+        Row: {
+          created_at: string;
+          id: string;
+          payload: Json;
+          payload_md: string | null;
+          resume_id: string;
+          source: string;
+        };
+        Insert: {
+          created_at?: string;
+          id?: string;
+          payload: Json;
+          payload_md?: string | null;
+          resume_id: string;
+          source: string;
+        };
+        Update: {
+          created_at?: string;
+          id?: string;
+          payload?: Json;
+          payload_md?: string | null;
+          resume_id?: string;
+          source?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'tailored_resume_versions_resume_id_fkey';
+            columns: ['resume_id'];
+            isOneToOne: false;
+            referencedRelation: 'documents';
+            referencedColumns: ['id'];
+          },
+        ];
+      };
+      documents: {
+        Row: {
+          approved_at: string | null;
+          cost_usd: number | null;
+          created_at: string;
+          document_type: string;
+          docx_payload_md_hash: string | null;
+          id: string;
+          input_tokens: number | null;
+          jd_snapshot: string;
+          jd_snapshot_hash: string;
+          job_posting_id: string | null;
+          latency_ms: number | null;
+          model: string | null;
+          output_tokens: number | null;
+          payload: Json;
+          payload_md: string | null;
+          resume_type: string;
+          source_resume_id: string | null;
+          storage_path: string | null;
+          updated_at: string | null;
+          user_id: string | null;
+          warnings: Json;
+        };
+        Insert: {
+          approved_at?: string | null;
+          cost_usd?: number | null;
+          created_at?: string;
+          document_type?: string;
+          docx_payload_md_hash?: string | null;
+          id?: string;
+          input_tokens?: number | null;
+          jd_snapshot: string;
+          jd_snapshot_hash: string;
+          job_posting_id?: string | null;
+          latency_ms?: number | null;
+          model?: string | null;
+          output_tokens?: number | null;
+          payload: Json;
+          payload_md?: string | null;
+          resume_type: string;
+          source_resume_id?: string | null;
+          storage_path?: string | null;
+          updated_at?: string | null;
+          user_id?: string | null;
+          warnings?: Json;
+        };
+        Update: {
+          approved_at?: string | null;
+          cost_usd?: number | null;
+          created_at?: string;
+          document_type?: string;
+          docx_payload_md_hash?: string | null;
+          id?: string;
+          input_tokens?: number | null;
+          jd_snapshot?: string;
+          jd_snapshot_hash?: string;
+          job_posting_id?: string | null;
+          latency_ms?: number | null;
+          model?: string | null;
+          output_tokens?: number | null;
+          payload?: Json;
+          payload_md?: string | null;
+          resume_type?: string;
+          source_resume_id?: string | null;
+          storage_path?: string | null;
+          updated_at?: string | null;
+          user_id?: string | null;
+          warnings?: Json;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'tailored_resumes_job_posting_id_fkey';
+            columns: ['job_posting_id'];
+            isOneToOne: false;
+            referencedRelation: 'jobs';
+            referencedColumns: ['id'];
+          },
+          {
+            foreignKeyName: 'tailored_resumes_source_resume_id_fkey';
+            columns: ['source_resume_id'];
+            isOneToOne: false;
+            referencedRelation: 'documents';
+            referencedColumns: ['id'];
+          },
+        ];
+      };
       email_log: {
         Row: {
           id: string;
@@ -71,24 +286,207 @@ export type Database = {
           },
         ];
       };
-      job_postings: {
+      experience_chunks: {
+        Row: {
+          chunk_ref: string;
+          chunk_type: string;
+          content: string;
+          created_at: string;
+          embedding: string | null;
+          id: string;
+          metadata: Json;
+          optimized_doc_id: string;
+        };
+        Insert: {
+          chunk_ref: string;
+          chunk_type: string;
+          content: string;
+          created_at?: string;
+          embedding?: string | null;
+          id?: string;
+          metadata?: Json;
+          optimized_doc_id: string;
+        };
+        Update: {
+          chunk_ref?: string;
+          chunk_type?: string;
+          content?: string;
+          created_at?: string;
+          embedding?: string | null;
+          id?: string;
+          metadata?: Json;
+          optimized_doc_id?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'experience_chunks_optimized_doc_id_fkey';
+            columns: ['optimized_doc_id'];
+            isOneToOne: false;
+            referencedRelation: 'experience_optimized_docs';
+            referencedColumns: ['id'];
+          },
+        ];
+      };
+      experience_conversation_turns: {
+        Row: {
+          content: string;
+          conversation_type: string;
+          created_at: string;
+          id: string;
+          metadata: Json;
+          prose_doc_id: string | null;
+          role: string;
+          skipped: boolean;
+          turn_index: number;
+          user_id: string | null;
+        };
+        Insert: {
+          content: string;
+          conversation_type: string;
+          created_at?: string;
+          id?: string;
+          metadata?: Json;
+          prose_doc_id?: string | null;
+          role: string;
+          skipped?: boolean;
+          turn_index: number;
+          user_id?: string | null;
+        };
+        Update: {
+          content?: string;
+          conversation_type?: string;
+          created_at?: string;
+          id?: string;
+          metadata?: Json;
+          prose_doc_id?: string | null;
+          role?: string;
+          skipped?: boolean;
+          turn_index?: number;
+          user_id?: string | null;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'experience_conversation_turns_prose_doc_id_fkey';
+            columns: ['prose_doc_id'];
+            isOneToOne: false;
+            referencedRelation: 'experience_prose_docs';
+            referencedColumns: ['id'];
+          },
+        ];
+      };
+      experience_optimized_docs: {
+        Row: {
+          created_at: string;
+          id: string;
+          markdown_view: string | null;
+          payload: Json;
+          prose_doc_id: string | null;
+          source: string;
+          user_id: string | null;
+          version: number;
+        };
+        Insert: {
+          created_at?: string;
+          id?: string;
+          markdown_view?: string | null;
+          payload: Json;
+          prose_doc_id?: string | null;
+          source?: string;
+          user_id?: string | null;
+          version: number;
+        };
+        Update: {
+          created_at?: string;
+          id?: string;
+          markdown_view?: string | null;
+          payload?: Json;
+          prose_doc_id?: string | null;
+          source?: string;
+          user_id?: string | null;
+          version?: number;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'experience_optimized_docs_prose_doc_id_fkey';
+            columns: ['prose_doc_id'];
+            isOneToOne: false;
+            referencedRelation: 'experience_prose_docs';
+            referencedColumns: ['id'];
+          },
+        ];
+      };
+      experience_preferences: {
+        Row: {
+          created_at: string;
+          id: string;
+          payload: Json;
+          updated_at: string;
+          user_id: string | null;
+        };
+        Insert: {
+          created_at?: string;
+          id?: string;
+          payload?: Json;
+          updated_at?: string;
+          user_id?: string | null;
+        };
+        Update: {
+          created_at?: string;
+          id?: string;
+          payload?: Json;
+          updated_at?: string;
+          user_id?: string | null;
+        };
+        Relationships: [];
+      };
+      experience_prose_docs: {
+        Row: {
+          content: string;
+          created_at: string;
+          id: string;
+          user_id: string | null;
+          version: number;
+        };
+        Insert: {
+          content: string;
+          created_at?: string;
+          id?: string;
+          user_id?: string | null;
+          version: number;
+        };
+        Update: {
+          content?: string;
+          created_at?: string;
+          id?: string;
+          user_id?: string | null;
+          version?: number;
+        };
+        Relationships: [];
+      };
+      jobs: {
         Row: {
           absolute_url: string | null;
           company_name: string;
           created_at: string | null;
           department: string | null;
           description_html: string | null;
+          external_id: number;
           first_seen_at: string | null;
-          greenhouse_id: number;
           greenhouse_updated_at: string | null;
           id: string;
+          llm_analysis_id: string | null;
+          llm_score: number | null;
           location: string | null;
+          salary_text: string | null;
           score: number;
           score_breakdown: Json | null;
           source_id: string;
           status: string;
+          target_id: string | null;
           title: string;
           updated_at: string | null;
+          url_validation_status: string | null;
+          url_validation_warnings: Json | null;
         };
         Insert: {
           absolute_url?: string | null;
@@ -96,17 +494,23 @@ export type Database = {
           created_at?: string | null;
           department?: string | null;
           description_html?: string | null;
+          external_id: number;
           first_seen_at?: string | null;
-          greenhouse_id: number;
           greenhouse_updated_at?: string | null;
           id?: string;
+          llm_analysis_id?: string | null;
+          llm_score?: number | null;
           location?: string | null;
+          salary_text?: string | null;
           score?: number;
           score_breakdown?: Json | null;
           source_id: string;
           status?: string;
+          target_id?: string | null;
           title: string;
           updated_at?: string | null;
+          url_validation_status?: string | null;
+          url_validation_warnings?: Json | null;
         };
         Update: {
           absolute_url?: string | null;
@@ -114,89 +518,44 @@ export type Database = {
           created_at?: string | null;
           department?: string | null;
           description_html?: string | null;
+          external_id?: number;
           first_seen_at?: string | null;
-          greenhouse_id?: number;
           greenhouse_updated_at?: string | null;
           id?: string;
+          llm_analysis_id?: string | null;
+          llm_score?: number | null;
           location?: string | null;
+          salary_text?: string | null;
           score?: number;
           score_breakdown?: Json | null;
           source_id?: string;
           status?: string;
+          target_id?: string | null;
           title?: string;
           updated_at?: string | null;
+          url_validation_status?: string | null;
+          url_validation_warnings?: Json | null;
         };
         Relationships: [
+          {
+            foreignKeyName: 'job_postings_llm_analysis_id_fkey';
+            columns: ['llm_analysis_id'];
+            isOneToOne: false;
+            referencedRelation: 'analyses';
+            referencedColumns: ['id'];
+          },
           {
             foreignKeyName: 'job_postings_source_id_fkey';
             columns: ['source_id'];
             isOneToOne: false;
-            referencedRelation: 'job_sources';
+            referencedRelation: 'sources';
             referencedColumns: ['id'];
           },
-        ];
-      };
-      job_sources: {
-        Row: {
-          board_token: string;
-          company_name: string;
-          created_at: string | null;
-          enabled: boolean | null;
-          id: string;
-          job_count: number | null;
-          last_polled_at: string | null;
-        };
-        Insert: {
-          board_token: string;
-          company_name: string;
-          created_at?: string | null;
-          enabled?: boolean | null;
-          id?: string;
-          job_count?: number | null;
-          last_polled_at?: string | null;
-        };
-        Update: {
-          board_token?: string;
-          company_name?: string;
-          created_at?: string | null;
-          enabled?: boolean | null;
-          id?: string;
-          job_count?: number | null;
-          last_polled_at?: string | null;
-        };
-        Relationships: [];
-      };
-      job_status_log: {
-        Row: {
-          created_at: string | null;
-          id: string;
-          new_status: string;
-          note: string | null;
-          old_status: string | null;
-          posting_id: string;
-        };
-        Insert: {
-          created_at?: string | null;
-          id?: string;
-          new_status: string;
-          note?: string | null;
-          old_status?: string | null;
-          posting_id: string;
-        };
-        Update: {
-          created_at?: string | null;
-          id?: string;
-          new_status?: string;
-          note?: string | null;
-          old_status?: string | null;
-          posting_id?: string;
-        };
-        Relationships: [
           {
-            foreignKeyName: 'job_status_log_posting_id_fkey';
-            columns: ['posting_id'];
+            foreignKeyName: 'job_postings_target_id_fkey';
+            columns: ['target_id'];
             isOneToOne: false;
-            referencedRelation: 'job_postings';
+            referencedRelation: 'targets';
             referencedColumns: ['id'];
           },
         ];
@@ -250,6 +609,131 @@ export type Database = {
             columns: ['scan_id'];
             isOneToOne: false;
             referencedRelation: 'scans';
+            referencedColumns: ['id'];
+          },
+        ];
+      };
+      llm_costs: {
+        Row: {
+          cache_creation_input_tokens: number;
+          cache_read_input_tokens: number;
+          cost_usd: number;
+          created_at: string;
+          id: string;
+          input_tokens: number;
+          latency_ms: number;
+          metadata: Json;
+          model: string;
+          output_tokens: number;
+          purpose: string;
+          user_id: string | null;
+        };
+        Insert: {
+          cache_creation_input_tokens?: number;
+          cache_read_input_tokens?: number;
+          cost_usd?: number;
+          created_at?: string;
+          id?: string;
+          input_tokens?: number;
+          latency_ms?: number;
+          metadata?: Json;
+          model: string;
+          output_tokens?: number;
+          purpose: string;
+          user_id?: string | null;
+        };
+        Update: {
+          cache_creation_input_tokens?: number;
+          cache_read_input_tokens?: number;
+          cost_usd?: number;
+          created_at?: string;
+          id?: string;
+          input_tokens?: number;
+          latency_ms?: number;
+          metadata?: Json;
+          model?: string;
+          output_tokens?: number;
+          purpose?: string;
+          user_id?: string | null;
+        };
+        Relationships: [];
+      };
+      notifications_sent: {
+        Row: {
+          channel: string;
+          external_id: string | null;
+          id: string;
+          job_posting_id: string;
+          score_at_send: number;
+          sent_at: string;
+          user_profile_id: string;
+        };
+        Insert: {
+          channel?: string;
+          external_id?: string | null;
+          id?: string;
+          job_posting_id: string;
+          score_at_send: number;
+          sent_at?: string;
+          user_profile_id: string;
+        };
+        Update: {
+          channel?: string;
+          external_id?: string | null;
+          id?: string;
+          job_posting_id?: string;
+          score_at_send?: number;
+          sent_at?: string;
+          user_profile_id?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'job_notification_sent_job_posting_id_fkey';
+            columns: ['job_posting_id'];
+            isOneToOne: false;
+            referencedRelation: 'jobs';
+            referencedColumns: ['id'];
+          },
+          {
+            foreignKeyName: 'job_notification_sent_user_profile_id_fkey';
+            columns: ['user_profile_id'];
+            isOneToOne: false;
+            referencedRelation: 'user_profiles';
+            referencedColumns: ['id'];
+          },
+        ];
+      };
+      reference_jds: {
+        Row: {
+          created_at: string | null;
+          extracted_profile: Json;
+          id: string;
+          jd_text: string;
+          jd_url: string | null;
+          target_id: string;
+        };
+        Insert: {
+          created_at?: string | null;
+          extracted_profile?: Json;
+          id?: string;
+          jd_text: string;
+          jd_url?: string | null;
+          target_id: string;
+        };
+        Update: {
+          created_at?: string | null;
+          extracted_profile?: Json;
+          id?: string;
+          jd_text?: string;
+          jd_url?: string | null;
+          target_id?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'target_reference_jds_target_id_fkey';
+            columns: ['target_id'];
+            isOneToOne: false;
+            referencedRelation: 'targets';
             referencedColumns: ['id'];
           },
         ];
@@ -396,12 +880,436 @@ export type Database = {
           },
         ];
       };
+      scores: {
+        Row: {
+          created_at: string;
+          excluded: boolean;
+          id: string;
+          job_posting_id: string;
+          matched_keywords: string[] | null;
+          score: number;
+          score_breakdown: Json | null;
+          scored_profile_version: number;
+          scoring_status: string;
+          target_id: string;
+          updated_at: string;
+        };
+        Insert: {
+          created_at?: string;
+          excluded?: boolean;
+          id?: string;
+          job_posting_id: string;
+          matched_keywords?: string[] | null;
+          score?: number;
+          score_breakdown?: Json | null;
+          scored_profile_version?: number;
+          scoring_status?: string;
+          target_id: string;
+          updated_at?: string;
+        };
+        Update: {
+          created_at?: string;
+          excluded?: boolean;
+          id?: string;
+          job_posting_id?: string;
+          matched_keywords?: string[] | null;
+          score?: number;
+          score_breakdown?: Json | null;
+          scored_profile_version?: number;
+          scoring_status?: string;
+          target_id?: string;
+          updated_at?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'job_target_scores_job_posting_id_fkey';
+            columns: ['job_posting_id'];
+            isOneToOne: false;
+            referencedRelation: 'jobs';
+            referencedColumns: ['id'];
+          },
+          {
+            foreignKeyName: 'job_target_scores_target_id_fkey';
+            columns: ['target_id'];
+            isOneToOne: false;
+            referencedRelation: 'targets';
+            referencedColumns: ['id'];
+          },
+        ];
+      };
+      sources: {
+        Row: {
+          board_token: string;
+          company_name: string;
+          created_at: string | null;
+          enabled: boolean | null;
+          id: string;
+          job_count: number | null;
+          last_polled_at: string | null;
+          provider: string;
+        };
+        Insert: {
+          board_token: string;
+          company_name: string;
+          created_at?: string | null;
+          enabled?: boolean | null;
+          id?: string;
+          job_count?: number | null;
+          last_polled_at?: string | null;
+          provider?: string;
+        };
+        Update: {
+          board_token?: string;
+          company_name?: string;
+          created_at?: string | null;
+          enabled?: boolean | null;
+          id?: string;
+          job_count?: number | null;
+          last_polled_at?: string | null;
+          provider?: string;
+        };
+        Relationships: [];
+      };
+      status_log: {
+        Row: {
+          created_at: string | null;
+          id: string;
+          new_status: string;
+          note: string | null;
+          old_status: string | null;
+          posting_id: string;
+        };
+        Insert: {
+          created_at?: string | null;
+          id?: string;
+          new_status: string;
+          note?: string | null;
+          old_status?: string | null;
+          posting_id: string;
+        };
+        Update: {
+          created_at?: string | null;
+          id?: string;
+          new_status?: string;
+          note?: string | null;
+          old_status?: string | null;
+          posting_id?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'job_status_log_posting_id_fkey';
+            columns: ['posting_id'];
+            isOneToOne: false;
+            referencedRelation: 'jobs';
+            referencedColumns: ['id'];
+          },
+        ];
+      };
+      targets: {
+        Row: {
+          activation_status: string;
+          created_at: string | null;
+          description: string | null;
+          id: string;
+          is_active: boolean;
+          label: string;
+          normalized_label: string | null;
+          profile_version: number;
+          scoring_profile: Json;
+          search_keywords: Json | null;
+          updated_at: string | null;
+        };
+        Insert: {
+          activation_status?: string;
+          created_at?: string | null;
+          description?: string | null;
+          id?: string;
+          is_active?: boolean;
+          label: string;
+          normalized_label?: string | null;
+          profile_version?: number;
+          scoring_profile?: Json;
+          search_keywords?: Json | null;
+          updated_at?: string | null;
+        };
+        Update: {
+          activation_status?: string;
+          created_at?: string | null;
+          description?: string | null;
+          id?: string;
+          is_active?: boolean;
+          label?: string;
+          normalized_label?: string | null;
+          profile_version?: number;
+          scoring_profile?: Json;
+          search_keywords?: Json | null;
+          updated_at?: string | null;
+        };
+        Relationships: [];
+      };
+      uploaded_resumes: {
+        Row: {
+          created_at: string;
+          extracted_text: string;
+          file_size_bytes: number;
+          file_type: string;
+          filename: string;
+          id: string;
+          page_count: number | null;
+          prose_doc_id: string | null;
+          storage_path: string;
+          user_id: string | null;
+          warnings: Json;
+        };
+        Insert: {
+          created_at?: string;
+          extracted_text: string;
+          file_size_bytes: number;
+          file_type: string;
+          filename: string;
+          id?: string;
+          page_count?: number | null;
+          prose_doc_id?: string | null;
+          storage_path: string;
+          user_id?: string | null;
+          warnings?: Json;
+        };
+        Update: {
+          created_at?: string;
+          extracted_text?: string;
+          file_size_bytes?: number;
+          file_type?: string;
+          filename?: string;
+          id?: string;
+          page_count?: number | null;
+          prose_doc_id?: string | null;
+          storage_path?: string;
+          user_id?: string | null;
+          warnings?: Json;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'resume_uploads_prose_doc_id_fkey';
+            columns: ['prose_doc_id'];
+            isOneToOne: false;
+            referencedRelation: 'experience_prose_docs';
+            referencedColumns: ['id'];
+          },
+        ];
+      };
+      user_profiles: {
+        Row: {
+          created_at: string;
+          email: string | null;
+          id: string;
+          job_notifications_enabled: boolean;
+          job_score_threshold: number;
+          linkedin_url: string | null;
+          location: string | null;
+          name: string | null;
+          phone_number: string | null;
+          sms_daily_limit: number;
+          sms_notifications_enabled: boolean;
+          sms_score_threshold: number;
+          unsubscribed_at: string | null;
+          updated_at: string;
+          user_id: string | null;
+          website_url: string | null;
+        };
+        Insert: {
+          created_at?: string;
+          email?: string | null;
+          id?: string;
+          job_notifications_enabled?: boolean;
+          job_score_threshold?: number;
+          linkedin_url?: string | null;
+          location?: string | null;
+          name?: string | null;
+          phone_number?: string | null;
+          sms_daily_limit?: number;
+          sms_notifications_enabled?: boolean;
+          sms_score_threshold?: number;
+          unsubscribed_at?: string | null;
+          updated_at?: string;
+          user_id?: string | null;
+          website_url?: string | null;
+        };
+        Update: {
+          created_at?: string;
+          email?: string | null;
+          id?: string;
+          job_notifications_enabled?: boolean;
+          job_score_threshold?: number;
+          linkedin_url?: string | null;
+          location?: string | null;
+          name?: string | null;
+          phone_number?: string | null;
+          sms_daily_limit?: number;
+          sms_notifications_enabled?: boolean;
+          sms_score_threshold?: number;
+          unsubscribed_at?: string | null;
+          updated_at?: string;
+          user_id?: string | null;
+          website_url?: string | null;
+        };
+        Relationships: [];
+      };
+      user_targets: {
+        Row: {
+          created_at: string;
+          fit_score: number | null;
+          fit_score_reasoning: string | null;
+          id: string;
+          is_active: boolean;
+          target_id: string;
+          updated_at: string;
+          user_id: string;
+        };
+        Insert: {
+          created_at?: string;
+          fit_score?: number | null;
+          fit_score_reasoning?: string | null;
+          id?: string;
+          is_active?: boolean;
+          target_id: string;
+          updated_at?: string;
+          user_id: string;
+        };
+        Update: {
+          created_at?: string;
+          fit_score?: number | null;
+          fit_score_reasoning?: string | null;
+          id?: string;
+          is_active?: boolean;
+          target_id?: string;
+          updated_at?: string;
+          user_id?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'user_targets_target_id_fkey';
+            columns: ['target_id'];
+            isOneToOne: false;
+            referencedRelation: 'targets';
+            referencedColumns: ['id'];
+          },
+        ];
+      };
     };
     Views: {
-      [_ in never]: never;
+      insights_domains_view: {
+        Row: {
+          domain: string | null;
+          latest_grade: string | null;
+          latest_scan_at: string | null;
+          scan_count: number | null;
+        };
+        Relationships: [];
+      };
+      insights_summary_view: {
+        Row: {
+          avg_overall_score: number | null;
+          top_violation: string | null;
+          total_scans: number | null;
+          unique_domains: number | null;
+        };
+        Relationships: [];
+      };
+      insights_violations_view: {
+        Row: {
+          category: string | null;
+          occurrence_count: number | null;
+          severity_critical: number | null;
+          severity_info: number | null;
+          severity_warning: number | null;
+          title: string | null;
+        };
+        Relationships: [];
+      };
     };
     Functions: {
-      [_ in never]: never;
+      bulk_update_salaries: { Args: { p_updates: Json }; Returns: number };
+      bulk_update_scores: { Args: { p_updates: Json }; Returns: number };
+      get_target_jobs: {
+        Args: {
+          p_ascending?: boolean;
+          p_company?: string;
+          p_limit?: number;
+          p_min_score?: number;
+          p_offset?: number;
+          p_search?: string;
+          p_sort?: string;
+          p_status?: string;
+          p_target_id: string;
+        };
+        Returns: {
+          absolute_url: string;
+          company_name: string;
+          created_at: string;
+          department: string;
+          external_id: number;
+          first_seen_at: string;
+          greenhouse_updated_at: string;
+          id: string;
+          location: string;
+          salary_text: string;
+          score: number;
+          score_breakdown: Json;
+          scoring_status: string;
+          source_id: string;
+          status: string;
+          title: string;
+          total_count: number;
+        }[];
+      };
+      insights_score_stats: {
+        Args: { period_days?: number };
+        Returns: {
+          avg_accessibility: number;
+          avg_best_practices: number;
+          avg_overall: number;
+          avg_performance: number;
+          avg_seo: number;
+          grade_a: number;
+          grade_b: number;
+          grade_c: number;
+          grade_d: number;
+          grade_f: number;
+          total: number;
+        }[];
+      };
+      insights_trends: {
+        Args: { bucket_interval?: string; period_months?: number };
+        Returns: {
+          avg_overall: number;
+          bucket_start: string;
+          scan_count: number;
+        }[];
+      };
+      match_target_by_label: {
+        Args: { query_label: string; threshold?: number };
+        Returns: {
+          activation_status: string;
+          created_at: string | null;
+          description: string | null;
+          id: string;
+          is_active: boolean;
+          label: string;
+          normalized_label: string | null;
+          profile_version: number;
+          scoring_profile: Json;
+          search_keywords: Json | null;
+          updated_at: string | null;
+        }[];
+        SetofOptions: {
+          from: '*';
+          to: 'targets';
+          isOneToOne: false;
+          isSetofReturn: true;
+        };
+      };
+      show_limit: { Args: never; Returns: number };
+      show_trgm: { Args: { '': string }; Returns: string[] };
     };
     Enums: {
       [_ in never]: never;

--- a/supabase/migrations/20260502120000_wyrdfold_rename_pass.sql
+++ b/supabase/migrations/20260502120000_wyrdfold_rename_pass.sql
@@ -1,0 +1,280 @@
+-- ============================================
+-- MIGRATION: WyrdFold rename pass (#592)
+-- ============================================
+--
+-- Strips the redundant `job_` prefix from tables in the wyrdfold
+-- (formerly /fitted) namespace, disambiguates `batch_jobs` vs job postings,
+-- renames `tailored_resumes` to `documents` (it now also holds cover letters),
+-- and consolidates ancillary names. See
+-- .claude/docs/wyrdfold-migration/supabase-schema.md §8 for the full mapping.
+--
+-- Scope: tables, functions, triggers, named constraints. Column names and
+-- explicit index names are intentionally left alone — they're internal and
+-- the noise of renaming them isn't worth the codemod blast radius.
+--
+-- Functions that embed renamed table names in their bodies (or return type)
+-- must be DROP + CREATE'd. CREATE OR REPLACE alone won't repair a
+-- `RETURNS SETOF <renamed_table>` signature.
+
+-- ------------------------------------------------------------
+-- 1. Drop dependent functions before renaming their backing tables.
+-- ------------------------------------------------------------
+DROP FUNCTION IF EXISTS public.bulk_update_job_scores(jsonb);
+DROP FUNCTION IF EXISTS public.bulk_update_job_salaries(jsonb);
+DROP FUNCTION IF EXISTS public.match_target_by_label(TEXT, FLOAT);
+DROP FUNCTION IF EXISTS public.get_target_jobs(UUID, INT, TEXT, TEXT, TEXT, TEXT, BOOLEAN, INT, INT);
+
+-- ------------------------------------------------------------
+-- 2. Rename tables.
+-- ------------------------------------------------------------
+ALTER TABLE IF EXISTS public.job_postings              RENAME TO jobs;
+ALTER TABLE IF EXISTS public.job_targets               RENAME TO targets;
+ALTER TABLE IF EXISTS public.job_sources               RENAME TO sources;
+ALTER TABLE IF EXISTS public.job_status_log            RENAME TO status_log;
+ALTER TABLE IF EXISTS public.job_analyses              RENAME TO analyses;
+ALTER TABLE IF EXISTS public.job_target_scores        RENAME TO scores;
+ALTER TABLE IF EXISTS public.job_notification_sent     RENAME TO notifications_sent;
+ALTER TABLE IF EXISTS public.target_reference_jds      RENAME TO reference_jds;
+ALTER TABLE IF EXISTS public.batch_jobs                RENAME TO batch_runs;
+ALTER TABLE IF EXISTS public.tailored_resumes          RENAME TO documents;
+ALTER TABLE IF EXISTS public.tailored_resume_versions  RENAME TO document_versions;
+ALTER TABLE IF EXISTS public.resume_uploads            RENAME TO uploaded_resumes;
+ALTER TABLE IF EXISTS public.llm_cost_log              RENAME TO llm_costs;
+
+-- ------------------------------------------------------------
+-- 3. Rename named CHECK / UNIQUE constraints.
+--    Anonymous constraints (FKs, _key, _check) auto-rename when the table
+--    rename matches Postgres' default naming rules; the ones below were
+--    created with explicit names, so we rename them by hand.
+-- ------------------------------------------------------------
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'job_postings_status_check'
+      AND conrelid = 'public.jobs'::regclass
+  ) THEN
+    ALTER TABLE public.jobs
+      RENAME CONSTRAINT job_postings_status_check TO jobs_status_check;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'job_postings_score_check'
+      AND conrelid = 'public.jobs'::regclass
+  ) THEN
+    ALTER TABLE public.jobs
+      RENAME CONSTRAINT job_postings_score_check TO jobs_score_check;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'job_postings_source_external_unique'
+      AND conrelid = 'public.jobs'::regclass
+  ) THEN
+    ALTER TABLE public.jobs
+      RENAME CONSTRAINT job_postings_source_external_unique TO jobs_source_external_unique;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'job_notification_sent_channel_check'
+      AND conrelid = 'public.notifications_sent'::regclass
+  ) THEN
+    ALTER TABLE public.notifications_sent
+      RENAME CONSTRAINT job_notification_sent_channel_check TO notifications_sent_channel_check;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'job_notification_sent_user_profile_job_channel_key'
+      AND conrelid = 'public.notifications_sent'::regclass
+  ) THEN
+    ALTER TABLE public.notifications_sent
+      RENAME CONSTRAINT job_notification_sent_user_profile_job_channel_key
+                     TO notifications_sent_user_profile_job_channel_key;
+  END IF;
+END$$;
+
+-- ------------------------------------------------------------
+-- 4. Recreate functions with new names + updated bodies pointing at
+--    renamed tables.
+-- ------------------------------------------------------------
+
+-- bulk_update_job_scores → bulk_update_scores
+CREATE OR REPLACE FUNCTION public.bulk_update_scores(p_updates jsonb)
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  cnt integer;
+BEGIN
+  IF p_updates IS NULL OR jsonb_array_length(p_updates) = 0 THEN
+    RETURN 0;
+  END IF;
+
+  WITH u AS (
+    SELECT (elem->>'id')::uuid    AS id,
+           (elem->>'score')::int  AS score
+    FROM   jsonb_array_elements(p_updates) elem
+  )
+  UPDATE public.jobs jp
+  SET    score = u.score
+  FROM   u
+  WHERE  jp.id = u.id;
+
+  GET DIAGNOSTICS cnt = ROW_COUNT;
+  RETURN cnt;
+END;
+$$;
+
+ALTER FUNCTION public.bulk_update_scores(jsonb)
+  SET search_path = public, pg_catalog;
+
+-- bulk_update_job_salaries → bulk_update_salaries
+CREATE OR REPLACE FUNCTION public.bulk_update_salaries(p_updates jsonb)
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  cnt integer;
+BEGIN
+  IF p_updates IS NULL OR jsonb_array_length(p_updates) = 0 THEN
+    RETURN 0;
+  END IF;
+
+  WITH u AS (
+    SELECT (elem->>'id')::uuid       AS id,
+           (elem->>'salary_text')    AS salary_text
+    FROM   jsonb_array_elements(p_updates) elem
+  )
+  UPDATE public.jobs jp
+  SET    salary_text = u.salary_text
+  FROM   u
+  WHERE  jp.id = u.id;
+
+  GET DIAGNOSTICS cnt = ROW_COUNT;
+  RETURN cnt;
+END;
+$$;
+
+ALTER FUNCTION public.bulk_update_salaries(jsonb)
+  SET search_path = public, pg_catalog;
+
+-- match_target_by_label: same name, return type now SETOF targets
+CREATE OR REPLACE FUNCTION public.match_target_by_label(
+  query_label TEXT,
+  threshold FLOAT DEFAULT 0.7
+)
+RETURNS SETOF public.targets
+LANGUAGE sql
+STABLE
+AS $$
+  SELECT *
+  FROM public.targets
+  WHERE similarity(normalized_label, query_label) >= threshold
+  ORDER BY similarity(normalized_label, query_label) DESC
+  LIMIT 1;
+$$;
+
+-- get_target_jobs: same name, body now joins scores ↔ jobs
+CREATE OR REPLACE FUNCTION public.get_target_jobs(
+  p_target_id UUID,
+  p_min_score INT DEFAULT 0,
+  p_status TEXT DEFAULT NULL,
+  p_company TEXT DEFAULT NULL,
+  p_search TEXT DEFAULT NULL,
+  p_sort TEXT DEFAULT 'score',
+  p_ascending BOOLEAN DEFAULT FALSE,
+  p_limit INT DEFAULT 20,
+  p_offset INT DEFAULT 0
+)
+RETURNS TABLE (
+  id UUID,
+  external_id BIGINT,
+  source_id UUID,
+  title TEXT,
+  company_name TEXT,
+  location TEXT,
+  department TEXT,
+  absolute_url TEXT,
+  score INT,
+  score_breakdown JSONB,
+  scoring_status TEXT,
+  status TEXT,
+  salary_text TEXT,
+  greenhouse_updated_at TIMESTAMPTZ,
+  first_seen_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ,
+  total_count BIGINT
+)
+LANGUAGE plpgsql
+STABLE
+AS $$
+BEGIN
+  RETURN QUERY
+  SELECT
+    jp.id,
+    jp.external_id,
+    jp.source_id,
+    jp.title,
+    jp.company_name,
+    jp.location,
+    jp.department,
+    jp.absolute_url,
+    s.score,
+    s.score_breakdown,
+    s.scoring_status,
+    jp.status,
+    jp.salary_text,
+    jp.greenhouse_updated_at,
+    jp.first_seen_at,
+    jp.created_at,
+    COUNT(*) OVER () AS total_count
+  FROM public.scores s
+  INNER JOIN public.jobs jp ON jp.id = s.job_posting_id
+  WHERE s.target_id = p_target_id
+    AND s.excluded = FALSE
+    AND s.score >= p_min_score
+    AND (p_status IS NULL OR jp.status = p_status)
+    AND (p_company IS NULL OR jp.company_name = p_company)
+    AND (p_search IS NULL OR jp.title ILIKE '%' || p_search || '%')
+  ORDER BY
+    CASE WHEN p_sort = 'score' AND NOT p_ascending THEN s.score END DESC NULLS LAST,
+    CASE WHEN p_sort = 'score' AND p_ascending THEN s.score END ASC NULLS LAST,
+    CASE WHEN p_sort = 'created_at' AND NOT p_ascending THEN jp.created_at END DESC NULLS LAST,
+    CASE WHEN p_sort = 'created_at' AND p_ascending THEN jp.created_at END ASC NULLS LAST,
+    CASE WHEN p_sort = 'company_name' AND NOT p_ascending THEN jp.company_name END DESC NULLS LAST,
+    CASE WHEN p_sort = 'company_name' AND p_ascending THEN jp.company_name END ASC NULLS LAST,
+    CASE WHEN p_sort = 'title' AND NOT p_ascending THEN jp.title END DESC NULLS LAST,
+    CASE WHEN p_sort = 'title' AND p_ascending THEN jp.title END ASC NULLS LAST
+  LIMIT p_limit
+  OFFSET p_offset;
+END;
+$$;
+
+-- sync_target_active: trigger function — body now references targets/user_targets.
+-- CREATE OR REPLACE keeps the existing trg_sync_target_active binding intact.
+CREATE OR REPLACE FUNCTION public.sync_target_active() RETURNS trigger AS $$
+DECLARE
+  _target_id UUID;
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    _target_id := OLD.target_id;
+  ELSE
+    _target_id := NEW.target_id;
+  END IF;
+
+  UPDATE public.targets SET is_active = EXISTS(
+    SELECT 1 FROM public.user_targets
+    WHERE target_id = _target_id AND is_active = TRUE
+  ) WHERE id = _target_id;
+
+  IF TG_OP = 'DELETE' THEN
+    RETURN OLD;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;


### PR DESCRIPTION
## Summary

Phase 2 of the WyrdFold migration (epic #564, parent #596, audit #592). Strips the redundant `job_` prefix from the wyrdfold-namespace tables, disambiguates `batch_jobs`, and renames `tailored_resumes → documents` (it now also holds cover letters per `document_type`). Codemodded all callers in lockstep so no surface is left calling the old names.

Per directive: applying renames in-place on the shared dev Supabase since there's no production data yet — no separate wyrdfold-prod project until beta volume justifies it. See `.claude/docs/wyrdfold-migration/supabase-schema.md` §8 for the full mapping.

## Changes

**Migration** (`supabase/migrations/20260502120000_wyrdfold_rename_pass.sql`)
- Renames 13 tables (e.g. `job_postings → jobs`, `job_targets → targets`, `tailored_resumes → documents`, `llm_cost_log → llm_costs`)
- Renames 5 explicitly-named CHECK/UNIQUE constraints
- DROP+CREATE for functions whose return types or bodies referenced renamed tables: `bulk_update_scores` (was `bulk_update_job_scores`), `bulk_update_salaries`, `match_target_by_label`, `get_target_jobs`
- `CREATE OR REPLACE` of `sync_target_active()` so the trigger binding stays intact

**Python codemod** (49 files in `apps/job-api/`)
- 191 occurrences swept across routers, services, models, tests, scripts
- Storage bucket names (`resume-uploads`, `tailored-resumes`) and column names (`job_posting_id`, `target_id`) deliberately untouched

**Frontend**
- `apps/root/src/app/api/jobs/tailor/cover-letter/route.ts` — only root reference to a renamed table; `.from('job_postings') → .from('jobs')`
- `apps/wyrdfold/src/lib/supabase/types.ts` — placeholder `Database` type (regen from wyrdfold schema after migration applies)

## Out of scope

- Storage bucket renames (`resume-uploads` stays — bucket renames touch storage.objects)
- Column renames (`job_posting_id` columns retain that name even though they FK to the new `jobs` table)
- Explicit index name renames (`idx_job_postings_*` etc — non-functional, follow-up if desired)
- Type regeneration — needs the migration applied to the dev DB first

## Test plan

- [x] `pnpm tsc --noEmit` clean
- [x] `nx typecheck job-api` (mypy) clean — 111 source files
- [x] `nx test job-api` — 736 passed, 79% coverage
- [x] `nx lint job-api` — 4 pre-existing baseline errors (verified via git stash; not introduced)
- [ ] **You**: apply migration to dev Supabase: `pnpm supabase db push`
- [ ] **You**: regenerate types: `pnpm supabase gen types typescript --project-id <id> > libs/shared/audit/src/lib/database.types.ts`
- [ ] **You**: smoke /fitted in dev — list jobs, view target detail, tailor a resume

## Next phase

Phase 3 — `apps/wyrdfold-api` FastAPI fork from job-api.

🤖 Generated with [Claude Code](https://claude.com/claude-code)