### PR TITLE
chore(wyrdfold): regenerate scaffold + untrack next-env.d.ts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ ruvector.db
 # Next.js
 .next
 out
+next-env.d.ts
 
 test-output
 .env*

--- a/apps/root/next-env.d.ts
+++ b/apps/root/next-env.d.ts
@@ -1,6 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/wyrdfold/next-env.d.ts
+++ b/apps/wyrdfold/next-env.d.ts
@@ -1,6 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/wyrdfold/next-env.d.ts
+++ b/apps/wyrdfold/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/wyrdfold/tsconfig.json
+++ b/apps/wyrdfold/tsconfig.json
@@ -48,7 +48,7 @@
   ],
   "references": [
     {
-      "path": "../../libs/shared/ui"
+      "path": "../../libs/shared/ui/tsconfig.json"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Rescaffold `apps/wyrdfold` and `apps/wyrdfold-e2e` from scratch via `@nx/next:application` (linter=eslint, unitTestRunner=jest, e2eTestRunner=playwright, appDir, src, useProjectJson) and restore the Phase 1b/1c customizations (proxy, sentry, instrumentation, lib, state, utils, custom layout/page/global.css, next.config.mjs, jest.config.cts shared-ui aliases, package.json workspace deps) from git history. Net diff vs `feature/fitted` is sync-driven reorders only — confirms current state is regenerable.
- Untrack auto-generated `next-env.d.ts` (added to `.gitignore`, `git rm --cached` for `apps/root` and `apps/wyrdfold`). Removes dirty-tree noise on every push since Next 16 flips the `routes.d.ts` import path between dev and build.

## Test plan
- [x] `pnpm nx run-many -t lint test --projects=wyrdfold,wyrdfold-e2e` ✓
- [x] `pnpm tsc --noEmit` ✓
- [x] `pnpm nx test root` ✓ (147 suites, 1113 tests)
- [x] `CI=true pnpm nx build wyrdfold` ✓ (Tailwind 4, Sentry, Supabase image hosts, proxy middleware all active)
- [x] Pre-commit hooks (eslint, prettier, full typecheck) pass on both commits

Fresh-clone caveat for `next-env.d.ts`: `tsc --noEmit` requires the file to exist (both `tsconfig.json`s include it). Any `nx build`/`nx dev` invocation regenerates it; CI is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)