### PR TITLE
feat(wyrdfold): port tailor + analysis BFF routes (Phase 4.4)

### DIFF
--- a/apps/wyrdfold/src/app/api/jobs/analysis/[id]/route.ts
+++ b/apps/wyrdfold/src/app/api/jobs/analysis/[id]/route.ts
@@ -1,0 +1,22 @@
+import { type NextRequest, NextResponse } from 'next/server';
+
+import { LLM_TIMEOUT_MS, proxyToWyrdfoldAPI } from '@/lib/api/proxy';
+
+type Params = { params: Promise<{ id: string }> };
+
+export async function POST(request: NextRequest, { params }: Params) {
+  const { id } = await params;
+  const targetId = request.nextUrl.searchParams.get('target_id');
+  if (!targetId) {
+    return NextResponse.json(
+      { error: 'target_id query param required' },
+      { status: 400 }
+    );
+  }
+
+  return proxyToWyrdfoldAPI(`/analysis/${id}`, {
+    method: 'POST',
+    searchParams: new URLSearchParams({ target_id: targetId }),
+    timeoutMs: LLM_TIMEOUT_MS,
+  });
+}

--- a/apps/wyrdfold/src/app/api/jobs/tailor/[id]/approve/route.ts
+++ b/apps/wyrdfold/src/app/api/jobs/tailor/[id]/approve/route.ts
@@ -1,0 +1,12 @@
+import type { NextRequest } from 'next/server';
+
+import { proxyToWyrdfoldAPI } from '@/lib/api/proxy';
+
+type Params = { params: Promise<{ id: string }> };
+
+export async function POST(_request: NextRequest, { params }: Params) {
+  const { id } = await params;
+  return proxyToWyrdfoldAPI(`/tailor/resumes/${id}/approve`, {
+    method: 'POST',
+  });
+}

--- a/apps/wyrdfold/src/app/api/jobs/tailor/[id]/checkpoint/route.ts
+++ b/apps/wyrdfold/src/app/api/jobs/tailor/[id]/checkpoint/route.ts
@@ -1,0 +1,23 @@
+import type { NextRequest } from 'next/server';
+
+import { proxyToWyrdfoldAPI } from '@/lib/api/proxy';
+
+type Params = { params: Promise<{ id: string }> };
+
+export async function POST(request: NextRequest, { params }: Params) {
+  const { id } = await params;
+  // Body may be empty (explicit checkpoint with no flush) or contain
+  // {markdown} for the sendBeacon flush case. Tolerate both.
+  let body: unknown = null;
+  try {
+    const text = await request.text();
+    if (text) body = JSON.parse(text);
+  } catch {
+    /* fall through with body null */
+  }
+
+  return proxyToWyrdfoldAPI(`/tailor/resumes/${id}/checkpoint`, {
+    method: 'POST',
+    ...(body ? { body } : {}),
+  });
+}

--- a/apps/wyrdfold/src/app/api/jobs/tailor/[id]/download/route.ts
+++ b/apps/wyrdfold/src/app/api/jobs/tailor/[id]/download/route.ts
@@ -1,0 +1,10 @@
+import type { NextRequest } from 'next/server';
+
+import { proxyToWyrdfoldAPI } from '@/lib/api/proxy';
+
+type Params = { params: Promise<{ id: string }> };
+
+export async function GET(_request: NextRequest, { params }: Params) {
+  const { id } = await params;
+  return proxyToWyrdfoldAPI(`/tailor/resumes/${id}/download`, { binary: true });
+}

--- a/apps/wyrdfold/src/app/api/jobs/tailor/[id]/route.ts
+++ b/apps/wyrdfold/src/app/api/jobs/tailor/[id]/route.ts
@@ -1,0 +1,19 @@
+import type { NextRequest } from 'next/server';
+
+import { proxyToWyrdfoldAPI } from '@/lib/api/proxy';
+
+type Params = { params: Promise<{ id: string }> };
+
+export async function GET(_request: NextRequest, { params }: Params) {
+  const { id } = await params;
+  return proxyToWyrdfoldAPI(`/tailor/resumes/${id}`);
+}
+
+export async function PATCH(request: NextRequest, { params }: Params) {
+  const { id } = await params;
+  const body = await request.json();
+  return proxyToWyrdfoldAPI(`/tailor/resumes/${id}`, {
+    method: 'PATCH',
+    body,
+  });
+}

