### PR TITLE
feat(wyrdfold-api): Supabase JWT auth (Phase 3b.2)

### DIFF
--- a/apps/wyrdfold-api/.env.example
+++ b/apps/wyrdfold-api/.env.example
@@ -2,12 +2,14 @@
 SUPABASE_URL=https://<project-ref>.supabase.co
 SUPABASE_SERVICE_ROLE_KEY=
 
-# Shared secret between Next.js proxy routes and this API (x-api-key header)
+# HS256 JWT secret from the Supabase project (Project Settings → API → JWT
+# Settings). Used to verify Bearer tokens minted by Supabase Auth.
+SUPABASE_JWT_SECRET=
+
+# Shared secret between Next.js proxy routes and this API (x-api-key header).
+# Reserved for cron / poller / batch jobs — user requests use Supabase JWTs.
 # Generate: `openssl rand -hex 32`
 WYRDFOLD_API_KEY=
-
-# Must match the admin session secret used by the Next.js app so JWTs verify
-ADMIN_SESSION_SECRET=
 
 # Greenhouse polling knobs
 GREENHOUSE_DELAY_MS=200

--- a/apps/wyrdfold-api/README.md
+++ b/apps/wyrdfold-api/README.md
@@ -1,6 +1,6 @@
 # wyrdfold-api
 
-FastAPI service that powers the standalone WyrdFold product. Forked from `apps/job-api` in Phase 3a (see `.claude/docs/wyrdfold-migration/PHASES.md` and `job-api.md`). Phase 3b.1 renamed the API-key env var (`JOB_API_KEY` → `WYRDFOLD_API_KEY`) and wired Sentry. The remaining 3b slices replace the single-user `tools-admin` JWT path with Supabase auth, thread real `user_id` through services + cache keys, and add per-user token-budget guards.
+FastAPI service that powers the standalone WyrdFold product. Forked from `apps/job-api` in Phase 3a (see `.claude/docs/wyrdfold-migration/PHASES.md` and `job-api.md`). Phase 3b.1 wired Sentry and renamed the shared-secret env var to `WYRDFOLD_API_KEY`. Phase 3b.2 swapped the locally-minted admin session JWT for Supabase auth — user requests now present a Supabase Bearer token, while `WYRDFOLD_API_KEY` is reserved for cron / poller / batch callers. The remaining slices thread real `user_id` through services + cache keys (3b.3) and add per-user token-budget guards (3b.4).
 
 ## Local
 
@@ -23,7 +23,7 @@ The service builds from the monorepo root so the uv workspace lockfile is in sco
      - **Watch Paths**: `apps/wyrdfold-api/**` (prevents rebuilds when only the Next.js app changes).
      - **Networking → Target Port**: `8001`. Must match the port the container binds to. A mismatch returns `502 "Application failed to respond"` with `x-railway-fallback: true` even though the container is healthy.
 
-2. **Set environment variables** (Settings → Variables) from `apps/wyrdfold-api/.env.example`. `WYRDFOLD_API_KEY` is the shared secret between the Next.js proxy and this API. Set `SENTRY_DSN` (and optionally `SENTRY_ENVIRONMENT`, `SENTRY_TRACES_SAMPLE_RATE`) to enable error reporting.
+2. **Set environment variables** (Settings → Variables) from `apps/wyrdfold-api/.env.example`. `SUPABASE_JWT_SECRET` (Supabase Project Settings → API → JWT Settings) verifies user Bearer tokens. `WYRDFOLD_API_KEY` is the cron-only shared secret (poller, batch). Set `SENTRY_DSN` (and optionally `SENTRY_ENVIRONMENT`, `SENTRY_TRACES_SAMPLE_RATE`) to enable error reporting.
 
 3. **Generate the public domain** (Settings → Networking → Generate Domain). Copy the hostname.
 
@@ -40,4 +40,4 @@ The service builds from the monorepo root so the uv workspace lockfile is in sco
 - The Dockerfile uses `ghcr.io/astral-sh/uv:latest` for deps, then `python:3.11-slim` at runtime.
 - Railway supplies `$PORT` at runtime; the `startCommand` in `railway.toml` binds to it.
 - Healthcheck path is `/health`; Railway marks the deploy live once it returns 200.
-- Still **single-tenant** through Phase 3b.1 (hardcoded `tools-admin` user, same as job-api). Do not deploy publicly until Phase 3b.2/3b.3 land Supabase JWT auth and per-user enforcement.
+- Auth is in place (Supabase JWT for users, API key for cron) but the service layer is **still single-tenant** through Phase 3b.2 — every persistence call still resolves to `SINGLE_USER_ID = "tools-admin"`. Do not deploy publicly until Phase 3b.3 threads real `user_id` through services and cache keys.

--- a/apps/wyrdfold-api/app/config.py
+++ b/apps/wyrdfold-api/app/config.py
@@ -8,7 +8,9 @@ class Settings(BaseSettings):
     supabase_url: str = ""
     supabase_service_role_key: str = Field(default="", repr=False)
     wyrdfold_api_key: str = Field(default="", repr=False)
