### PR TITLE
feat(wyrdfold): port experience BFF routes (Phase 4.2)

### DIFF
--- a/apps/wyrdfold/src/app/api/career/experience/conversation/next-probe/route.ts
+++ b/apps/wyrdfold/src/app/api/career/experience/conversation/next-probe/route.ts
@@ -1,0 +1,7 @@
+import { LLM_TIMEOUT_MS, proxyToWyrdfoldAPI } from '@/lib/api/proxy';
+
+export async function GET() {
+  return proxyToWyrdfoldAPI('/experience/conversation/next-probe', {
+    timeoutMs: LLM_TIMEOUT_MS,
+  });
+}

--- a/apps/wyrdfold/src/app/api/career/experience/conversation/reset/route.ts
+++ b/apps/wyrdfold/src/app/api/career/experience/conversation/reset/route.ts
@@ -1,0 +1,7 @@
+import { proxyToWyrdfoldAPI } from '@/lib/api/proxy';
+
+export async function POST() {
+  return proxyToWyrdfoldAPI('/experience/conversation/reset', {
+    method: 'POST',
+  });
+}

--- a/apps/wyrdfold/src/app/api/career/experience/conversation/turn/route.ts
+++ b/apps/wyrdfold/src/app/api/career/experience/conversation/turn/route.ts
@@ -1,0 +1,12 @@
+import type { NextRequest } from 'next/server';
+
+import { LLM_TIMEOUT_MS, proxyToWyrdfoldAPI } from '@/lib/api/proxy';
+
+export async function POST(request: NextRequest) {
+  const body = await request.json();
+  return proxyToWyrdfoldAPI('/experience/conversation/turn', {
+    method: 'POST',
+    body,
+    timeoutMs: LLM_TIMEOUT_MS,
+  });
+}

--- a/apps/wyrdfold/src/app/api/career/experience/derive/route.ts
+++ b/apps/wyrdfold/src/app/api/career/experience/derive/route.ts
@@ -1,0 +1,8 @@
+import { LLM_TIMEOUT_MS, proxyToWyrdfoldAPI } from '@/lib/api/proxy';
+
+export async function POST() {
+  return proxyToWyrdfoldAPI('/experience/derive', {
+    method: 'POST',
+    timeoutMs: LLM_TIMEOUT_MS,
+  });
+}

--- a/apps/wyrdfold/src/app/api/career/experience/derive/stream/route.ts
+++ b/apps/wyrdfold/src/app/api/career/experience/derive/stream/route.ts
@@ -1,0 +1,7 @@
+import { proxyStreamingToWyrdfoldAPI } from '@/lib/api/proxy';
+
+export async function POST(request: Request) {
+  return proxyStreamingToWyrdfoldAPI('/experience/derive/stream', request, {
+    method: 'POST',
+  });
+}

--- a/apps/wyrdfold/src/app/api/career/experience/gap-health/route.ts
+++ b/apps/wyrdfold/src/app/api/career/experience/gap-health/route.ts
@@ -1,0 +1,5 @@
+import { proxyToWyrdfoldAPI } from '@/lib/api/proxy';
+
+export async function GET() {
+  return proxyToWyrdfoldAPI('/experience/gap-health');
+}

--- a/apps/wyrdfold/src/app/api/career/experience/preferences/route.ts
+++ b/apps/wyrdfold/src/app/api/career/experience/preferences/route.ts
@@ -1,0 +1,19 @@
+import type { NextRequest } from 'next/server';
+
+import { proxyToWyrdfoldAPI } from '@/lib/api/proxy';
+
+export async function GET() {
+  return proxyToWyrdfoldAPI('/experience/preferences');
+}
+
+export async function PUT(request: NextRequest) {
+  const body = await request.json();
+  return proxyToWyrdfoldAPI('/experience/preferences', {
+    method: 'PUT',
+    body,
+  });
+}
+
+export async function DELETE() {
+  return proxyToWyrdfoldAPI('/experience/preferences', { method: 'DELETE' });
+}

--- a/apps/wyrdfold/src/app/api/career/experience/prose/consolidate/route.ts
+++ b/apps/wyrdfold/src/app/api/career/experience/prose/consolidate/route.ts
@@ -1,0 +1,8 @@
+import { LLM_TIMEOUT_MS, proxyToWyrdfoldAPI } from '@/lib/api/proxy';
+
+export async function POST() {
+  return proxyToWyrdfoldAPI('/experience/prose/consolidate', {
+    method: 'POST',
+    timeoutMs: LLM_TIMEOUT_MS,
+  });
+}

