### PR TITLE
feat(wyrdfold): port auth shell + app layout from root/fitted (Phase 6.1)

### DIFF
--- a/apps/wyrdfold/specs/index.spec.tsx
+++ b/apps/wyrdfold/specs/index.spec.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import Page from '../src/app/page';
+import DashboardPage from '../src/app/(app)/page';
 
-describe('Page', () => {
+describe('DashboardPage', () => {
   it('should render successfully', () => {
-    const { baseElement } = render(<Page />);
+    const { baseElement } = render(<DashboardPage />);
     expect(baseElement).toBeTruthy();
   });
 });

--- a/apps/wyrdfold/src/app/(app)/WyrdfoldSidebar.tsx
+++ b/apps/wyrdfold/src/app/(app)/WyrdfoldSidebar.tsx
@@ -1,0 +1,321 @@
+'use client';
+
+import { useState, useCallback, useEffect, useRef } from 'react';
+import Link from 'next/link';
+import { usePathname, useRouter } from 'next/navigation';
+import {
+  LayoutDashboard,
+  Briefcase,
+  Target,
+  User,
+  BarChart3,
+  Settings,
+  MoreHorizontal,
+  LogOut,
+  X,
+} from 'lucide-react';
+import { Sidebar, type SidebarItem } from '@danieljoffe.com/shared-ui/Sidebar';
+import Button from '@/components/Button';
+import { cn } from '@/lib/cn';
+import { useFocusTrap } from '@/hooks/useFocusTrap';
+import { createAuthBrowserClient } from '@/lib/supabase/auth-client';
+import DarkModeToggle from '@/components/Nav/DarkModeToggle';
+
+type Icon = typeof LayoutDashboard;
+type NavItem = SidebarItem & { href: string; lucide: Icon };
+
+const NAV_ITEMS: NavItem[] = [
+  {
+    id: 'dashboard',
+    label: 'Dashboard',
+    href: '/',
+    lucide: LayoutDashboard,
+    icon: <LayoutDashboard className='size-4' aria-hidden />,
+  },
+  {
+    id: 'jobs',
+    label: 'Jobs',
+    href: '/jobs',
+    lucide: Briefcase,
+    icon: <Briefcase className='size-4' aria-hidden />,
+  },
+  {
+    id: 'targets',
+    label: 'Targets',
+    href: '/targets',
+    lucide: Target,
+    icon: <Target className='size-4' aria-hidden />,
+  },
+  {
+    id: 'profile',
+    label: 'Profile',
+    href: '/profile',
+    lucide: User,
+    icon: <User className='size-4' aria-hidden />,
+  },
+  {
+    id: 'insights',
+    label: 'Insights',
+    href: '/insights',
+    lucide: BarChart3,
+    icon: <BarChart3 className='size-4' aria-hidden />,
+  },
+  {
+    id: 'settings',
+    label: 'Settings',
+    href: '/settings',
+    lucide: Settings,
+    icon: <Settings className='size-4' aria-hidden />,
+  },
+];
+
+// Mobile shows the four daily-use tabs + More; the sheet picks up the rest.
+const MOBILE_PRIMARY_IDS = ['dashboard', 'jobs', 'targets', 'profile'] as const;
+const PRIMARY_ITEMS = MOBILE_PRIMARY_IDS.flatMap(id => {
+  const item = NAV_ITEMS.find(n => n.id === id);
+  return item ? [item] : [];
+});
+const MORE_ITEMS = NAV_ITEMS.filter(
+  n => !MOBILE_PRIMARY_IDS.includes(n.id as (typeof MOBILE_PRIMARY_IDS)[number])
+);
+
+function activeIdFrom(pathname: string): string | undefined {
+  if (pathname === '/' || pathname === '') return 'dashboard';
+  const match = NAV_ITEMS.find(
+    item => item.id !== 'dashboard' && pathname.startsWith(item.href)
+  );
+  return match?.id;
+}
+
+export default function WyrdfoldSidebar() {
+  const router = useRouter();
+  const pathname = usePathname();
+  const activeId = activeIdFrom(pathname ?? '') ?? '';
+  const isMoreActive = MORE_ITEMS.some(item => item.id === activeId);
+
+  const [sheetOpen, setSheetOpen] = useState(false);
+  const moreButtonRef = useRef<HTMLButtonElement>(null);
+  const sheetRef = useFocusTrap(sheetOpen) as React.RefObject<HTMLDivElement>;
+
+  const closeSheet = useCallback(() => {
+    setSheetOpen(false);
+    moreButtonRef.current?.focus();
+  }, []);
+
+  // Close on Escape
+  useEffect(() => {
+    if (!sheetOpen) return;
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') closeSheet();
+    };
+    document.addEventListener('keydown', handleKey);
+    return () => document.removeEventListener('keydown', handleKey);
+  }, [sheetOpen, closeSheet]);
+
+  // Lock body scroll when sheet is open
+  useEffect(() => {
+    if (sheetOpen) {
+      document.body.style.overflow = 'hidden';
+    } else {
+      document.body.style.overflow = '';
+    }
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, [sheetOpen]);
+
+  const handleSheetLink = useCallback(
+    (href: string) => {
+      setSheetOpen(false);
+      requestAnimationFrame(() => router.push(href));
+    },
+    [router]
+  );
+
+  async function handleSignOut() {
+    setSheetOpen(false);
+    const supabase = createAuthBrowserClient();
+    await supabase.auth.signOut();
+    router.replace('/login');
+    router.refresh();
+  }
+
+  // --- Desktop sidebar ---
+  const handleDesktopSelect = useCallback(
+    (id: string) => {
+      const item = NAV_ITEMS.find(n => n.id === id);
+      if (item) router.push(item.href);
+    },
+    [router]
+  );
+
+  const sidebarHeader = (
+    <span className='text-sm font-semibold text-text-primary'>WyrdFold</span>
+  );
+
+  const sidebarFooter = (
+    <div className='flex flex-col gap-2'>
+      <DarkModeToggle />
+      <Button
+        name='wyrdfold-sign-out'
+        variant='outline'
+        size='sm'
+        onClick={handleSignOut}
+        className='w-full justify-center'
+      >
+        <LogOut className='size-4' aria-hidden />
+        <span>Sign out</span>
+      </Button>
+    </div>
+  );
+
+  return (
+    <>
+      {/* Desktop sidebar */}
+      <div className='hidden md:block'>
+        <Sidebar
+          items={NAV_ITEMS}
+          activeId={activeId}
+          onSelect={handleDesktopSelect}
+          header={sidebarHeader}
+          footer={sidebarFooter}
+        />
+      </div>
+
+      {/* Mobile bottom bar */}
+      <div
+        className='md:hidden fixed bottom-0 left-0 right-0 z-50 bg-surface/95 backdrop-blur-md border-t border-border/60'
+        style={{ paddingBottom: 'env(safe-area-inset-bottom, 0px)' }}
+      >
+        <nav
+          className='flex items-stretch justify-around h-14'
+          aria-label='WyrdFold mobile navigation'
+        >
+          {PRIMARY_ITEMS.map(item => {
+            const Icon = item.lucide;
+            const active = activeId === item.id;
+            return (
+              <Link
+                key={item.id}
+                href={item.href}
+                aria-current={active ? 'page' : undefined}
+                className={cn(
+                  'flex flex-col items-center justify-center flex-1 gap-0.5 text-[10px] font-medium transition-colors',
+                  active
+                    ? 'text-brand-500'
+                    : 'text-text-tertiary active:text-text-primary'
+                )}
+              >
+                <Icon className='h-5 w-5' aria-hidden='true' />
+                {item.label}
+              </Link>
+            );
+          })}
+
+          <Button
+            name='wyrdfold-mobile-more'
+            variant='bare'
+            ref={moreButtonRef}
+            onClick={sheetOpen ? closeSheet : () => setSheetOpen(true)}
+            aria-expanded={sheetOpen}
+            aria-label={sheetOpen ? 'Close more menu' : 'Open more menu'}
+            className={cn(
+              'flex flex-col items-center justify-center flex-1 gap-0.5 p-0 rounded-none hover:scale-100 text-[10px] font-medium transition-colors cursor-pointer',
+              isMoreActive || sheetOpen
+                ? 'text-brand-500'
+                : 'text-text-tertiary active:text-text-primary'
+            )}
+          >
+            <MoreHorizontal className='h-5 w-5' aria-hidden='true' />
+            More
+          </Button>
+        </nav>
+      </div>
+
+      {/* Mobile backdrop */}
+      {sheetOpen && (
+        <div
+          className='md:hidden fixed inset-0 z-40 bg-black/40 backdrop-blur-[2px] transition-opacity'
+          onClick={closeSheet}
+          aria-hidden='true'
+        />
+      )}
+
+      {/* Mobile bottom sheet — slides up from above the bar */}
+      <div
+        ref={sheetRef}
+        role='dialog'
+        aria-label='More navigation'
+        aria-modal='true'
+        aria-hidden={!sheetOpen}
+        inert={!sheetOpen ? true : undefined}
+        className={cn(
+          'md:hidden fixed bottom-0 left-0 right-0 z-50 bg-surface border-t border-border rounded-t-2xl shadow-2xl transition-transform duration-300 ease-out max-h-[60vh] overflow-y-auto px-6 py-5',
+          sheetOpen ? 'translate-y-0' : 'translate-y-full pointer-events-none'
+        )}
+        style={{
+          paddingBottom: sheetOpen
+            ? 'calc(3.5rem + env(safe-area-inset-bottom, 0px) + 1.25rem)'
+            : undefined,
+        }}
+      >
+        <div className='flex items-center justify-between mb-3'>
+          <span className='text-xs font-semibold text-text-tertiary uppercase tracking-wider'>
+            More
+          </span>
+          <div className='flex items-center gap-1'>
+            <DarkModeToggle />
+            <Button
+              name='wyrdfold-close-more'
+              variant='bare'
+              size='sm'
+              iconOnly
+              onClick={closeSheet}
+              aria-label='Close more menu'
+              className='rounded-lg text-text-tertiary hover:text-text-primary'
+            >
+              <X className='h-4 w-4' />
+            </Button>
+          </div>
+        </div>
+        <nav aria-label='More links'>
+          <ul className='space-y-1'>
+            {MORE_ITEMS.map(item => {
+              const Icon = item.lucide;
+              const active = activeId === item.id;
+              return (
+                <li key={item.id}>
+                  <Button
+                    name={`wyrdfold-more-${item.id}`}
+                    variant='bare'
+                    onClick={() => handleSheetLink(item.href)}
+                    className={cn(
+                      'w-full flex items-center justify-start gap-3 px-3 py-2.5 rounded-lg hover:scale-100 text-sm font-medium transition-colors cursor-pointer',
+                      active
+                        ? 'text-brand-500 bg-surface-tertiary'
+                        : 'text-text-secondary hover:text-text-primary hover:bg-surface-tertiary'
+                    )}
+                  >
+                    <Icon className='h-4 w-4' aria-hidden='true' />
+                    {item.label}
+                  </Button>
+                </li>
+              );
+            })}
+            <li>
+              <Button
+                name='wyrdfold-more-sign-out'
+                variant='bare'
+                onClick={handleSignOut}
+                className='w-full flex items-center justify-start gap-3 px-3 py-2.5 rounded-lg hover:scale-100 text-sm font-medium transition-colors cursor-pointer text-text-secondary hover:text-text-primary hover:bg-surface-tertiary'
+              >
+                <LogOut className='h-4 w-4' aria-hidden='true' />
+                Sign out
+              </Button>
+            </li>
+          </ul>
+        </nav>
+      </div>
+    </>
+  );
+}

--- a/apps/wyrdfold/src/app/(app)/error.tsx
+++ b/apps/wyrdfold/src/app/(app)/error.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import * as Sentry from '@sentry/nextjs';
+import { useEffect } from 'react';
+import { Card, CardContent } from '@danieljoffe.com/shared-ui/Card';
+import { Heading } from '@danieljoffe.com/shared-ui/Heading';
+import { Text } from '@danieljoffe.com/shared-ui/Text';
+import Button from '@/components/Button';
+
+export default function AppError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    Sentry.withScope(scope => {
+      scope.setTag('route', '/(app)');
+      if (error.digest) {
+        scope.setExtra('digest', error.digest);
+      }
+      Sentry.captureException(error);
+    });
+  }, [error]);
+
+  return (
+    <div className='flex flex-col gap-6'>
+      <Heading variant='hero' as='h1'>
+        Something went wrong
+      </Heading>
+      <Card>
+        <CardContent className='flex flex-col items-center gap-4 py-12 text-center'>
+          <Text variant='body' as='p' className='max-w-md'>
+            This page failed to load. The error has been reported. Try again, or
+            head back to your dashboard.
+          </Text>
+          <div className='flex gap-2'>
+            <Button
+              name='wyrdfold-error-retry'
+              variant='primary'
+              size='sm'
+              onClick={() => reset()}
+            >
+              Try again
+            </Button>
+            <Button
+              name='wyrdfold-error-home'
+              variant='outline'
+              size='sm'
+              as='link'
+              href='/'
+            >
+              Back to dashboard
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/wyrdfold/src/app/(app)/layout.tsx
+++ b/apps/wyrdfold/src/app/(app)/layout.tsx
@@ -1,0 +1,39 @@
+import type { ReactNode } from 'react';
+import { redirect } from 'next/navigation';
+import { createAuthServerClient } from '@/lib/supabase/auth-server';
+import WyrdfoldSidebar from './WyrdfoldSidebar';
+
+/**
+ * Server-side auth backstop for /(app)/* routes. The proxy.ts middleware
+ * already redirects unauthenticated requests, but Next.js Router Cache can
+ * replay a previously-rendered RSC payload on client-side nav before the
+ * middleware runs. Re-checking the session here means any cached payload
+ * still has to pass an authenticated render — no auth, no shell.
+ */
+export default async function AppLayout({ children }: { children: ReactNode }) {
+  const supabase = await createAuthServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect('/login');
+  }
+
+  return (
+    <div className='flex min-h-screen'>
+      <WyrdfoldSidebar />
+      <main className='flex-1 overflow-x-hidden p-4 md:p-6'>
+        {children}
+        {/* Clearance for the mobile bottom nav (h-14) + iOS home indicator. */}
+        <div
+          aria-hidden='true'
+          className='md:hidden'
+          style={{
+            height: 'calc(3.5rem + env(safe-area-inset-bottom, 0px) + 1rem)',
+          }}
+        />
+      </main>
+    </div>
+  );
+}

