### PR TITLE
feat(wyrdfold): BFF foundation for proxying wyrdfold-api (Phase 4.1)

### DIFF
--- a/apps/wyrdfold/.env.example
+++ b/apps/wyrdfold/.env.example
@@ -9,6 +9,5 @@ SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
 NEXT_PUBLIC_SENTRY_CONFIG_ID=your-wyrdfold-sentry-dsn
 SENTRY_AUTH_TOKEN=your-sentry-cli-token
 
-# Job API (BFF target — wired in Phase 4)
-JOB_API_URL=http://localhost:8000
-JOB_API_TOKEN=your-shared-secret
+# WyrdFold API (Python/FastAPI backend — proxied via /api/* BFF routes)
+WYRDFOLD_API_URL=http://localhost:8000

--- a/apps/wyrdfold/src/app/api/career/experience/optimized/route.ts
+++ b/apps/wyrdfold/src/app/api/career/experience/optimized/route.ts
@@ -1,0 +1,5 @@
+import { proxyToWyrdfoldAPI } from '@/lib/api/proxy';
+
+export async function GET(): Promise<ReturnType<typeof proxyToWyrdfoldAPI>> {
+  return proxyToWyrdfoldAPI('/experience/optimized');
+}

--- a/apps/wyrdfold/src/lib/api/proxy.test.ts
+++ b/apps/wyrdfold/src/lib/api/proxy.test.ts
@@ -1,0 +1,287 @@
+/**
+ * @jest-environment node
+ */
+// proxy.ts captures WYRDFOLD_API_URL at module load — set before import.
+process.env['WYRDFOLD_API_URL'] = 'http://wyrdfold-api.test';
+
+const mockGetSession = jest.fn();
+
+jest.mock('@/lib/supabase/auth-server', () => ({
+  createAuthServerClient: () =>
+    Promise.resolve({ auth: { getSession: mockGetSession } }),
+}));
+
+import {
+  proxyMultipartToWyrdfoldAPI,
+  proxyStreamingToWyrdfoldAPI,
+  proxyToWyrdfoldAPI,
+} from './proxy';
+
+const ORIGINAL_FETCH = global.fetch;
+
+afterAll(() => {
+  global.fetch = ORIGINAL_FETCH;
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGetSession.mockResolvedValue({
+    data: { session: { access_token: 'jwt-token' } },
+  });
+});
+
+function mockFetch(response: Response): jest.Mock {
+  const fn = jest.fn().mockResolvedValue(response);
+  global.fetch = fn as unknown as typeof fetch;
+  return fn;
+}
+
+describe('proxyToWyrdfoldAPI', () => {
+  it('returns 401 when no Supabase session', async () => {
+    mockGetSession.mockResolvedValueOnce({ data: { session: null } });
+    const fetchMock = mockFetch(new Response('{}'));
+
+    const res = await proxyToWyrdfoldAPI('/experience/optimized');
+
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: 'Unauthorized' });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 when getSession throws', async () => {
+    mockGetSession.mockRejectedValueOnce(new Error('cookie error'));
+    const fetchMock = mockFetch(new Response('{}'));
+
+    const res = await proxyToWyrdfoldAPI('/experience/optimized');
+
+    expect(res.status).toBe(401);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('forwards the access token as Bearer auth and returns upstream JSON', async () => {
+    const fetchMock = mockFetch(
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+
+    const res = await proxyToWyrdfoldAPI('/experience/optimized');
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('http://wyrdfold-api.test/experience/optimized');
+    expect(init.method).toBe('GET');
+    expect((init.headers as Record<string, string>).Authorization).toBe(
+      'Bearer jwt-token'
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+  });
+
+  it('appends search params to the upstream URL', async () => {
+    const fetchMock = mockFetch(new Response('{}', { status: 200 }));
+
+    await proxyToWyrdfoldAPI('/jobs', {
+      searchParams: new URLSearchParams({ status: 'open', page: '2' }),
+    });
+
+    const [url] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('http://wyrdfold-api.test/jobs?status=open&page=2');
+  });
+
+  it('serializes the request body as JSON when provided', async () => {
+    const fetchMock = mockFetch(new Response('{}', { status: 201 }));
+
+    await proxyToWyrdfoldAPI('/jobs', {
+      method: 'POST',
+      body: { title: 'Senior FE' },
+    });
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(init.method).toBe('POST');
+    expect(init.body).toBe(JSON.stringify({ title: 'Senior FE' }));
+  });
+
+  it('returns 502 when upstream returns non-JSON', async () => {
+    mockFetch(new Response('<html>oops</html>', { status: 200 }));
+
+    const res = await proxyToWyrdfoldAPI('/experience/optimized');
+
+    expect(res.status).toBe(502);
+    expect(await res.json()).toMatchObject({
+      error: 'Upstream returned non-JSON',
+      upstreamStatus: 200,
+    });
+  });
+
+  it('returns 503 when fetch rejects', async () => {
+    global.fetch = jest
+      .fn()
+      .mockRejectedValue(new Error('ECONNREFUSED')) as unknown as typeof fetch;
+
+    const res = await proxyToWyrdfoldAPI('/experience/optimized');
+
+    expect(res.status).toBe(503);
+    expect(await res.json()).toMatchObject({
+      error: 'WyrdFold API unavailable',
+    });
+  });
+
+  it('passes through binary bodies with upstream Content-Type and Disposition', async () => {
+    const bytes = new Uint8Array([0x50, 0x4b, 0x03, 0x04]);
+    mockFetch(
+      new Response(bytes, {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/zip',
+          'Content-Disposition': 'attachment; filename="export.zip"',
+        },
+      })
+    );
+
+    const res = await proxyToWyrdfoldAPI('/exports/zip', { binary: true });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toBe('application/zip');
+    expect(res.headers.get('Content-Disposition')).toBe(
+      'attachment; filename="export.zip"'
+    );
+    const buf = new Uint8Array(await res.arrayBuffer());
+    expect(Array.from(buf)).toEqual([0x50, 0x4b, 0x03, 0x04]);
+  });
+});
+
+describe('proxyStreamingToWyrdfoldAPI', () => {
+  function makeRequest(): Request {
+    return new Request('http://localhost/api/stream', { method: 'POST' });
+  }
+
+  it('returns 401 when no Supabase session', async () => {
+    mockGetSession.mockResolvedValueOnce({ data: { session: null } });
+    const fetchMock = mockFetch(new Response('{}'));
+
+    const res = await proxyStreamingToWyrdfoldAPI(
+      '/experience/derive/stream',
+      makeRequest()
+    );
+
+    expect(res.status).toBe(401);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('passes the body stream through with SSE headers on success', async () => {
+    const sseBody = new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode('data: hello\n\n'));
+        controller.close();
+      },
+    });
+    mockFetch(
+      new Response(sseBody, {
+        status: 200,
+        headers: { 'Content-Type': 'text/event-stream' },
+      })
+    );
+
+    const res = await proxyStreamingToWyrdfoldAPI(
+      '/experience/derive/stream',
+      makeRequest(),
+      { body: { hint: 'go' } }
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toBe('text/event-stream');
+    expect(res.headers.get('Cache-Control')).toBe('no-cache, no-transform');
+    expect(res.headers.get('X-Accel-Buffering')).toBe('no');
+    expect(await res.text()).toBe('data: hello\n\n');
+  });
+
+  it('surfaces upstream JSON errors before any SSE frames', async () => {
+    mockFetch(
+      new Response(JSON.stringify({ detail: 'budget exceeded' }), {
+        status: 429,
+      })
+    );
+
+    const res = await proxyStreamingToWyrdfoldAPI(
+      '/experience/derive/stream',
+      makeRequest()
+    );
+
+    expect(res.status).toBe(429);
+    expect(await res.json()).toEqual({ detail: 'budget exceeded' });
+  });
+
+  it('returns 503 when upstream fetch rejects', async () => {
+    global.fetch = jest
+      .fn()
+      .mockRejectedValue(new Error('boom')) as unknown as typeof fetch;
+
+    const res = await proxyStreamingToWyrdfoldAPI(
+      '/experience/derive/stream',
+      makeRequest()
+    );
+
+    expect(res.status).toBe(503);
+  });
+});
+
+describe('proxyMultipartToWyrdfoldAPI', () => {
+  function makeMultipartRequest(): Request {
+    return new Request('http://localhost/api/upload', {
+      method: 'POST',
+      headers: { 'Content-Type': 'multipart/form-data; boundary=---x' },
+      body: '---x\r\nContent-Disposition: form-data; name="file"\r\n\r\nhi\r\n---x--',
+    });
+  }
+
+  it('returns 401 when no Supabase session', async () => {
+    mockGetSession.mockResolvedValueOnce({ data: { session: null } });
+    const fetchMock = mockFetch(new Response('{}'));
+
+    const res = await proxyMultipartToWyrdfoldAPI(
+      '/experience/upload-resume',
+      makeMultipartRequest()
+    );
+
+    expect(res.status).toBe(401);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('forwards the multipart Content-Type and JWT to upstream', async () => {
+    const fetchMock = mockFetch(
+      new Response(JSON.stringify({ uploaded: true }), { status: 200 })
+    );
+
+    const res = await proxyMultipartToWyrdfoldAPI(
+      '/experience/upload-resume',
+      makeMultipartRequest()
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('http://wyrdfold-api.test/experience/upload-resume');
+    expect(init.method).toBe('POST');
+    const headers = init.headers as Record<string, string>;
+    expect(headers.Authorization).toBe('Bearer jwt-token');
+    expect(headers['Content-Type']).toBe('multipart/form-data; boundary=---x');
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ uploaded: true });
+  });
+
+  it('returns 502 when upstream returns non-JSON', async () => {
+    mockFetch(new Response('<html>err</html>', { status: 500 }));
+
+    const res = await proxyMultipartToWyrdfoldAPI(
+      '/experience/upload-resume',
+      makeMultipartRequest()
+    );
+
+    expect(res.status).toBe(502);
+    expect(await res.json()).toMatchObject({
+      error: 'Upstream returned non-JSON',
+      upstreamStatus: 500,
+    });
+  });
+});

--- a/apps/wyrdfold/src/lib/api/proxy.ts
+++ b/apps/wyrdfold/src/lib/api/proxy.ts
@@ -1,0 +1,231 @@
+import { NextResponse } from 'next/server';
+
+import { createAuthServerClient } from '@/lib/supabase/auth-server';
+
+/** Read at call-time so route handlers see the live env (test-friendly). */
+function apiBaseUrl(): string {
+  return process.env['WYRDFOLD_API_URL'] ?? '';
+}
+
+/** Default upstream timeout in milliseconds. */
+const DEFAULT_TIMEOUT_MS = 30_000;
+/** Longer timeout for LLM-backed routes (conversation, derive, tailor). */
+export const LLM_TIMEOUT_MS = 120_000;
+
+/**
+ * Resolve the current Supabase session's access token. Returns null when
+ * the request has no session — callers should treat that as 401 and skip
+ * the upstream round-trip.
+ */
+export async function getAccessToken(): Promise<string | null> {
+  try {
+    const supabase = await createAuthServerClient();
+    const {
+      data: { session },
+    } = await supabase.auth.getSession();
+    return session?.access_token ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function unauthorized(): NextResponse {
+  return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+}
+
+function unavailable(err: unknown): NextResponse {
+  const detail =
+    process.env.NODE_ENV !== 'production' && err instanceof Error
+      ? {
+          message: err.message,
+          cause: err.cause ? String(err.cause) : undefined,
+        }
+      : undefined;
+  return NextResponse.json(
+    { error: 'WyrdFold API unavailable', ...(detail ? { detail } : {}) },
+    { status: 503 }
+  );
+}
+
+function nonJsonUpstream(rawBody: string, status: number): NextResponse {
+  return NextResponse.json(
+    {
+      error: 'Upstream returned non-JSON',
+      upstreamStatus: status,
+      ...(process.env.NODE_ENV !== 'production'
+        ? { bodyPreview: rawBody.slice(0, 300) }
+        : {}),
+    },
+    { status: 502 }
+  );
+}
+
+/**
+ * Forward a JSON request/response to wyrdfold-api with the user's
+ * Supabase JWT as Bearer auth.
+ *
+ * `binary: true` returns the raw response body (bytes) with the
+ * upstream Content-Type/Disposition preserved — used for `.docx`
+ * downloads and zip exports.
+ */
+export async function proxyToWyrdfoldAPI(
+  path: string,
+  options: {
+    method?: string;
+    body?: unknown;
+    searchParams?: URLSearchParams;
+    binary?: boolean;
+    timeoutMs?: number;
+  } = {}
+): Promise<NextResponse> {
+  const { method = 'GET', body, searchParams, binary = false } = options;
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+  const accessToken = await getAccessToken();
+  if (accessToken === null) return unauthorized();
+
+  const qs = searchParams ? `?${searchParams.toString()}` : '';
+  const url = `${apiBaseUrl()}${path}${qs}`;
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const res = await fetch(url, {
+      method,
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: body ? JSON.stringify(body) : null,
+      signal: controller.signal,
+    });
+
+    if (binary) {
+      const buffer = await res.arrayBuffer();
+      const headers: Record<string, string> = {
+        'Content-Type':
+          res.headers.get('Content-Type') ?? 'application/octet-stream',
+      };
+      const disposition = res.headers.get('Content-Disposition');
+      if (disposition) headers['Content-Disposition'] = disposition;
+      return new NextResponse(buffer, { status: res.status, headers });
+    }
+
+    const rawBody = await res.text();
+    try {
+      return NextResponse.json(JSON.parse(rawBody), { status: res.status });
+    } catch {
+      return nonJsonUpstream(rawBody, res.status);
+    }
+  } catch (err) {
+    return unavailable(err);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Stream the upstream response body straight through. Used for SSE
+ * endpoints — buffering would defeat the point. The caller's
+ * `Request.signal` cancels the upstream fetch when the client
+ * disconnects, so we don't leave LLM calls running.
+ */
+export async function proxyStreamingToWyrdfoldAPI(
+  path: string,
+  request: Request,
+  options: { method?: string; body?: unknown } = {}
+): Promise<NextResponse> {
+  const { method = 'POST', body } = options;
+
+  const accessToken = await getAccessToken();
+  if (accessToken === null) return unauthorized();
+
+  const url = `${apiBaseUrl()}${path}`;
+
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      method,
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: body ? JSON.stringify(body) : null,
+      signal: request.signal,
+    });
+  } catch (err) {
+    return unavailable(err);
+  }
+
+  // Non-streaming error path: surface upstream errors as JSON before any
+  // SSE frames. The upstream emits text/event-stream only on success.
+  if (!res.ok || !res.body) {
+    const text = await res.text();
+    try {
+      return NextResponse.json(JSON.parse(text), { status: res.status });
+    } catch {
+      return NextResponse.json(
+        { error: 'Upstream error', upstreamStatus: res.status },
+        { status: res.status || 502 }
+      );
+    }
+  }
+
+  return new NextResponse(res.body, {
+    status: 200,
+    headers: {
+      'Content-Type': res.headers.get('Content-Type') ?? 'text/event-stream',
+      'Cache-Control': 'no-cache, no-transform',
+      'X-Accel-Buffering': 'no',
+    },
+  });
+}
+
+/**
+ * Forward a multipart/form-data request to wyrdfold-api. Pipes the raw
+ * body through so the multipart boundary is preserved.
+ */
+export async function proxyMultipartToWyrdfoldAPI(
+  path: string,
+  request: Request,
+  options: { searchParams?: URLSearchParams; timeoutMs?: number } = {}
+): Promise<NextResponse> {
+  const { searchParams } = options;
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+  const accessToken = await getAccessToken();
+  if (accessToken === null) return unauthorized();
+
+  const qs = searchParams ? `?${searchParams.toString()}` : '';
+  const url = `${apiBaseUrl()}${path}${qs}`;
+  const contentType = request.headers.get('Content-Type') ?? '';
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        'Content-Type': contentType,
+      },
+      body: request.body,
+      signal: controller.signal,
+      // @ts-expect-error -- Node fetch supports duplex for streaming request bodies
+      duplex: 'half',
+    });
+
+    const rawBody = await res.text();
+    try {
+      return NextResponse.json(JSON.parse(rawBody), { status: res.status });
+    } catch {
+      return nonJsonUpstream(rawBody, res.status);
+    }
+  } catch (err) {
+    return unavailable(err);
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/apps/wyrdfold/src/lib/supabase/auth-server.ts
+++ b/apps/wyrdfold/src/lib/supabase/auth-server.ts
@@ -1,0 +1,33 @@
+import { createServerClient } from '@supabase/ssr';
+import { cookies } from 'next/headers';
+
+/**
+ * Supabase client for server-side auth operations (Route Handlers,
+ * Server Components, Server Actions). Uses the anon key + request
+ * cookies, so RLS applies under the authenticated user's identity.
+ */
+export async function createAuthServerClient() {
+  const supabaseUrl = process.env['NEXT_PUBLIC_SUPABASE_URL'];
+  const anonKey = process.env['NEXT_PUBLIC_SUPABASE_ANON_ID'];
+
+  if (!supabaseUrl || !anonKey) {
+    throw new Error(
+      'Missing NEXT_PUBLIC_SUPABASE_URL or NEXT_PUBLIC_SUPABASE_ANON_ID environment variables'
+    );
+  }
+
+  const cookieStore = await cookies();
+
+  return createServerClient(supabaseUrl, anonKey, {
+    cookies: {
+      getAll() {
+        return cookieStore.getAll();
+      },
+      setAll(cookiesToSet) {
+        for (const { name, value, options } of cookiesToSet) {
+          cookieStore.set(name, value, options);
+        }
+      },
+    },
+  });
+}


### PR DESCRIPTION
## Summary

- Adds Next.js Route Handler primitives that sit between the browser and `wyrdfold-api`, forwarding the user's Supabase JWT as Bearer auth so browser code never sees the API URL or shared secrets.
- `proxyToWyrdfoldAPI` (JSON + binary), `proxyStreamingToWyrdfoldAPI` (SSE pass-through using request signal so client disconnects cancel the upstream LLM call), and `proxyMultipartToWyrdfoldAPI` (raw body stream so multipart boundaries survive) cover all three response shapes.
- Sentinel `GET /api/career/experience/optimized` route validates the foundation end-to-end. Future Phase 4 PRs will add the rest.
- `.env.example`: renames `JOB_API_URL` → `WYRDFOLD_API_URL`. Drops `JOB_API_TOKEN` — the BFF forwards the user's JWT, no shared-secret api-key.

## Why

Phase 3b.4 enabled per-user JWT auth + LLM budget enforcement on the Python side. Phase 4 puts the BFF in front of it so the browser never calls the Python API directly, hiding the upstream URL and giving us a place to enforce session before any upstream round-trip.

## Test plan

- [x] `pnpm nx test wyrdfold` — 16 tests covering 401-without-session, JWT forwarding, search params, JSON body serialization, 502 on non-JSON, 503 on fetch error, binary pass-through, SSE pass-through, multipart Content-Type preservation
- [x] `pnpm nx lint wyrdfold` — clean
- [x] `pnpm nx build wyrdfold` — Next.js compile + typecheck pass; sentinel route registered as dynamic
- [x] `pnpm tsc --noEmit` — workspace-wide typecheck clean
- [ ] Smoke test the sentinel route against a running `wyrdfold-api` after merge (deferred to a later phase when more routes land)

## Notes

- `proxy.ts` reads `WYRDFOLD_API_URL` at call time (not module load) so tests can mutate env without `jest.isolateModules` gymnastics.
- No app-side handlers wired beyond the sentinel — Phases 4.2–4.5 will port the experience/targets/tailor/jobs route trees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)