### PR TITLE
feat(wyrdfold): port targets BFF routes (Phase 4.3)

### DIFF
--- a/apps/wyrdfold/src/app/api/targets/[id]/activate/route.ts
+++ b/apps/wyrdfold/src/app/api/targets/[id]/activate/route.ts
@@ -1,0 +1,13 @@
+import type { NextRequest } from 'next/server';
+
+import { LLM_TIMEOUT_MS, proxyToWyrdfoldAPI } from '@/lib/api/proxy';
+
+type Params = { params: Promise<{ id: string }> };
+
+export async function POST(_request: NextRequest, { params }: Params) {
+  const { id } = await params;
+  return proxyToWyrdfoldAPI(`/targets/${id}/activate`, {
+    method: 'POST',
+    timeoutMs: LLM_TIMEOUT_MS,
+  });
+}

--- a/apps/wyrdfold/src/app/api/targets/[id]/deactivate/route.ts
+++ b/apps/wyrdfold/src/app/api/targets/[id]/deactivate/route.ts
@@ -1,0 +1,10 @@
+import type { NextRequest } from 'next/server';
+
+import { proxyToWyrdfoldAPI } from '@/lib/api/proxy';
+
+type Params = { params: Promise<{ id: string }> };
+
+export async function POST(_request: NextRequest, { params }: Params) {
+  const { id } = await params;
+  return proxyToWyrdfoldAPI(`/targets/${id}/deactivate`, { method: 'POST' });
+}

--- a/apps/wyrdfold/src/app/api/targets/[id]/derive-profile/route.ts
+++ b/apps/wyrdfold/src/app/api/targets/[id]/derive-profile/route.ts
@@ -1,0 +1,13 @@
+import type { NextRequest } from 'next/server';
+
+import { LLM_TIMEOUT_MS, proxyToWyrdfoldAPI } from '@/lib/api/proxy';
+
+type Params = { params: Promise<{ id: string }> };
+
+export async function POST(_request: NextRequest, { params }: Params) {
+  const { id } = await params;
+  return proxyToWyrdfoldAPI(`/targets/${id}/derive-profile`, {
+    method: 'POST',
+    timeoutMs: LLM_TIMEOUT_MS,
+  });
+}

--- a/apps/wyrdfold/src/app/api/targets/[id]/link/route.ts
+++ b/apps/wyrdfold/src/app/api/targets/[id]/link/route.ts
@@ -1,0 +1,13 @@
+import type { NextRequest } from 'next/server';
+
+import { LLM_TIMEOUT_MS, proxyToWyrdfoldAPI } from '@/lib/api/proxy';
+
+type Params = { params: Promise<{ id: string }> };
+
+export async function POST(_request: NextRequest, { params }: Params) {
+  const { id } = await params;
+  return proxyToWyrdfoldAPI(`/targets/${id}/link`, {
+    method: 'POST',
+    timeoutMs: LLM_TIMEOUT_MS,
+  });
+}

--- a/apps/wyrdfold/src/app/api/targets/[id]/poll-jobs/route.ts
+++ b/apps/wyrdfold/src/app/api/targets/[id]/poll-jobs/route.ts
@@ -1,0 +1,10 @@
+import type { NextRequest } from 'next/server';
+
+import { proxyToWyrdfoldAPI } from '@/lib/api/proxy';
+
+type Params = { params: Promise<{ id: string }> };
+
+export async function POST(_request: NextRequest, { params }: Params) {
+  const { id } = await params;
+  return proxyToWyrdfoldAPI(`/targets/${id}/poll-jobs`, { method: 'POST' });
+}

--- a/apps/wyrdfold/src/app/api/targets/[id]/reference-jds/[refId]/route.ts
+++ b/apps/wyrdfold/src/app/api/targets/[id]/reference-jds/[refId]/route.ts
@@ -1,0 +1,12 @@
+import type { NextRequest } from 'next/server';
+
+import { proxyToWyrdfoldAPI } from '@/lib/api/proxy';
+
+type Params = { params: Promise<{ id: string; refId: string }> };
+
+export async function DELETE(_request: NextRequest, { params }: Params) {
+  const { id, refId } = await params;
+  return proxyToWyrdfoldAPI(`/targets/${id}/reference-jds/${refId}`, {
+    method: 'DELETE',
+  });
+}

