### PR TITLE
feat(wyrdfold): port jobs/insights/sources/profile BFF routes (Phase 4.5)

### DIFF
--- a/apps/wyrdfold/src/app/api/jobs/[id]/route.ts
+++ b/apps/wyrdfold/src/app/api/jobs/[id]/route.ts
@@ -1,0 +1,15 @@
+import type { NextRequest } from 'next/server';
+
+import { proxyToWyrdfoldAPI } from '@/lib/api/proxy';
+
+type Params = { params: Promise<{ id: string }> };
+
+export async function GET(_request: NextRequest, { params }: Params) {
+  const { id } = await params;
+  return proxyToWyrdfoldAPI(`/jobs/${id}`);
+}
+
+export async function DELETE(_request: NextRequest, { params }: Params) {
+  const { id } = await params;
+  return proxyToWyrdfoldAPI(`/jobs/${id}`, { method: 'DELETE' });
+}

--- a/apps/wyrdfold/src/app/api/jobs/[id]/status-history/route.ts
+++ b/apps/wyrdfold/src/app/api/jobs/[id]/status-history/route.ts
@@ -1,0 +1,10 @@
+import type { NextRequest } from 'next/server';
+
+import { proxyToWyrdfoldAPI } from '@/lib/api/proxy';
+
+type Params = { params: Promise<{ id: string }> };
+
+export async function GET(_request: NextRequest, { params }: Params) {
+  const { id } = await params;
+  return proxyToWyrdfoldAPI(`/jobs/${id}/status-history`);
+}

--- a/apps/wyrdfold/src/app/api/jobs/[id]/status/route.ts
+++ b/apps/wyrdfold/src/app/api/jobs/[id]/status/route.ts
@@ -1,0 +1,11 @@
+import type { NextRequest } from 'next/server';
+
+import { proxyToWyrdfoldAPI } from '@/lib/api/proxy';
+
+type Params = { params: Promise<{ id: string }> };
+
+export async function POST(request: NextRequest, { params }: Params) {
+  const { id } = await params;
+  const body = await request.json();
+  return proxyToWyrdfoldAPI(`/jobs/${id}/status`, { method: 'POST', body });
+}

--- a/apps/wyrdfold/src/app/api/jobs/backfill-salary/route.ts
+++ b/apps/wyrdfold/src/app/api/jobs/backfill-salary/route.ts
@@ -1,0 +1,5 @@
+import { proxyToWyrdfoldAPI } from '@/lib/api/proxy';
+
+export async function POST() {
+  return proxyToWyrdfoldAPI('/jobs/backfill-salary', { method: 'POST' });
+}

--- a/apps/wyrdfold/src/app/api/jobs/insights/pipeline/route.ts
+++ b/apps/wyrdfold/src/app/api/jobs/insights/pipeline/route.ts
@@ -1,0 +1,13 @@
+import type { NextRequest } from 'next/server';
+
+import { proxyToWyrdfoldAPI } from '@/lib/api/proxy';
+
+import { validatePeriod } from '../validatePeriod';
+
+export async function GET(request: NextRequest) {
+  const invalid = validatePeriod(request);
+  if (invalid) return invalid;
+  return proxyToWyrdfoldAPI('/insights/pipeline', {
+    searchParams: request.nextUrl.searchParams,
+  });
+}

--- a/apps/wyrdfold/src/app/api/jobs/insights/skills-cost/route.ts
+++ b/apps/wyrdfold/src/app/api/jobs/insights/skills-cost/route.ts
@@ -1,0 +1,13 @@
+import type { NextRequest } from 'next/server';
+
+import { proxyToWyrdfoldAPI } from '@/lib/api/proxy';
+
+import { validatePeriod } from '../validatePeriod';
+
+export async function GET(request: NextRequest) {
+  const invalid = validatePeriod(request);
+  if (invalid) return invalid;
+  return proxyToWyrdfoldAPI('/insights/skills-cost', {
+    searchParams: request.nextUrl.searchParams,
+  });
+}