-    admin_session_secret: str = Field(default="", repr=False)
+    # HS256 secret from the Supabase project (Project Settings → API → JWT
+    # Settings). Used to verify Bearer tokens minted by Supabase Auth.
+    supabase_jwt_secret: str = Field(default="", repr=False)
     greenhouse_delay_ms: int = Field(default=200, ge=0, le=10_000)
     score_normalizer: int = 30
     allowed_hosts: str = ""

--- a/apps/wyrdfold-api/app/dependencies.py
+++ b/apps/wyrdfold-api/app/dependencies.py
@@ -14,6 +14,13 @@ if TYPE_CHECKING:
 
 api_key_header = APIKeyHeader(name="x-api-key", auto_error=False)
 
+# Sentinel user_id returned for api-key callers (cron / poller / batch jobs).
+# Real users authenticate via Supabase JWT and `get_current_user_id` returns
+# their JWT `sub` (a UUID). Phase 3b.3 will thread these per-user IDs through
+# the service layer; until then api-key callers stay single-tenant under this
+# label, matching the legacy `tools-admin` value to avoid orphaning rows.
+SINGLE_USER_ID = "tools-admin"
+
 
 def get_settings() -> Settings:
     return settings
@@ -68,58 +75,62 @@ def _extract_bearer_token(request: Request) -> str | None:
     return auth.split(" ", 1)[1].strip() or None
 
 
