### PR TITLE
feat(wyrdfold-api): thread real user_id through services (Phase 3b.3)

### DIFF
--- a/apps/wyrdfold-api/app/dependencies.py
+++ b/apps/wyrdfold-api/app/dependencies.py
@@ -14,13 +14,6 @@ if TYPE_CHECKING:
 
 api_key_header = APIKeyHeader(name="x-api-key", auto_error=False)
 
-# Sentinel user_id returned for api-key callers (cron / poller / batch jobs).
-# Real users authenticate via Supabase JWT and `get_current_user_id` returns
-# their JWT `sub` (a UUID). Phase 3b.3 will thread these per-user IDs through
-# the service layer; until then api-key callers stay single-tenant under this
-# label, matching the legacy `tools-admin` value to avoid orphaning rows.
-SINGLE_USER_ID = "tools-admin"
-
 
 def get_settings() -> Settings:
     return settings
@@ -133,27 +126,49 @@ def verify_api_key_or_jwt(
     raise HTTPException(status_code=401, detail="Unauthorized")
 
 
+def _try_decode_jwt_sub(request: Request, s: Settings) -> str | None:
+    """Return the JWT `sub` if a valid Bearer token is present, else None."""
+    if not s.supabase_jwt_secret:
+        return None
+    token = _extract_bearer_token(request)
+    if not token:
+        return None
+    try:
+        payload = _decode_supabase_jwt(token, s.supabase_jwt_secret)
+    except HTTPException:
+        return None
+    return str(payload["sub"])
+
+
 def get_current_user_id(
+    request: Request,
+    s: Settings = Depends(get_settings),
+) -> str:
+    """Return the JWT `sub` for the current request (JWT-required).
+
+    Use on endpoints that need a real user identity (no api-key fallback).
+    """
+    sub = _try_decode_jwt_sub(request, s)
+    if sub is None:
+        raise HTTPException(status_code=401, detail="Unauthorized")
+    return sub
+
+
+def get_current_user_id_optional(
     request: Request,
     key: str | None = Security(api_key_header),
     s: Settings = Depends(get_settings),
-) -> str:
-    """Return the stable user_id for the current request.
+) -> str | None:
+    """Return the JWT `sub`, or None for api-key callers (cron/poller/batch).
 
-    Supabase JWT callers get their `sub` (a UUID). API-key callers (cron,
-    poller, batch) get the ``SINGLE_USER_ID`` sentinel — Phase 3b.3 will
-    replace the sentinel with proper per-user routing for cron jobs that
-    iterate users explicitly.
+    Routes accepting both auth modes use this to thread the user identity
+    through the service layer: JWT → real per-user data, api-key → legacy
+    single-tenant rows (where user_id IS NULL). Raises 401 if neither auth
+    mode matches.
     """
-    if s.supabase_jwt_secret:
-        token = _extract_bearer_token(request)
-        if token:
-            try:
-                payload = _decode_supabase_jwt(token, s.supabase_jwt_secret)
-            except HTTPException:
-                pass
-            else:
-                return str(payload["sub"])
+    sub = _try_decode_jwt_sub(request, s)
+    if sub is not None:
+        return sub
     if _api_key_matches(key, s.wyrdfold_api_key):
-        return SINGLE_USER_ID
+        return None
     raise HTTPException(status_code=401, detail="Unauthorized")

--- a/apps/wyrdfold-api/app/routers/analysis.py
+++ b/apps/wyrdfold-api/app/routers/analysis.py
@@ -10,7 +10,12 @@ from typing import Any, cast
 from fastapi import APIRouter, Depends, HTTPException, Query
 from supabase import Client
 
-from app.dependencies import get_llm_client, get_supabase, verify_api_key_or_jwt
+from app.dependencies import (
+    get_current_user_id_optional,
+    get_llm_client,
+    get_supabase,
+    verify_api_key_or_jwt,
+)
 from app.models.analysis import JobAnalysisRecord
 from app.services.analysis import persistence
 from app.services.analysis.analyze import DEFAULT_PURPOSE, analyze_job
@@ -32,9 +37,10 @@ async def create_analysis(
     target_id: str = Query(..., description="Target the user is viewing the job under"),
     supabase: Client = Depends(get_supabase),
     llm: LLMClient = Depends(get_llm_client),
+    user_id: str | None = Depends(get_current_user_id_optional),
 ) -> JobAnalysisRecord:
     # 1. Fetch optimized doc (needed for cache key)
-    current_optimized = optimized.get_latest(supabase, user_id=None)
+    current_optimized = optimized.get_latest(supabase, user_id=user_id)
     if current_optimized is None:
         raise HTTPException(
             status_code=404,
@@ -47,7 +53,7 @@ async def create_analysis(
         job_id,
         target_id=target_id,
         optimized_doc_id=current_optimized.id,
-        user_id=None,
+        user_id=user_id,
     )
     if cached is not None:
         return cached
@@ -90,7 +96,7 @@ async def create_analysis(
     # 6. Log cost
     cost_log.record(
         supabase,
-        user_id=None,
+        user_id=user_id,
         purpose=DEFAULT_PURPOSE,
         result=llm_result,
         metadata={
@@ -105,7 +111,7 @@ async def create_analysis(
         supabase,
         job_posting_id=job_id,
         target_id=target_id,
-        user_id=None,
+        user_id=user_id,
         optimized_doc_id=current_optimized.id,
         analysis=analysis,
         llm_result=llm_result,

--- a/apps/wyrdfold-api/app/routers/experience.py
+++ b/apps/wyrdfold-api/app/routers/experience.py
@@ -17,6 +17,7 @@ from pydantic import ValidationError
 from supabase import Client
 
 from app.dependencies import (
+    get_current_user_id_optional,
     get_embeddings_client,
     get_llm_client,
     get_supabase,
@@ -75,8 +76,9 @@ router = APIRouter(
 @router.get("/prose")
 async def get_prose(
     supabase: Client = Depends(get_supabase),
+    user_id: str | None = Depends(get_current_user_id_optional),
 ) -> ProseDoc | dict[str, None]:
-    doc = prose.get_latest(supabase, user_id=None)
+    doc = prose.get_latest(supabase, user_id=user_id)
     if doc is None:
         return {"prose": None}
     return doc
@@ -86,14 +88,16 @@ async def get_prose(
 async def create_prose(
     body: ProseDocCreate,
     supabase: Client = Depends(get_supabase),
+    user_id: str | None = Depends(get_current_user_id_optional),
 ) -> ProseDoc:
-    return prose.create_version(supabase, user_id=None, content=body.content)
+    return prose.create_version(supabase, user_id=user_id, content=body.content)
 
 
 @router.post("/prose/consolidate")
 async def consolidate_prose(
     supabase: Client = Depends(get_supabase),
     llm: LLMClient = Depends(get_llm_client),
+    user_id: str | None = Depends(get_current_user_id_optional),
 ) -> ProseConsolidateResponse:
     """LLM-dedupe the latest prose doc and persist as a new version.
 
@@ -101,7 +105,7 @@ async def consolidate_prose(
     contain multiple near-identical resume copies. This pass merges them.
     The result is always a new version — the original stays in history.
     """
-    latest = prose.get_latest(supabase, user_id=None)
+    latest = prose.get_latest(supabase, user_id=user_id)
     if latest is None:
         raise HTTPException(status_code=404, detail="no prose doc to consolidate")
 
@@ -119,7 +123,7 @@ async def consolidate_prose(
             metadata["fallback_reason"] = fallback_reason
         cost_log.record(
             supabase,
-            user_id=None,
+            user_id=user_id,
             purpose=consolidate.DEFAULT_PURPOSE,
             result=result,
             metadata=metadata,
@@ -139,7 +143,7 @@ async def consolidate_prose(
             fallback_reason=fallback_reason,
         )
 
-    new_doc = prose.create_version(supabase, user_id=None, content=consolidated)
+    new_doc = prose.create_version(supabase, user_id=user_id, content=consolidated)
     return ProseConsolidateResponse(
         prose=new_doc,
         chars_before=len(latest.content),
@@ -159,6 +163,7 @@ async def upload_resume(
     supabase: Client = Depends(get_supabase),
     llm: LLMClient = Depends(get_llm_client),
     embeddings: EmbeddingsClient = Depends(get_embeddings_client),
+    user_id: str | None = Depends(get_current_user_id_optional),
 ) -> ResumeUploadResponse:
     """Upload a resume file (PDF/DOCX), extract text, merge into prose doc."""
     content_type = file.content_type or ""
@@ -195,7 +200,7 @@ async def upload_resume(
     try:
         storage_path = upload_file(
             supabase,
-            user_id=None,
+            user_id=user_id,
             upload_id=upload_id,
             file_bytes=file_bytes,
             file_ext=file_ext,
@@ -206,17 +211,17 @@ async def upload_resume(
         storage_path = ""
 
     # Merge into prose doc — semantic merge via LLM (#497).
-    existing = prose.get_latest(supabase, user_id=None)
+    existing = prose.get_latest(supabase, user_id=user_id)
     merged, merge_result = await merge_into_prose(
         llm,
         existing_content=existing.content if existing else None,
         parsed=parsed,
     )
-    prose_doc = prose.create_version(supabase, user_id=None, content=merged)
+    prose_doc = prose.create_version(supabase, user_id=user_id, content=merged)
     if merge_result is not None:
         cost_log.record(
             supabase,
-            user_id=None,
+            user_id=user_id,
             purpose="experience.ingest_merge",
             result=merge_result,
             metadata={"prose_doc_id": prose_doc.id, "filename": filename},
@@ -225,7 +230,7 @@ async def upload_resume(
     # Track the upload
     upload_row: dict[str, Any] = {
         "id": upload_id,
-        "user_id": None,
+        "user_id": user_id,
         "filename": filename,
         "file_type": parsed.file_type,
         "storage_path": storage_path,
@@ -245,7 +250,7 @@ async def upload_resume(
         )
         cost_log.record(
             supabase,
-            user_id=None,
+            user_id=user_id,
             purpose=derive.DEFAULT_PURPOSE,
             result=result,
             metadata={"prose_doc_id": prose_doc.id, "prose_version": prose_doc.version},
@@ -253,7 +258,7 @@ async def upload_resume(
 
         # Carry forward annotations from previous doc and merge with any
         # the LLM extracted from inline prose comments this round (#499).
-        previous_opt = optimized.get_latest(supabase, user_id=None)
+        previous_opt = optimized.get_latest(supabase, user_id=user_id)
         carried = (
             annotations.validate_annotation_refs(
                 previous_opt.payload.annotations, payload
@@ -266,12 +271,12 @@ async def upload_resume(
 
         doc = optimized.create_version(
             supabase,
-            user_id=None,
+            user_id=user_id,
             payload=payload,
             prose_doc_id=prose_doc.id,
             source="llm",
         )
-        await chunks.upsert_for_optimized(supabase, embeddings, doc, user_id=None)
+        await chunks.upsert_for_optimized(supabase, embeddings, doc, user_id=user_id)
         optimized_doc_id = doc.id
 
     return ResumeUploadResponse(
@@ -292,8 +297,9 @@ async def upload_resume(
 @router.get("/optimized")
 def get_optimized(
     supabase: Client = Depends(get_supabase),
+    user_id: str | None = Depends(get_current_user_id_optional),
 ) -> OptimizedDoc | dict[str, None]:
-    doc = optimized.get_latest(supabase, user_id=None)
+    doc = optimized.get_latest(supabase, user_id=user_id)
     if doc is None:
         return {"optimized": None}
     return doc
@@ -304,10 +310,11 @@ async def create_optimized(
     body: OptimizedDocUpsert,
     supabase: Client = Depends(get_supabase),
     embeddings: EmbeddingsClient = Depends(get_embeddings_client),
+    user_id: str | None = Depends(get_current_user_id_optional),
 ) -> OptimizedDoc:
     doc = optimized.create_version(
         supabase,
-        user_id=None,
+        user_id=user_id,
         payload=body.payload,
         prose_doc_id=body.prose_doc_id,
         source=body.source,
@@ -317,7 +324,7 @@ async def create_optimized(
         supabase,
         embeddings,
         doc,
-        user_id=None,
+        user_id=user_id,
     )
     return doc
 
@@ -327,6 +334,7 @@ async def derive_optimized(
     supabase: Client = Depends(get_supabase),
     llm: LLMClient = Depends(get_llm_client),
     embeddings: EmbeddingsClient = Depends(get_embeddings_client),
+    user_id: str | None = Depends(get_current_user_id_optional),
 ) -> OptimizedDoc:
     """Read the latest prose doc, derive an OptimizedPayload via LLM,
     persist it as a new optimized version, embed its chunks, and log cost.
@@ -336,11 +344,11 @@ async def derive_optimized(
     otherwise. User-edited optimized docs (source="user_edit") never
     short-circuit; the user has explicitly asked to regenerate.
     """
-    prose_doc = prose.get_latest(supabase, user_id=None)
+    prose_doc = prose.get_latest(supabase, user_id=user_id)
     if prose_doc is None:
         raise HTTPException(status_code=404, detail="no prose doc to derive from")
 
-    previous = optimized.get_latest(supabase, user_id=None)
+    previous = optimized.get_latest(supabase, user_id=user_id)
     if (
         previous is not None
         and previous.prose_doc_id == prose_doc.id
@@ -354,7 +362,7 @@ async def derive_optimized(
     )
     cost_log.record(
         supabase,
-        user_id=None,
+        user_id=user_id,
         purpose=derive.DEFAULT_PURPOSE,
         result=result,
         metadata={"prose_doc_id": prose_doc.id, "prose_version": prose_doc.version},
@@ -374,7 +382,7 @@ async def derive_optimized(
 
     doc = optimized.create_version(
         supabase,
-        user_id=None,
+        user_id=user_id,
         payload=payload,
         prose_doc_id=prose_doc.id,
         source="llm",
@@ -383,7 +391,7 @@ async def derive_optimized(
         supabase,
         embeddings,
         doc,
-        user_id=None,
+        user_id=user_id,
     )
     return doc
 
@@ -404,6 +412,7 @@ async def derive_optimized_stream(
     supabase: Client = Depends(get_supabase),
     llm: LLMClient = Depends(get_llm_client),
     embeddings: EmbeddingsClient = Depends(get_embeddings_client),
+    user_id: str | None = Depends(get_current_user_id_optional),
 ) -> StreamingResponse:
     """Streaming variant of /derive.
 
@@ -419,11 +428,11 @@ async def derive_optimized_stream(
     have already been sent. Pre-flight errors (missing prose) still come
     back as HTTP 404 before any SSE frame is written.
     """
-    prose_doc = prose.get_latest(supabase, user_id=None)
+    prose_doc = prose.get_latest(supabase, user_id=user_id)
     if prose_doc is None:
         raise HTTPException(status_code=404, detail="no prose doc to derive from")
 
-    previous = optimized.get_latest(supabase, user_id=None)
+    previous = optimized.get_latest(supabase, user_id=user_id)
 
     async def generate() -> AsyncIterator[bytes]:
         if (
@@ -469,7 +478,7 @@ async def derive_optimized_stream(
 
         cost_log.record(
             supabase,
-            user_id=None,
+            user_id=user_id,
             purpose=derive.DEFAULT_PURPOSE,
             result=result,
             metadata={
@@ -491,7 +500,7 @@ async def derive_optimized_stream(
 
         doc = optimized.create_version(
             supabase,
-            user_id=None,
+            user_id=user_id,
             payload=payload,
             prose_doc_id=prose_doc.id,
             source="llm",
@@ -500,7 +509,7 @@ async def derive_optimized_stream(
             supabase,
             embeddings,
             doc,
-            user_id=None,
+            user_id=user_id,
         )
 
         yield _sse_event(
@@ -524,8 +533,9 @@ async def derive_optimized_stream(
 @router.get("/gap-health")
 def get_gap_health(
     supabase: Client = Depends(get_supabase),
+    user_id: str | None = Depends(get_current_user_id_optional),
 ) -> GapHealthResult:
-    doc = optimized.get_latest(supabase, user_id=None)
+    doc = optimized.get_latest(supabase, user_id=user_id)
     if doc is None:
         return gap_tracker.gap_health(OptimizedPayload())
     return gap_tracker.gap_health(doc.payload)
@@ -537,8 +547,9 @@ def get_gap_health(
 @router.get("/preferences")
 async def get_preferences(
     supabase: Client = Depends(get_supabase),
+    user_id: str | None = Depends(get_current_user_id_optional),
 ) -> Preferences | dict[str, None]:
-    row = preferences.get(supabase, user_id=None)
+    row = preferences.get(supabase, user_id=user_id)
     if row is None:
         return {"preferences": None}
     return row
@@ -548,15 +559,17 @@ async def get_preferences(
 async def upsert_preferences(
     body: PreferencesUpsert,
     supabase: Client = Depends(get_supabase),
+    user_id: str | None = Depends(get_current_user_id_optional),
 ) -> Preferences:
-    return preferences.upsert(supabase, user_id=None, payload=body.payload)
+    return preferences.upsert(supabase, user_id=user_id, payload=body.payload)
 
 
 @router.delete("/preferences")
 async def reset_preferences(
     supabase: Client = Depends(get_supabase),
+    user_id: str | None = Depends(get_current_user_id_optional),
 ) -> dict[str, bool]:
-    preferences.reset(supabase, user_id=None)
+    preferences.reset(supabase, user_id=user_id)
     return {"success": True}
 
 
@@ -568,10 +581,11 @@ async def list_turns(
     conversation_type: ConversationType | None = Query(default=None),
     limit: int = Query(default=200, ge=1, le=1000),
     supabase: Client = Depends(get_supabase),
+    user_id: str | None = Depends(get_current_user_id_optional),
 ) -> dict[str, Any]:
     rows = turns.list_turns(
         supabase,
-        user_id=None,
+        user_id=user_id,
         conversation_type=conversation_type,
         limit=limit,
     )
@@ -582,12 +596,13 @@ async def list_turns(
 async def append_turn(
     body: TurnAppend,
     supabase: Client = Depends(get_supabase),
+    user_id: str | None = Depends(get_current_user_id_optional),
 ) -> dict[str, Any]:
     if body.skipped and body.role != "user":
         raise HTTPException(status_code=400, detail="only user turns can be skipped")
     turn = turns.append(
         supabase,
-        user_id=None,
+        user_id=user_id,
         conversation_type=body.conversation_type,
         role=body.role,
         content=body.content,
@@ -605,6 +620,7 @@ async def conversation_turn(
     body: TurnRequest,
     supabase: Client = Depends(get_supabase),
     llm: LLMClient = Depends(get_llm_client),
+    user_id: str | None = Depends(get_current_user_id_optional),
 ) -> TurnResult:
     """Run one orchestrated turn. Persists user + assistant turns,
     appends to prose doc if the LLM determined fresh content was shared.
@@ -612,7 +628,7 @@ async def conversation_turn(
     return await orchestrator.handle_turn(
         supabase,
         llm,
-        user_id=None,
+        user_id=user_id,
         conversation_type=body.conversation_type,
         user_content=body.content,
         skipped=body.skipped,
@@ -622,17 +638,19 @@ async def conversation_turn(
 @router.post("/conversation/reset")
 async def conversation_reset(
     supabase: Client = Depends(get_supabase),
+    user_id: str | None = Depends(get_current_user_id_optional),
 ) -> ResetResult:
     """Wipe prose, optimized (chunks cascade), and turns. Preferences are
     preserved — delete them via DELETE /experience/preferences if wanted.
     """
-    return orchestrator.reset_content(supabase, user_id=None)
+    return orchestrator.reset_content(supabase, user_id=user_id)
 
 
 @router.get("/conversation/next-probe")
 async def conversation_next_probe(
     supabase: Client = Depends(get_supabase),
     llm: LLMClient = Depends(get_llm_client),
+    user_id: str | None = Depends(get_current_user_id_optional),
 ) -> ProbeResult:
     """Top-priority gap phrased as a user-facing question by the LLM."""
-    return await orchestrator.next_probe(supabase, llm, user_id=None)
+    return await orchestrator.next_probe(supabase, llm, user_id=user_id)

--- a/apps/wyrdfold-api/app/routers/jobs.py
+++ b/apps/wyrdfold-api/app/routers/jobs.py
@@ -11,7 +11,11 @@ from postgrest.types import CountMethod
 from supabase import Client
 
 from app.cache import job_list_cache, make_cache_key
-from app.dependencies import get_supabase, verify_api_key_or_jwt
+from app.dependencies import (
+    get_current_user_id_optional,
+    get_supabase,
+    verify_api_key_or_jwt,
+)
 from app.http_client import get_http_client
 from app.models.schemas import (
     ManualJobRequest,
@@ -243,11 +247,14 @@ def list_jobs(
     search: str | None = Query(None, max_length=200),
     target_id: str | None = Query(None),
     supabase: Client = Depends(get_supabase),
+    user_id: str | None = Depends(get_current_user_id_optional),
 ) -> dict[str, Any]:
     offset = (page - 1) * page_size
     ascending = order == "asc"
 
-    # Check cache (60s TTL — data only changes on poll/manual-add cycles)
+    # Check cache (60s TTL — data only changes on poll/manual-add cycles).
+    # user_id participates in the key so per-user views (saved/dismissed,
+    # future filtering) never cross-leak between accounts.
     cache_key = make_cache_key(
         "jobs",
         page=page,
@@ -259,6 +266,7 @@ def list_jobs(
         company=company,
         search=search,
         target_id=target_id,
+        user_id=user_id,
     )
     cached: dict[str, Any] | None = job_list_cache.get(cache_key)
     if cached is not None:

--- a/apps/wyrdfold-api/app/routers/tailor.py
+++ b/apps/wyrdfold-api/app/routers/tailor.py
@@ -25,6 +25,7 @@ from fastapi.responses import Response
 from supabase import Client
 
 from app.dependencies import (
+    get_current_user_id_optional,
     get_llm_client,
     get_supabase,
     verify_api_key_or_jwt,
@@ -82,8 +83,9 @@ async def create_tailored_resume(
     body: TailorRequest,
     supabase: Client = Depends(get_supabase),
     llm: LLMClient = Depends(get_llm_client),
+    user_id: str | None = Depends(get_current_user_id_optional),
 ) -> TailorResponse:
-    current_optimized = optimized.get_latest(supabase, user_id=None)
+    current_optimized = optimized.get_latest(supabase, user_id=user_id)
     if current_optimized is None:
         raise HTTPException(
             status_code=404,
@@ -143,7 +145,7 @@ async def create_tailored_resume(
                                 source=reusable,
                                 job_posting_id=body.job_posting_id,
                                 job_description=body.job_description,
-                                user_id=None,
+                                user_id=user_id,
                             )
                             persistence.mark_job_resume_draft(
                                 supabase, body.job_posting_id
@@ -153,14 +155,14 @@ async def create_tailored_resume(
                                 lint_warnings=[],
                             )
 
-    prefs_row = preferences.get(supabase, user_id=None)
+    prefs_row = preferences.get(supabase, user_id=user_id)
     prefs_payload = prefs_row.payload if prefs_row else None
     contact = await resolve_contact(supabase, body.contact)
 
     result = await run_tailor_pipeline(
         supabase,
         llm,
-        user_id=None,
+        user_id=user_id,
         optimized=current_optimized,
         job_description=body.job_description,
         contact=contact,
@@ -199,8 +201,9 @@ async def create_tailored_cover_letter(
     body: CoverLetterRequest,
     supabase: Client = Depends(get_supabase),
     llm: LLMClient = Depends(get_llm_client),
+    user_id: str | None = Depends(get_current_user_id_optional),
 ) -> TailorResponse:
-    current_optimized = optimized.get_latest(supabase, user_id=None)
+    current_optimized = optimized.get_latest(supabase, user_id=user_id)
     if current_optimized is None:
         raise HTTPException(
             status_code=404,
@@ -222,14 +225,14 @@ async def create_tailored_cover_letter(
             },
         )
 
-    prefs_row = preferences.get(supabase, user_id=None)
+    prefs_row = preferences.get(supabase, user_id=user_id)
     prefs_payload = prefs_row.payload if prefs_row else None
     contact = await resolve_contact(supabase, body.contact)
 
     result = await run_cover_letter_pipeline(
         supabase,
         llm,
-        user_id=None,
+        user_id=user_id,
         optimized=current_optimized,
         job_description=body.job_description,
         company_name=body.company_name,
@@ -262,10 +265,11 @@ async def create_tailored_cover_letter(
 async def list_documents(
     limit: int = 50,
     supabase: Client = Depends(get_supabase),
+    user_id: str | None = Depends(get_current_user_id_optional),
 ) -> dict[str, list[TailoredResumeRecord]]:
     rows = persistence.list_recent(
         supabase,
-        user_id=None,
+        user_id=user_id,
         limit=max(1, min(limit, 200)),
         document_type="resume",
     )
@@ -276,10 +280,11 @@ async def list_documents(
 async def list_tailored_cover_letters(
     limit: int = 50,
     supabase: Client = Depends(get_supabase),
+    user_id: str | None = Depends(get_current_user_id_optional),
 ) -> dict[str, list[TailoredResumeRecord]]:
     rows = persistence.list_recent(
         supabase,
-        user_id=None,
+        user_id=user_id,
         limit=max(1, min(limit, 200)),
         document_type="cover_letter",
     )
@@ -599,13 +604,14 @@ async def create_batch_resumes(
     background_tasks: BackgroundTasks,
     supabase: Client = Depends(get_supabase),
     llm: LLMClient = Depends(get_llm_client),
+    user_id: str | None = Depends(get_current_user_id_optional),
 ) -> BatchResponse:
     """Kick off batch resume generation for multiple job postings.
 
     Returns immediately with a batch_id. Poll GET /tailor/batch/{id}
     for progress.
     """
-    current_optimized = optimized.get_latest(supabase, user_id=None)
+    current_optimized = optimized.get_latest(supabase, user_id=user_id)
     if current_optimized is None:
         raise HTTPException(
             status_code=404,
@@ -632,13 +638,13 @@ async def create_batch_resumes(
     # Derive common target_id from first posting (all batch jobs share a target)
     target_id: str | None = postings[0].get("target_id") if postings else None
 
-    prefs_row = preferences.get(supabase, user_id=None)
+    prefs_row = preferences.get(supabase, user_id=user_id)
     prefs_payload = prefs_row.payload if prefs_row else None
     contact = await resolve_contact(supabase, body.contact)
 
     batch = create_batch(
         supabase,
-        user_id=None,
+        user_id=user_id,
         job_posting_ids=body.job_posting_ids,
     )
 
@@ -647,7 +653,7 @@ async def create_batch_resumes(
         supabase,
         llm,
         batch_id=batch.id,
-        user_id=None,
+        user_id=user_id,
         optimized=current_optimized,
         jobs=postings,
         contact=contact,

--- a/apps/wyrdfold-api/app/routers/targets.py
+++ b/apps/wyrdfold-api/app/routers/targets.py
@@ -15,6 +15,7 @@ from supabase import Client
 
 from app.dependencies import (
     get_current_user_id,
+    get_current_user_id_optional,
     get_llm_client,
     get_supabase,
     verify_api_key_or_jwt,
@@ -77,7 +78,7 @@ router = APIRouter(
 
 
 async def _activate_pipeline(
-    supabase: Client, llm: LLMClient, target: JobTarget
+    supabase: Client, llm: LLMClient, target: JobTarget, user_id: str
 ) -> None:
     """Derive profile (if needed) then poll jobs for a target. Runs as BackgroundTask."""
     target_id = target.id
@@ -89,7 +90,7 @@ async def _activate_pipeline(
             crud.update(
                 supabase, target_id, TargetUpdate(activation_status="deriving")
             )
-            doc = optimized.get_latest(supabase, user_id=None)
+            doc = optimized.get_latest(supabase, user_id=user_id)
             if doc is None:
                 logger.warning("No OptimizedDoc for target %s — skipping derive", target_id)
                 crud.update(
@@ -102,7 +103,7 @@ async def _activate_pipeline(
             )
             cost_log.record(
                 supabase,
-                user_id=None,
+                user_id=user_id,
                 purpose=DERIVE_LABEL_PURPOSE,
                 result=result,
                 metadata={"target_id": target_id, "trigger": "activation"},
@@ -166,7 +167,7 @@ async def create_target_from_manual(
     creates a new target (with a profile derived from label + experience)
     and links the user. The user always ends up with a ``user_targets`` row.
     """
-    doc = optimized.get_latest(supabase, user_id=None)
+    doc = optimized.get_latest(supabase, user_id=user_id)
     if doc is None:
         raise HTTPException(
             status_code=404,
@@ -197,7 +198,7 @@ async def create_target_from_url(
     re-merged (corpus building); on no match a new target is created. The
     user is always linked.
     """
-    doc = optimized.get_latest(supabase, user_id=None)
+    doc = optimized.get_latest(supabase, user_id=user_id)
     if doc is None:
         raise HTTPException(
             status_code=404,
@@ -245,7 +246,7 @@ async def suggest(
     Returns each suggestion paired with its matched target (if one exists)
     or flagged as new. Excludes targets the user already has.
     """
-    doc = optimized.get_latest(supabase, user_id=None)
+    doc = optimized.get_latest(supabase, user_id=user_id)
     if doc is None:
         raise HTTPException(status_code=404, detail="No experience profile found")
 
@@ -254,7 +255,7 @@ async def suggest(
     )
     cost_log.record(
         supabase,
-        user_id=None,
+        user_id=user_id,
         purpose=SUGGEST_PURPOSE,
         result=result,
         metadata={"user_id": user_id},
@@ -321,7 +322,7 @@ async def activate_target(
     refreshed = crud.get(supabase, target_id) or target
 
     background_tasks.add_task(
-        _activate_pipeline, supabase, llm, refreshed
+        _activate_pipeline, supabase, llm, refreshed, user_id
     )
     return refreshed
 
@@ -357,14 +358,14 @@ async def link_target(
     # Derive fit score if we have an experience profile
     fit_score: int | None = None
     fit_reasoning: str | None = None
-    doc = optimized.get_latest(supabase, user_id=None)
+    doc = optimized.get_latest(supabase, user_id=user_id)
     if doc is not None:
         fit_result, result = await derive_fit_score(
             llm, payload=doc.payload, target=target
         )
         cost_log.record(
             supabase,
-            user_id=None,
+            user_id=user_id,
             purpose=FIT_SCORE_PURPOSE,
             result=result,
             metadata={"target_id": target_id, "user_id": user_id},
@@ -386,13 +387,14 @@ async def derive_target_profile(
     target_id: str,
     supabase: Client = Depends(get_supabase),
     llm: LLMClient = Depends(get_llm_client),
+    user_id: str | None = Depends(get_current_user_id_optional),
 ) -> JobTarget:
     """Derive a scoring profile + search keywords from the target label + user experience."""
     target = crud.get(supabase, target_id)
     if target is None:
         raise HTTPException(status_code=404, detail="Target not found")
 
-    doc = optimized.get_latest(supabase, user_id=None)
+    doc = optimized.get_latest(supabase, user_id=user_id)
     if doc is None:
         raise HTTPException(status_code=404, detail="No experience profile found")
 
@@ -401,7 +403,7 @@ async def derive_target_profile(
     )
     cost_log.record(
         supabase,
-        user_id=None,
+        user_id=user_id,
         purpose=DERIVE_LABEL_PURPOSE,
         result=result,
         metadata={"target_id": target_id},
@@ -481,6 +483,7 @@ async def create_target_from_posting(
     posting_id: str,
     supabase: Client = Depends(get_supabase),
     llm: LLMClient = Depends(get_llm_client),
+    user_id: str | None = Depends(get_current_user_id_optional),
 ) -> JobTarget:
     """Create a target from an existing job posting.
 
@@ -515,7 +518,7 @@ async def create_target_from_posting(
             )
             cost_log.record(
                 supabase,
-                user_id=None,
+                user_id=user_id,
                 purpose=DEFAULT_PURPOSE,
                 result=result,
                 metadata={
@@ -604,6 +607,7 @@ async def add_reference_jd(
     body: ReferenceJDAdd,
     supabase: Client = Depends(get_supabase),
     llm: LLMClient = Depends(get_llm_client),
+    user_id: str | None = Depends(get_current_user_id_optional),
 ) -> JobTarget:
     """Add a reference JD, derive a scoring profile via LLM, and merge.
 
@@ -641,7 +645,7 @@ async def add_reference_jd(
     )
     cost_log.record(
         supabase,
-        user_id=None,
+        user_id=user_id,
         purpose=DEFAULT_PURPOSE,
         result=result,
         metadata={"target_id": target_id, "jd_url": body.jd_url or ""},

--- a/apps/wyrdfold-api/app/services/targets/from_input.py
+++ b/apps/wyrdfold-api/app/services/targets/from_input.py
@@ -72,7 +72,7 @@ async def _link_with_fit_score(
     )
     cost_log.record(
         supabase,
-        user_id=None,
+        user_id=user_id,
         purpose=FIT_SCORE_PURPOSE,
         result=llm_result,
         metadata={"target_id": target.id, "user_id": user_id},
@@ -108,7 +108,7 @@ async def from_manual(
     )
     cost_log.record(
         supabase,
-        user_id=None,
+        user_id=user_id,
         purpose=NORMALIZE_PURPOSE,
         result=norm_result,
         metadata={"user_id": user_id, "raw_label": label},
@@ -128,7 +128,7 @@ async def from_manual(
     )
     cost_log.record(
         supabase,
-        user_id=None,
+        user_id=user_id,
         purpose=DERIVE_LABEL_PURPOSE,
         result=derive_result,
         metadata={"user_id": user_id, "label": suggestion.label},
@@ -171,7 +171,7 @@ async def from_url(
     derived, derive_result = await derive_profile_from_jd(llm, jd_text=jd_text)
     cost_log.record(
         supabase,
-        user_id=None,
+        user_id=user_id,
         purpose=DERIVE_JD_PURPOSE,
         result=derive_result,
         metadata={"user_id": user_id, "jd_url": final_url},

--- a/apps/wyrdfold-api/scripts/backfill_fit_scores.py
+++ b/apps/wyrdfold-api/scripts/backfill_fit_scores.py
@@ -18,7 +18,6 @@ import logging
 from datetime import UTC, datetime
 from typing import Any, cast
 
-from app.dependencies import SINGLE_USER_ID
 from app.services.experience import optimized
 from app.services.llm import cost_log
 from app.services.llm import get_default_client as get_llm_client
@@ -64,7 +63,7 @@ async def backfill() -> int:
         # NULL-user_id experience_optimized_docs row from before multi-user.
         cache_key = user_id
         if cache_key not in payload_cache:
-            legacy_admin_ids = {SINGLE_USER_ID, "__system__"}
+            legacy_admin_ids = {"tools-admin", "__system__"}
             lookup_user = None if user_id in legacy_admin_ids else user_id
             doc = optimized.get_latest(supabase, user_id=lookup_user)
             payload_cache[cache_key] = doc.payload if doc else None

--- a/apps/wyrdfold-api/tests/test_analysis.py
+++ b/apps/wyrdfold-api/tests/test_analysis.py
@@ -345,6 +345,7 @@ async def test_router_cache_hit_skips_llm(
     app.dependency_overrides[get_supabase] = lambda: supabase
     app.dependency_overrides[get_llm_client] = lambda: llm
     app.dependency_overrides[verify_api_key_or_jwt] = lambda: "test"
+    app.dependency_overrides[get_current_user_id_optional] = lambda: None
 
     try:
         tc = TestClient(app)
@@ -397,6 +398,7 @@ async def test_router_cache_miss_runs_llm_and_persists(
     app.dependency_overrides[get_supabase] = lambda: supabase
     app.dependency_overrides[get_llm_client] = lambda: llm
     app.dependency_overrides[verify_api_key_or_jwt] = lambda: "test"
+    app.dependency_overrides[get_current_user_id_optional] = lambda: None
 
     try:
         tc = TestClient(app)
@@ -426,6 +428,7 @@ async def test_router_missing_optimized_doc_returns_404(
     app.dependency_overrides[get_supabase] = lambda: MagicMock()
     app.dependency_overrides[get_llm_client] = lambda: MockLLMClient()
     app.dependency_overrides[verify_api_key_or_jwt] = lambda: "test"
+    app.dependency_overrides[get_current_user_id_optional] = lambda: None
 
     try:
         tc = TestClient(app)
@@ -462,6 +465,7 @@ async def test_router_empty_description_returns_422(
     app.dependency_overrides[get_supabase] = lambda: supabase
     app.dependency_overrides[get_llm_client] = lambda: MockLLMClient()
     app.dependency_overrides[verify_api_key_or_jwt] = lambda: "test"
+    app.dependency_overrides[get_current_user_id_optional] = lambda: None
 
     try:
         tc = TestClient(app)
@@ -495,6 +499,7 @@ async def test_router_missing_job_posting_returns_404(
     app.dependency_overrides[get_supabase] = lambda: supabase
     app.dependency_overrides[get_llm_client] = lambda: MockLLMClient()
     app.dependency_overrides[verify_api_key_or_jwt] = lambda: "test"
+    app.dependency_overrides[get_current_user_id_optional] = lambda: None
 
     try:
         tc = TestClient(app)
@@ -526,6 +531,7 @@ async def test_router_missing_target_returns_404(
     app.dependency_overrides[get_supabase] = lambda: MagicMock()
     app.dependency_overrides[get_llm_client] = lambda: MockLLMClient()
     app.dependency_overrides[verify_api_key_or_jwt] = lambda: "test"
+    app.dependency_overrides[get_current_user_id_optional] = lambda: None
 
     try:
         tc = TestClient(app)
@@ -537,4 +543,9 @@ async def test_router_missing_target_returns_404(
 
 
 # Need these imports for dependency overrides
-from app.dependencies import get_llm_client, get_supabase, verify_api_key_or_jwt
+from app.dependencies import (
+    get_current_user_id_optional,
+    get_llm_client,
+    get_supabase,
+    verify_api_key_or_jwt,
+)

--- a/apps/wyrdfold-api/tests/test_dependencies.py
+++ b/apps/wyrdfold-api/tests/test_dependencies.py
@@ -6,9 +6,9 @@ from fastapi import HTTPException, Request
 
 from app.config import Settings
 from app.dependencies import (
-    SINGLE_USER_ID,
     _api_key_matches,
     get_current_user_id,
+    get_current_user_id_optional,
     verify_api_key,
     verify_api_key_or_jwt,
     verify_supabase_jwt,
@@ -167,24 +167,49 @@ def test_verify_api_key_or_jwt_rejects_invalid_jwt():
 
 def test_get_current_user_id_returns_jwt_sub():
     req = _make_request({"authorization": f"Bearer {_mint()}"})
-    assert get_current_user_id(req, key=None, s=_settings()) == USER_SUB
+    assert get_current_user_id(req, s=_settings()) == USER_SUB
 
 
-def test_get_current_user_id_returns_sentinel_for_api_key():
+def test_get_current_user_id_rejects_api_key_only():
+    """get_current_user_id is JWT-required — api-key callers must use
+    get_current_user_id_optional or a cron-only auth dep instead.
+    """
     req = _make_request()
-    assert get_current_user_id(req, key="testkey", s=_settings()) == SINGLE_USER_ID
+    with pytest.raises(HTTPException) as exc:
+        get_current_user_id(req, s=_settings())
+    assert exc.value.status_code == 401
 
 
 def test_get_current_user_id_rejects_unauthenticated():
     req = _make_request()
     with pytest.raises(HTTPException) as exc:
-        get_current_user_id(req, key=None, s=_settings())
+        get_current_user_id(req, s=_settings())
     assert exc.value.status_code == 401
 
 
-def test_get_current_user_id_prefers_jwt_over_api_key():
+def test_get_current_user_id_optional_returns_jwt_sub():
+    req = _make_request({"authorization": f"Bearer {_mint()}"})
+    assert get_current_user_id_optional(req, key=None, s=_settings()) == USER_SUB
+
+
+def test_get_current_user_id_optional_returns_none_for_api_key():
+    """API-key callers (cron/poller/batch) get None — services map None to
+    the legacy NULL-user_id rows, preserving single-tenant behavior.
+    """
+    req = _make_request()
+    assert get_current_user_id_optional(req, key="testkey", s=_settings()) is None
+
+
+def test_get_current_user_id_optional_rejects_unauthenticated():
+    req = _make_request()
+    with pytest.raises(HTTPException) as exc:
+        get_current_user_id_optional(req, key=None, s=_settings())
+    assert exc.value.status_code == 401
+
+
+def test_get_current_user_id_optional_prefers_jwt_over_api_key():
     """If both a valid JWT and a valid API key are present, prefer the JWT
-    so the request runs under the user's identity, not the cron sentinel.
+    so the request runs under the user's identity, not the cron path.
     """
     req = _make_request({"authorization": f"Bearer {_mint()}"})
-    assert get_current_user_id(req, key="testkey", s=_settings()) == USER_SUB
+    assert get_current_user_id_optional(req, key="testkey", s=_settings()) == USER_SUB

--- a/apps/wyrdfold-api/tests/test_tailor_gap_gate.py
+++ b/apps/wyrdfold-api/tests/test_tailor_gap_gate.py
@@ -5,7 +5,11 @@ from unittest.mock import MagicMock, patch
 import pytest
 from fastapi.testclient import TestClient
 
-from app.dependencies import get_supabase, verify_api_key_or_jwt
+from app.dependencies import (
+    get_current_user_id_optional,
+    get_supabase,
+    verify_api_key_or_jwt,
+)
 from app.main import app
 from app.models.experience import (
     OptimizedDoc,
@@ -63,6 +67,7 @@ class TestGapGateResume:
     def _overrides(self):
         app.dependency_overrides[verify_api_key_or_jwt] = lambda: "test"
         app.dependency_overrides[get_supabase] = lambda: MagicMock()
+        app.dependency_overrides[get_current_user_id_optional] = lambda: None
         yield
         app.dependency_overrides.clear()
 

--- a/apps/wyrdfold-api/tests/test_target_scoring.py
+++ b/apps/wyrdfold-api/tests/test_target_scoring.py
@@ -244,7 +244,11 @@ def test_list_jobs_without_target_returns_global_view(
     """Global view queries jobs directly with global scores."""
     from fastapi.testclient import TestClient
 
-    from app.dependencies import get_supabase, verify_api_key_or_jwt
+    from app.dependencies import (
+        get_current_user_id_optional,
+        get_supabase,
+        verify_api_key_or_jwt,
+    )
     from app.main import app
 
     def _fluent_mock(data: list[dict]) -> MagicMock:
@@ -270,6 +274,7 @@ def test_list_jobs_without_target_returns_global_view(
 
     app.dependency_overrides[get_supabase] = lambda: supabase
     app.dependency_overrides[verify_api_key_or_jwt] = lambda: "test"
+    app.dependency_overrides[get_current_user_id_optional] = lambda: None
 
     try:
         tc = TestClient(app)
@@ -288,7 +293,11 @@ def test_list_jobs_with_target_overlays_target_score(
 ) -> None:
     from fastapi.testclient import TestClient
 
-    from app.dependencies import get_supabase, verify_api_key_or_jwt
+    from app.dependencies import (
+        get_current_user_id_optional,
+        get_supabase,
+        verify_api_key_or_jwt,
+    )
     from app.main import app
 
     def _fluent_mock(data: list[dict]) -> MagicMock:
@@ -331,6 +340,7 @@ def test_list_jobs_with_target_overlays_target_score(
 
     app.dependency_overrides[get_supabase] = lambda: supabase
     app.dependency_overrides[verify_api_key_or_jwt] = lambda: "test"
+    app.dependency_overrides[get_current_user_id_optional] = lambda: None
 
     try:
         tc = TestClient(app)

--- a/apps/wyrdfold-api/tests/test_upload_resume.py
+++ b/apps/wyrdfold-api/tests/test_upload_resume.py
@@ -312,6 +312,7 @@ class TestUploadResumeEndpoint:
             supabase=supabase,
             llm=MagicMock(),
             embeddings=MagicMock(),
+            user_id=None,
         )
 
         assert result.success is True


### PR DESCRIPTION
## Summary

- Replaces `SINGLE_USER_ID` sentinel with the JWT `sub` (or `None` for api-key callers) so per-user data flows through 8 routers and 13+ service modules.
- Adds `get_current_user_id_optional` dep returning `str | None` — JWT sub for users, `None` for cron/poller/batch (api-key). Keeps service signatures `str | None` and maps `None` to legacy `user_id IS NULL` rows so single-tenant data remains accessible during the rollout.
- `get_current_user_id` is now JWT-required (no api-key fallback) for endpoints that need a real identity.
- User-keys `job_list_cache` (no-op while `None`, isolates per-user views once JWTs flow on the frontend).
- Inlines the legacy admin-id sentinel set in `scripts/backfill_fit_scores.py` so the SINGLE_USER_ID import can be removed.

## Test plan

- [x] `pnpm nx test wyrdfold-api` — 746 passed (was 12 failed pre-fix)
- [x] `uv run mypy app` — clean (112 files)
- [x] Lint failures on this branch are pre-existing on `feature/fitted` (4 unrelated issues in `tailor.py`/`pandoc_render.py`/`annotations.py`)
- [x] Backfill script imports cleanly without the SINGLE_USER_ID symbol
- [ ] Smoke-test against staging once merged to confirm JWT users see their own targets/jobs/docs and cron poller still writes NULL-user rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)