--- a/apps/wyrdfold/src/app/api/jobs/insights/targets/route.ts
+++ b/apps/wyrdfold/src/app/api/jobs/insights/targets/route.ts
@@ -1,0 +1,13 @@
+import type { NextRequest } from 'next/server';
+
+import { proxyToWyrdfoldAPI } from '@/lib/api/proxy';
+
+import { validatePeriod } from '../validatePeriod';
+
+export async function GET(request: NextRequest) {
+  const invalid = validatePeriod(request);
+  if (invalid) return invalid;
+  return proxyToWyrdfoldAPI('/insights/targets', {
+    searchParams: request.nextUrl.searchParams,
+  });
+}

--- a/apps/wyrdfold/src/app/api/jobs/insights/validatePeriod.ts
+++ b/apps/wyrdfold/src/app/api/jobs/insights/validatePeriod.ts
@@ -1,0 +1,24 @@
+import { NextResponse, type NextRequest } from 'next/server';
+
+const VALID_PERIODS = new Set(['7d', '30d', '90d', 'all']);
+
+/**
+ * Reject malformed `?period=` values at the proxy layer with a typed error
+ * payload (`code: 'invalid_period'`) so the UI can distinguish bad input
+ * from a transient upstream failure. Returns null when the parameter is
+ * absent or valid; the caller proceeds with the proxy call.
+ */
+export function validatePeriod(request: NextRequest): NextResponse | null {
+  const period = request.nextUrl.searchParams.get('period');
+  if (period === null) return null;
+  if (!VALID_PERIODS.has(period)) {
+    return NextResponse.json(
+      {
+        error: `Invalid period: '${period}'. Must be one of: 7d, 30d, 90d, all.`,
+        code: 'invalid_period',
+      },
+      { status: 400 }
+    );
+  }
+  return null;
+}

--- a/apps/wyrdfold/src/app/api/jobs/manual/route.ts
+++ b/apps/wyrdfold/src/app/api/jobs/manual/route.ts
@@ -1,0 +1,8 @@
+import type { NextRequest } from 'next/server';
+
+import { proxyToWyrdfoldAPI } from '@/lib/api/proxy';
+
+export async function POST(request: NextRequest) {
+  const body = await request.json();
+  return proxyToWyrdfoldAPI('/jobs/manual', { method: 'POST', body });
+}

--- a/apps/wyrdfold/src/app/api/jobs/poll/route.ts
+++ b/apps/wyrdfold/src/app/api/jobs/poll/route.ts
@@ -1,0 +1,70 @@
+import { timingSafeEqual } from 'node:crypto';
+import { type NextRequest, NextResponse } from 'next/server';
+
+import { getAccessToken } from '@/lib/api/proxy';
+
+function constantTimeEqual(a: string, b: string): boolean {
+  const aBuf = Buffer.from(a, 'utf8');
+  const bBuf = Buffer.from(b, 'utf8');
+  if (aBuf.length !== bBuf.length) return false;
+  return timingSafeEqual(aBuf, bBuf);
+}
+
+export async function POST(request: NextRequest) {
+  const cronSecret = process.env['CRON_SECRET'];
+  const authHeader = request.headers.get('authorization') ?? '';
+  const presented = authHeader.startsWith('Bearer ')
+    ? authHeader.slice('Bearer '.length)
+    : '';
+  const isCron = !!cronSecret && constantTimeEqual(presented, cronSecret);
+
+  if (!isCron) {
+    const accessToken = await getAccessToken();
+    if (accessToken === null) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+  }
+
+  // Upstream /poll is API-key-gated (cron path). Convert here regardless of
+  // whether the caller arrived via cron secret or session — the BFF is the
+  // only thing that holds the API key.
+  const apiKey = process.env['WYRDFOLD_API_KEY'];
+  if (!apiKey) {
+    return NextResponse.json(
+      { error: 'WYRDFOLD_API_KEY not configured' },
+      { status: 503 }
+    );
+  }
+
+  const baseUrl = process.env['WYRDFOLD_API_URL'] ?? '';
+  try {
+    const res = await fetch(`${baseUrl}/poll`, {
+      method: 'POST',
+      headers: {
+        'x-api-key': apiKey,
+        'Content-Type': 'application/json',
+      },
+    });
+    const text = await res.text();
+    try {
+      return NextResponse.json(JSON.parse(text), { status: res.status });
+    } catch {
+      return NextResponse.json(
+        { error: 'Upstream returned non-JSON', upstreamStatus: res.status },
+        { status: 502 }
+      );
+    }
+  } catch (err) {
+    const detail =
+      process.env.NODE_ENV !== 'production' && err instanceof Error
+        ? { message: err.message }
+        : undefined;
+    return NextResponse.json(
+      {
+        error: 'WyrdFold API unavailable',
+        ...(detail ? { detail } : {}),
+      },
+      { status: 503 }
+    );
+  }
+}