-def verify_session_jwt(
+def _decode_supabase_jwt(token: str, secret: str) -> dict[str, object]:
+    """Decode an HS256 Supabase access token.
+
+    Raises ``HTTPException(401)`` on any verification failure. ``sub`` and
+    ``exp`` are required so the token always identifies an account and a
+    deadline.
+    """
+    try:
+        payload: dict[str, object] = jwt.decode(
+            token,
+            secret,
+            algorithms=["HS256"],
+            options={"require": ["exp", "sub"]},
+            # Supabase signs access tokens with aud="authenticated".
+            audience="authenticated",
+        )
+    except jwt.PyJWTError as exc:
+        raise HTTPException(status_code=401, detail="Invalid auth token") from exc
+    sub = payload.get("sub")
+    if not isinstance(sub, str) or not sub:
+        raise HTTPException(status_code=401, detail="Invalid auth token")
+    return payload
+
+
+def verify_supabase_jwt(
     request: Request,
     s: Settings = Depends(get_settings),
 ) -> str:
-    if not s.admin_session_secret or len(s.admin_session_secret) < 32:
-        raise HTTPException(status_code=503, detail="Session auth not configured")
+    """Require a valid Supabase Bearer token. Returns the user's `sub`."""
+    if not s.supabase_jwt_secret:
+        raise HTTPException(status_code=503, detail="JWT auth not configured")
     token = _extract_bearer_token(request)
     if not token:
-        raise HTTPException(status_code=401, detail="Missing session token")
-    try:
-        payload = jwt.decode(
-            token,
-            s.admin_session_secret,
-            algorithms=["HS256"],
-            options={"require": ["exp", "sub"]},
-        )
-    except jwt.PyJWTError as exc:
-        raise HTTPException(status_code=401, detail="Invalid session token") from exc
-    if payload.get("sub") != "tools-admin":
-        raise HTTPException(status_code=401, detail="Invalid session token")
+        raise HTTPException(status_code=401, detail="Missing auth token")
+    payload = _decode_supabase_jwt(token, s.supabase_jwt_secret)
     return str(payload["sub"])
 
 
-def verify_api_key_or_session(
+def verify_api_key_or_jwt(
     request: Request,
     key: str | None = Security(api_key_header),
     s: Settings = Depends(get_settings),
 ) -> str:
+    """Accept either the shared API key (cron) or a Supabase JWT (user)."""
     if _api_key_matches(key, s.wyrdfold_api_key):
         return "api-key"
-    if s.admin_session_secret and len(s.admin_session_secret) >= 32:
+    if s.supabase_jwt_secret:
         token = _extract_bearer_token(request)
         if token:
             try:
-                payload = jwt.decode(
-                    token,
-                    s.admin_session_secret,
-                    algorithms=["HS256"],
-                    options={"require": ["exp", "sub"]},
-                )
-            except jwt.PyJWTError:
+                _decode_supabase_jwt(token, s.supabase_jwt_secret)
+            except HTTPException:
                 pass
             else:
-                if payload.get("sub") == "tools-admin":
-                    return "session"
+                return "jwt"
     raise HTTPException(status_code=401, detail="Unauthorized")
-
-
-# Single-admin user identifier used for per-user data (user_targets, etc.)
-# until multi-user auth lands. Matches the JWT `sub` claim minted by
-# apps/root/src/lib/adminSession.ts.
-SINGLE_USER_ID = "tools-admin"
 
 
 def get_current_user_id(
@@ -129,27 +140,20 @@ def get_current_user_id(
 ) -> str:
     """Return the stable user_id for the current request.
 
-    Today there's only one admin (sub=`tools-admin`), so this returns
-    `SINGLE_USER_ID` for both session and API-key callers. When real
-    multi-user auth lands, this will return the JWT sub directly so each
-    user gets their own user_targets rows.
+    Supabase JWT callers get their `sub` (a UUID). API-key callers (cron,
+    poller, batch) get the ``SINGLE_USER_ID`` sentinel — Phase 3b.3 will
+    replace the sentinel with proper per-user routing for cron jobs that
+    iterate users explicitly.
     """
-    if s.admin_session_secret and len(s.admin_session_secret) >= 32:
+    if s.supabase_jwt_secret:
         token = _extract_bearer_token(request)
         if token:
             try:
-                payload = jwt.decode(
-                    token,
-                    s.admin_session_secret,
-                    algorithms=["HS256"],
-                    options={"require": ["exp", "sub"]},
-                )
-            except jwt.PyJWTError:
+                payload = _decode_supabase_jwt(token, s.supabase_jwt_secret)
+            except HTTPException:
                 pass
             else:
-                sub = payload.get("sub")
-                if isinstance(sub, str) and sub:
-                    return sub
+                return str(payload["sub"])
     if _api_key_matches(key, s.wyrdfold_api_key):
         return SINGLE_USER_ID
     raise HTTPException(status_code=401, detail="Unauthorized")

--- a/apps/wyrdfold-api/app/routers/analysis.py
+++ b/apps/wyrdfold-api/app/routers/analysis.py
@@ -10,7 +10,7 @@ from typing import Any, cast
 from fastapi import APIRouter, Depends, HTTPException, Query
 from supabase import Client
 
-from app.dependencies import get_llm_client, get_supabase, verify_api_key_or_session
+from app.dependencies import get_llm_client, get_supabase, verify_api_key_or_jwt
 from app.models.analysis import JobAnalysisRecord
 from app.services.analysis import persistence
 from app.services.analysis.analyze import DEFAULT_PURPOSE, analyze_job
@@ -22,7 +22,7 @@ from app.services.targets import crud as targets_crud
 router = APIRouter(
     prefix="/analysis",
     tags=["analysis"],
-    dependencies=[Depends(verify_api_key_or_session)],
+    dependencies=[Depends(verify_api_key_or_jwt)],
 )
 
 

--- a/apps/wyrdfold-api/app/routers/experience.py
+++ b/apps/wyrdfold-api/app/routers/experience.py
@@ -20,7 +20,7 @@ from app.dependencies import (
     get_embeddings_client,
     get_llm_client,
     get_supabase,
-    verify_api_key_or_session,
+    verify_api_key_or_jwt,
 )
 from app.models.conversation import (
     GapHealthResult,
@@ -65,7 +65,7 @@ from app.services.llm.client import LLMClient, strip_markdown_fence
 router = APIRouter(
     prefix="/experience",
     tags=["experience"],
-    dependencies=[Depends(verify_api_key_or_session)],
+    dependencies=[Depends(verify_api_key_or_jwt)],
 )
 
 

--- a/apps/wyrdfold-api/app/routers/insights.py
+++ b/apps/wyrdfold-api/app/routers/insights.py
@@ -10,14 +10,14 @@ from datetime import UTC, datetime, timedelta
 from fastapi import APIRouter, Depends, Query
 from supabase import Client
 
-from app.dependencies import get_supabase, verify_api_key_or_session
+from app.dependencies import get_supabase, verify_api_key_or_jwt
 from app.models.insights import PipelineInsights, SkillsCostInsights, TargetInsights
 from app.services.insights import compute_pipeline, compute_skills_cost, compute_targets
 
 router = APIRouter(
     prefix="/insights",
     tags=["insights"],
-    dependencies=[Depends(verify_api_key_or_session)],
+    dependencies=[Depends(verify_api_key_or_jwt)],
 )
 
 _PERIOD_DAYS: dict[str, int | None] = {

--- a/apps/wyrdfold-api/app/routers/jobs.py
+++ b/apps/wyrdfold-api/app/routers/jobs.py
@@ -11,7 +11,7 @@ from postgrest.types import CountMethod
 from supabase import Client
 
 from app.cache import job_list_cache, make_cache_key
-from app.dependencies import get_supabase, verify_api_key_or_session
+from app.dependencies import get_supabase, verify_api_key_or_jwt
 from app.http_client import get_http_client
 from app.models.schemas import (
     ManualJobRequest,
@@ -50,7 +50,7 @@ logger = logging.getLogger(__name__)
 router = APIRouter(
     prefix="/jobs",
     tags=["jobs"],
-    dependencies=[Depends(verify_api_key_or_session)],
+    dependencies=[Depends(verify_api_key_or_jwt)],
 )
 
 _JP_SELECT_COLS = (

--- a/apps/wyrdfold-api/app/routers/sources.py
+++ b/apps/wyrdfold-api/app/routers/sources.py
@@ -4,7 +4,7 @@ import httpx
 from fastapi import APIRouter, Depends, HTTPException, Query
 from supabase import Client
 
-from app.dependencies import get_supabase, verify_api_key_or_session
+from app.dependencies import get_supabase, verify_api_key_or_jwt
 from app.http_client import get_http_client
 from app.models.schemas import SourceAction
 from app.seed.company_seed import COMPANY_SEED
@@ -14,7 +14,7 @@ from app.services.greenhouse import GREENHOUSE_BASE
 router = APIRouter(
     prefix="/sources",
     tags=["sources"],
-    dependencies=[Depends(verify_api_key_or_session)],
+    dependencies=[Depends(verify_api_key_or_jwt)],
 )
 
 

--- a/apps/wyrdfold-api/app/routers/status.py
+++ b/apps/wyrdfold-api/app/routers/status.py
@@ -5,13 +5,13 @@ from fastapi import APIRouter, Depends, HTTPException
 from supabase import Client
 
 from app.cache import job_list_cache
-from app.dependencies import get_supabase, verify_api_key_or_session
+from app.dependencies import get_supabase, verify_api_key_or_jwt
 from app.models.schemas import StatusUpdate
 
 router = APIRouter(
     prefix="/jobs",
     tags=["status"],
-    dependencies=[Depends(verify_api_key_or_session)],
+    dependencies=[Depends(verify_api_key_or_jwt)],
 )
 
 

--- a/apps/wyrdfold-api/app/routers/tailor.py
+++ b/apps/wyrdfold-api/app/routers/tailor.py
@@ -27,7 +27,7 @@ from supabase import Client
 from app.dependencies import (
     get_llm_client,
     get_supabase,
-    verify_api_key_or_session,
+    verify_api_key_or_jwt,
 )
 from app.models.batch import BatchJob, BatchRequest, BatchResponse
 from app.models.tailor import (
@@ -71,7 +71,7 @@ from app.services.tailor.reuse import (
 router = APIRouter(
     prefix="/tailor",
     tags=["tailor"],
-    dependencies=[Depends(verify_api_key_or_session)],
+    dependencies=[Depends(verify_api_key_or_jwt)],
 )
 
 @router.post(

--- a/apps/wyrdfold-api/app/routers/targets.py
+++ b/apps/wyrdfold-api/app/routers/targets.py
@@ -17,7 +17,7 @@ from app.dependencies import (
     get_current_user_id,
     get_llm_client,
     get_supabase,
-    verify_api_key_or_session,
+    verify_api_key_or_jwt,
 )
 from app.http_client import get_http_client
 from app.models.schemas import PollResult
@@ -69,7 +69,7 @@ logger = logging.getLogger(__name__)
 router = APIRouter(
     prefix="/targets",
     tags=["targets"],
-    dependencies=[Depends(verify_api_key_or_session)],
+    dependencies=[Depends(verify_api_key_or_jwt)],
 )
 
 

--- a/apps/wyrdfold-api/app/routers/user_profile.py
+++ b/apps/wyrdfold-api/app/routers/user_profile.py
@@ -7,7 +7,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from supabase import Client
 
 from app.config import settings
-from app.dependencies import get_supabase, verify_api_key_or_session
+from app.dependencies import get_supabase, verify_api_key_or_jwt
 from app.models.user_profile import (
     IdentityFields,
     IdentityFieldsUpdate,
@@ -35,7 +35,7 @@ def _sms_channel_available() -> bool:
 router = APIRouter(
     prefix="/profile",
     tags=["profile"],
-    dependencies=[Depends(verify_api_key_or_session)],
+    dependencies=[Depends(verify_api_key_or_jwt)],
 )
 
 # Columns we read / allow writing

--- a/apps/wyrdfold-api/tests/conftest.py
+++ b/apps/wyrdfold-api/tests/conftest.py
@@ -1,7 +1,7 @@
 import os
 
 # Set required env vars BEFORE importing the app so Settings picks them up.
-os.environ.setdefault("ADMIN_SESSION_SECRET", "x" * 32)
+os.environ.setdefault("SUPABASE_JWT_SECRET", "x" * 32)
 os.environ.setdefault("WYRDFOLD_API_KEY", "testkey")
 # Force-overwrite so a local .env with restrictive hosts can't break tests.
 os.environ["ALLOWED_HOSTS"] = "*"

--- a/apps/wyrdfold-api/tests/test_analysis.py
+++ b/apps/wyrdfold-api/tests/test_analysis.py
@@ -344,7 +344,7 @@ async def test_router_cache_hit_skips_llm(
 
     app.dependency_overrides[get_supabase] = lambda: supabase
     app.dependency_overrides[get_llm_client] = lambda: llm
-    app.dependency_overrides[verify_api_key_or_session] = lambda: "test"
+    app.dependency_overrides[verify_api_key_or_jwt] = lambda: "test"
 
     try:
         tc = TestClient(app)
@@ -396,7 +396,7 @@ async def test_router_cache_miss_runs_llm_and_persists(
 
     app.dependency_overrides[get_supabase] = lambda: supabase
     app.dependency_overrides[get_llm_client] = lambda: llm
-    app.dependency_overrides[verify_api_key_or_session] = lambda: "test"
+    app.dependency_overrides[verify_api_key_or_jwt] = lambda: "test"
 
     try:
         tc = TestClient(app)
@@ -425,7 +425,7 @@ async def test_router_missing_optimized_doc_returns_404(
 
     app.dependency_overrides[get_supabase] = lambda: MagicMock()
     app.dependency_overrides[get_llm_client] = lambda: MockLLMClient()
-    app.dependency_overrides[verify_api_key_or_session] = lambda: "test"
+    app.dependency_overrides[verify_api_key_or_jwt] = lambda: "test"
 
     try:
         tc = TestClient(app)
@@ -461,7 +461,7 @@ async def test_router_empty_description_returns_422(
 
     app.dependency_overrides[get_supabase] = lambda: supabase
     app.dependency_overrides[get_llm_client] = lambda: MockLLMClient()
-    app.dependency_overrides[verify_api_key_or_session] = lambda: "test"
+    app.dependency_overrides[verify_api_key_or_jwt] = lambda: "test"
 
     try:
         tc = TestClient(app)
@@ -494,7 +494,7 @@ async def test_router_missing_job_posting_returns_404(
 
     app.dependency_overrides[get_supabase] = lambda: supabase
     app.dependency_overrides[get_llm_client] = lambda: MockLLMClient()
-    app.dependency_overrides[verify_api_key_or_session] = lambda: "test"
+    app.dependency_overrides[verify_api_key_or_jwt] = lambda: "test"
 
     try:
         tc = TestClient(app)
@@ -525,7 +525,7 @@ async def test_router_missing_target_returns_404(
 
     app.dependency_overrides[get_supabase] = lambda: MagicMock()
     app.dependency_overrides[get_llm_client] = lambda: MockLLMClient()
-    app.dependency_overrides[verify_api_key_or_session] = lambda: "test"
+    app.dependency_overrides[verify_api_key_or_jwt] = lambda: "test"
 
     try:
         tc = TestClient(app)
@@ -537,4 +537,4 @@ async def test_router_missing_target_returns_404(
 
 
 # Need these imports for dependency overrides
-from app.dependencies import get_llm_client, get_supabase, verify_api_key_or_session
+from app.dependencies import get_llm_client, get_supabase, verify_api_key_or_jwt

--- a/apps/wyrdfold-api/tests/test_dependencies.py
+++ b/apps/wyrdfold-api/tests/test_dependencies.py
@@ -6,13 +6,16 @@ from fastapi import HTTPException, Request
 
 from app.config import Settings
 from app.dependencies import (
+    SINGLE_USER_ID,
     _api_key_matches,
+    get_current_user_id,
     verify_api_key,
-    verify_api_key_or_session,
-    verify_session_jwt,
+    verify_api_key_or_jwt,
+    verify_supabase_jwt,
 )
 
-SECRET = "x" * 32
+JWT_SECRET = "x" * 32
+USER_SUB = "11111111-1111-1111-1111-111111111111"
 
 
 def _make_request(headers: dict[str, str] | None = None) -> Request:
@@ -29,13 +32,18 @@ def _make_request(headers: dict[str, str] | None = None) -> Request:
     return Request(scope)
 
 
-def _settings(api_key: str = "testkey", secret: str = SECRET) -> Settings:
-    return Settings(wyrdfold_api_key=api_key, admin_session_secret=secret)
+def _settings(api_key: str = "testkey", jwt_secret: str = JWT_SECRET) -> Settings:
+    return Settings(wyrdfold_api_key=api_key, supabase_jwt_secret=jwt_secret)
 
 
-def _mint(sub: str = "tools-admin", secret: str = SECRET) -> str:
+def _mint(
+    sub: str = USER_SUB,
+    secret: str = JWT_SECRET,
+    aud: str = "authenticated",
+) -> str:
     payload = {
         "sub": sub,
+        "aud": aud,
         "exp": datetime.now(UTC) + timedelta(hours=1),
     }
     return jwt.encode(payload, secret, algorithm="HS256")
@@ -77,53 +85,106 @@ def test_verify_api_key_returns_on_match():
     assert verify_api_key(key="testkey", s=_settings()) == "testkey"
 
 
-def test_verify_session_jwt_short_secret():
+def test_verify_supabase_jwt_unconfigured():
     req = _make_request({"authorization": f"Bearer {_mint()}"})
     with pytest.raises(HTTPException) as exc:
-        verify_session_jwt(req, s=_settings(secret="short"))
+        verify_supabase_jwt(req, s=_settings(jwt_secret=""))
     assert exc.value.status_code == 503
 
 
-def test_verify_session_jwt_missing_token():
+def test_verify_supabase_jwt_missing_token():
     req = _make_request()
     with pytest.raises(HTTPException) as exc:
-        verify_session_jwt(req, s=_settings())
+        verify_supabase_jwt(req, s=_settings())
     assert exc.value.status_code == 401
 
 
-def test_verify_session_jwt_wrong_key():
+def test_verify_supabase_jwt_wrong_signature():
     bad_token = _mint(secret="y" * 32)
     req = _make_request({"authorization": f"Bearer {bad_token}"})
     with pytest.raises(HTTPException) as exc:
-        verify_session_jwt(req, s=_settings())
+        verify_supabase_jwt(req, s=_settings())
     assert exc.value.status_code == 401
 
 
-def test_verify_session_jwt_wrong_sub():
-    bad_token = _mint(sub="someone-else")
+def test_verify_supabase_jwt_wrong_audience():
+    bad_token = _mint(aud="anon")
     req = _make_request({"authorization": f"Bearer {bad_token}"})
     with pytest.raises(HTTPException) as exc:
-        verify_session_jwt(req, s=_settings())
+        verify_supabase_jwt(req, s=_settings())
     assert exc.value.status_code == 401
 
 
-def test_verify_session_jwt_valid():
+def test_verify_supabase_jwt_expired():
+    payload = {
+        "sub": USER_SUB,
+        "aud": "authenticated",
+        "exp": datetime.now(UTC) - timedelta(hours=1),
+    }
+    token = jwt.encode(payload, JWT_SECRET, algorithm="HS256")
+    req = _make_request({"authorization": f"Bearer {token}"})
+    with pytest.raises(HTTPException) as exc:
+        verify_supabase_jwt(req, s=_settings())
+    assert exc.value.status_code == 401
+
+
+def test_verify_supabase_jwt_malformed_bearer():
+    req = _make_request({"authorization": "Token abc.def.ghi"})
+    with pytest.raises(HTTPException) as exc:
+        verify_supabase_jwt(req, s=_settings())
+    assert exc.value.status_code == 401
+
+
+def test_verify_supabase_jwt_valid_returns_sub():
     req = _make_request({"authorization": f"Bearer {_mint()}"})
-    assert verify_session_jwt(req, s=_settings()) == "tools-admin"
+    assert verify_supabase_jwt(req, s=_settings()) == USER_SUB
 
 
-def test_verify_api_key_or_session_accepts_api_key():
+def test_verify_api_key_or_jwt_accepts_api_key():
     req = _make_request()
-    assert verify_api_key_or_session(req, key="testkey", s=_settings()) == "api-key"
+    assert verify_api_key_or_jwt(req, key="testkey", s=_settings()) == "api-key"
 
 
-def test_verify_api_key_or_session_accepts_session():
+def test_verify_api_key_or_jwt_accepts_jwt():
     req = _make_request({"authorization": f"Bearer {_mint()}"})
-    assert verify_api_key_or_session(req, key=None, s=_settings()) == "session"
+    assert verify_api_key_or_jwt(req, key=None, s=_settings()) == "jwt"
 
 
-def test_verify_api_key_or_session_rejects_both_missing():
+def test_verify_api_key_or_jwt_rejects_both_missing():
     req = _make_request()
     with pytest.raises(HTTPException) as exc:
-        verify_api_key_or_session(req, key=None, s=_settings())
+        verify_api_key_or_jwt(req, key=None, s=_settings())
     assert exc.value.status_code == 401
+
+
+def test_verify_api_key_or_jwt_rejects_invalid_jwt():
+    bad_token = _mint(secret="y" * 32)
+    req = _make_request({"authorization": f"Bearer {bad_token}"})
+    with pytest.raises(HTTPException) as exc:
+        verify_api_key_or_jwt(req, key=None, s=_settings())
+    assert exc.value.status_code == 401
+
+
+def test_get_current_user_id_returns_jwt_sub():
+    req = _make_request({"authorization": f"Bearer {_mint()}"})
+    assert get_current_user_id(req, key=None, s=_settings()) == USER_SUB
+
+
+def test_get_current_user_id_returns_sentinel_for_api_key():
+    req = _make_request()
+    assert get_current_user_id(req, key="testkey", s=_settings()) == SINGLE_USER_ID
+
+
+def test_get_current_user_id_rejects_unauthenticated():
+    req = _make_request()
+    with pytest.raises(HTTPException) as exc:
+        get_current_user_id(req, key=None, s=_settings())
+    assert exc.value.status_code == 401
+
+
+def test_get_current_user_id_prefers_jwt_over_api_key():
+    """If both a valid JWT and a valid API key are present, prefer the JWT
+    so the request runs under the user's identity, not the cron sentinel.
+    """
+    req = _make_request({"authorization": f"Bearer {_mint()}"})
+    assert get_current_user_id(req, key="testkey", s=_settings()) == USER_SUB

--- a/apps/wyrdfold-api/tests/test_routers_sources.py
+++ b/apps/wyrdfold-api/tests/test_routers_sources.py
@@ -5,7 +5,7 @@ import httpx
 import pytest
 from fastapi.testclient import TestClient
 
-from app.dependencies import get_supabase, verify_api_key_or_session
+from app.dependencies import get_supabase, verify_api_key_or_jwt
 from app.main import app
 from app.seed.company_seed import COMPANY_SEED
 
@@ -20,7 +20,7 @@ def client_factory():
     def _make(supabase: MagicMock, *, authed: bool = True) -> TestClient:
         app.dependency_overrides[get_supabase] = lambda: supabase
         if authed:
-            app.dependency_overrides[verify_api_key_or_session] = lambda: "test"
+            app.dependency_overrides[verify_api_key_or_jwt] = lambda: "test"
         return TestClient(app)
 
     yield _make

--- a/apps/wyrdfold-api/tests/test_routers_status.py
+++ b/apps/wyrdfold-api/tests/test_routers_status.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock
 import pytest
 from fastapi.testclient import TestClient
 
-from app.dependencies import get_supabase, verify_api_key_or_session
+from app.dependencies import get_supabase, verify_api_key_or_jwt
 from app.main import app
 
 
@@ -32,7 +32,7 @@ def client_factory():
     def _make(supabase: MagicMock, *, authed: bool = True) -> TestClient:
         app.dependency_overrides[get_supabase] = lambda: supabase
         if authed:
-            app.dependency_overrides[verify_api_key_or_session] = lambda: "test"
+            app.dependency_overrides[verify_api_key_or_jwt] = lambda: "test"
         c = TestClient(app)
         return c
 

--- a/apps/wyrdfold-api/tests/test_tailor_gap_gate.py
+++ b/apps/wyrdfold-api/tests/test_tailor_gap_gate.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from fastapi.testclient import TestClient
 
-from app.dependencies import get_supabase, verify_api_key_or_session
+from app.dependencies import get_supabase, verify_api_key_or_jwt
 from app.main import app
 from app.models.experience import (
     OptimizedDoc,
@@ -61,7 +61,7 @@ def _high_gap_pct_but_structural_ok() -> OptimizedPayload:
 class TestGapGateResume:
     @pytest.fixture(autouse=True)
     def _overrides(self):
-        app.dependency_overrides[verify_api_key_or_session] = lambda: "test"
+        app.dependency_overrides[verify_api_key_or_jwt] = lambda: "test"
         app.dependency_overrides[get_supabase] = lambda: MagicMock()
         yield
         app.dependency_overrides.clear()

--- a/apps/wyrdfold-api/tests/test_target_scoring.py
+++ b/apps/wyrdfold-api/tests/test_target_scoring.py
@@ -244,7 +244,7 @@ def test_list_jobs_without_target_returns_global_view(
     """Global view queries jobs directly with global scores."""
     from fastapi.testclient import TestClient
 
-    from app.dependencies import get_supabase, verify_api_key_or_session
+    from app.dependencies import get_supabase, verify_api_key_or_jwt
     from app.main import app
 
     def _fluent_mock(data: list[dict]) -> MagicMock:
@@ -269,7 +269,7 @@ def test_list_jobs_without_target_returns_global_view(
     supabase.table.return_value = jp_mock
 
     app.dependency_overrides[get_supabase] = lambda: supabase
-    app.dependency_overrides[verify_api_key_or_session] = lambda: "test"
+    app.dependency_overrides[verify_api_key_or_jwt] = lambda: "test"
 
     try:
         tc = TestClient(app)
@@ -288,7 +288,7 @@ def test_list_jobs_with_target_overlays_target_score(
 ) -> None:
     from fastapi.testclient import TestClient
 
-    from app.dependencies import get_supabase, verify_api_key_or_session
+    from app.dependencies import get_supabase, verify_api_key_or_jwt
     from app.main import app
 
     def _fluent_mock(data: list[dict]) -> MagicMock:
@@ -330,7 +330,7 @@ def test_list_jobs_with_target_overlays_target_score(
     )
 
     app.dependency_overrides[get_supabase] = lambda: supabase
-    app.dependency_overrides[verify_api_key_or_session] = lambda: "test"
+    app.dependency_overrides[verify_api_key_or_jwt] = lambda: "test"
 
     try:
         tc = TestClient(app)
@@ -353,7 +353,7 @@ def test_rescore_endpoint_returns_count(
 ) -> None:
     from fastapi.testclient import TestClient
 
-    from app.dependencies import get_supabase, verify_api_key_or_session
+    from app.dependencies import get_supabase, verify_api_key_or_jwt
     from app.main import app
     from app.routers import jobs as jobs_router
 
@@ -363,7 +363,7 @@ def test_rescore_endpoint_returns_count(
 
     supabase = MagicMock()
     app.dependency_overrides[get_supabase] = lambda: supabase
-    app.dependency_overrides[verify_api_key_or_session] = lambda: "test"
+    app.dependency_overrides[verify_api_key_or_jwt] = lambda: "test"
 
     try:
         tc = TestClient(app)
@@ -381,7 +381,7 @@ def test_rescore_endpoint_missing_target_returns_404(
 ) -> None:
     from fastapi.testclient import TestClient
 
-    from app.dependencies import get_supabase, verify_api_key_or_session
+    from app.dependencies import get_supabase, verify_api_key_or_jwt
     from app.main import app
     from app.routers import jobs as jobs_router
 
@@ -389,7 +389,7 @@ def test_rescore_endpoint_missing_target_returns_404(
 
     supabase = MagicMock()
     app.dependency_overrides[get_supabase] = lambda: supabase
-    app.dependency_overrides[verify_api_key_or_session] = lambda: "test"
+    app.dependency_overrides[verify_api_key_or_jwt] = lambda: "test"
 
     try:
         tc = TestClient(app)

--- a/apps/wyrdfold-api/tests/test_user_profile_router.py
+++ b/apps/wyrdfold-api/tests/test_user_profile_router.py
@@ -8,7 +8,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from app.config import settings
-from app.dependencies import get_supabase, verify_api_key_or_session
+from app.dependencies import get_supabase, verify_api_key_or_jwt
 from app.main import app
 
 
@@ -22,7 +22,7 @@ class _Resp:
 def client_factory():
     def _make(supabase: MagicMock) -> TestClient:
         app.dependency_overrides[get_supabase] = lambda: supabase
-        app.dependency_overrides[verify_api_key_or_session] = lambda: "test"
+        app.dependency_overrides[verify_api_key_or_jwt] = lambda: "test"
         return TestClient(app)
 
     yield _make


### PR DESCRIPTION
## Summary

Replaces the inherited admin-session JWT (HS256 over `ADMIN_SESSION_SECRET`, hardcoded `sub=tools-admin`) with real Supabase Bearer-token verification. The two callers stay separate:

- **Users** present a Supabase access token (HS256 over `SUPABASE_JWT_SECRET`, `aud=authenticated`, `sub` is the user UUID).
- **Cron / poller / batch** continue to use the `x-api-key` header keyed by `WYRDFOLD_API_KEY`.

Service-layer multi-tenancy isn't done yet — every persistence call still resolves to `SINGLE_USER_ID = "tools-admin"`. That's Phase 3b.3.

## Changes

- `app/dependencies.py`
  - New `_decode_supabase_jwt` — central HS256 verifier. Requires `sub`, `exp`; enforces `aud="authenticated"`.
  - New `verify_supabase_jwt` (returns the user's `sub`) and `verify_api_key_or_jwt` (returns `"api-key"` or `"jwt"`).
  - `get_current_user_id`: prefers the JWT `sub` over the api-key fallback so a request carrying both runs under the user's identity.
  - Drops `verify_session_jwt` + `verify_api_key_or_session` and the `admin_session_secret` setting.
- `app/config.py` — `admin_session_secret` → `supabase_jwt_secret`.
- All routers: mechanical rename `verify_api_key_or_session` → `verify_api_key_or_jwt`.
- `tests/test_dependencies.py` — rewrites the auth tests against the Supabase token shape: valid token, expired, wrong audience, wrong signature, malformed Bearer, missing token, and JWT-vs-api-key precedence.
- `tests/conftest.py` + `.env.example`: `ADMIN_SESSION_SECRET` → `SUPABASE_JWT_SECRET`.
- README: refreshed Phase 3b status.

## Phase 3b plan

- ✅ 3b.1 — Sentry + env-var rename (#616, merged)
- ✅ **3b.2 (this PR)** — Supabase JWT auth
- 3b.3 — Thread real `user_id` through services + cache keys; remove the `SINGLE_USER_ID` sentinel
- 3b.4 — Per-user token-budget guards

## Verification

- `pnpm nx test wyrdfold-api` — **743 passed** (+7 vs 3b.1: new auth-test coverage, dropped one obsolete admin-session test)
- `pnpm nx typecheck wyrdfold-api` — mypy success on 112 source files
- `pnpm nx dev wyrdfold-api` (with `ALLOWED_HOSTS='*'`) → `GET /health` returns `{"status":"ok"}`

`pnpm nx lint wyrdfold-api` still reports the 4 pre-existing inherited errors — out of scope.

## Ops impact

`SUPABASE_JWT_SECRET` becomes a required env var on staging/prod (find it in the Supabase project's Settings → API → JWT Settings). `ADMIN_SESSION_SECRET` is no longer read.

## Test plan

- [ ] CI green (typecheck, test)
- [ ] When wiring Phase 4 BFF routes, confirm a Supabase user token survives the proxy hop and decodes here

🤖 Generated with [Claude Code](https://claude.com/claude-code)