--- a/apps/wyrdfold/src/app/(app)/loading.tsx
+++ b/apps/wyrdfold/src/app/(app)/loading.tsx
@@ -1,0 +1,17 @@
+import { Skeleton } from '@danieljoffe.com/shared-ui/Skeleton';
+
+export default function AppLoading() {
+  return (
+    <div role='status' aria-label='Loading' className='flex flex-col gap-6'>
+      <div>
+        <Skeleton variant='text' size='lg' className='w-32' />
+        <Skeleton variant='text' className='mt-2 w-56' />
+      </div>
+      <div className='grid grid-cols-2 gap-3 sm:grid-cols-4'>
+        {[0, 1, 2, 3].map(i => (
+          <Skeleton key={i} variant='rectangular' height={88} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/wyrdfold/src/app/(app)/not-found.tsx
+++ b/apps/wyrdfold/src/app/(app)/not-found.tsx
@@ -1,0 +1,31 @@
+import { Card, CardContent } from '@danieljoffe.com/shared-ui/Card';
+import { Heading } from '@danieljoffe.com/shared-ui/Heading';
+import { Text } from '@danieljoffe.com/shared-ui/Text';
+import Button from '@/components/Button';
+
+export default function AppNotFound() {
+  return (
+    <div className='flex flex-col gap-6'>
+      <Heading variant='hero' as='h1'>
+        Page not found
+      </Heading>
+      <Card>
+        <CardContent className='flex flex-col items-center gap-4 py-12 text-center'>
+          <Text variant='body' as='p' className='max-w-md'>
+            We couldn&apos;t find that page. It may have been moved or the URL
+            is incorrect.
+          </Text>
+          <Button
+            name='wyrdfold-not-found-home'
+            variant='primary'
+            size='sm'
+            as='link'
+            href='/'
+          >
+            Back to dashboard
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/wyrdfold/src/app/(app)/page.tsx
+++ b/apps/wyrdfold/src/app/(app)/page.tsx
@@ -1,0 +1,33 @@
+import type { Metadata } from 'next';
+import { Card, CardContent } from '@danieljoffe.com/shared-ui/Card';
+import { Heading } from '@danieljoffe.com/shared-ui/Heading';
+import { Text } from '@danieljoffe.com/shared-ui/Text';
+
+export const metadata: Metadata = {
+  title: 'Dashboard',
+};
+
+// Stub dashboard for Phase 6.1. The full DashboardPage (327 LOC, depends on
+// jobs + targets types) lands alongside Phase 6.2/6.3 when those types port.
+export default function DashboardPage() {
+  return (
+    <div className='flex flex-col gap-6'>
+      <div>
+        <Heading variant='hero' as='h1'>
+          Dashboard
+        </Heading>
+        <Text variant='body' className='mt-2'>
+          Welcome to WyrdFold.
+        </Text>
+      </div>
+      <Card>
+        <CardContent className='py-8 text-center'>
+          <Text variant='body'>
+            Jobs, targets, and insights are coming online — sign-in works,
+            navigation works, the rest of the UI ports next.
+          </Text>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/wyrdfold/src/app/auth/callback/route.ts
+++ b/apps/wyrdfold/src/app/auth/callback/route.ts
@@ -1,0 +1,55 @@
+import { cookies } from 'next/headers';
+import { NextResponse } from 'next/server';
+import { createAuthServerClient } from '@/lib/supabase/auth-server';
+
+const DEFAULT_NEXT = '/';
+const NEXT_COOKIE = 'wyrdfold_login_next';
+
+/**
+ * Constrains `next` to a same-origin relative path. Anything else
+ * (absolute URL, protocol-relative `//evil.com`, missing leading `/`)
+ * falls back to the default destination so the magic link can't be
+ * abused as an open redirect.
+ */
+function safeNext(value: string | null | undefined): string {
+  if (!value) return DEFAULT_NEXT;
+  if (!value.startsWith('/') || value.startsWith('//')) return DEFAULT_NEXT;
+  return value;
+}
+
+/**
+ * Handles the magic link callback from Supabase Auth.
+ *
+ * When a user clicks the magic link in their email, Supabase redirects
+ * to this route with a `code` query parameter. We exchange that code
+ * for a session, then redirect to the page the user originally tried
+ * to reach. The destination is stashed in a short-lived cookie set by
+ * the login form (a query-string `next` is also accepted as a fallback,
+ * but cookie is preferred — Supabase strips query strings off the
+ * redirect URL when it doesn't match the project's allowlist).
+ */
+export async function GET(request: Request) {
+  const { searchParams, origin } = new URL(request.url);
+  const code = searchParams.get('code');
+
+  const cookieStore = await cookies();
+  const cookieNext = cookieStore.get(NEXT_COOKIE)?.value;
+  const next = safeNext(
+    cookieNext ? decodeURIComponent(cookieNext) : searchParams.get('next')
+  );
+
+  if (code) {
+    const supabase = await createAuthServerClient();
+    const { error } = await supabase.auth.exchangeCodeForSession(code);
+
+    if (!error) {
+      const response = NextResponse.redirect(`${origin}${next}`);
+      if (cookieNext) {
+        response.cookies.delete(NEXT_COOKIE);
+      }
+      return response;
+    }
+  }
+
+  return NextResponse.redirect(`${origin}/login`);
+}

--- a/apps/wyrdfold/src/app/layout.tsx
+++ b/apps/wyrdfold/src/app/layout.tsx
@@ -1,17 +1,24 @@
 import type { ReactNode } from 'react';
 import { ToastProvider } from '@/state/Toast/ToastProvider';
+import { ThemeProvider } from '@/state/Theme/ThemeProvider';
 import './global.css';
 
 export const metadata = {
-  title: 'WyrdFold',
-  description: 'Personal AI-assisted job application workspace.',
+  title: {
+    template: '%s | WyrdFold',
+    default: 'WyrdFold',
+  },
+  description: 'AI-assisted job search command center.',
+  robots: { index: false, follow: false },
 };
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang='en' className='pyre dark'>
       <body>
-        <ToastProvider>{children}</ToastProvider>
+        <ThemeProvider>
+          <ToastProvider>{children}</ToastProvider>
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/apps/wyrdfold/src/app/login/MagicLinkForm.tsx
+++ b/apps/wyrdfold/src/app/login/MagicLinkForm.tsx
@@ -1,0 +1,155 @@
+'use client';
+
+import { useState } from 'react';
+import { Heading } from '@danieljoffe.com/shared-ui/Heading';
+import { PageLayout } from '@danieljoffe.com/shared-ui/PageLayout';
+import { Section } from '@danieljoffe.com/shared-ui/Section';
+import { Text } from '@danieljoffe.com/shared-ui/Text';
+import {
+  BASE_FIELD,
+  FIELD_PADDING,
+  FIELD_PLACEHOLDER,
+} from '@danieljoffe.com/shared-ui/styles/formStyles';
+import { cn } from '@/lib/cn';
+import Button from '@/components/Button';
+import { createAuthBrowserClient } from '@/lib/supabase/auth-client';
+
+type FormState = 'idle' | 'loading' | 'sent' | 'error';
+
+interface MagicLinkFormProps {
+  next: string | undefined;
+}
+
+const NEXT_COOKIE = 'wyrdfold_login_next';
+const NEXT_COOKIE_MAX_AGE_S = 600;
+
+/**
+ * Stash `next` in a short-lived cookie instead of appending it to
+ * `emailRedirectTo`. Adding a query string to the redirect URL forces
+ * Supabase to treat it as a different URL and — depending on the
+ * project's Redirect URL allowlist — silently fall back to the Site URL
+ * (production), dropping `next` and breaking dev login. The cookie sits
+ * alongside the request, the callback reads it after exchanging the
+ * code, then clears it.
+ */
+function stashNextInCookie(next: string): void {
+  document.cookie = `${NEXT_COOKIE}=${encodeURIComponent(next)}; max-age=${NEXT_COOKIE_MAX_AGE_S}; path=/; samesite=lax`;
+}
+
+export default function MagicLinkForm({ next }: MagicLinkFormProps) {
+  const [email, setEmail] = useState('');
+  const [formState, setFormState] = useState<FormState>('idle');
+  const [error, setError] = useState('');
+
+  async function handleSubmit(e: React.SyntheticEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setFormState('loading');
+    setError('');
+
+    if (next) {
+      stashNextInCookie(next);
+    }
+
+    const supabase = createAuthBrowserClient();
+    const { error: authError } = await supabase.auth.signInWithOtp({
+      email,
+      options: {
+        emailRedirectTo: `${window.location.origin}/auth/callback`,
+      },
+    });
+
+    if (authError) {
+      setError(authError.message);
+      setFormState('error');
+    } else {
+      setFormState('sent');
+    }
+  }
+
+  if (formState === 'sent') {
+    return (
+      <PageLayout>
+        <Section padding='none' center className='gap-4'>
+          <div className='text-center space-y-2'>
+            <Heading variant='hero' as='h1'>
+              Check your email
+            </Heading>
+            <Text variant='body'>
+              A magic link has been sent to{' '}
+              <span className='font-medium text-text-primary'>{email}</span>.
+              Click the link in the email to sign in.
+            </Text>
+          </div>
+
+          <div className='max-w-sm mx-auto'>
+            <Button
+              name='wyrdfold-back-to-login'
+              variant='secondary'
+              className='w-full'
+              onClick={() => {
+                setFormState('idle');
+                setEmail('');
+              }}
+            >
+              Use a different email
+            </Button>
+          </div>
+        </Section>
+      </PageLayout>
+    );
+  }
+
+  return (
+    <PageLayout>
+      <Section
+        background='elevated'
+        padding='lg'
+        center
+        className='rounded-lg border border-border gap-4'
+      >
+        <div className='text-center space-y-2'>
+          <Heading variant='hero' as='h1'>
+            Sign in to WyrdFold
+          </Heading>
+          <Text variant='body'>Enter your email to receive a magic link.</Text>
+        </div>
+
+        <form onSubmit={handleSubmit}>
+          <div className='flex flex-col gap-4'>
+            <input
+              type='email'
+              placeholder='you@example.com'
+              value={email}
+              onChange={e => setEmail(e.target.value)}
+              aria-label='Email address'
+              aria-describedby={
+                formState === 'error' ? 'login-error' : undefined
+              }
+              autoFocus
+              required
+              data-sentry-mask
+              className={cn(BASE_FIELD, FIELD_PADDING, FIELD_PLACEHOLDER)}
+            />
+            {formState === 'error' && (
+              <Text
+                variant='error'
+                className='text-center'
+                role='alert'
+                id='login-error'
+              >
+                {error}
+              </Text>
+            )}
+            <Button
+              type='submit'
+              name='wyrdfold-sign-in'
+              disabled={formState === 'loading' || !email}
+            >
+              {formState === 'loading' ? 'Sending...' : 'Send magic link'}
+            </Button>
+          </div>
+        </form>
+      </Section>
+    </PageLayout>
+  );
+}

--- a/apps/wyrdfold/src/app/login/page.tsx
+++ b/apps/wyrdfold/src/app/login/page.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from 'next';
+import MagicLinkForm from './MagicLinkForm';
+
+export const metadata: Metadata = {
+  title: 'Sign in to WyrdFold',
+  robots: { index: false, follow: false },
+};
+
+export default async function LoginPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ next?: string }>;
+}) {
+  const { next } = await searchParams;
+  return <MagicLinkForm next={next} />;
+}

--- a/apps/wyrdfold/src/app/not-found.tsx
+++ b/apps/wyrdfold/src/app/not-found.tsx
@@ -1,0 +1,41 @@
+import { Card, CardContent } from '@danieljoffe.com/shared-ui/Card';
+import { Heading } from '@danieljoffe.com/shared-ui/Heading';
+import { Text } from '@danieljoffe.com/shared-ui/Text';
+import Button from '@/components/Button';
+
+/**
+ * Catches unmatched URLs that don't fall inside any route segment.
+ *
+ * `(app)/not-found.tsx` only fires when a page *inside* the `(app)`
+ * group calls `notFound()`. For URLs that match nothing at all (e.g.
+ * `/jobs` before that page is ported), Next.js looks for a root-level
+ * `not-found.tsx` — this one. The middleware has already redirected
+ * unauthenticated users to `/login`, so anyone landing here is signed
+ * in and just typed a wrong URL.
+ */
+export default function NotFound() {
+  return (
+    <main className='min-h-screen flex items-center justify-center p-6'>
+      <Card className='max-w-md w-full'>
+        <CardContent className='flex flex-col items-center gap-4 py-12 text-center'>
+          <Heading variant='hero' as='h1'>
+            Page not found
+          </Heading>
+          <Text variant='body' as='p' className='max-w-sm'>
+            We couldn&apos;t find that page. It may have moved, been removed, or
+            never existed.
+          </Text>
+          <Button
+            name='wyrdfold-root-not-found-home'
+            variant='primary'
+            size='sm'
+            as='link'
+            href='/'
+          >
+            Back to dashboard
+          </Button>
+        </CardContent>
+      </Card>
+    </main>
+  );
+}

--- a/apps/wyrdfold/src/app/page.tsx
+++ b/apps/wyrdfold/src/app/page.tsx
@@ -1,8 +1,0 @@
-export default function HomePage() {
-  return (
-    <main className='min-h-screen p-8'>
-      <h1>WyrdFold</h1>
-      <p className='text-text-secondary mt-2'>Coming soon.</p>
-    </main>
-  );
-}

--- a/apps/wyrdfold/src/components/Button.tsx
+++ b/apps/wyrdfold/src/components/Button.tsx
@@ -1,0 +1,209 @@
+'use client';
+import React, {
+  useCallback,
+  type ComponentProps,
+  type ButtonHTMLAttributes,
+  type ReactNode,
+} from 'react';
+import Link from 'next/link';
+import { Url } from 'next/dist/shared/lib/router/router';
+import { useRouter } from 'next/navigation';
+import { cn } from '@/lib/cn';
+
+type ButtonVariant =
+  | 'bare'
+  | 'primary'
+  | 'secondary'
+  | 'ghost'
+  | 'outline'
+  | 'success'
+  | 'error'
+  | 'warning'
+  | 'info';
+
+type ButtonSize = 'sm' | 'md' | 'lg';
+
+interface ButtonBase {
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+  children: ReactNode;
+  name?: string;
+}
+
+interface ButtonProps
+  extends
+    ButtonBase,
+    Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'children'> {
+  loading?: boolean;
+  iconOnly?: boolean;
+}
+
+interface AsButtonProps extends ButtonProps {
+  as?: 'button';
+  ref?: React.Ref<HTMLButtonElement>;
+}
+
+interface AsLinkProps
+  extends
+    React.AnchorHTMLAttributes<HTMLAnchorElement>,
+    Omit<ButtonBase, 'children'> {
+  as: 'link';
+  highlighted?: boolean;
+  outline?: boolean;
+  disabled?: boolean;
+}
+
+type AppButtonProps = AsButtonProps | AsLinkProps;
+
+const baseButtonStyles =
+  'inline-flex items-center justify-center gap-2 rounded-md transition duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2 focus-visible:ring-offset-surface disabled:opacity-50 disabled:cursor-not-allowed hover:cursor-pointer motion-reduce:transition-none motion-reduce:hover:transform-none';
+
+const variantButtonStyles: Record<string, string> = {
+  primary:
+    'hover:shadow-lg/12.5 bg-brand-500 text-white hover:bg-brand-600 active:bg-brand-700',
+  secondary:
+    'hover:shadow-lg/12.5 bg-surface-elevated text-text-primary hover:bg-surface border border-border',
+  ghost:
+    'hover:shadow-lg/12.5 text-text-secondary hover:bg-surface-elevated hover:text-text-primary',
+  outline:
+    'hover:shadow-lg/12.5 border border-border-secondary text-text-primary hover:bg-surface-elevated',
+  success: 'hover:shadow-lg/12.5 bg-success text-white hover:opacity-90',
+  error: 'hover:shadow-lg/12.5 bg-error text-text-inverse hover:opacity-90',
+  warning: 'hover:shadow-lg/12.5 bg-warning text-text-inverse hover:opacity-90',
+  info: 'hover:shadow-lg/12.5 bg-info text-text-inverse hover:opacity-90',
+  bare: '',
+};
+
+const sizeButtonStyles: Record<string, string> = {
+  sm: 'px-3 py-1.5 text-sm hover:scale-[1.1]',
+  md: 'px-4 py-3 hover:scale-[1.05]',
+  lg: 'px-6 py-3 text-lg hover:scale-[1.025]',
+};
+
+const iconOnlySizeStyles: Record<string, string> = {
+  sm: 'p-1.5 text-sm hover:scale-[1.1]',
+  md: 'p-2.5 hover:scale-[1.05]',
+  lg: 'p-3 text-lg hover:scale-[1.025]',
+};
+
+const variantLinkOutline: Record<string, string> = {
+  bare: 'focus-visible:ring-offset-0',
+};
+
+function LinkAsButton(props: AsLinkProps) {
+  const router = useRouter();
+  const {
+    as: _as,
+    highlighted,
+    outline,
+    disabled,
+    variant,
+    size,
+    children,
+    className,
+    ...rest
+  } = props;
+  const classes = cn(
+    baseButtonStyles,
+    variantButtonStyles[variant ?? 'primary'],
+    sizeButtonStyles[size ?? 'md'],
+    highlighted && 'text-brand-500 underline underline-offset-4',
+    disabled && 'pointer-events-none',
+    outline && variantLinkOutline[variant ?? 'bare'],
+    className
+  );
+
+  const handleMouseEnter = useCallback(
+    (href: Url) => {
+      if (href && href.toString().startsWith('/')) {
+        router.prefetch(href.toString());
+      }
+    },
+    [router]
+  );
+
+  if (rest.href == null || rest.href.length === 0) return null;
+
+  if (disabled) {
+    return (
+      <span className={classes} aria-disabled={true} role='link' tabIndex={-1}>
+        {children}
+      </span>
+    );
+  }
+
+  const {
+    href,
+    id,
+    target,
+    'aria-label': ariaLabel,
+  } = rest as ComponentProps<typeof Link>;
+
+  const rel = target === '_blank' ? 'noopener noreferrer' : undefined;
+
+  return (
+    <Link
+      {...(rest as ComponentProps<typeof Link>)}
+      className={classes}
+      onMouseEnter={() => handleMouseEnter(href)}
+      id={id ?? ariaLabel?.replace(' ', '-')}
+      href={href}
+      aria-label={ariaLabel}
+      rel={rel}
+    >
+      {children}
+    </Link>
+  );
+}
+
+function Button(props: AppButtonProps) {
+  const { as, ...rest } = props;
+
+  if (as === 'link') {
+    return <LinkAsButton {...(rest as Omit<AsLinkProps, 'as'>)} as='link' />;
+  }
+
+  const { onClick, ref, ...restButton } = rest as Omit<AsButtonProps, 'as'>;
+
+  const onKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      if (!restButton.disabled && onClick) {
+        onClick(e as unknown as React.MouseEvent<HTMLButtonElement>);
+      }
+    }
+  };
+
+  const {
+    type = 'button',
+    children,
+    variant,
+    size,
+    iconOnly,
+    className,
+    ...buttonRest
+  } = restButton;
+
+  const sizeMap = iconOnly ? iconOnlySizeStyles : sizeButtonStyles;
+
+  return (
+    <button
+      {...buttonRest}
+      ref={ref}
+      disabled={restButton.disabled}
+      type={type}
+      onClick={restButton.disabled ? undefined : onClick}
+      onKeyDown={onKeyDown}
+      className={cn(
+        baseButtonStyles,
+        variantButtonStyles[variant ?? 'primary'],
+        sizeMap[size ?? 'md'],
+        className
+      )}
+    >
+      {children}
+    </button>
+  );
+}
+
+export default Button;

--- a/apps/wyrdfold/src/components/Nav/DarkModeToggle.tsx
+++ b/apps/wyrdfold/src/components/Nav/DarkModeToggle.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { useCallback } from 'react';
+import { Moon, Sun, Monitor } from 'lucide-react';
+import { Kbd } from '@danieljoffe.com/shared-ui/Kbd';
+import { useTheme } from '@/state/Theme/ThemeProvider';
+import { analytics } from '@/lib/analytics';
+import { useKeyboardShortcut } from '@/hooks/useKeyboardShortcut';
+
+const themeIcons = {
+  light: Sun,
+  dark: Moon,
+  system: Monitor,
+} as const;
+
+const cycleOrder: ('light' | 'dark' | 'system')[] = ['light', 'dark', 'system'];
+
+export default function DarkModeToggle() {
+  const { theme, setTheme } = useTheme();
+
+  const cycleTheme = useCallback(() => {
+    const currentIndex = cycleOrder.indexOf(theme);
+    const next = cycleOrder[(currentIndex + 1) % cycleOrder.length];
+    analytics.themeToggle(next);
+    setTheme(next);
+  }, [theme, setTheme]);
+
+  useKeyboardShortcut('d', cycleTheme);
+
+  const Icon = themeIcons[theme];
+  const nextIndex = (cycleOrder.indexOf(theme) + 1) % cycleOrder.length;
+  const nextLabel = cycleOrder[nextIndex];
+
+  return (
+    <button
+      onClick={cycleTheme}
+      title={`Theme: ${theme}`}
+      aria-label={`Switch to ${nextLabel} mode`}
+      className='flex items-center gap-1.5 p-1.5 rounded-lg text-text-tertiary hover:text-text-primary hover:bg-surface-tertiary transition-colors cursor-pointer'
+    >
+      <Icon className='h-4 w-4' aria-hidden='true' />
+      <Kbd>D</Kbd>
+    </button>
+  );
+}

--- a/apps/wyrdfold/src/hooks/useFocusTrap.ts
+++ b/apps/wyrdfold/src/hooks/useFocusTrap.ts
@@ -1,0 +1,59 @@
+import { useEffect, useRef } from 'react';
+
+export function useFocusTrap(isActive: boolean) {
+  const containerRef = useRef<HTMLElement>(null);
+
+  useEffect(() => {
+    if (!isActive || !containerRef.current) return;
+
+    const container = containerRef.current;
+    const focusableElements = container.querySelectorAll(
+      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+    ) as NodeListOf<HTMLElement>;
+
+    if (focusableElements.length === 0) return;
+
+    const firstElement = focusableElements[0];
+    const lastElement = focusableElements[focusableElements.length - 1];
+
+    const handleTabKey = (e: KeyboardEvent) => {
+      if (e.key !== 'Tab') return;
+
+      if (e.shiftKey) {
+        if (document.activeElement === firstElement) {
+          e.preventDefault();
+          lastElement.focus();
+        }
+      } else {
+        if (document.activeElement === lastElement) {
+          e.preventDefault();
+          firstElement.focus();
+        }
+      }
+    };
+
+    const handleEscapeKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        const previouslyFocusedElement = document.querySelector(
+          '[data-previously-focused]'
+        ) as HTMLElement;
+        if (previouslyFocusedElement) {
+          previouslyFocusedElement.focus();
+          previouslyFocusedElement.removeAttribute('data-previously-focused');
+        }
+      }
+    };
+
+    firstElement.focus();
+
+    document.addEventListener('keydown', handleTabKey);
+    document.addEventListener('keydown', handleEscapeKey);
+
+    return () => {
+      document.removeEventListener('keydown', handleTabKey);
+      document.removeEventListener('keydown', handleEscapeKey);
+    };
+  }, [isActive]);
+
+  return containerRef;
+}

--- a/apps/wyrdfold/src/hooks/useKeyboardShortcut.ts
+++ b/apps/wyrdfold/src/hooks/useKeyboardShortcut.ts
@@ -1,0 +1,31 @@
+import { useEffect } from 'react';
+
+/**
+ * Registers a global keyboard shortcut that fires only when no input/textarea
+ * is focused and no modifier keys are held.
+ */
+export function useKeyboardShortcut(key: string, callback: () => void) {
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      const target = e.target as HTMLElement;
+      if (
+        target.tagName === 'INPUT' ||
+        target.tagName === 'TEXTAREA' ||
+        target.tagName === 'SELECT' ||
+        target.isContentEditable
+      ) {
+        return;
+      }
+
+      if (e.metaKey || e.ctrlKey || e.altKey) return;
+
+      if (e.key.toLowerCase() === key.toLowerCase()) {
+        e.preventDefault();
+        callback();
+      }
+    };
+
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [key, callback]);
+}