--- a/apps/wyrdfold/src/app/api/jobs/rescore/[id]/route.ts
+++ b/apps/wyrdfold/src/app/api/jobs/rescore/[id]/route.ts
@@ -1,0 +1,10 @@
+import type { NextRequest } from 'next/server';
+
+import { proxyToWyrdfoldAPI } from '@/lib/api/proxy';
+
+type Params = { params: Promise<{ id: string }> };
+
+export async function POST(_request: NextRequest, { params }: Params) {
+  const { id } = await params;
+  return proxyToWyrdfoldAPI(`/jobs/rescore/${id}`, { method: 'POST' });
+}

--- a/apps/wyrdfold/src/app/api/jobs/route.ts
+++ b/apps/wyrdfold/src/app/api/jobs/route.ts
@@ -1,0 +1,9 @@
+import type { NextRequest } from 'next/server';
+
+import { proxyToWyrdfoldAPI } from '@/lib/api/proxy';
+
+export async function GET(request: NextRequest) {
+  return proxyToWyrdfoldAPI('/jobs', {
+    searchParams: request.nextUrl.searchParams,
+  });
+}

--- a/apps/wyrdfold/src/app/api/jobs/sources/detect/route.ts
+++ b/apps/wyrdfold/src/app/api/jobs/sources/detect/route.ts
@@ -1,0 +1,9 @@
+import type { NextRequest } from 'next/server';
+
+import { proxyToWyrdfoldAPI } from '@/lib/api/proxy';
+
+export async function GET(request: NextRequest) {
+  return proxyToWyrdfoldAPI('/sources/detect', {
+    searchParams: request.nextUrl.searchParams,
+  });
+}

--- a/apps/wyrdfold/src/app/api/jobs/sources/route.ts
+++ b/apps/wyrdfold/src/app/api/jobs/sources/route.ts
@@ -1,0 +1,18 @@
+import type { NextRequest } from 'next/server';
+
+import { proxyToWyrdfoldAPI } from '@/lib/api/proxy';
+
+type SourceAction =
+  | { action: 'add'; board_token: string; company_name: string }
+  | { action: 'remove' | 'toggle'; board_token: string }
+  | { action: 'seed' };
+
+export async function GET() {
+  return proxyToWyrdfoldAPI('/sources');
+}
+
+export async function POST(request: NextRequest) {
+  const body = (await request.json()) as SourceAction;
+  const path = body.action === 'seed' ? '/sources/seed' : '/sources';
+  return proxyToWyrdfoldAPI(path, { method: 'POST', body });
+}

--- a/apps/wyrdfold/src/app/api/jobs/sources/verify/route.ts
+++ b/apps/wyrdfold/src/app/api/jobs/sources/verify/route.ts
@@ -1,0 +1,9 @@
+import type { NextRequest } from 'next/server';
+
+import { proxyToWyrdfoldAPI } from '@/lib/api/proxy';
+
+export async function GET(request: NextRequest) {
+  return proxyToWyrdfoldAPI('/sources/verify', {
+    searchParams: request.nextUrl.searchParams,
+  });
+}