--- a/apps/wyrdfold/src/app/api/targets/[id]/reference-jds/route.ts
+++ b/apps/wyrdfold/src/app/api/targets/[id]/reference-jds/route.ts
@@ -1,0 +1,20 @@
+import type { NextRequest } from 'next/server';
+
+import { LLM_TIMEOUT_MS, proxyToWyrdfoldAPI } from '@/lib/api/proxy';
+
+type Params = { params: Promise<{ id: string }> };
+
+export async function GET(_request: NextRequest, { params }: Params) {
+  const { id } = await params;
+  return proxyToWyrdfoldAPI(`/targets/${id}/reference-jds`);
+}
+
+export async function POST(request: NextRequest, { params }: Params) {
+  const { id } = await params;
+  const body = await request.json();
+  return proxyToWyrdfoldAPI(`/targets/${id}/reference-jds`, {
+    method: 'POST',
+    body,
+    timeoutMs: LLM_TIMEOUT_MS,
+  });
+}

--- a/apps/wyrdfold/src/app/api/targets/[id]/route.ts
+++ b/apps/wyrdfold/src/app/api/targets/[id]/route.ts
@@ -1,0 +1,21 @@
+import type { NextRequest } from 'next/server';
+
+import { proxyToWyrdfoldAPI } from '@/lib/api/proxy';
+
+type Params = { params: Promise<{ id: string }> };
+
+export async function GET(_request: NextRequest, { params }: Params) {
+  const { id } = await params;
+  return proxyToWyrdfoldAPI(`/targets/${id}`);
+}
+
+export async function PATCH(request: NextRequest, { params }: Params) {
+  const { id } = await params;
+  const body = await request.json();
+  return proxyToWyrdfoldAPI(`/targets/${id}`, { method: 'PATCH', body });
+}
+
+export async function DELETE(_request: NextRequest, { params }: Params) {
+  const { id } = await params;
+  return proxyToWyrdfoldAPI(`/targets/${id}`, { method: 'DELETE' });
+}

--- a/apps/wyrdfold/src/app/api/targets/[id]/status/route.ts
+++ b/apps/wyrdfold/src/app/api/targets/[id]/status/route.ts
@@ -1,0 +1,10 @@
+import type { NextRequest } from 'next/server';
+
+import { proxyToWyrdfoldAPI } from '@/lib/api/proxy';
+
+type Params = { params: Promise<{ id: string }> };
+
+export async function GET(_request: NextRequest, { params }: Params) {
+  const { id } = await params;
+  return proxyToWyrdfoldAPI(`/targets/${id}/status`);
+}

--- a/apps/wyrdfold/src/app/api/targets/active/route.ts
+++ b/apps/wyrdfold/src/app/api/targets/active/route.ts
@@ -1,0 +1,5 @@
+import { proxyToWyrdfoldAPI } from '@/lib/api/proxy';
+
+export async function GET() {
+  return proxyToWyrdfoldAPI('/targets/active');
+}

--- a/apps/wyrdfold/src/app/api/targets/from-manual/route.ts
+++ b/apps/wyrdfold/src/app/api/targets/from-manual/route.ts
@@ -1,0 +1,12 @@
+import type { NextRequest } from 'next/server';
+
+import { LLM_TIMEOUT_MS, proxyToWyrdfoldAPI } from '@/lib/api/proxy';
+
+export async function POST(request: NextRequest) {
+  const body = await request.json();
+  return proxyToWyrdfoldAPI('/targets/from-manual', {
+    method: 'POST',
+    body,
+    timeoutMs: LLM_TIMEOUT_MS,
+  });
+}

--- a/apps/wyrdfold/src/app/api/targets/from-posting/[id]/route.ts
+++ b/apps/wyrdfold/src/app/api/targets/from-posting/[id]/route.ts
@@ -1,0 +1,13 @@
+import type { NextRequest } from 'next/server';
+
+import { LLM_TIMEOUT_MS, proxyToWyrdfoldAPI } from '@/lib/api/proxy';
+
+type Params = { params: Promise<{ id: string }> };
+
+export async function POST(_request: NextRequest, { params }: Params) {
+  const { id } = await params;
+  return proxyToWyrdfoldAPI(`/targets/from-posting/${id}`, {
+    method: 'POST',
+    timeoutMs: LLM_TIMEOUT_MS,
+  });
+}

