### PR TITLE
feat(wyrdfold-api): per-user LLM token-budget guard (Phase 3b.4)

### DIFF
--- a/apps/wyrdfold-api/.env.example
+++ b/apps/wyrdfold-api/.env.example
@@ -24,3 +24,10 @@ ALLOWED_HOSTS=*
 SENTRY_DSN=
 SENTRY_ENVIRONMENT=development
 SENTRY_TRACES_SAMPLE_RATE=0.1
+
+# Per-user LLM budget (defense-in-depth on cost). Rolling window over llm_costs.
+# Set to 0 to disable a window. API-key callers (cron) bypass — system paths
+# are trusted and gated by the operator. Hourly is checked first so a spam
+# burst trips the smaller window before exhausting the day.
+USER_LLM_DAILY_BUDGET_USD=5.0
+USER_LLM_HOURLY_BUDGET_USD=1.0

--- a/apps/wyrdfold-api/app/config.py
+++ b/apps/wyrdfold-api/app/config.py
@@ -51,6 +51,12 @@ class Settings(BaseSettings):
     # at WARNING with method/path/duration. Set to 0 to log every request.
     slow_request_threshold_ms: int = Field(default=500, ge=0, le=60_000)
 
+    # Per-user LLM budget (defense-in-depth). Rolling window over llm_costs.
+    # Set to 0 to disable a window. API-key callers (cron) bypass — system
+    # paths are trusted and gated by the operator.
+    user_llm_daily_budget_usd: float = Field(default=5.0, ge=0.0)
+    user_llm_hourly_budget_usd: float = Field(default=1.0, ge=0.0)
+
     model_config = {"env_file": ".env", "env_file_encoding": "utf-8"}
 
     @property