--- a/apps/wyrdfold/src/app/api/profile/identity/route.ts
+++ b/apps/wyrdfold/src/app/api/profile/identity/route.ts
@@ -1,0 +1,15 @@
+import type { NextRequest } from 'next/server';
+
+import { proxyToWyrdfoldAPI } from '@/lib/api/proxy';
+
+export async function GET() {
+  return proxyToWyrdfoldAPI('/profile/identity');
+}
+
+export async function PATCH(request: NextRequest) {
+  const body = await request.json();
+  return proxyToWyrdfoldAPI('/profile/identity', {
+    method: 'PATCH',
+    body,
+  });
+}

--- a/apps/wyrdfold/src/app/api/profile/notifications/route.ts
+++ b/apps/wyrdfold/src/app/api/profile/notifications/route.ts
@@ -1,0 +1,38 @@
+import { type NextRequest, NextResponse } from 'next/server';
+
+import { proxyToWyrdfoldAPI } from '@/lib/api/proxy';
+
+// Email alerts are sent by the Next.js layer via Resend; the FastAPI
+// only knows it can call back into us. AND its `email_available` flag
+// with the actual Resend key check so a half-configured deployment
+// (FastAPI knows where to call but Resend isn't wired up) reads as off.
+function hasResendKey(): boolean {
+  return Boolean(process.env['RESEND_API_KEY']);
+}
+
+export async function GET() {
+  const upstream = await proxyToWyrdfoldAPI('/profile/notifications');
+  if (upstream.status !== 200) return upstream;
+  const body = (await upstream.json()) as Record<string, unknown> & {
+    email_available?: boolean;
+  };
+  body.email_available = Boolean(body.email_available) && hasResendKey();
+  return NextResponse.json(body);
+}
+
+export async function PATCH(request: NextRequest) {
+  const body = (await request.json()) as Record<string, unknown>;
+  if (body['job_notifications_enabled'] === true && !hasResendKey()) {
+    return NextResponse.json(
+      {
+        detail:
+          'Email notifications are unavailable: the operator has not configured email provider credentials.',
+      },
+      { status: 400 }
+    );
+  }
+  return proxyToWyrdfoldAPI('/profile/notifications', {
+    method: 'PATCH',
+    body,
+  });
+}


### PR DESCRIPTION
## Summary

Final BFF phase. Mirrors root's existing `/api/jobs/*` and `/api/profile/*` surface, proxying to wyrdfold-api routers (`jobs`, `status`, `sources`, `insights`, `user_profile`, `poll`). Browsers hit these handlers; secrets and the upstream URL stay server-side.

Closes the BFF migration. After this lands, every wyrdfold-api router has a Next.js Route Handler in front of it.

## Routes added (17 files)

### Jobs (CRUD + ops)
| Verb | Path | Notes |
|---|---|---|
| GET | `/api/jobs` | list with searchParams (page, sort, status, target_id, …) |
| GET | `/api/jobs/[id]` |  |
| DELETE | `/api/jobs/[id]` |  |
| POST | `/api/jobs/[id]/status` | status transition |
| GET | `/api/jobs/[id]/status-history` |  |
| POST | `/api/jobs/manual` | manual posting add |
| POST | `/api/jobs/backfill-salary` |  |
| POST | `/api/jobs/rescore/[id]` | path id is `target_id` |

### Sources (Greenhouse boards)
| Verb | Path | Notes |
|---|---|---|
| GET | `/api/jobs/sources` |  |
| POST | `/api/jobs/sources` | action: `add` \| `remove` \| `toggle` \| `seed` (seed → `/sources/seed`) |
| GET | `/api/jobs/sources/detect` | URL → board_token |
| GET | `/api/jobs/sources/verify` |  |