--- a/apps/wyrdfold/src/lib/analytics.ts
+++ b/apps/wyrdfold/src/lib/analytics.ts
@@ -1,0 +1,14 @@
+type EventParams = Record<string, string | number | boolean>;
+
+function trackEvent(eventName: string, params?: EventParams) {
+  if (typeof window === 'undefined') return;
+  window.gtag?.('event', eventName, params ?? {});
+}
+
+// Minimal surface — wyrdfold only uses what its components emit. Add
+// new events as they're introduced; mirror root/lib/analytics.ts
+// patterns when the surface grows past a handful of events.
+export const analytics = {
+  themeToggle: (theme: 'light' | 'dark' | 'system') =>
+    trackEvent('theme_toggle', { theme }),
+};

--- a/apps/wyrdfold/src/lib/cn.ts
+++ b/apps/wyrdfold/src/lib/cn.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/apps/wyrdfold/src/lib/supabase/auth-client.ts
+++ b/apps/wyrdfold/src/lib/supabase/auth-client.ts
@@ -1,0 +1,20 @@
+'use client';
+
+import { createBrowserClient } from '@supabase/ssr';
+
+/**
+ * Creates a Supabase client for browser-side auth operations.
+ * Uses @supabase/ssr for automatic cookie-based session management.
+ */
+export function createAuthBrowserClient() {
+  const supabaseUrl = process.env['NEXT_PUBLIC_SUPABASE_URL'];
+  const anonKey = process.env['NEXT_PUBLIC_SUPABASE_ANON_ID'];
+
+  if (!supabaseUrl || !anonKey) {
+    throw new Error(
+      'Missing NEXT_PUBLIC_SUPABASE_URL or NEXT_PUBLIC_SUPABASE_ANON_ID environment variables'
+    );
+  }
+
+  return createBrowserClient(supabaseUrl, anonKey);
+}