--- a/apps/wyrdfold/src/app/api/targets/from-url/route.ts
+++ b/apps/wyrdfold/src/app/api/targets/from-url/route.ts
@@ -1,0 +1,12 @@
+import type { NextRequest } from 'next/server';
+
+import { LLM_TIMEOUT_MS, proxyToWyrdfoldAPI } from '@/lib/api/proxy';
+
+export async function POST(request: NextRequest) {
+  const body = await request.json();
+  return proxyToWyrdfoldAPI('/targets/from-url', {
+    method: 'POST',
+    body,
+    timeoutMs: LLM_TIMEOUT_MS,
+  });
+}

--- a/apps/wyrdfold/src/app/api/targets/mine/route.ts
+++ b/apps/wyrdfold/src/app/api/targets/mine/route.ts
@@ -1,0 +1,5 @@
+import { proxyToWyrdfoldAPI } from '@/lib/api/proxy';
+
+export async function GET() {
+  return proxyToWyrdfoldAPI('/targets/mine');
+}

--- a/apps/wyrdfold/src/app/api/targets/route.ts
+++ b/apps/wyrdfold/src/app/api/targets/route.ts
@@ -1,0 +1,12 @@
+import type { NextRequest } from 'next/server';
+
+import { proxyToWyrdfoldAPI } from '@/lib/api/proxy';
+
+export async function GET() {
+  return proxyToWyrdfoldAPI('/targets');
+}
+
+export async function POST(request: NextRequest) {
+  const body = await request.json();
+  return proxyToWyrdfoldAPI('/targets', { method: 'POST', body });
+}

--- a/apps/wyrdfold/src/app/api/targets/suggest/route.ts
+++ b/apps/wyrdfold/src/app/api/targets/suggest/route.ts
@@ -1,0 +1,8 @@
+import { LLM_TIMEOUT_MS, proxyToWyrdfoldAPI } from '@/lib/api/proxy';
+
+export async function POST() {
+  return proxyToWyrdfoldAPI('/targets/suggest', {
+    method: 'POST',
+    timeoutMs: LLM_TIMEOUT_MS,
+  });
+}


### PR DESCRIPTION
## Summary

Mirror `wyrdfold-api`'s `targets.py` router 1:1 under `/api/targets/*` — 16 route files covering 20 endpoint methods. Five are LLM-backed; the per-user budget guard from Phase 3b.4 enforces caps server-side, so no BFF-side rate limiting was ported.

| Route | Methods | LLM |
|---|---|---|
| `targets` | GET, POST | |
| `targets/from-manual` | POST | ✓ |
| `targets/from-url` | POST | ✓ |
| `targets/suggest` | POST | ✓ |
| `targets/active` | GET | |
| `targets/mine` | GET | |
| `targets/[id]` | GET, PATCH, DELETE | |
| `targets/[id]/activate` | POST | ✓ |
| `targets/[id]/deactivate` | POST | |
| `targets/[id]/link` | POST | ✓ |
| `targets/[id]/derive-profile` | POST | ✓ |
| `targets/[id]/poll-jobs` | POST | |
| `targets/[id]/status` | GET | |
| `targets/[id]/reference-jds` | GET, POST | ✓ (POST) |
| `targets/[id]/reference-jds/[refId]` | DELETE | |
| `targets/from-posting/[id]` | POST | ✓ |

## Notes

- Path params follow Next.js `[id]` / `[refId]` (the API uses `target_id` / `ref_jd_id` in FastAPI signatures — same value, different name; the destructure in the handler maps them).
- Standardized the params type as `type Params = { params: Promise<{ id: string }> }` per Next.js 15+ async-params signature; root has the same shape inlined.
- LLM routes use `LLM_TIMEOUT_MS` (120s) so fit-score derivation and JD merging don't hit the 30s default.

## Test plan

- [x] `pnpm nx lint wyrdfold` — clean
- [x] `pnpm nx test wyrdfold` — 16 proxy tests still passing
- [x] `pnpm nx build wyrdfold` — all 16 target routes registered as dynamic
- [x] `pnpm tsc --noEmit` — clean
- [ ] End-to-end smoke deferred until client wiring lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)