--- a/apps/wyrdfold/src/app/api/jobs/tailor/[id]/unapprove/route.ts
+++ b/apps/wyrdfold/src/app/api/jobs/tailor/[id]/unapprove/route.ts
@@ -1,0 +1,12 @@
+import type { NextRequest } from 'next/server';
+
+import { proxyToWyrdfoldAPI } from '@/lib/api/proxy';
+
+type Params = { params: Promise<{ id: string }> };
+
+export async function POST(_request: NextRequest, { params }: Params) {
+  const { id } = await params;
+  return proxyToWyrdfoldAPI(`/tailor/resumes/${id}/unapprove`, {
+    method: 'POST',
+  });
+}

--- a/apps/wyrdfold/src/app/api/jobs/tailor/[id]/versions/route.ts
+++ b/apps/wyrdfold/src/app/api/jobs/tailor/[id]/versions/route.ts
@@ -1,0 +1,10 @@
+import type { NextRequest } from 'next/server';
+
+import { proxyToWyrdfoldAPI } from '@/lib/api/proxy';
+
+type Params = { params: Promise<{ id: string }> };
+
+export async function GET(_request: NextRequest, { params }: Params) {
+  const { id } = await params;
+  return proxyToWyrdfoldAPI(`/tailor/resumes/${id}/versions`);
+}

--- a/apps/wyrdfold/src/app/api/jobs/tailor/batch/[id]/route.ts
+++ b/apps/wyrdfold/src/app/api/jobs/tailor/batch/[id]/route.ts
@@ -1,0 +1,10 @@
+import type { NextRequest } from 'next/server';
+
+import { proxyToWyrdfoldAPI } from '@/lib/api/proxy';
+
+type Params = { params: Promise<{ id: string }> };
+
+export async function GET(_request: NextRequest, { params }: Params) {
+  const { id } = await params;
+  return proxyToWyrdfoldAPI(`/tailor/batch/${id}`);
+}

--- a/apps/wyrdfold/src/app/api/jobs/tailor/batch/route.ts
+++ b/apps/wyrdfold/src/app/api/jobs/tailor/batch/route.ts
@@ -1,0 +1,12 @@
+import type { NextRequest } from 'next/server';
+
+import { LLM_TIMEOUT_MS, proxyToWyrdfoldAPI } from '@/lib/api/proxy';
+
+export async function POST(request: NextRequest) {
+  const body = await request.json();
+  return proxyToWyrdfoldAPI('/tailor/batch', {
+    method: 'POST',
+    body,
+    timeoutMs: LLM_TIMEOUT_MS,
+  });
+}

--- a/apps/wyrdfold/src/app/api/jobs/tailor/by-job/[id]/cover-letter/route.ts
+++ b/apps/wyrdfold/src/app/api/jobs/tailor/by-job/[id]/cover-letter/route.ts
@@ -1,0 +1,10 @@
+import type { NextRequest } from 'next/server';
+
+import { proxyToWyrdfoldAPI } from '@/lib/api/proxy';
+
+type Params = { params: Promise<{ id: string }> };
+
+export async function GET(_request: NextRequest, { params }: Params) {
+  const { id } = await params;
+  return proxyToWyrdfoldAPI(`/tailor/cover-letters/by-job/${id}`);
+}

--- a/apps/wyrdfold/src/app/api/jobs/tailor/by-job/[id]/route.ts
+++ b/apps/wyrdfold/src/app/api/jobs/tailor/by-job/[id]/route.ts
@@ -1,0 +1,10 @@
+import type { NextRequest } from 'next/server';
+
+import { proxyToWyrdfoldAPI } from '@/lib/api/proxy';
+
+type Params = { params: Promise<{ id: string }> };
+
+export async function GET(_request: NextRequest, { params }: Params) {
+  const { id } = await params;
+  return proxyToWyrdfoldAPI(`/tailor/resumes/by-job/${id}`);
+}

--- a/apps/wyrdfold/src/app/api/jobs/tailor/cover-letter/route.ts
+++ b/apps/wyrdfold/src/app/api/jobs/tailor/cover-letter/route.ts
@@ -1,0 +1,12 @@
+import type { NextRequest } from 'next/server';
+
+import { LLM_TIMEOUT_MS, proxyToWyrdfoldAPI } from '@/lib/api/proxy';
+
+export async function POST(request: NextRequest) {
+  const body = await request.json();
+  return proxyToWyrdfoldAPI('/tailor/cover-letter', {
+    method: 'POST',
+    body,
+    timeoutMs: LLM_TIMEOUT_MS,
+  });
+}