--- a/apps/wyrdfold/src/state/Theme/ThemeProvider.tsx
+++ b/apps/wyrdfold/src/state/Theme/ThemeProvider.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+import {
+  type ReactNode,
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+
+type Theme = 'light' | 'dark' | 'system';
+
+interface ThemeContextType {
+  theme: Theme;
+  resolvedTheme: 'light' | 'dark';
+  isDarkMode: boolean;
+  setTheme: (theme: Theme) => void;
+  toggleDarkMode: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextType>({
+  theme: 'system',
+  resolvedTheme: 'light',
+  isDarkMode: false,
+  setTheme: () => undefined,
+  toggleDarkMode: () => undefined,
+});
+
+export function useTheme(): ThemeContextType {
+  return useContext(ThemeContext);
+}
+
+const THEME_STORAGE_KEY = 'theme';
+
+function getSystemPrefersDark(): boolean {
+  if (typeof window === 'undefined') return false;
+  return window.matchMedia('(prefers-color-scheme: dark)').matches;
+}
+
+function getStoredTheme(): Theme {
+  if (typeof window === 'undefined') return 'system';
+  const stored = localStorage.getItem(THEME_STORAGE_KEY);
+  if (stored === 'light' || stored === 'dark' || stored === 'system') {
+    return stored;
+  }
+  return 'system';
+}
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [theme, _setTheme] = useState<Theme>('system');
+  const [systemPrefersDark, setSystemPrefersDark] = useState(false);
+
+  useEffect(() => {
+    queueMicrotask(() => {
+      _setTheme(getStoredTheme());
+      setSystemPrefersDark(getSystemPrefersDark());
+    });
+  }, []);
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+    const handleChange = (e: MediaQueryListEvent) => {
+      setSystemPrefersDark(e.matches);
+    };
+    mediaQuery.addEventListener('change', handleChange);
+    return () => mediaQuery.removeEventListener('change', handleChange);
+  }, []);
+
+  const isDarkMode = useMemo(() => {
+    if (theme === 'system') return systemPrefersDark;
+    return theme === 'dark';
+  }, [theme, systemPrefersDark]);
+
+  const resolvedTheme: 'light' | 'dark' = isDarkMode ? 'dark' : 'light';
+
+  useEffect(() => {
+    document.documentElement.classList.toggle('dark', isDarkMode);
+  }, [isDarkMode]);
+
+  const setTheme = useCallback((mode: Theme) => {
+    _setTheme(mode);
+    localStorage.setItem(THEME_STORAGE_KEY, mode);
+  }, []);
+
+  const toggleDarkMode = useCallback(() => {
+    const newMode = isDarkMode ? 'light' : 'dark';
+    setTheme(newMode);
+  }, [isDarkMode, setTheme]);
+
+  const value = useMemo(
+    () => ({ theme, resolvedTheme, isDarkMode, setTheme, toggleDarkMode }),
+    [theme, resolvedTheme, isDarkMode, setTheme, toggleDarkMode]
+  );
+
+  return (
+    <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>
+  );
+}