--- a/apps/wyrdfold/src/app/api/career/experience/prose/route.ts
+++ b/apps/wyrdfold/src/app/api/career/experience/prose/route.ts
@@ -3,13 +3,10 @@ import type { NextRequest } from 'next/server';
 import { proxyToWyrdfoldAPI } from '@/lib/api/proxy';
 
 export async function GET() {
-  return proxyToWyrdfoldAPI('/experience/optimized');
+  return proxyToWyrdfoldAPI('/experience/prose');
 }
 
 export async function POST(request: NextRequest) {
   const body = await request.json();
-  return proxyToWyrdfoldAPI('/experience/optimized', {
-    method: 'POST',
-    body,
-  });
+  return proxyToWyrdfoldAPI('/experience/prose', { method: 'POST', body });
 }

--- a/apps/wyrdfold/src/app/api/career/experience/turns/route.ts
+++ b/apps/wyrdfold/src/app/api/career/experience/turns/route.ts
@@ -1,0 +1,14 @@
+import type { NextRequest } from 'next/server';
+
+import { proxyToWyrdfoldAPI } from '@/lib/api/proxy';
+
+export async function GET(request: NextRequest) {
+  return proxyToWyrdfoldAPI('/experience/turns', {
+    searchParams: request.nextUrl.searchParams,
+  });
+}
+
+export async function POST(request: NextRequest) {
+  const body = await request.json();
+  return proxyToWyrdfoldAPI('/experience/turns', { method: 'POST', body });
+}

--- a/apps/wyrdfold/src/app/api/career/experience/upload-resume/route.ts
+++ b/apps/wyrdfold/src/app/api/career/experience/upload-resume/route.ts
@@ -1,0 +1,12 @@
+import type { NextRequest } from 'next/server';
+
+import { LLM_TIMEOUT_MS, proxyMultipartToWyrdfoldAPI } from '@/lib/api/proxy';
+
+export async function POST(request: NextRequest) {
+  const autoDerives =
+    request.nextUrl.searchParams.get('auto_derive') === 'true';
+  return proxyMultipartToWyrdfoldAPI('/experience/upload-resume', request, {
+    searchParams: request.nextUrl.searchParams,
+    ...(autoDerives ? { timeoutMs: LLM_TIMEOUT_MS } : {}),
+  });
+}


### PR DESCRIPTION
## Summary

Mirror `wyrdfold-api`'s `experience.py` router 1:1 under `/api/career/experience/*` — 12 route files covering all 16 endpoint methods. The proxy helpers from Phase 4.1 handle auth and 401 internally, so each handler is a thin pass-through.

| Route | Methods | Notes |
|---|---|---|
| `prose` | GET, POST | |
| `prose/consolidate` | POST | LLM timeout |
| `upload-resume` | POST | multipart; LLM timeout when `?auto_derive=true` |
| `optimized` | + POST | GET landed in 4.1 |
| `derive` | POST | LLM timeout |
| `derive/stream` | POST | SSE pass-through; client signal cancels upstream |
| `gap-health` | GET | |
| `preferences` | GET, PUT, DELETE | |
| `turns` | GET, POST | |
| `conversation/turn` | POST | LLM timeout |
| `conversation/reset` | POST | |
| `conversation/next-probe` | GET | LLM timeout |

## Why

Phase 4.1 wired the foundation (proxy helpers + auth + sentinel). This batch covers the experience surface — the largest router in `wyrdfold-api` and the one the resume/conversation flows hit on every interaction. Targets, tailor, and jobs follow in 4.3–4.5.

## Notes

- **No BFF-side rate limiting** — Phase 3b.4 added a per-user rolling daily/hourly LLM budget at the Python layer, which is the new model. Root's `checkDeriveRateLimit` / `checkUploadRateLimit` were not ported.
- `exactOptionalPropertyTypes` caught a subtle bug: passing `timeoutMs: undefined` is a type error against the optional `timeoutMs?: number` signature. Fixed with conditional spread `...(autoDerives ? { timeoutMs: LLM_TIMEOUT_MS } : {})`.

## Test plan

- [x] `pnpm nx lint wyrdfold` — clean
- [x] `pnpm nx test wyrdfold` — 16 proxy tests still passing (no new tests needed; routes are 4-line thin wrappers)
- [x] `pnpm nx build wyrdfold` — all 12 routes registered as dynamic
- [x] `pnpm tsc --noEmit` — workspace-wide typecheck clean
- [ ] End-to-end smoke against running `wyrdfold-api` (deferred to a later phase when client wiring lands)

🤖 Generated with [Claude Code](https://claude.com/claude-code)