--- a/apps/wyrdfold/src/app/api/jobs/tailor/cover-letters/route.ts
+++ b/apps/wyrdfold/src/app/api/jobs/tailor/cover-letters/route.ts
@@ -1,0 +1,9 @@
+import type { NextRequest } from 'next/server';
+
+import { proxyToWyrdfoldAPI } from '@/lib/api/proxy';
+
+export async function GET(request: NextRequest) {
+  return proxyToWyrdfoldAPI('/tailor/cover-letters', {
+    searchParams: request.nextUrl.searchParams,
+  });
+}

--- a/apps/wyrdfold/src/app/api/jobs/tailor/export-zip/route.ts
+++ b/apps/wyrdfold/src/app/api/jobs/tailor/export-zip/route.ts
@@ -1,0 +1,12 @@
+import type { NextRequest } from 'next/server';
+
+import { proxyToWyrdfoldAPI } from '@/lib/api/proxy';
+
+export async function POST(request: NextRequest) {
+  const body = await request.json();
+  return proxyToWyrdfoldAPI('/tailor/resumes/export-zip', {
+    method: 'POST',
+    body,
+    binary: true,
+  });
+}

--- a/apps/wyrdfold/src/app/api/jobs/tailor/resume/route.ts
+++ b/apps/wyrdfold/src/app/api/jobs/tailor/resume/route.ts
@@ -1,0 +1,12 @@
+import type { NextRequest } from 'next/server';
+
+import { LLM_TIMEOUT_MS, proxyToWyrdfoldAPI } from '@/lib/api/proxy';
+
+export async function POST(request: NextRequest) {
+  const body = await request.json();
+  return proxyToWyrdfoldAPI('/tailor/resume', {
+    method: 'POST',
+    body,
+    timeoutMs: LLM_TIMEOUT_MS,
+  });
+}

--- a/apps/wyrdfold/src/app/api/jobs/tailor/resumes/route.ts
+++ b/apps/wyrdfold/src/app/api/jobs/tailor/resumes/route.ts
@@ -1,0 +1,9 @@
+import type { NextRequest } from 'next/server';
+
+import { proxyToWyrdfoldAPI } from '@/lib/api/proxy';
+
+export async function GET(request: NextRequest) {
+  return proxyToWyrdfoldAPI('/tailor/resumes', {
+    searchParams: request.nextUrl.searchParams,
+  });
+}


### PR DESCRIPTION
## Summary

Mirror `wyrdfold-api`'s `tailor.py` and `analysis.py` routers 1:1 under `/api/jobs/tailor/*` and `/api/jobs/analysis/[id]`. 16 route files, 17 endpoint methods, 5 LLM-backed (server-side budget enforcement carries over from Phase 3b.4).

### Tailor (`/tailor/*`)

| Route | Methods | Notes |
|---|---|---|
| `tailor/resume` | POST | LLM |
| `tailor/cover-letter` | POST | LLM |
| `tailor/resumes` | GET | `?limit=` |
| `tailor/cover-letters` | GET | `?limit=` |
| `tailor/by-job/[id]` | GET | resume by job posting |
| `tailor/by-job/[id]/cover-letter` | GET | |
| `tailor/export-zip` | POST | **binary** (.zip) |
| `tailor/[id]` | GET, PATCH | proxies to `/tailor/resumes/{id}` |
| `tailor/[id]/checkpoint` | POST | empty-body tolerant for `sendBeacon` flush |
| `tailor/[id]/approve` | POST | |
| `tailor/[id]/unapprove` | POST | |
| `tailor/[id]/versions` | GET | |
| `tailor/[id]/download` | GET | **binary** (.docx) |
| `tailor/batch` | POST | LLM |
| `tailor/batch/[id]` | GET | |

### Analysis (`/analysis/*`)

| Route | Methods | Notes |
|---|---|---|
| `analysis/[id]` | POST | LLM; **400** if `target_id` query param missing |

## Notes

- URL conventions match root's existing tailor BFF (`/api/jobs/tailor/*`) so downstream UI can be ported with minimal rewiring. Some BFF segments diverge from API segments (`tailor/[id]` → `/tailor/resumes/{id}`, `tailor/by-job/[id]` → `/tailor/resumes/by-job/{id}`) — preserved for parity.
- `tailor/resumes` (GET list) was missing in root's BFF — added here as a parallel to `cover-letters`.
- `analysis/[id]` validates `target_id` at the BFF before touching upstream — saves a round-trip on the most likely client bug.

## Test plan

- [x] `pnpm nx lint wyrdfold` — clean
- [x] `pnpm nx test wyrdfold` — 16 proxy tests still passing
- [x] `pnpm nx build wyrdfold` — all 16 routes registered
- [x] `pnpm tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)