--- a/apps/wyrdfold/src/types/window.d.ts
+++ b/apps/wyrdfold/src/types/window.d.ts
@@ -1,0 +1,13 @@
+declare global {
+  interface Window {
+    dataLayer?: unknown[];
+    gtag?: (
+      command: 'event' | 'config' | 'set' | 'js',
+      targetId: string | Date,
+      params?: Record<string, unknown>
+    ) => void;
+    [key: string]: unknown[] | undefined;
+  }
+}
+
+export {};


### PR DESCRIPTION
## Summary

First UI port phase. Brings the **magic-link login flow**, authenticated app layout, sidebar nav, and dashboard skeleton across from `apps/root/src/app/fitted/`. Closes the `/login` 404 the proxy.ts middleware has been redirecting to since the BFF stood up.

Mostly mechanical — same shape as `root/fitted`, with hrefs adjusted (`/fitted/foo` → `/foo`) and brand strings updated (Fitted → WyrdFold). Auth was already Supabase-based in root, so no auth refactor needed.

## What you can do after this lands

- Hit `localhost:3000` → bounce to `/login`
- See the magic-link form, enter email → "Check your email"
- Click magic link → land on the dashboard stub
- Sidebar nav (desktop + mobile bottom-bar + bottom sheet) renders, all links navigate
- Sign out works