--- a/apps/wyrdfold-api/app/dependencies.py
+++ b/apps/wyrdfold-api/app/dependencies.py
@@ -172,3 +172,27 @@ def get_current_user_id_optional(
     if _api_key_matches(key, s.wyrdfold_api_key):
         return None
     raise HTTPException(status_code=401, detail="Unauthorized")
+
+
+def enforce_llm_budget(
+    user_id: str | None = Depends(get_current_user_id_optional),
+    supabase: Client = Depends(get_supabase),
+    s: Settings = Depends(get_settings),
+) -> None:
+    """Defense-in-depth budget gate for LLM-touching routes.
+
+    JWT users get checked against rolling daily/hourly cost caps from
+    `llm_costs`. API-key callers (cron/poller/batch) bypass — those
+    system paths are trusted and gated by the operator. Limits are
+    configured via `user_llm_*_budget_usd` settings; 0 disables.
+    """
+    if user_id is None:
+        return
+    from app.services.llm import budget
+
+    budget.check_user_budget(
+        supabase,
+        user_id=user_id,
+        daily_limit_usd=s.user_llm_daily_budget_usd,
+        hourly_limit_usd=s.user_llm_hourly_budget_usd,
+    )

--- a/apps/wyrdfold-api/app/routers/analysis.py
+++ b/apps/wyrdfold-api/app/routers/analysis.py
@@ -11,6 +11,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from supabase import Client
 
 from app.dependencies import (
+    enforce_llm_budget,
     get_current_user_id_optional,
     get_llm_client,
     get_supabase,
@@ -31,7 +32,7 @@ router = APIRouter(
 )
 
 
-@router.post("/{job_id}")
+@router.post("/{job_id}", dependencies=[Depends(enforce_llm_budget)])
 async def create_analysis(
     job_id: str,
     target_id: str = Query(..., description="Target the user is viewing the job under"),

--- a/apps/wyrdfold-api/app/routers/experience.py
+++ b/apps/wyrdfold-api/app/routers/experience.py
@@ -17,6 +17,7 @@ from pydantic import ValidationError
 from supabase import Client
 
 from app.dependencies import (
+    enforce_llm_budget,
     get_current_user_id_optional,
     get_embeddings_client,
     get_llm_client,
@@ -93,7 +94,7 @@ async def create_prose(
     return prose.create_version(supabase, user_id=user_id, content=body.content)
 
 
-@router.post("/prose/consolidate")
+@router.post("/prose/consolidate", dependencies=[Depends(enforce_llm_budget)])
 async def consolidate_prose(
     supabase: Client = Depends(get_supabase),
     llm: LLMClient = Depends(get_llm_client),
@@ -156,7 +157,7 @@ async def consolidate_prose(
 # ---- Resume upload --------------------------------------------------------
 
 
-@router.post("/upload-resume")
+@router.post("/upload-resume", dependencies=[Depends(enforce_llm_budget)])
 async def upload_resume(
     file: UploadFile,
     auto_derive: bool = Query(default=False),
@@ -329,7 +330,7 @@ async def create_optimized(
     return doc
 
 
-@router.post("/derive")
+@router.post("/derive", dependencies=[Depends(enforce_llm_budget)])
 async def derive_optimized(
     supabase: Client = Depends(get_supabase),
     llm: LLMClient = Depends(get_llm_client),
@@ -407,7 +408,7 @@ def _sse_event(event: str, data: dict[str, Any]) -> bytes:
     return f"event: {event}\ndata: {json.dumps(data)}\n\n".encode()
 
 
-@router.post("/derive/stream")
+@router.post("/derive/stream", dependencies=[Depends(enforce_llm_budget)])
 async def derive_optimized_stream(
     supabase: Client = Depends(get_supabase),
     llm: LLMClient = Depends(get_llm_client),
@@ -615,7 +616,7 @@ async def append_turn(
 # ---- Conversation orchestrator (P2d) -------------------------------------
 
 
-@router.post("/conversation/turn")
+@router.post("/conversation/turn", dependencies=[Depends(enforce_llm_budget)])
 async def conversation_turn(
     body: TurnRequest,
     supabase: Client = Depends(get_supabase),
@@ -646,7 +647,7 @@ async def conversation_reset(
     return orchestrator.reset_content(supabase, user_id=user_id)
 
 
-@router.get("/conversation/next-probe")
+@router.get("/conversation/next-probe", dependencies=[Depends(enforce_llm_budget)])
 async def conversation_next_probe(
     supabase: Client = Depends(get_supabase),
     llm: LLMClient = Depends(get_llm_client),

--- a/apps/wyrdfold-api/app/routers/tailor.py
+++ b/apps/wyrdfold-api/app/routers/tailor.py
@@ -25,6 +25,7 @@ from fastapi.responses import Response
 from supabase import Client
 
 from app.dependencies import (
+    enforce_llm_budget,
     get_current_user_id_optional,
     get_llm_client,
     get_supabase,
@@ -78,6 +79,7 @@ router = APIRouter(
 @router.post(
     "/resume",
     responses={422: {"model": TailorLintFailureResponse | GapGateFailureResponse}},
+    dependencies=[Depends(enforce_llm_budget)],
 )
 async def create_tailored_resume(
     body: TailorRequest,
@@ -196,6 +198,7 @@ async def create_tailored_resume(
 @router.post(
     "/cover-letter",
     responses={422: {"model": TailorLintFailureResponse | GapGateFailureResponse}},
+    dependencies=[Depends(enforce_llm_budget)],
 )
 async def create_tailored_cover_letter(
     body: CoverLetterRequest,
@@ -598,7 +601,7 @@ async def download_tailored_resume(
 # ---- Batch resume generation (#503) ----------------------------------------
 
 
-@router.post("/batch")
+@router.post("/batch", dependencies=[Depends(enforce_llm_budget)])
 async def create_batch_resumes(
     body: BatchRequest,
     background_tasks: BackgroundTasks,

--- a/apps/wyrdfold-api/app/routers/targets.py
+++ b/apps/wyrdfold-api/app/routers/targets.py
@@ -14,6 +14,7 @@ from postgrest.types import CountMethod
 from supabase import Client
 
 from app.dependencies import (
+    enforce_llm_budget,
     get_current_user_id,
     get_current_user_id_optional,
     get_llm_client,
@@ -153,7 +154,7 @@ async def create_target(
     return crud.create(supabase, payload=body)
 
 
-@router.post("/from-manual")
+@router.post("/from-manual", dependencies=[Depends(enforce_llm_budget)])
 async def create_target_from_manual(
     body: TargetFromManual,
     supabase: Client = Depends(get_supabase),
@@ -183,7 +184,7 @@ async def create_target_from_manual(
     )
 
 
-@router.post("/from-url")
+@router.post("/from-url", dependencies=[Depends(enforce_llm_budget)])
 async def create_target_from_url(
     body: TargetFromUrl,
     supabase: Client = Depends(get_supabase),
@@ -235,7 +236,7 @@ def list_targets(
     return {"targets": targets}
 
 
-@router.post("/suggest")
+@router.post("/suggest", dependencies=[Depends(enforce_llm_budget)])
 async def suggest(
     supabase: Client = Depends(get_supabase),
     llm: LLMClient = Depends(get_llm_client),
@@ -304,7 +305,7 @@ def update_target(
     return target
 
 
-@router.post("/{target_id}/activate")
+@router.post("/{target_id}/activate", dependencies=[Depends(enforce_llm_budget)])
 async def activate_target(
     target_id: str,
     background_tasks: BackgroundTasks,
@@ -343,7 +344,7 @@ async def deactivate_target(
     return crud.get(supabase, target_id) or target
 
 
-@router.post("/{target_id}/link")
+@router.post("/{target_id}/link", dependencies=[Depends(enforce_llm_budget)])
 async def link_target(
     target_id: str,
     supabase: Client = Depends(get_supabase),
@@ -382,7 +383,7 @@ async def link_target(
     )
 
 
-@router.post("/{target_id}/derive-profile")
+@router.post("/{target_id}/derive-profile", dependencies=[Depends(enforce_llm_budget)])
 async def derive_target_profile(
     target_id: str,
     supabase: Client = Depends(get_supabase),
@@ -478,7 +479,7 @@ async def delete_target(
 # ---- Create from job posting -----------------------------------------------
 
 
-@router.post("/from-posting/{posting_id}")
+@router.post("/from-posting/{posting_id}", dependencies=[Depends(enforce_llm_budget)])
 async def create_target_from_posting(
     posting_id: str,
     supabase: Client = Depends(get_supabase),
@@ -601,7 +602,7 @@ async def _fetch_jd_from_url(url: str) -> tuple[str | None, str]:
     return extraction.title, jd_text
 
 
-@router.post("/{target_id}/reference-jds")
+@router.post("/{target_id}/reference-jds", dependencies=[Depends(enforce_llm_budget)])
 async def add_reference_jd(
     target_id: str,
     body: ReferenceJDAdd,

--- a/apps/wyrdfold-api/app/services/llm/budget.py
+++ b/apps/wyrdfold-api/app/services/llm/budget.py
@@ -1,0 +1,63 @@
+"""Per-user LLM budget guard (defense-in-depth on cost).
+
+Reads recent rows from ``llm_costs`` for the user and refuses new LLM
+calls when the rolling daily or hourly spend exceeds a configured cap.
+API-key callers (cron/poller/batch) are NOT checked here — system paths
+are trusted and gated separately by the operator.
+
+The guard is advisory: a single in-flight call can still push spend
+*past* the cap, since cost is recorded only after the LLM returns. Pair
+with provider-side spend alerts for a hard ceiling.
+"""
+
+from datetime import UTC, datetime, timedelta
+
+from fastapi import HTTPException
+from supabase import Client
+
+from app.services.llm import cost_log
+
+
+def check_user_budget(
+    supabase: Client,
+    *,
+    user_id: str,
+    daily_limit_usd: float,
+    hourly_limit_usd: float,
+) -> None:
+    """Raise 429 if the user has hit their rolling daily or hourly cap.
+
+    Limits of ``0`` disable that window. Hourly is checked first so a
+    spam burst trips the smaller window before exhausting the day.
+    """
+    now = datetime.now(UTC)
+
+    if hourly_limit_usd > 0:
+        spent_hour = cost_log.total_spend(
+            supabase, user_id=user_id, since=now - timedelta(hours=1)
+        )
+        if spent_hour >= hourly_limit_usd:
+            raise HTTPException(
+                status_code=429,
+                detail={
+                    "code": "llm_budget_exceeded",
+                    "scope": "hourly",
+                    "limit_usd": hourly_limit_usd,
+                    "spent_usd": spent_hour,
+                },
+            )
+
+    if daily_limit_usd > 0:
+        spent_day = cost_log.total_spend(
+            supabase, user_id=user_id, since=now - timedelta(hours=24)
+        )
+        if spent_day >= daily_limit_usd:
+            raise HTTPException(
+                status_code=429,
+                detail={
+                    "code": "llm_budget_exceeded",
+                    "scope": "daily",
+                    "limit_usd": daily_limit_usd,
+                    "spent_usd": spent_day,
+                },
+            )

--- a/apps/wyrdfold-api/tests/test_dependencies.py
+++ b/apps/wyrdfold-api/tests/test_dependencies.py
@@ -1,4 +1,5 @@
 from datetime import UTC, datetime, timedelta
+from unittest.mock import MagicMock
 
 import jwt
 import pytest
@@ -7,6 +8,7 @@ from fastapi import HTTPException, Request
 from app.config import Settings
 from app.dependencies import (
     _api_key_matches,
+    enforce_llm_budget,
     get_current_user_id,
     get_current_user_id_optional,
     verify_api_key,
@@ -213,3 +215,68 @@ def test_get_current_user_id_optional_prefers_jwt_over_api_key():
     """
     req = _make_request({"authorization": f"Bearer {_mint()}"})
     assert get_current_user_id_optional(req, key="testkey", s=_settings()) == USER_SUB
+
+
+def _budget_settings(daily: float = 5.0, hourly: float = 1.0) -> Settings:
+    return Settings(
+        wyrdfold_api_key="testkey",
+        supabase_jwt_secret=JWT_SECRET,
+        user_llm_daily_budget_usd=daily,
+        user_llm_hourly_budget_usd=hourly,
+    )
+
+
+def test_enforce_llm_budget_apikey_caller_bypasses(monkeypatch):
+    """API-key callers (user_id=None) skip the budget check entirely — no
+    supabase round-trip, no spend lookup. System paths are trusted.
+    """
+    from app.services.llm import budget as budget_mod
+
+    called = False
+
+    def _spy(*a, **kw):
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr(budget_mod, "check_user_budget", _spy)
+    enforce_llm_budget(user_id=None, supabase=MagicMock(), s=_budget_settings())
+    assert called is False
+
+
+def test_enforce_llm_budget_jwt_user_invokes_check(monkeypatch):
+    from app.services.llm import budget as budget_mod
+
+    captured: dict = {}
+
+    def _spy(supabase, *, user_id, daily_limit_usd, hourly_limit_usd):
+        captured.update(
+            user_id=user_id,
+            daily_limit_usd=daily_limit_usd,
+            hourly_limit_usd=hourly_limit_usd,
+        )
+
+    monkeypatch.setattr(budget_mod, "check_user_budget", _spy)
+    enforce_llm_budget(
+        user_id=USER_SUB, supabase=MagicMock(), s=_budget_settings(daily=7.0, hourly=2.0)
+    )
+    assert captured == {
+        "user_id": USER_SUB,
+        "daily_limit_usd": 7.0,
+        "hourly_limit_usd": 2.0,
+    }
+
+
+def test_enforce_llm_budget_propagates_429(monkeypatch):
+    """If the underlying check raises 429, the dep surfaces it unchanged."""
+    from app.services.llm import budget as budget_mod
+
+    def _raise(*a, **kw):
+        raise HTTPException(
+            status_code=429, detail={"code": "llm_budget_exceeded", "scope": "hourly"}
+        )
+
+    monkeypatch.setattr(budget_mod, "check_user_budget", _raise)
+    with pytest.raises(HTTPException) as exc:
+        enforce_llm_budget(user_id=USER_SUB, supabase=MagicMock(), s=_budget_settings())
+    assert exc.value.status_code == 429
+    assert exc.value.detail["scope"] == "hourly"

--- a/apps/wyrdfold-api/tests/test_llm_budget.py
+++ b/apps/wyrdfold-api/tests/test_llm_budget.py
@@ -1,0 +1,105 @@
+from datetime import UTC, datetime
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+from app.services.llm import budget, cost_log
+
+
+@pytest.fixture
+def fake_supabase() -> MagicMock:
+    return MagicMock()
+
+
+def _patch_spend(monkeypatch: pytest.MonkeyPatch, *, hourly: float, daily: float) -> list[dict]:
+    """Stub cost_log.total_spend. Routes by window width inferred from `since`."""
+    calls: list[dict] = []
+
+    def fake_total_spend(_supabase, *, user_id, since):
+        calls.append({"user_id": user_id, "since": since})
+        elapsed_s = (datetime.now(UTC) - since).total_seconds()
+        # Hourly window is ~3600s; daily is ~86400s. Split at 2h.
+        return hourly if elapsed_s < 7200 else daily
+
+    monkeypatch.setattr(cost_log, "total_spend", fake_total_spend)
+    return calls
+
+
+def test_under_both_limits_passes(monkeypatch, fake_supabase):
+    _patch_spend(monkeypatch, hourly=0.5, daily=2.0)
+    budget.check_user_budget(
+        fake_supabase, user_id="u1", daily_limit_usd=5.0, hourly_limit_usd=1.0
+    )
+
+
+def test_hourly_exceeded_raises_429(monkeypatch, fake_supabase):
+    _patch_spend(monkeypatch, hourly=1.0, daily=0.0)
+    with pytest.raises(HTTPException) as exc:
+        budget.check_user_budget(
+            fake_supabase, user_id="u1", daily_limit_usd=5.0, hourly_limit_usd=1.0
+        )
+    assert exc.value.status_code == 429
+    assert exc.value.detail["scope"] == "hourly"
+    assert exc.value.detail["code"] == "llm_budget_exceeded"
+    assert exc.value.detail["limit_usd"] == 1.0
+
+
+def test_daily_exceeded_raises_429(monkeypatch, fake_supabase):
+    _patch_spend(monkeypatch, hourly=0.5, daily=5.0)
+    with pytest.raises(HTTPException) as exc:
+        budget.check_user_budget(
+            fake_supabase, user_id="u1", daily_limit_usd=5.0, hourly_limit_usd=1.0
+        )
+    assert exc.value.status_code == 429
+    assert exc.value.detail["scope"] == "daily"
+    assert exc.value.detail["limit_usd"] == 5.0
+
+
+def test_hourly_disabled_skips_query(monkeypatch, fake_supabase):
+    calls = _patch_spend(monkeypatch, hourly=999.0, daily=2.0)
+    budget.check_user_budget(
+        fake_supabase, user_id="u1", daily_limit_usd=5.0, hourly_limit_usd=0.0
+    )
+    # Only the daily query should fire.
+    assert len(calls) == 1
+
+
+def test_daily_disabled_skips_query(monkeypatch, fake_supabase):
+    calls = _patch_spend(monkeypatch, hourly=0.5, daily=999.0)
+    budget.check_user_budget(
+        fake_supabase, user_id="u1", daily_limit_usd=0.0, hourly_limit_usd=1.0
+    )
+    assert len(calls) == 1
+
+
+def test_both_disabled_no_queries(monkeypatch, fake_supabase):
+    calls = _patch_spend(monkeypatch, hourly=999.0, daily=999.0)
+    budget.check_user_budget(
+        fake_supabase, user_id="u1", daily_limit_usd=0.0, hourly_limit_usd=0.0
+    )
+    assert calls == []
+
+
+def test_hourly_trips_first_when_both_exceeded(monkeypatch, fake_supabase):
+    """Hourly is the smaller window — a spam burst should trip it before daily."""
+    _patch_spend(monkeypatch, hourly=2.0, daily=10.0)
+    with pytest.raises(HTTPException) as exc:
+        budget.check_user_budget(
+            fake_supabase, user_id="u1", daily_limit_usd=5.0, hourly_limit_usd=1.0
+        )
+    assert exc.value.detail["scope"] == "hourly"
+
+
+def test_window_since_is_now_minus_offset(monkeypatch, fake_supabase):
+    """Hourly window is 1h, daily is 24h, both anchored on now."""
+    calls = _patch_spend(monkeypatch, hourly=0.0, daily=0.0)
+    budget.check_user_budget(
+        fake_supabase, user_id="u1", daily_limit_usd=5.0, hourly_limit_usd=1.0
+    )
+    assert len(calls) == 2
+    hourly_since: datetime = calls[0]["since"]
+    daily_since: datetime = calls[1]["since"]
+    delta_seconds = (daily_since.replace(tzinfo=None) - hourly_since.replace(tzinfo=None)).total_seconds()
+    # 24h - 1h = 23h = 82800s; allow a few seconds of clock drift between calls.
+    assert -82800 - 5 < delta_seconds < -82800 + 5


### PR DESCRIPTION
## Summary

Defense-in-depth on LLM cost. JWT users now hit a rolling daily/hourly cap on `llm_costs` spend before any LLM-touching route runs. API-key callers (cron/poller/batch) bypass — system paths are trusted and gated separately by the operator (provider-side spend alerts).

- New `app/services/llm/budget.py` — `check_user_budget` with hourly-first ordering so a spam burst trips the smaller window before exhausting the day
- New `enforce_llm_budget` dep wired into **18 LLM-touching routes** across `analysis`, `experience`, `tailor`, `targets` routers
- Limits configurable via `user_llm_{daily,hourly}_budget_usd` settings (defaults: $5 / $1, set 0 to disable a window)
- Returns **429** with structured detail `{code, scope, limit_usd, spent_usd}` on cap hit
- Closes the 3b "API hardening" arc before staging deploy + Phase 4 (BFF routes)

The guard is advisory — a single in-flight call can still push spend *past* the cap, since cost is recorded only after the LLM returns. Pair with provider-side spend alerts for a hard ceiling.

## Routes gated

| Router | Routes |
|---|---|
| `analysis` | `POST /{job_id}` |
| `experience` | `POST /prose/consolidate`, `/upload-resume`, `/derive`, `/derive/stream`, `/conversation/turn`, `GET /conversation/next-probe` |
| `tailor` | `POST /resume`, `/cover-letter`, `/batch` |
| `targets` | `POST /from-manual`, `/from-url`, `/suggest`, `/{id}/activate`, `/{id}/link`, `/{id}/derive-profile`, `/from-posting/{posting_id}`, `/{id}/reference-jds` |

## Test plan

- [x] 8 new unit tests in `test_llm_budget.py` — cover under-limit pass, hourly-exceeded 429, daily-exceeded 429, disabled windows skip queries, hourly trips first when both exceeded, window offsets correct
- [x] 3 new dep tests in `test_dependencies.py` — api-key caller bypasses, JWT user invokes check with right limits, 429 propagates
- [x] Full suite: 757 passed (was 746; +11 new)
- [x] mypy clean
- [x] ruff clean for changed files (4 pre-existing errors on base, untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)