### Insights (period-validated)
| Verb | Path | Notes |
|---|---|---|
| GET | `/api/jobs/insights/pipeline` | rejects bad `?period=` with `code: invalid_period` |
| GET | `/api/jobs/insights/skills-cost` | same |
| GET | `/api/jobs/insights/targets` | same |

Plus helper: `apps/wyrdfold/src/app/api/jobs/insights/validatePeriod.ts`.

### Profile
| Verb | Path | Notes |
|---|---|---|
| GET | `/api/profile/identity` |  |
| PATCH | `/api/profile/identity` |  |
| GET | `/api/profile/notifications` | BFF AND-gates `email_available` with `RESEND_API_KEY` |
| PATCH | `/api/profile/notifications` | pre-validates email gate before upstream round-trip |

### Poll (cron + admin trigger)
| Verb | Path | Notes |
|---|---|---|
| POST | `/api/jobs/poll` | cron secret OR session, forwards `X-API-Key` |

## Notes

- **Poll is the only API-key route.** wyrdfold-api `/poll` is gated by `x-api-key` (cron-only at the FastAPI layer). The BFF accepts either a `CRON_SECRET` Bearer (Vercel Cron) or a Supabase session, then converts to outgoing `X-API-Key` from `WYRDFOLD_API_KEY`. Returns 503 if `WYRDFOLD_API_KEY` is missing — make sure it's set in Vercel env. Inline rather than a fourth proxy helper since it's a one-off.
- **Profile/notifications defense-in-depth.** wyrdfold-api already returns `email_available`, but a half-configured deploy (FastAPI thinks email is on, Vercel doesn't have `RESEND_API_KEY`) would silently break. BFF AND-gates the flag and pre-validates `job_notifications_enabled=true` PATCH so the UI gets a 400 before the upstream round-trip.
- **Insights pre-validation** mirrors root: typed `code: invalid_period` payload at the proxy layer instead of relying on FastAPI's 422.
- **Sources POST routes by action.** `seed` goes to `/sources/seed`, everything else goes to `/sources` — matches both root and wyrdfold-api shape.

## URL convention

Same as Phase 4.4 — paths mirror root's existing structure (`/api/jobs/*`, `/api/profile/*`) so the UI port is mechanical. The `/api/jobs/` umbrella still hosts non-jobs concerns (insights, sources, poll) for parity with root, even though it's conceptually loose now that wyrdfold *is* the job-search app.

## Verification

All green:
- ✅ `pnpm nx lint wyrdfold` — clean
- ✅ `pnpm nx test wyrdfold` — 16 proxy tests passing (no test additions in this phase; coverage rides on the foundation tests from 4.1)
- ✅ `pnpm nx build wyrdfold` — all 17 new routes registered as dynamic (ƒ)
- ✅ `pnpm tsc --noEmit` — workspace-wide typecheck clean

## Test plan

- [ ] Set `WYRDFOLD_API_KEY` in Vercel preview env so `/api/jobs/poll` doesn't 503 in preview
- [ ] Set `CRON_SECRET` in Vercel preview env if cron will be wired up via the BFF
- [ ] Smoke `GET /api/jobs?page=1&page_size=5` against running wyrdfold-api once preview deploys
- [ ] Smoke `GET /api/profile/notifications` and confirm `email_available` is `false` in preview if `RESEND_API_KEY` isn't set there
- [ ] Smoke `GET /api/jobs/insights/pipeline?period=bogus` → expect 400 with `code: invalid_period`

## Phase 4 BFF migration: complete

| Phase | Surface | PR |
|---|---|---|
| 4.1 | Foundation (`proxyToWyrdfoldAPI` + multipart + streaming) | #620 |
| 4.2 | Experience routes | #621 |
| 4.3 | Targets routes | #622 |
| 4.4 | Tailor + Analysis routes | #623 |
| **4.5** | **Jobs / Insights / Sources / Profile / Poll** | **(this PR)** |

After this lands, the BFF is at parity with root's `/api/*` surface. Next phase: UI port from root → wyrdfold (separate epic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)