## What's NOT in this phase

- **Real DashboardPage** (327 LOC in root) — depends on jobs + targets types that port in Phase 6.2/6.3. Replaced with a small stub for now.
- Anything inside the sidebar links (jobs/targets/profile/settings/insights pages) — those are the next phases. Clicking them currently 404s through `(app)/not-found.tsx`.

## Files

### Auth shell
- `src/app/login/{page,MagicLinkForm}.tsx`
- `src/app/auth/callback/route.ts`

### App shell
- `src/app/(app)/{layout,page}.tsx` — `(app)` is a route group; `page.tsx` renders at `/`
- `src/app/(app)/WyrdfoldSidebar.tsx`
- `src/app/(app)/{error,loading,not-found}.tsx`

### Infra ported from root
- `src/lib/cn.ts`
- `src/lib/analytics.ts` (minimal — only `themeToggle` for now)
- `src/lib/supabase/auth-client.ts`
- `src/components/Button.tsx`
- `src/components/Nav/DarkModeToggle.tsx`
- `src/hooks/{useFocusTrap,useKeyboardShortcut}.ts`
- `src/state/Theme/ThemeProvider.tsx`
- `src/types/window.d.ts` (gtag global)

### Modified
- `src/app/layout.tsx` — wrap children in `ThemeProvider`; expand metadata template; mark robots noindex
- `specs/index.spec.tsx` — repoint at the new `(app)/page.tsx`

### Removed
- `src/app/page.tsx` — superseded by `src/app/(app)/page.tsx`

## Decisions worth flagging

- **Login NEXT cookie namespaced** `wyrdfold_login_next` (not `fitted_login_next`) so root and wyrdfold can coexist on the same domain without colliding.
- **`analytics.ts` intentionally minimal** — only `themeToggle`. Mirrors root's pattern but doesn't pull in audit-funnel events that don't apply here. Add events as components introduce them.
- **`DarkModeToggle` keyboard shortcut "d"** cycles theme. Same UX as root.
- **`pyre dark`** kept on the html className. ThemeProvider toggles `dark` post-hydration; `pyre` is the brand theme class and is stable.

## Verification

- ✅ `pnpm nx lint wyrdfold` — clean
- ✅ `pnpm nx test wyrdfold` — passes (16 incl. updated dashboard render test)
- ✅ `pnpm nx build wyrdfold` — all routes register; `/`, `/login`, `/auth/callback` dynamic
- ✅ `pnpm tsc --noEmit` — workspace clean
- ✅ Browser smoke (localhost:3000):

| Request | Result |
|---|---|
| `GET /` (no session) | 307 → `/login?next=%2F` ✓ |
| `GET /login` | 200 — page renders with "Sign in to WyrdFold" |
| `GET /jobs` (no session) | 307 → `/login?next=%2Fjobs` ✓ |
| `GET /auth/callback` (no code) | 307 → `/login` ✓ (graceful fallback) |

Full happy-path (real magic-link click → session cookie → dashboard) hasn't been smoked end-to-end yet — that's a 30-second manual test once this lands.

## Phase 6 progress

| Phase | Status | What |
|---|---|---|
| **6.1** | **(this PR)** | Auth shell + app layout |
| 6.2 | next | Targets + onboarding |
| 6.3 | | Jobs core + insights |
| 6.4 | | Tailor (resume + cover letter) |
| 6.5 | | Profile + settings + polish + delete `root/fitted/` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)