### PR TITLE
feat(wyrdfold): port targets + onboarding from root/fitted (Phase 6.2)

### DIFF
--- a/apps/wyrdfold/src/app/(app)/targets/CreateTargetModal.tsx
+++ b/apps/wyrdfold/src/app/(app)/targets/CreateTargetModal.tsx
@@ -1,0 +1,173 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+import { Modal } from '@danieljoffe.com/shared-ui/Modal';
+import { Input } from '@danieljoffe.com/shared-ui/Input';
+import { Textarea } from '@danieljoffe.com/shared-ui/Textarea';
+import { Tabs, type Tab } from '@danieljoffe.com/shared-ui/Tabs';
+import Button from '@/components/Button';
+
+export interface ManualSubmission {
+  label: string;
+  description: string | undefined;
+}
+
+export interface UrlSubmission {
+  jd_url: string;
+  label: string | undefined;
+}
+
+type Mode = 'manual' | 'url';
+
+interface CreateTargetModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSubmitManual: (payload: ManualSubmission) => void;
+  onSubmitUrl: (payload: UrlSubmission) => void;
+}
+
+export default function CreateTargetModal({
+  isOpen,
+  onClose,
+  onSubmitManual,
+  onSubmitUrl,
+}: CreateTargetModalProps) {
+  const [mode, setMode] = useState<Mode>('manual');
+  const [label, setLabel] = useState('');
+  const [description, setDescription] = useState('');
+  const [urlLabel, setUrlLabel] = useState('');
+  const [jdUrl, setJdUrl] = useState('');
+
+  const reset = useCallback(() => {
+    setLabel('');
+    setDescription('');
+    setUrlLabel('');
+    setJdUrl('');
+    setMode('manual');
+  }, []);
+
+  const handleClose = useCallback(() => {
+    reset();
+    onClose();
+  }, [reset, onClose]);
+
+  const handleSubmit = useCallback(() => {
+    if (mode === 'manual') {
+      const trimmedLabel = label.trim();
+      if (!trimmedLabel) return;
+      const trimmedDescription = description.trim();
+      onSubmitManual({
+        label: trimmedLabel,
+        description: trimmedDescription || undefined,
+      });
+    } else {
+      const trimmedUrl = jdUrl.trim();
+      if (!trimmedUrl) return;
+      const trimmedLabel = urlLabel.trim();
+      onSubmitUrl({
+        jd_url: trimmedUrl,
+        label: trimmedLabel || undefined,
+      });
+    }
+    reset();
+  }, [
+    mode,
+    label,
+    description,
+    urlLabel,
+    jdUrl,
+    onSubmitManual,
+    onSubmitUrl,
+    reset,
+  ]);
+
+  const canSubmit =
+    mode === 'manual' ? label.trim().length > 0 : jdUrl.trim().length > 0;
+
+  const tabs: Tab[] = [
+    {
+      id: 'manual',
+      label: 'Manual',
+      content: (
+        <div className='flex flex-col gap-4 pt-4'>
+          <Input
+            label='Title'
+            placeholder='e.g. Senior Frontend Engineer'
+            value={label}
+            onChange={e => setLabel(e.target.value)}
+            maxLength={200}
+          />
+          <Textarea
+            label='Description (optional)'
+            helperText='A short note about this role. The LLM will use it (alongside your experience) to canonicalize the target and derive a scoring profile.'
+            placeholder='Roles I want to optimize for...'
+            value={description}
+            onChange={e => setDescription(e.target.value)}
+            rows={4}
+          />
+        </div>
+      ),
+    },
+    {
+      id: 'url',
+      label: 'From URL',
+      content: (
+        <div className='flex flex-col gap-4 pt-4'>
+          <Input
+            label='Job description URL'
+            helperText="We'll fetch the page and derive a scoring profile from the job description."
+            placeholder='https://...'
+            value={jdUrl}
+            onChange={e => setJdUrl(e.target.value)}
+            type='url'
+          />
+          <Input
+            label='Title (optional)'
+            helperText='Leave blank to use the role title from the job posting.'
+            placeholder='e.g. Senior Frontend Engineer'
+            value={urlLabel}
+            onChange={e => setUrlLabel(e.target.value)}
+            maxLength={200}
+          />
+        </div>
+      ),
+    },
+  ];
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={handleClose}
+      title='New Target'
+      size='lg'
+      footer={
+        <div className='flex justify-end gap-2'>
+          <Button
+            name='target-create-cancel'
+            variant='outline'
+            size='sm'
+            onClick={handleClose}
+          >
+            Cancel
+          </Button>
+          <Button
+            name='target-create-submit'
+            variant='primary'
+            size='sm'
+            onClick={handleSubmit}
+            disabled={!canSubmit}
+          >
+            Create Target
+          </Button>
+        </div>
+      }
+    >
+      <Tabs
+        tabs={tabs}
+        defaultTab='manual'
+        variant='underline'
+        onChange={id => setMode(id as Mode)}
+      />
+    </Modal>
+  );
+}

--- a/apps/wyrdfold/src/app/(app)/targets/PendingTargetCard.tsx
+++ b/apps/wyrdfold/src/app/(app)/targets/PendingTargetCard.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import { Card, CardContent } from '@danieljoffe.com/shared-ui/Card';
+import { Skeleton } from '@danieljoffe.com/shared-ui/Skeleton';
+import { Spinner } from '@danieljoffe.com/shared-ui/Spinner';
+
+interface PendingTargetCardProps {
+  /** Best-known title for this in-flight target. May be empty for URL mode. */
+  label: string;
+}
+
+export default function PendingTargetCard({ label }: PendingTargetCardProps) {
+  return (
+    <Card
+      padding='none'
+      aria-busy='true'
+      aria-live='polite'
+      className='min-w-0'
+    >
+      <CardContent className='flex flex-col gap-2.5 p-4'>
+        <header className='flex items-start justify-between gap-2'>
+          <div className='flex min-w-0 flex-1 items-center gap-2'>
+            {label ? (
+              <span className='min-w-0 flex-1 truncate text-sm font-medium leading-tight text-text-primary'>
+                {label}
+              </span>
+            ) : (
+              <Skeleton width='70%' size='sm' />
+            )}
+          </div>
+          <Spinner
+            size='sm'
+            aria-label='Creating target'
+            className='shrink-0'
+          />
+        </header>
+
+        <hr className='-mx-4 border-border' />
+
+        <dl className='grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-xs'>
+          <dt className='text-text-tertiary'>Categories</dt>
+          <dd className='flex justify-end'>
+            <Skeleton width={20} size='sm' />
+          </dd>
+          <dt className='text-text-tertiary'>Keywords</dt>
+          <dd className='flex justify-end'>
+            <Skeleton width={24} size='sm' />
+          </dd>
+          <dt className='text-text-tertiary'>Updated</dt>
+          <dd className='flex justify-end'>
+            <Skeleton width={70} size='sm' />
+          </dd>
+        </dl>
+
+        <hr className='-mx-4 border-border' />
+
+        <div className='flex justify-end'>
+          <span className='inline-flex items-center gap-1.5 text-xs text-text-tertiary'>
+            <Spinner size='sm' aria-label='Building scoring profile' />
+            Building…
+          </span>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/wyrdfold/src/app/(app)/targets/TargetCard.tsx
+++ b/apps/wyrdfold/src/app/(app)/targets/TargetCard.tsx
@@ -1,0 +1,156 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { Briefcase, MoreVertical, Power, Trash2 } from 'lucide-react';
+import { Badge } from '@danieljoffe.com/shared-ui/Badge';
+import { Card, CardContent } from '@danieljoffe.com/shared-ui/Card';
+import { Dropdown } from '@danieljoffe.com/shared-ui/Dropdown';
+import type { DropdownItem } from '@danieljoffe.com/shared-ui/Dropdown';
+import { cn } from '@/lib/cn';
+import type { JobTarget } from './types';
+
+interface TargetCardProps {
+  target: JobTarget;
+  fitScore: number | null;
+  fitScoreReasoning: string | null;
+  onActivate: (id: string) => void;
+  onDeactivate: (id: string) => void;
+  onDelete: (id: string) => void;
+  onViewJobs: (id: string) => void;
+}
+
+function countKeywords(target: JobTarget): number {
+  return Object.values(target.scoring_profile.categories).reduce(
+    (sum, cat) => sum + Object.keys(cat.keywords).length,
+    0
+  );
+}
+
+function fitScoreVariant(
+  score: number
+): 'success' | 'brand' | 'warning' | 'default' {
+  if (score >= 85) return 'success';
+  if (score >= 70) return 'brand';
+  if (score >= 50) return 'warning';
+  return 'default';
+}
+
+export default function TargetCard({
+  target,
+  fitScore,
+  fitScoreReasoning,
+  onActivate,
+  onDeactivate,
+  onDelete,
+  onViewJobs,
+}: TargetCardProps) {
+  const router = useRouter();
+  const detailHref = `/targets/${target.id}`;
+  const categoryCount = Object.keys(target.scoring_profile.categories).length;
+  const keywordCount = countKeywords(target);
+
+  function handleNavigate() {
+    router.push(detailHref);
+  }
+
+  const items: DropdownItem[] = [
+    {
+      label: 'View jobs',
+      icon: <Briefcase className='size-4' aria-hidden />,
+      onClick: () => onViewJobs(target.id),
+      disabled: !target.is_active,
+    },
+    {
+      label: target.is_active ? 'Deactivate' : 'Activate',
+      icon: <Power className='size-4' aria-hidden />,
+      onClick: () =>
+        target.is_active ? onDeactivate(target.id) : onActivate(target.id),
+    },
+    { label: '', divider: true },
+    {
+      label: 'Delete',
+      icon: <Trash2 className='size-4' aria-hidden />,
+      danger: true,
+      onClick: () => onDelete(target.id),
+    },
+  ];
+
+  return (
+    <Card padding='none' className='min-w-0'>
+      <CardContent
+        className={cn(
+          'flex cursor-pointer flex-col gap-2.5 p-4 transition-colors',
+          'hover:bg-surface-secondary',
+          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2'
+        )}
+        onClick={handleNavigate}
+        onKeyDown={e => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            handleNavigate();
+          }
+        }}
+        tabIndex={0}
+        role='button'
+        aria-label={`Open target ${target.label}`}
+      >
+        <header className='flex items-start justify-between gap-2'>
+          <div className='flex min-w-0 flex-1 items-center gap-2'>
+            {fitScore !== null && (
+              <Badge
+                variant={fitScoreVariant(fitScore)}
+                size='sm'
+                title={fitScoreReasoning ?? undefined}
+                className='shrink-0'
+              >
+                {fitScore}
+              </Badge>
+            )}
+            <span className='min-w-0 flex-1 truncate text-sm font-medium leading-tight text-text-primary'>
+              {target.label}
+            </span>
+          </div>
+          <div className='shrink-0' onClick={e => e.stopPropagation()}>
+            <Dropdown
+              trigger={
+                <span className='inline-flex rounded p-1 text-text-secondary hover:bg-surface-tertiary hover:text-text-primary'>
+                  <MoreVertical className='size-4' aria-hidden />
+                </span>
+              }
+              items={items}
+              align='right'
+            />
+          </div>
+        </header>
+
+        <hr className='-mx-4 border-border' />
+
+        <dl className='grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-xs'>
+          <dt className='text-text-tertiary'>Categories</dt>
+          <dd className='text-right text-text-secondary'>{categoryCount}</dd>
+          <dt className='text-text-tertiary'>Keywords</dt>
+          <dd className='text-right text-text-secondary'>{keywordCount}</dd>
+          <dt className='text-text-tertiary'>Updated</dt>
+          <dd className='text-right text-text-secondary'>
+            {new Date(target.updated_at).toLocaleDateString()}
+          </dd>
+        </dl>
+
+        <hr className='-mx-4 border-border' />
+
+        <div className='flex justify-end'>
+          <span className='inline-flex items-center gap-1.5 text-xs text-text-secondary'>
+            <span
+              className={cn(
+                'inline-block size-2 rounded-full',
+                target.is_active ? 'bg-success' : 'bg-text-tertiary'
+              )}
+              aria-hidden
+            />
+            {target.is_active ? 'Active' : 'Inactive'}
+          </span>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/wyrdfold/src/app/(app)/targets/TargetsList.tsx
+++ b/apps/wyrdfold/src/app/(app)/targets/TargetsList.tsx
@@ -1,0 +1,456 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Plus, Sparkles } from 'lucide-react';
+import { Badge } from '@danieljoffe.com/shared-ui/Badge';
+import { Heading } from '@danieljoffe.com/shared-ui/Heading';
+import { Spinner } from '@danieljoffe.com/shared-ui/Spinner';
+import { Text } from '@danieljoffe.com/shared-ui/Text';
+import { Card, CardContent } from '@danieljoffe.com/shared-ui/Card';
+import { Skeleton } from '@danieljoffe.com/shared-ui/Skeleton';
+import Button from '@/components/Button';
+import { useToast } from '@/state/Toast/ToastProvider';
+import TargetCard from './TargetCard';
+import CreateTargetModal, {
+  type ManualSubmission,
+  type UrlSubmission,
+} from './CreateTargetModal';
+import PendingTargetCard from './PendingTargetCard';
+import type {
+  CreateOrLinkResult,
+  MatchedSuggestion,
+  MatchedSuggestions,
+  UserTarget,
+  UserTargetWithTarget,
+} from './types';
+
+interface PendingTarget {
+  id: string;
+  label: string;
+}
+
+export default function TargetsList() {
+  const [targets, setTargets] = useState<UserTargetWithTarget[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [modalOpen, setModalOpen] = useState(false);
+  const { toast } = useToast();
+  const router = useRouter();
+
+  const fetchTargets = useCallback(async () => {
+    try {
+      const res = await fetch('/api/targets/mine');
+      if (!res.ok) throw new Error('Failed to fetch targets');
+      const { targets } = (await res.json()) as {
+        targets: UserTargetWithTarget[];
+      };
+      setTargets(targets);
+    } catch {
+      toast({ variant: 'error', title: 'Failed to load targets' });
+    } finally {
+      setLoading(false);
+    }
+  }, [toast]);
+
+  useEffect(() => {
+    fetchTargets();
+  }, [fetchTargets]);
+
+  const handleActivate = useCallback(
+    async (id: string) => {
+      try {
+        const res = await fetch(`/api/targets/${id}/activate`, {
+          method: 'POST',
+        });
+        if (!res.ok) throw new Error('Activate failed');
+        toast({ variant: 'success', title: 'Target activated' });
+        fetchTargets();
+      } catch {
+        toast({ variant: 'error', title: 'Failed to activate target' });
+      }
+    },
+    [toast, fetchTargets]
+  );
+
+  const handleDeactivate = useCallback(
+    async (id: string) => {
+      try {
+        const res = await fetch(`/api/targets/${id}/deactivate`, {
+          method: 'POST',
+        });
+        if (!res.ok) throw new Error('Deactivate failed');
+        toast({ variant: 'success', title: 'Target deactivated' });
+        fetchTargets();
+      } catch {
+        toast({ variant: 'error', title: 'Failed to deactivate target' });
+      }
+    },
+    [toast, fetchTargets]
+  );
+
+  const handleDelete = useCallback(
+    async (id: string) => {
+      /* eslint-disable no-alert -- personal tool */
+      if (!window.confirm('Delete this target?')) return;
+      /* eslint-enable no-alert */
+
+      try {
+        const res = await fetch(`/api/targets/${id}`, { method: 'DELETE' });
+        if (!res.ok) throw new Error('Delete failed');
+        toast({ variant: 'success', title: 'Target deleted' });
+        fetchTargets();
+      } catch {
+        toast({ variant: 'error', title: 'Failed to delete target' });
+      }
+    },
+    [toast, fetchTargets]
+  );
+
+  const handleViewJobs = useCallback(
+    (id: string) => {
+      router.push(`/jobs?target=${id}`);
+    },
+    [router]
+  );
+
+  const [pendingTargets, setPendingTargets] = useState<PendingTarget[]>([]);
+
+  const runCreate = useCallback(
+    async (
+      endpoint: '/api/targets/from-manual' | '/api/targets/from-url',
+      body: object,
+      pendingLabel: string
+    ) => {
+      const pendingId =
+        typeof crypto !== 'undefined' && 'randomUUID' in crypto
+          ? crypto.randomUUID()
+          : `pending-${Date.now()}-${Math.random()}`;
+      setPendingTargets(p => [...p, { id: pendingId, label: pendingLabel }]);
+      setModalOpen(false);
+      setSuggestions([]);
+
+      try {
+        const res = await fetch(endpoint, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+        });
+        if (!res.ok) {
+          const err = await res.json().catch(() => null);
+          throw new Error(
+            (err as Record<string, string> | null)?.detail ??
+              'Failed to add target'
+          );
+        }
+        const result = (await res.json()) as CreateOrLinkResult;
+        const alreadyLinked = targets.some(
+          t => t.target.id === result.target.id
+        );
+        toast({
+          variant: 'success',
+          title: result.was_matched
+            ? alreadyLinked
+              ? `Already in your targets: ${result.target.label}`
+              : `Linked to existing target: ${result.target.label}`
+            : `Target added: ${result.target.label}`,
+        });
+        // Use the response directly so the new card shows even if /mine
+        // is slow or fails. Replace any existing entry with the same
+        // target id (covers the was_matched=true relink path).
+        setTargets(prev => [
+          { user_target: result.user_target, target: result.target },
+          ...prev.filter(t => t.target.id !== result.target.id),
+        ]);
+      } catch (e) {
+        toast({
+          variant: 'error',
+          title: e instanceof Error ? e.message : 'Failed to add target',
+        });
+      } finally {
+        setPendingTargets(p => p.filter(t => t.id !== pendingId));
+      }
+    },
+    [toast, targets]
+  );
+
+  const handleSubmitManual = useCallback(
+    (payload: ManualSubmission) => {
+      void runCreate('/api/targets/from-manual', payload, payload.label);
+    },
+    [runCreate]
+  );
+
+  const handleSubmitUrl = useCallback(
+    (payload: UrlSubmission) => {
+      void runCreate('/api/targets/from-url', payload, payload.label ?? '');
+    },
+    [runCreate]
+  );
+
+  const [suggestions, setSuggestions] = useState<MatchedSuggestion[]>([]);
+  const [suggesting, setSuggesting] = useState(false);
+  const [addingSuggestion, setAddingSuggestion] = useState<string | null>(null);
+
+  const handleSuggest = useCallback(async () => {
+    setSuggesting(true);
+    setSuggestions([]);
+    try {
+      const res = await fetch('/api/targets/suggest', { method: 'POST' });
+      if (!res.ok) throw new Error('Suggest failed');
+      const data = (await res.json()) as MatchedSuggestions;
+      setSuggestions(data.matches);
+      if (data.matches.length === 0) {
+        toast({
+          variant: 'info',
+          title: 'No new suggestions',
+          description:
+            'Your existing targets already cover roles that fit your experience.',
+        });
+      }
+    } catch {
+      toast({ variant: 'error', title: 'Failed to generate suggestions' });
+    } finally {
+      setSuggesting(false);
+    }
+  }, [toast]);
+
+  const handleAddSuggestion = useCallback(
+    async (match: MatchedSuggestion) => {
+      const label = match.suggestion.label;
+      setAddingSuggestion(label);
+      try {
+        let entry: UserTargetWithTarget;
+        if (match.is_new) {
+          const res = await fetch('/api/targets/from-manual', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              label,
+              description: match.suggestion.description,
+            }),
+          });
+          if (!res.ok) {
+            const err = await res.json().catch(() => null);
+            throw new Error(
+              (err as Record<string, string> | null)?.detail ??
+                'Failed to add target'
+            );
+          }
+          const result = (await res.json()) as CreateOrLinkResult;
+          entry = { user_target: result.user_target, target: result.target };
+        } else {
+          const matchedTarget = match.matched_target!;
+          const linkRes = await fetch(`/api/targets/${matchedTarget.id}/link`, {
+            method: 'POST',
+          });
+          if (!linkRes.ok) throw new Error('Link failed');
+          const userTarget = (await linkRes.json()) as UserTarget;
+          entry = { user_target: userTarget, target: matchedTarget };
+        }
+
+        toast({
+          variant: 'success',
+          title: `Added "${label}"`,
+        });
+        setSuggestions(prev => prev.filter(s => s.suggestion.label !== label));
+        setTargets(prev => [
+          entry,
+          ...prev.filter(t => t.target.id !== entry.target.id),
+        ]);
+      } catch (e) {
+        toast({
+          variant: 'error',
+          title: e instanceof Error ? e.message : 'Failed to add target',
+        });
+      } finally {
+        setAddingSuggestion(null);
+      }
+    },
+    [toast]
+  );
+
+  if (loading) {
+    return (
+      <div className='flex flex-col gap-6' aria-label='Loading targets'>
+        <div className='flex items-center justify-between'>
+          <Skeleton width={120} height={28} />
+          <Skeleton variant='rectangular' width={110} height={36} />
+        </div>
+        <div className='grid gap-4 sm:grid-cols-2 lg:grid-cols-3'>
+          {Array.from({ length: 3 }).map((_, i) => (
+            <Card key={i} padding='none'>
+              <CardContent className='flex flex-col gap-2.5 p-4'>
+                <Skeleton width='70%' size='sm' />
+                <hr className='-mx-4 border-border' />
+                <Skeleton variant='text' lines={3} />
+                <hr className='-mx-4 border-border' />
+                <div className='flex justify-end'>
+                  <Skeleton width={60} size='sm' />
+                </div>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  const hasContent = targets.length > 0 || pendingTargets.length > 0;
+
+  return (
+    <div className='flex flex-col gap-6'>
+      <div className='flex items-start justify-between gap-3'>
+        <div>
+          <Heading variant='hero' as='h1'>
+            Targets
+          </Heading>
+          <Text variant='body' className='mt-1 text-text-secondary'>
+            Role profiles you score new jobs against
+          </Text>
+        </div>
+        {hasContent && (
+          <Button
+            name='target-create'
+            variant='primary'
+            size='sm'
+            iconOnly
+            aria-label='Create target'
+            className='rounded-full'
+            onClick={() => setModalOpen(true)}
+          >
+            <Plus className='size-4' aria-hidden />
+          </Button>
+        )}
+      </div>
+
+      {!hasContent ? (
+        <Card>
+          <CardContent className='flex flex-col items-center gap-3 py-12'>
+            <Text variant='body' as='p'>
+              No targets yet. Create your first target to start scoring jobs
+              against a specific role profile.
+            </Text>
+            <div className='flex flex-col items-stretch gap-3 sm:flex-row sm:items-center'>
+              <Button
+                name='target-create-empty'
+                variant='primary'
+                size='sm'
+                onClick={() => setModalOpen(true)}
+              >
+                <Plus className='size-4' aria-hidden />
+                <span>Create Target</span>
+              </Button>
+              <Button
+                name='target-suggest-empty'
+                variant='outline'
+                size='sm'
+                onClick={handleSuggest}
+                disabled={suggesting}
+              >
+                <Sparkles className='size-4' aria-hidden />
+                <span>Suggest from Experience</span>
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      ) : (
+        <>
+          <div className='grid gap-4 sm:grid-cols-2 lg:grid-cols-3'>
+            {pendingTargets.map(p => (
+              <PendingTargetCard key={p.id} label={p.label} />
+            ))}
+            {targets.map(({ user_target, target }) => (
+              <TargetCard
+                key={target.id}
+                target={target}
+                fitScore={user_target.fit_score}
+                fitScoreReasoning={user_target.fit_score_reasoning}
+                onActivate={handleActivate}
+                onDeactivate={handleDeactivate}
+                onDelete={handleDelete}
+                onViewJobs={handleViewJobs}
+              />
+            ))}
+          </div>
+
+          <div className='flex items-center justify-center'>
+            <Button
+              name='target-suggest'
+              variant='outline'
+              size='sm'
+              onClick={handleSuggest}
+              disabled={suggesting}
+            >
+              {suggesting ? (
+                <>
+                  <Spinner size='sm' aria-label='Suggesting' />
+                  <span>Suggesting...</span>
+                </>
+              ) : (
+                <>
+                  <Sparkles className='size-4' aria-hidden />
+                  <span>Suggest from Experience</span>
+                </>
+              )}
+            </Button>
+          </div>
+        </>
+      )}
+
+      {suggestions.length > 0 && (
+        <div className='flex flex-col gap-3'>
+          <Text variant='caption'>Suggested targets from your experience</Text>
+          <div className='grid gap-3 sm:grid-cols-2 lg:grid-cols-3'>
+            {suggestions.map(match => (
+              <Card key={match.suggestion.label} padding='none'>
+                <CardContent className='p-4 flex flex-col gap-2'>
+                  <div className='flex items-center gap-2'>
+                    <Heading variant='cardTitle'>
+                      {match.suggestion.label}
+                    </Heading>
+                    {!match.is_new && (
+                      <Badge variant='default' size='sm'>
+                        Existing
+                      </Badge>
+                    )}
+                  </div>
+                  <Text variant='caption' className='text-text-secondary'>
+                    {match.suggestion.description}
+                  </Text>
+                  {match.suggestion.core_skills.length > 0 && (
+                    <div className='flex flex-wrap gap-1'>
+                      {match.suggestion.core_skills.map(skill => (
+                        <Badge key={skill} variant='default' size='sm'>
+                          {skill}
+                        </Badge>
+                      ))}
+                    </div>
+                  )}
+                  <Button
+                    name={`add-suggestion-${match.suggestion.label}`}
+                    variant='primary'
+                    size='sm'
+                    onClick={() => handleAddSuggestion(match)}
+                    disabled={addingSuggestion === match.suggestion.label}
+                    className='mt-1 self-start'
+                  >
+                    {addingSuggestion === match.suggestion.label
+                      ? 'Adding...'
+                      : 'Add Target'}
+                  </Button>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        </div>
+      )}
+
+      <CreateTargetModal
+        isOpen={modalOpen}
+        onClose={() => setModalOpen(false)}
+        onSubmitManual={handleSubmitManual}
+        onSubmitUrl={handleSubmitUrl}
+      />
+    </div>
+  );
+}

--- a/apps/wyrdfold/src/app/(app)/targets/[id]/AddReferenceJDModal.tsx
+++ b/apps/wyrdfold/src/app/(app)/targets/[id]/AddReferenceJDModal.tsx
@@ -1,0 +1,156 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+import { Modal } from '@danieljoffe.com/shared-ui/Modal';
+import { Textarea } from '@danieljoffe.com/shared-ui/Textarea';
+import { Input } from '@danieljoffe.com/shared-ui/Input';
+import { Spinner } from '@danieljoffe.com/shared-ui/Spinner';
+import { Text } from '@danieljoffe.com/shared-ui/Text';
+import Button from '@/components/Button';
+import { useToast } from '@/state/Toast/ToastProvider';
+
+interface AddReferenceJDModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  targetId: string;
+  onAdded: () => void;
+}
+
+export default function AddReferenceJDModal({
+  isOpen,
+  onClose,
+  targetId,
+  onAdded,
+}: AddReferenceJDModalProps) {
+  const [jdText, setJdText] = useState('');
+  const [jdUrl, setJdUrl] = useState('');
+  const [saving, setSaving] = useState(false);
+  const { toast } = useToast();
+
+  const reset = useCallback(() => {
+    setJdText('');
+    setJdUrl('');
+    setSaving(false);
+  }, []);
+
+  const handleClose = useCallback(() => {
+    if (saving) return;
+    reset();
+    onClose();
+  }, [saving, reset, onClose]);
+
+  const trimmedText = jdText.trim();
+  const isValid = trimmedText.length >= 50;
+
+  const handleSubmit = useCallback(async () => {
+    if (!isValid) return;
+
+    setSaving(true);
+    try {
+      const res = await fetch(`/api/targets/${targetId}/reference-jds`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          jd_text: trimmedText,
+          ...(jdUrl.trim() ? { jd_url: jdUrl.trim() } : {}),
+        }),
+      });
+
+      if (!res.ok) {
+        const err = await res.json().catch(() => null);
+        toast({
+          variant: 'error',
+          title:
+            (err as Record<string, string> | null)?.detail ??
+            'Failed to add reference JD',
+        });
+        setSaving(false);
+        return;
+      }
+
+      toast({
+        variant: 'success',
+        title: 'Reference JD added and profile updated',
+      });
+      reset();
+      onAdded();
+    } catch {
+      toast({ variant: 'error', title: 'Network error adding reference JD' });
+      setSaving(false);
+    }
+  }, [targetId, trimmedText, jdUrl, isValid, toast, reset, onAdded]);
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={handleClose}
+      title='Add Reference JD'
+      size='lg'
+      closeOnBackdropClick={!saving}
+      footer={
+        <div className='flex justify-end gap-2'>
+          <Button
+            name='target-ref-jd-cancel'
+            variant='outline'
+            size='sm'
+            onClick={handleClose}
+            disabled={saving}
+          >
+            Cancel
+          </Button>
+          <Button
+            name='target-ref-jd-submit'
+            variant='primary'
+            size='sm'
+            onClick={handleSubmit}
+            disabled={saving || !isValid}
+          >
+            {saving ? (
+              <>
+                <Spinner size='sm' />
+                <span>Analyzing...</span>
+              </>
+            ) : (
+              'Add'
+            )}
+          </Button>
+        </div>
+      }
+    >
+      <div className='flex flex-col gap-4'>
+        <Textarea
+          label='Job description text'
+          helperText={`Paste the full JD. Minimum 50 characters (${trimmedText.length}/50).`}
+          placeholder='Paste the full job description here...'
+          value={jdText}
+          onChange={e => setJdText(e.target.value)}
+          disabled={saving}
+          rows={10}
+          error={
+            trimmedText.length > 0 && trimmedText.length < 50
+              ? 'Minimum 50 characters required'
+              : undefined
+          }
+        />
+
+        <Input
+          label='Source URL (optional)'
+          placeholder='https://...'
+          value={jdUrl}
+          onChange={e => setJdUrl(e.target.value)}
+          disabled={saving}
+          type='url'
+        />
+
+        {saving && (
+          <div className='flex items-center gap-2 rounded-lg bg-surface-secondary p-3'>
+            <Spinner size='sm' />
+            <Text variant='caption' as='span'>
+              Analyzing job description and merging into scoring profile...
+            </Text>
+          </div>
+        )}
+      </div>
+    </Modal>
+  );
+}

--- a/apps/wyrdfold/src/app/(app)/targets/[id]/ReferenceJDList.tsx
+++ b/apps/wyrdfold/src/app/(app)/targets/[id]/ReferenceJDList.tsx
@@ -1,0 +1,139 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+import { ExternalLink, Trash2 } from 'lucide-react';
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from '@danieljoffe.com/shared-ui/Card';
+import { Text } from '@danieljoffe.com/shared-ui/Text';
+import Button from '@/components/Button';
+import { useToast } from '@/state/Toast/ToastProvider';
+import type { TargetReferenceJD } from '../types';
+import AddReferenceJDModal from './AddReferenceJDModal';
+
+interface ReferenceJDListProps {
+  targetId: string;
+  referenceJDs: TargetReferenceJD[];
+  onChanged: () => void;
+}
+
+export default function ReferenceJDList({
+  targetId,
+  referenceJDs,
+  onChanged,
+}: ReferenceJDListProps) {
+  const [modalOpen, setModalOpen] = useState(false);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+  const { toast } = useToast();
+
+  const handleDelete = useCallback(
+    async (refId: string) => {
+      /* eslint-disable no-alert -- personal tool */
+      if (
+        !window.confirm(
+          'Delete this reference JD? The scoring profile will be re-merged.'
+        )
+      )
+        return;
+      /* eslint-enable no-alert */
+
+      setDeletingId(refId);
+      try {
+        const res = await fetch(
+          `/api/targets/${targetId}/reference-jds/${refId}`,
+          { method: 'DELETE' }
+        );
+        if (!res.ok) throw new Error('Delete failed');
+        toast({ variant: 'success', title: 'Reference JD removed' });
+        onChanged();
+      } catch {
+        toast({ variant: 'error', title: 'Failed to delete reference JD' });
+      } finally {
+        setDeletingId(null);
+      }
+    },
+    [targetId, toast, onChanged]
+  );
+
+  const handleAdded = useCallback(() => {
+    setModalOpen(false);
+    onChanged();
+  }, [onChanged]);
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className='flex items-center justify-between'>
+          <CardTitle>Reference JDs ({referenceJDs.length})</CardTitle>
+          <Button
+            name='target-ref-jd-add'
+            variant='outline'
+            size='sm'
+            onClick={() => setModalOpen(true)}
+          >
+            Add Reference JD
+          </Button>
+        </div>
+      </CardHeader>
+      <CardContent>
+        {referenceJDs.length === 0 ? (
+          <Text variant='body' as='p' className='text-text-secondary'>
+            No reference JDs yet. Add one to automatically derive a scoring
+            profile from a job description.
+          </Text>
+        ) : (
+          <div className='flex flex-col gap-3'>
+            {referenceJDs.map(jd => (
+              <div
+                key={jd.id}
+                className='flex items-start justify-between gap-3 rounded-lg border border-border p-3'
+              >
+                <div className='flex flex-col gap-1 min-w-0'>
+                  {jd.jd_url && (
+                    <a
+                      href={jd.jd_url}
+                      target='_blank'
+                      rel='noopener noreferrer'
+                      className='flex items-center gap-1 text-xs text-brand-500 hover:underline'
+                    >
+                      <ExternalLink className='size-3 shrink-0' aria-hidden />
+                      <span className='truncate'>{jd.jd_url}</span>
+                    </a>
+                  )}
+                  <Text variant='caption' as='p' className='line-clamp-2'>
+                    {jd.jd_text}
+                  </Text>
+                  <Text variant='meta' as='span'>
+                    Added {new Date(jd.created_at).toLocaleDateString()}
+                  </Text>
+                </div>
+                <Button
+                  name={`target-ref-jd-delete-${jd.id}`}
+                  variant='bare'
+                  size='sm'
+                  iconOnly
+                  onClick={() => handleDelete(jd.id)}
+                  disabled={deletingId === jd.id}
+                  aria-label='Delete reference JD'
+                  className='text-text-tertiary hover:text-error shrink-0'
+                >
+                  <Trash2 className='size-3.5' />
+                </Button>
+              </div>
+            ))}
+          </div>
+        )}
+      </CardContent>
+
+      <AddReferenceJDModal
+        isOpen={modalOpen}
+        onClose={() => setModalOpen(false)}
+        targetId={targetId}
+        onAdded={handleAdded}
+      />
+    </Card>
+  );
+}

--- a/apps/wyrdfold/src/app/(app)/targets/[id]/ScoringProfileEditor.tsx
+++ b/apps/wyrdfold/src/app/(app)/targets/[id]/ScoringProfileEditor.tsx
@@ -1,0 +1,616 @@
+'use client';
+
+import { useCallback, useMemo, useState } from 'react';
+import { Plus, Trash2 } from 'lucide-react';
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from '@danieljoffe.com/shared-ui/Card';
+import { Text } from '@danieljoffe.com/shared-ui/Text';
+import { Badge } from '@danieljoffe.com/shared-ui/Badge';
+import { Input } from '@danieljoffe.com/shared-ui/Input';
+import { Spinner } from '@danieljoffe.com/shared-ui/Spinner';
+import Button from '@/components/Button';
+import { useToast } from '@/state/Toast/ToastProvider';
+import type {
+  JobTarget,
+  ScoringProfile,
+  CategoryProfile,
+  SeniorityProfile,
+  DomainProfile,
+  NegativeProfile,
+} from '../types';
+import { emptyScoringProfile } from '../types';
+
+interface ScoringProfileEditorProps {
+  target: JobTarget;
+  onSaved: () => void;
+}
+
+function weightBadgeVariant(w: number): 'default' | 'info' | 'brand' {
+  if (w === 1) return 'default';
+  if (w === 2) return 'info';
+  return 'brand';
+}
+
+export default function ScoringProfileEditor({
+  target,
+  onSaved,
+}: ScoringProfileEditorProps) {
+  const [profile, setProfile] = useState<ScoringProfile>(
+    () => target.scoring_profile ?? emptyScoringProfile()
+  );
+  const [saving, setSaving] = useState(false);
+  const [newCategoryName, setNewCategoryName] = useState('');
+  const [newKeywordByCategory, setNewKeywordByCategory] = useState<
+    Record<string, string>
+  >({});
+  const [newSenioritySignal, setNewSenioritySignal] = useState('');
+  const [newDomainSignal, setNewDomainSignal] = useState('');
+  const [newNegativeKeyword, setNewNegativeKeyword] = useState('');
+  const { toast } = useToast();
+
+  const isDirty = useMemo(
+    () => JSON.stringify(profile) !== JSON.stringify(target.scoring_profile),
+    [profile, target.scoring_profile]
+  );
+
+  const handleSave = useCallback(async () => {
+    setSaving(true);
+    try {
+      const res = await fetch(`/api/targets/${target.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ scoring_profile: profile }),
+      });
+      if (!res.ok) throw new Error('Save failed');
+      toast({ variant: 'success', title: 'Scoring profile saved' });
+      onSaved();
+    } catch {
+      toast({ variant: 'error', title: 'Failed to save scoring profile' });
+    } finally {
+      setSaving(false);
+    }
+  }, [target.id, profile, toast, onSaved]);
+
+  // ---- Category operations ----
+
+  const addCategory = useCallback(() => {
+    const name = newCategoryName.trim().toLowerCase().replace(/\s+/g, '_');
+    if (!name || profile.categories[name]) return;
+    setProfile(prev => ({
+      ...prev,
+      categories: {
+        ...prev.categories,
+        [name]: { keywords: {}, weight: 1.0 },
+      },
+    }));
+    setNewCategoryName('');
+  }, [newCategoryName, profile.categories]);
+
+  const removeCategory = useCallback((name: string) => {
+    setProfile(prev => {
+      const { [name]: _, ...rest } = prev.categories;
+      return { ...prev, categories: rest };
+    });
+  }, []);
+
+  const updateCategoryWeight = useCallback(
+    (catName: string, weight: number) => {
+      setProfile(prev => ({
+        ...prev,
+        categories: {
+          ...prev.categories,
+          [catName]: { ...prev.categories[catName], weight },
+        },
+      }));
+    },
+    []
+  );
+
+  // ---- Keyword operations ----
+
+  const addKeyword = useCallback(
+    (catName: string) => {
+      const raw = (newKeywordByCategory[catName] ?? '').trim().toLowerCase();
+      if (!raw || profile.categories[catName]?.keywords[raw] !== undefined)
+        return;
+      setProfile(prev => ({
+        ...prev,
+        categories: {
+          ...prev.categories,
+          [catName]: {
+            ...prev.categories[catName],
+            keywords: { ...prev.categories[catName].keywords, [raw]: 2 },
+          },
+        },
+      }));
+      setNewKeywordByCategory(prev => ({ ...prev, [catName]: '' }));
+    },
+    [newKeywordByCategory, profile.categories]
+  );
+
+  const removeKeyword = useCallback((catName: string, keyword: string) => {
+    setProfile(prev => {
+      const { [keyword]: _, ...rest } = prev.categories[catName].keywords;
+      return {
+        ...prev,
+        categories: {
+          ...prev.categories,
+          [catName]: { ...prev.categories[catName], keywords: rest },
+        },
+      };
+    });
+  }, []);
+
+  const cycleKeywordWeight = useCallback((catName: string, keyword: string) => {
+    setProfile(prev => {
+      const current = prev.categories[catName].keywords[keyword];
+      const next = current >= 3 ? 1 : current + 1;
+      return {
+        ...prev,
+        categories: {
+          ...prev.categories,
+          [catName]: {
+            ...prev.categories[catName],
+            keywords: {
+              ...prev.categories[catName].keywords,
+              [keyword]: next,
+            },
+          },
+        },
+      };
+    });
+  }, []);
+
+  // ---- Seniority operations ----
+
+  const updateSeniority = useCallback((updates: Partial<SeniorityProfile>) => {
+    setProfile(prev => ({
+      ...prev,
+      seniority: { ...prev.seniority, ...updates },
+    }));
+  }, []);
+
+  const addSenioritySignal = useCallback(() => {
+    const signal = newSenioritySignal.trim();
+    if (!signal || profile.seniority.signals.includes(signal)) return;
+    updateSeniority({ signals: [...profile.seniority.signals, signal] });
+    setNewSenioritySignal('');
+  }, [newSenioritySignal, profile.seniority.signals, updateSeniority]);
+
+  const removeSenioritySignal = useCallback(
+    (signal: string) => {
+      updateSeniority({
+        signals: profile.seniority.signals.filter(s => s !== signal),
+      });
+    },
+    [profile.seniority.signals, updateSeniority]
+  );
+
+  // ---- Domain operations ----
+
+  const updateDomain = useCallback((updates: Partial<DomainProfile>) => {
+    setProfile(prev => ({
+      ...prev,
+      domain: { ...prev.domain, ...updates },
+    }));
+  }, []);
+
+  const addDomainSignal = useCallback(() => {
+    const signal = newDomainSignal.trim();
+    if (!signal || profile.domain.signals.includes(signal)) return;
+    updateDomain({ signals: [...profile.domain.signals, signal] });
+    setNewDomainSignal('');
+  }, [newDomainSignal, profile.domain.signals, updateDomain]);
+
+  const removeDomainSignal = useCallback(
+    (signal: string) => {
+      updateDomain({
+        signals: profile.domain.signals.filter(s => s !== signal),
+      });
+    },
+    [profile.domain.signals, updateDomain]
+  );
+
+  // ---- Negative operations ----
+
+  const updateNegative = useCallback((updates: Partial<NegativeProfile>) => {
+    setProfile(prev => ({
+      ...prev,
+      negative: { ...prev.negative, ...updates },
+    }));
+  }, []);
+
+  const addNegativeKeyword = useCallback(() => {
+    const kw = newNegativeKeyword.trim().toLowerCase();
+    if (!kw || profile.negative.keywords.includes(kw)) return;
+    updateNegative({ keywords: [...profile.negative.keywords, kw] });
+    setNewNegativeKeyword('');
+  }, [newNegativeKeyword, profile.negative.keywords, updateNegative]);
+
+  const removeNegativeKeyword = useCallback(
+    (kw: string) => {
+      updateNegative({
+        keywords: profile.negative.keywords.filter(k => k !== kw),
+      });
+    },
+    [profile.negative.keywords, updateNegative]
+  );
+
+  const totalKeywords = useMemo(
+    () =>
+      Object.values(profile.categories).reduce(
+        (sum, c) => sum + Object.keys(c.keywords).length,
+        0
+      ),
+    [profile.categories]
+  );
+
+  return (
+    <div className='flex flex-col gap-4'>
+      {/* ---- Categories ---- */}
+      <Card>
+        <CardHeader>
+          <div className='flex items-baseline justify-between gap-2'>
+            <CardTitle>Categories</CardTitle>
+            <Text variant='meta' className='text-text-tertiary'>
+              {Object.keys(profile.categories).length} categories ·{' '}
+              {totalKeywords} keywords
+            </Text>
+          </div>
+          <Text variant='meta' className='text-text-secondary'>
+            Group keywords by theme. Each keyword gets a 1–3 weight (click to
+            cycle); category weight scales the whole group.
+          </Text>
+        </CardHeader>
+        <CardContent className='flex flex-col gap-3'>
+          {Object.entries(profile.categories).map(
+            ([catName, cat]: [string, CategoryProfile]) => (
+              <div
+                key={catName}
+                className='rounded-lg border border-border p-4 flex flex-col gap-3'
+              >
+                <div className='flex items-center justify-between gap-2'>
+                  <Text variant='label' as='span'>
+                    {catName}
+                  </Text>
+                  <div className='flex items-center gap-2'>
+                    <label className='flex items-center gap-1 text-xs text-text-secondary'>
+                      Weight:
+                      <input
+                        type='number'
+                        aria-label={`Weight for ${catName} category`}
+                        value={cat.weight}
+                        onChange={e =>
+                          updateCategoryWeight(
+                            catName,
+                            parseFloat(e.target.value) || 0
+                          )
+                        }
+                        step={0.1}
+                        min={0}
+                        className='w-16 rounded border border-border bg-surface px-2 py-1 text-xs text-text-primary'
+                      />
+                    </label>
+                    <Button
+                      name={`target-cat-delete-${catName}`}
+                      variant='bare'
+                      size='sm'
+                      iconOnly
+                      onClick={() => removeCategory(catName)}
+                      aria-label={`Remove ${catName} category`}
+                      className='text-text-tertiary hover:text-error'
+                    >
+                      <Trash2 className='size-3.5' />
+                    </Button>
+                  </div>
+                </div>
+
+                <div className='flex flex-wrap gap-2'>
+                  {Object.entries(cat.keywords).map(([kw, weight]) => (
+                    <span
+                      key={kw}
+                      className='group flex items-center gap-1 rounded-full border border-border px-2.5 py-1 text-xs'
+                    >
+                      <button
+                        type='button'
+                        onClick={() => cycleKeywordWeight(catName, kw)}
+                        className='flex items-center gap-1 transition-colors hover:text-brand-500'
+                        aria-label={`Cycle weight for ${kw}`}
+                      >
+                        <span className='text-text-primary'>{kw}</span>
+                        <Badge variant={weightBadgeVariant(weight)} size='sm'>
+                          {weight}
+                        </Badge>
+                      </button>
+                      <button
+                        type='button'
+                        onClick={() => removeKeyword(catName, kw)}
+                        className='ml-0.5 text-text-tertiary hover:text-error'
+                        aria-label={`Remove ${kw}`}
+                      >
+                        &times;
+                      </button>
+                    </span>
+                  ))}
+                </div>
+
+                <div className='flex items-center gap-2'>
+                  <input
+                    type='text'
+                    placeholder='Add keyword'
+                    aria-label={`Add keyword to ${catName}`}
+                    value={newKeywordByCategory[catName] ?? ''}
+                    onChange={e =>
+                      setNewKeywordByCategory(prev => ({
+                        ...prev,
+                        [catName]: e.target.value,
+                      }))
+                    }
+                    onKeyDown={e => {
+                      if (e.key === 'Enter') addKeyword(catName);
+                    }}
+                    className='flex-1 rounded border border-border bg-surface px-2 py-1 text-xs text-text-primary placeholder:text-text-tertiary'
+                  />
+                  <Button
+                    name={`target-kw-add-${catName}`}
+                    variant='outline'
+                    size='sm'
+                    onClick={() => addKeyword(catName)}
+                  >
+                    <Plus className='size-3' aria-hidden />
+                  </Button>
+                </div>
+              </div>
+            )
+          )}
+
+          <div className='flex items-center gap-2'>
+            <input
+              type='text'
+              placeholder='New category name'
+              aria-label='New category name'
+              value={newCategoryName}
+              onChange={e => setNewCategoryName(e.target.value)}
+              onKeyDown={e => {
+                if (e.key === 'Enter') addCategory();
+              }}
+              className='flex-1 rounded border border-border bg-surface px-2 py-1 text-sm text-text-primary placeholder:text-text-tertiary'
+            />
+            <Button
+              name='target-cat-add'
+              variant='outline'
+              size='sm'
+              onClick={addCategory}
+            >
+              <Plus className='size-4' aria-hidden />
+              <span>Add Category</span>
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* ---- Seniority ---- */}
+      <Card>
+        <CardHeader>
+          <div className='flex items-baseline justify-between gap-2'>
+            <CardTitle>Seniority</CardTitle>
+            <Text variant='meta' className='text-text-tertiary'>
+              {profile.seniority.signals.length} signals
+            </Text>
+          </div>
+          <Text variant='meta' className='text-text-secondary'>
+            What level you&rsquo;re aiming for and the language that signals it
+            in a posting.
+          </Text>
+        </CardHeader>
+        <CardContent className='flex flex-col gap-3'>
+          <div className='max-w-xs'>
+            <Input
+              label='Level'
+              value={profile.seniority.level ?? ''}
+              onChange={e =>
+                updateSeniority({
+                  level: e.target.value || null,
+                })
+              }
+              placeholder='e.g. senior, staff'
+              size='sm'
+            />
+          </div>
+          <TagList
+            label='Signals'
+            items={profile.seniority.signals}
+            newValue={newSenioritySignal}
+            onNewValueChange={setNewSenioritySignal}
+            onAdd={addSenioritySignal}
+            onRemove={removeSenioritySignal}
+          />
+        </CardContent>
+      </Card>
+
+      {/* ---- Domain ---- */}
+      <Card>
+        <CardHeader>
+          <div className='flex items-baseline justify-between gap-2'>
+            <CardTitle>Domain</CardTitle>
+            <Text variant='meta' className='text-text-tertiary'>
+              {profile.domain.signals.length} signals
+            </Text>
+          </div>
+          <Text variant='meta' className='text-text-secondary'>
+            Industry / problem-space cues. Multiplier applied to the bucket as a
+            whole.
+          </Text>
+        </CardHeader>
+        <CardContent className='flex flex-col gap-3'>
+          <label className='flex items-center gap-1 text-xs text-text-secondary'>
+            Weight:
+            <input
+              type='number'
+              aria-label='Domain weight'
+              value={profile.domain.weight}
+              onChange={e =>
+                updateDomain({
+                  weight: parseFloat(e.target.value) || 0,
+                })
+              }
+              step={0.1}
+              className='w-16 rounded border border-border bg-surface px-2 py-1 text-xs text-text-primary'
+            />
+          </label>
+          <TagList
+            label='Signals'
+            items={profile.domain.signals}
+            newValue={newDomainSignal}
+            onNewValueChange={setNewDomainSignal}
+            onAdd={addDomainSignal}
+            onRemove={removeDomainSignal}
+          />
+        </CardContent>
+      </Card>
+
+      {/* ---- Negative ---- */}
+      <Card>
+        <CardHeader>
+          <div className='flex items-baseline justify-between gap-2'>
+            <CardTitle>Penalties</CardTitle>
+            <Text variant='meta' className='text-text-tertiary'>
+              {profile.negative.keywords.length} keywords
+            </Text>
+          </div>
+          <Text variant='meta' className='text-text-secondary'>
+            Keywords that should drag a posting&rsquo;s score down (e.g.
+            misaligned tech, role types).
+          </Text>
+        </CardHeader>
+        <CardContent className='flex flex-col gap-3'>
+          <label className='flex items-center gap-1 text-xs text-text-secondary'>
+            Weight:
+            <input
+              type='number'
+              aria-label='Negative keywords weight'
+              value={profile.negative.weight}
+              onChange={e =>
+                updateNegative({
+                  weight: parseFloat(e.target.value) || 0,
+                })
+              }
+              step={1}
+              className='w-16 rounded border border-border bg-surface px-2 py-1 text-xs text-text-primary'
+            />
+          </label>
+          <TagList
+            label='Keywords'
+            items={profile.negative.keywords}
+            newValue={newNegativeKeyword}
+            onNewValueChange={setNewNegativeKeyword}
+            onAdd={addNegativeKeyword}
+            onRemove={removeNegativeKeyword}
+          />
+        </CardContent>
+      </Card>
+
+      {/* Sticky save bar — only visible while there are unsaved changes.
+          Sits above any other bottom-fixed UI (jobs batch bar reserves
+          its own space at the route level). */}
+      {isDirty && (
+        <div
+          className='sticky bottom-4 z-10 flex items-center justify-between gap-3 rounded-lg border border-border bg-surface-elevated px-4 py-2.5 shadow-lg'
+          role='status'
+          aria-live='polite'
+        >
+          <Text variant='caption' className='text-warning'>
+            Unsaved changes
+          </Text>
+          <Button
+            name='target-profile-save'
+            variant='primary'
+            size='sm'
+            onClick={handleSave}
+            disabled={saving}
+          >
+            {saving ? (
+              <>
+                <Spinner size='sm' />
+                <span>Saving...</span>
+              </>
+            ) : (
+              'Save'
+            )}
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---- Reusable tag list sub-component ----
+
+interface TagListProps {
+  label: string;
+  items: string[];
+  newValue: string;
+  onNewValueChange: (v: string) => void;
+  onAdd: () => void;
+  onRemove: (item: string) => void;
+}
+
+function TagList({
+  label,
+  items,
+  newValue,
+  onNewValueChange,
+  onAdd,
+  onRemove,
+}: TagListProps) {
+  return (
+    <div className='flex flex-col gap-2'>
+      <Text variant='label' as='span'>
+        {label}
+      </Text>
+      <div className='flex flex-wrap gap-1.5'>
+        {items.map(item => (
+          <span
+            key={item}
+            className='flex items-center gap-1 rounded-full bg-surface-secondary px-2.5 py-1 text-xs text-text-primary'
+          >
+            {item}
+            <button
+              type='button'
+              onClick={() => onRemove(item)}
+              className='text-text-tertiary hover:text-error'
+              aria-label={`Remove ${item}`}
+            >
+              &times;
+            </button>
+          </span>
+        ))}
+      </div>
+      <div className='flex items-center gap-2'>
+        <input
+          type='text'
+          placeholder={`Add ${label.toLowerCase()}`}
+          aria-label={`Add ${label.toLowerCase()}`}
+          value={newValue}
+          onChange={e => onNewValueChange(e.target.value)}
+          onKeyDown={e => {
+            if (e.key === 'Enter') onAdd();
+          }}
+          className='flex-1 rounded border border-border bg-surface px-2 py-1 text-xs text-text-primary placeholder:text-text-tertiary'
+        />
+        <Button
+          name={`target-tag-add-${label.toLowerCase().replace(/\s+/g, '-')}`}
+          variant='outline'
+          size='sm'
+          onClick={onAdd}
+        >
+          <Plus className='size-3' aria-hidden />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/wyrdfold/src/app/(app)/targets/[id]/TargetDetail.tsx
+++ b/apps/wyrdfold/src/app/(app)/targets/[id]/TargetDetail.tsx
@@ -1,0 +1,191 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import Link from 'next/link';
+import { ArrowLeft, Check, Pencil } from 'lucide-react';
+import { Heading } from '@danieljoffe.com/shared-ui/Heading';
+import { Badge } from '@danieljoffe.com/shared-ui/Badge';
+import Button from '@/components/Button';
+import { useToast } from '@/state/Toast/ToastProvider';
+import type { JobTarget, TargetReferenceJD } from '../types';
+import ScoringProfileEditor from './ScoringProfileEditor';
+import ReferenceJDList from './ReferenceJDList';
+import TargetDetailSkeleton from './TargetDetailSkeleton';
+
+interface TargetDetailProps {
+  id: string;
+}
+
+export default function TargetDetail({ id }: TargetDetailProps) {
+  const [target, setTarget] = useState<JobTarget | null>(null);
+  const [referenceJDs, setReferenceJDs] = useState<TargetReferenceJD[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [editingLabel, setEditingLabel] = useState(false);
+  const [labelDraft, setLabelDraft] = useState('');
+  const [savingLabel, setSavingLabel] = useState(false);
+  const { toast } = useToast();
+
+  const fetchTarget = useCallback(async () => {
+    try {
+      const res = await fetch(`/api/targets/${id}`);
+      if (!res.ok) throw new Error('Failed to fetch target');
+      const data = (await res.json()) as JobTarget;
+      setTarget(data);
+      setLabelDraft(data.label);
+    } catch {
+      toast({ variant: 'error', title: 'Failed to load target' });
+    }
+  }, [id, toast]);
+
+  const fetchReferenceJDs = useCallback(async () => {
+    try {
+      const res = await fetch(`/api/targets/${id}/reference-jds`);
+      if (!res.ok) throw new Error('Failed to fetch reference JDs');
+      const payload = (await res.json()) as {
+        reference_jds: TargetReferenceJD[];
+      };
+      setReferenceJDs(payload.reference_jds);
+    } catch {
+      toast({ variant: 'error', title: 'Failed to load reference JDs' });
+    }
+  }, [id, toast]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    Promise.all([fetchTarget(), fetchReferenceJDs()]).finally(() => {
+      if (!cancelled) setLoading(false);
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [fetchTarget, fetchReferenceJDs]);
+
+  const handleSaveLabel = useCallback(async () => {
+    const trimmed = labelDraft.trim();
+    if (!trimmed || trimmed === target?.label) {
+      setEditingLabel(false);
+      return;
+    }
+
+    setSavingLabel(true);
+    try {
+      const res = await fetch(`/api/targets/${id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ label: trimmed }),
+      });
+      if (!res.ok) throw new Error('Failed to update label');
+      setTarget(prev => (prev ? { ...prev, label: trimmed } : prev));
+      setEditingLabel(false);
+      toast({ variant: 'success', title: 'Label updated' });
+    } catch {
+      toast({ variant: 'error', title: 'Failed to update label' });
+    } finally {
+      setSavingLabel(false);
+    }
+  }, [id, labelDraft, target?.label, toast]);
+
+  const handleRefresh = useCallback(() => {
+    fetchTarget();
+    fetchReferenceJDs();
+  }, [fetchTarget, fetchReferenceJDs]);
+
+  if (loading) {
+    return <TargetDetailSkeleton />;
+  }
+
+  if (!target) {
+    return (
+      <div className='flex flex-col items-center gap-4 py-20'>
+        <Heading variant='hero' as='h1'>
+          Target not found
+        </Heading>
+        <Link href='/targets' className='text-brand-500 hover:underline'>
+          Back to targets
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className='flex flex-col gap-6'>
+      <Link
+        href='/targets'
+        className='flex items-center gap-1 text-sm text-text-secondary hover:text-text-primary transition-colors w-fit'
+      >
+        <ArrowLeft className='size-4' aria-hidden />
+        <span>Back to targets</span>
+      </Link>
+
+      <div className='flex items-center gap-3'>
+        {editingLabel ? (
+          <div className='flex items-center gap-2'>
+            <input
+              aria-label='Target label'
+              aria-describedby='label-edit-hint'
+              value={labelDraft}
+              onChange={e => setLabelDraft(e.target.value)}
+              onKeyDown={e => {
+                if (e.key === 'Enter') handleSaveLabel();
+                if (e.key === 'Escape') {
+                  setEditingLabel(false);
+                  setLabelDraft(target.label);
+                }
+              }}
+              className='text-xl font-semibold bg-transparent border-b-2 border-brand-500 outline-none text-text-primary'
+              maxLength={200}
+              autoFocus
+              disabled={savingLabel}
+            />
+            <span id='label-edit-hint' className='sr-only'>
+              Press Enter to save, Escape to cancel
+            </span>
+            <Button
+              name='target-label-save'
+              variant='bare'
+              size='sm'
+              iconOnly
+              onClick={handleSaveLabel}
+              disabled={savingLabel}
+              aria-label='Save label'
+            >
+              <Check className='size-4' />
+            </Button>
+          </div>
+        ) : (
+          <div className='flex items-center gap-2'>
+            <Heading variant='hero' as='h1'>
+              {target.label}
+            </Heading>
+            <Button
+              name='target-label-edit'
+              variant='bare'
+              size='sm'
+              iconOnly
+              onClick={() => setEditingLabel(true)}
+              aria-label='Edit label'
+            >
+              <Pencil className='size-3.5' />
+            </Button>
+          </div>
+        )}
+
+        {target.is_active && (
+          <Badge variant='brand-solid' size='sm'>
+            Active
+          </Badge>
+        )}
+      </div>
+
+      <ScoringProfileEditor target={target} onSaved={fetchTarget} />
+
+      <ReferenceJDList
+        targetId={id}
+        referenceJDs={referenceJDs}
+        onChanged={handleRefresh}
+      />
+    </div>
+  );
+}

--- a/apps/wyrdfold/src/app/(app)/targets/[id]/TargetDetailSkeleton.tsx
+++ b/apps/wyrdfold/src/app/(app)/targets/[id]/TargetDetailSkeleton.tsx
@@ -1,0 +1,56 @@
+import { Card, CardContent, CardHeader } from '@danieljoffe.com/shared-ui/Card';
+import { Skeleton } from '@danieljoffe.com/shared-ui/Skeleton';
+
+function SectionCardSkeleton({ rows = 1 }: { rows?: number }) {
+  return (
+    <Card>
+      <CardHeader>
+        <div className='flex items-baseline justify-between gap-2'>
+          <Skeleton width={140} height={20} />
+          <Skeleton width={90} height={14} />
+        </div>
+        <Skeleton width='80%' height={14} className='mt-1' />
+      </CardHeader>
+      <CardContent className='flex flex-col gap-3'>
+        {Array.from({ length: rows }).map((_, i) => (
+          <Skeleton key={i} variant='rectangular' height={72} />
+        ))}
+      </CardContent>
+    </Card>
+  );
+}
+
+export default function TargetDetailSkeleton() {
+  return (
+    <div className='flex flex-col gap-4' aria-label='Loading target'>
+      <Skeleton width={120} size='sm' />
+
+      <div className='flex items-center gap-3'>
+        <Skeleton width={280} height={32} />
+        <Skeleton variant='rectangular' width={56} height={20} />
+      </div>
+
+      {/* Categories — taller (multiple sub-rows) */}
+      <SectionCardSkeleton rows={3} />
+
+      {/* Seniority / Domain / Penalties — single content blocks */}
+      <SectionCardSkeleton />
+      <SectionCardSkeleton />
+      <SectionCardSkeleton />
+
+      {/* Reference JDs */}
+      <Card>
+        <CardHeader>
+          <div className='flex items-center justify-between'>
+            <Skeleton width={160} height={20} />
+            <Skeleton variant='rectangular' width={140} height={32} />
+          </div>
+        </CardHeader>
+        <CardContent className='flex flex-col gap-3'>
+          <Skeleton variant='rectangular' height={56} />
+          <Skeleton variant='rectangular' height={56} />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/wyrdfold/src/app/(app)/targets/[id]/loading.tsx
+++ b/apps/wyrdfold/src/app/(app)/targets/[id]/loading.tsx
@@ -1,0 +1,5 @@
+import TargetDetailSkeleton from './TargetDetailSkeleton';
+
+export default function FittedTargetDetailLoading() {
+  return <TargetDetailSkeleton />;
+}

--- a/apps/wyrdfold/src/app/(app)/targets/[id]/page.tsx
+++ b/apps/wyrdfold/src/app/(app)/targets/[id]/page.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from 'next';
+import TargetDetail from './TargetDetail';
+
+export const metadata: Metadata = {
+  title: 'Target Detail',
+};
+
+export default async function FittedTargetDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  return <TargetDetail id={id} />;
+}

--- a/apps/wyrdfold/src/app/(app)/targets/__tests__/types.spec.ts
+++ b/apps/wyrdfold/src/app/(app)/targets/__tests__/types.spec.ts
@@ -1,0 +1,38 @@
+import { emptyScoringProfile } from '../types';
+
+describe('emptyScoringProfile', () => {
+  it('returns an empty categories map', () => {
+    const profile = emptyScoringProfile();
+    expect(profile.categories).toEqual({});
+  });
+
+  it('seeds seniority with null level + empty signals', () => {
+    const profile = emptyScoringProfile();
+    expect(profile.seniority).toEqual({ level: null, signals: [] });
+  });
+
+  it('seeds the domain profile with weight 0.5', () => {
+    const profile = emptyScoringProfile();
+    expect(profile.domain.weight).toBe(0.5);
+    expect(profile.domain.signals).toEqual([]);
+  });
+
+  // The negative weight is intentionally large and negative — a positive or
+  // small value would let "negative" keywords *boost* a job's score, which
+  // defeats the whole point of the negative bucket.
+  it('seeds the negative profile with weight -10', () => {
+    const profile = emptyScoringProfile();
+    expect(profile.negative.weight).toBe(-10);
+    expect(profile.negative.keywords).toEqual([]);
+  });
+
+  it('returns a fresh object on each call (no shared references)', () => {
+    const a = emptyScoringProfile();
+    const b = emptyScoringProfile();
+    expect(a).not.toBe(b);
+    expect(a.categories).not.toBe(b.categories);
+    expect(a.seniority.signals).not.toBe(b.seniority.signals);
+    expect(a.domain.signals).not.toBe(b.domain.signals);
+    expect(a.negative.keywords).not.toBe(b.negative.keywords);
+  });
+});

--- a/apps/wyrdfold/src/app/(app)/targets/loading.tsx
+++ b/apps/wyrdfold/src/app/(app)/targets/loading.tsx
@@ -1,0 +1,28 @@
+import { Card, CardContent } from '@danieljoffe.com/shared-ui/Card';
+import { Skeleton } from '@danieljoffe.com/shared-ui/Skeleton';
+
+export default function FittedTargetsLoading() {
+  return (
+    <div className='flex flex-col gap-6' aria-label='Loading targets'>
+      <div className='flex items-center justify-between'>
+        <Skeleton width={120} height={28} />
+        <Skeleton variant='rectangular' width={110} height={36} />
+      </div>
+      <div className='grid gap-4 sm:grid-cols-2 lg:grid-cols-3'>
+        {Array.from({ length: 3 }).map((_, i) => (
+          <Card key={i} padding='none'>
+            <CardContent className='flex flex-col gap-2.5 p-4'>
+              <Skeleton width='70%' size='sm' />
+              <hr className='-mx-4 border-border' />
+              <Skeleton variant='text' lines={3} />
+              <hr className='-mx-4 border-border' />
+              <div className='flex justify-end'>
+                <Skeleton width={60} size='sm' />
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/wyrdfold/src/app/(app)/targets/page.tsx
+++ b/apps/wyrdfold/src/app/(app)/targets/page.tsx
@@ -1,0 +1,10 @@
+import type { Metadata } from 'next';
+import TargetsList from './TargetsList';
+
+export const metadata: Metadata = {
+  title: 'Targets',
+};
+
+export default function FittedTargetsPage() {
+  return <TargetsList />;
+}

--- a/apps/wyrdfold/src/app/(app)/targets/types.ts
+++ b/apps/wyrdfold/src/app/(app)/targets/types.ts
@@ -1,0 +1,96 @@
+export interface CategoryProfile {
+  keywords: Record<string, number>; // keyword -> weight 1-3
+  weight: number; // category multiplier
+}
+
+export interface SeniorityProfile {
+  level: string | null;
+  signals: string[];
+}
+
+export interface DomainProfile {
+  signals: string[];
+  weight: number;
+}
+
+export interface NegativeProfile {
+  keywords: string[];
+  weight: number;
+}
+
+export interface ScoringProfile {
+  categories: Record<string, CategoryProfile>;
+  seniority: SeniorityProfile;
+  domain: DomainProfile;
+  negative: NegativeProfile;
+}
+
+export interface JobTarget {
+  id: string;
+  label: string;
+  description: string | null;
+  normalized_label: string | null;
+  scoring_profile: ScoringProfile;
+  search_keywords: string[];
+  activation_status: string;
+  profile_version: number;
+  is_active: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface UserTarget {
+  id: string;
+  user_id: string;
+  target_id: string;
+  is_active: boolean;
+  fit_score: number | null;
+  fit_score_reasoning: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface UserTargetWithTarget {
+  user_target: UserTarget;
+  target: JobTarget;
+}
+
+export interface CreateOrLinkResult {
+  user_target: UserTarget;
+  target: JobTarget;
+  was_matched: boolean;
+}
+
+export interface TargetReferenceJD {
+  id: string;
+  target_id: string;
+  jd_url: string | null;
+  jd_text: string;
+  extracted_profile: ScoringProfile;
+  created_at: string;
+}
+
+export interface TargetSuggestion {
+  label: string;
+  description: string;
+  core_skills: string[];
+}
+
+export interface MatchedSuggestion {
+  suggestion: TargetSuggestion;
+  matched_target: JobTarget | null;
+  is_new: boolean;
+}
+
+export interface MatchedSuggestions {
+  matches: MatchedSuggestion[];
+}
+
+export function emptyScoringProfile(): ScoringProfile {
+  return {
+    categories: {},
+    seniority: { level: null, signals: [] },
+    domain: { signals: [], weight: 0.5 },
+    negative: { keywords: [], weight: -10 },
+  };
+}

--- a/apps/wyrdfold/src/app/_components/ConversationChat.tsx
+++ b/apps/wyrdfold/src/app/_components/ConversationChat.tsx
@@ -1,0 +1,309 @@
+'use client';
+
+import { useState, useCallback, useEffect, useRef, useId } from 'react';
+import { Send } from 'lucide-react';
+import { Card } from '@danieljoffe.com/shared-ui/Card';
+import { Text } from '@danieljoffe.com/shared-ui/Text';
+import { Heading } from '@danieljoffe.com/shared-ui/Heading';
+import { Spinner } from '@danieljoffe.com/shared-ui/Spinner';
+import { Alert } from '@danieljoffe.com/shared-ui/Alert';
+import { Textarea } from '@danieljoffe.com/shared-ui/Textarea';
+import Button from '@/components/Button';
+
+interface ConversationChatProps {
+  onComplete: () => void;
+  onSkip: () => void;
+}
+
+interface Message {
+  id: string;
+  role: 'assistant' | 'user';
+  content: string;
+}
+
+export default function ConversationChat({
+  onComplete,
+  onSkip,
+}: ConversationChatProps) {
+  const idPrefix = useId();
+  const msgCountRef = useRef(0);
+  function nextMsgId(): string {
+    return `${idPrefix}-msg-${++msgCountRef.current}`;
+  }
+
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [input, setInput] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [sending, setSending] = useState(false);
+  const [deriving, setDeriving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  // Scroll to bottom when messages change
+  useEffect(() => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+    }
+  }, [messages, loading, sending]);
+
+  // Fetch initial probe question
+  useEffect(() => {
+    let cancelled = false;
+
+    async function fetchProbe() {
+      try {
+        const res = await fetch(
+          '/api/career/experience/conversation/next-probe'
+        );
+        if (!res.ok) throw new Error('Failed to load question');
+        const data = (await res.json()) as { question: string };
+        if (!cancelled) {
+          setMessages([
+            { id: nextMsgId(), role: 'assistant', content: data.question },
+          ]);
+        }
+      } catch {
+        if (!cancelled)
+          setError('Could not start conversation. Please try again.');
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+
+    fetchProbe();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const handleSend = useCallback(async () => {
+    const trimmed = input.trim();
+    if (!trimmed || sending) return;
+
+    setInput('');
+    setError(null);
+    setSending(true);
+    setMessages(prev => [
+      ...prev,
+      { id: nextMsgId(), role: 'user', content: trimmed },
+    ]);
+
+    try {
+      const res = await fetch('/api/career/experience/conversation/turn', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          conversation_type: 'onboarding',
+          content: trimmed,
+          skipped: false,
+        }),
+      });
+
+      if (!res.ok) throw new Error('Failed to send message');
+
+      const data = (await res.json()) as {
+        assistant_message: string;
+        done: boolean;
+      };
+
+      setMessages(prev => [
+        ...prev,
+        { id: nextMsgId(), role: 'assistant', content: data.assistant_message },
+      ]);
+
+      if (data.done) {
+        // Derive master doc from conversation
+        setDeriving(true);
+        const deriveRes = await fetch('/api/career/experience/derive', {
+          method: 'POST',
+        });
+        if (!deriveRes.ok) throw new Error('Failed to build master document');
+        setDeriving(false);
+
+        setTimeout(onComplete, 800);
+      }
+    } catch (err) {
+      setDeriving(false);
+      setError(
+        err instanceof Error ? err.message : 'Something went wrong. Try again.'
+      );
+    } finally {
+      setSending(false);
+    }
+  }, [input, sending, onComplete]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Enter' && !e.shiftKey) {
+        e.preventDefault();
+        handleSend();
+      }
+    },
+    [handleSend]
+  );
+
+  const handleSkipQuestion = useCallback(async () => {
+    if (sending) return;
+
+    setError(null);
+    setSending(true);
+
+    try {
+      const res = await fetch('/api/career/experience/conversation/turn', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          conversation_type: 'onboarding',
+          content: '',
+          skipped: true,
+        }),
+      });
+
+      if (!res.ok) throw new Error('Failed to skip question');
+
+      const data = (await res.json()) as {
+        assistant_message: string;
+        done: boolean;
+      };
+
+      setMessages(prev => [
+        ...prev,
+        { id: nextMsgId(), role: 'assistant', content: data.assistant_message },
+      ]);
+
+      if (data.done) {
+        setDeriving(true);
+        const deriveRes = await fetch('/api/career/experience/derive', {
+          method: 'POST',
+        });
+        if (!deriveRes.ok) throw new Error('Failed to build master document');
+        setDeriving(false);
+        setTimeout(onComplete, 800);
+      }
+    } catch (err) {
+      setDeriving(false);
+      setError(
+        err instanceof Error ? err.message : 'Something went wrong. Try again.'
+      );
+    } finally {
+      setSending(false);
+    }
+  }, [sending, onComplete]);
+
+  return (
+    <div className='flex flex-col gap-4'>
+      <div className='text-center'>
+        <Heading variant='cardTitle' as='h2'>
+          Let&apos;s build your profile
+        </Heading>
+        <Text variant='caption' className='mt-1 text-text-secondary'>
+          Answer a few questions about your experience. Skip any you&apos;d
+          rather not answer.
+        </Text>
+      </div>
+
+      {/* Messages area */}
+      <Card
+        padding='none'
+        className='flex h-[400px] flex-col'
+        aria-label='Conversation'
+      >
+        <div ref={scrollRef} className='flex-1 overflow-y-auto p-4'>
+          <div role='log' aria-live='polite' className='flex flex-col gap-3'>
+            {messages.map(msg => (
+              <div
+                key={msg.id}
+                className={
+                  msg.role === 'assistant'
+                    ? 'flex justify-start'
+                    : 'flex justify-end'
+                }
+              >
+                <div
+                  className={[
+                    'max-w-[80%] rounded-lg px-4 py-2.5 text-sm',
+                    msg.role === 'assistant'
+                      ? 'bg-surface-tertiary text-text-primary'
+                      : 'bg-brand-500 text-white',
+                  ].join(' ')}
+                >
+                  {msg.content}
+                </div>
+              </div>
+            ))}
+
+            {(loading || sending) && (
+              <div className='flex justify-start'>
+                <div className='rounded-lg bg-surface-tertiary px-4 py-2.5'>
+                  <Spinner size='sm' aria-label='Thinking' />
+                </div>
+              </div>
+            )}
+
+            {deriving && (
+              <div className='flex justify-start'>
+                <div className='flex items-center gap-2 rounded-lg bg-surface-tertiary px-4 py-2.5 text-sm text-text-secondary'>
+                  <Spinner size='sm' aria-label='Building master document' />
+                  Building your master document...
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* Input area */}
+        <div className='border-t border-border p-3'>
+          <div className='flex gap-2'>
+            <Textarea
+              value={input}
+              onChange={e => setInput(e.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder='Type your answer...'
+              disabled={loading || sending || deriving}
+              rows={2}
+              className='flex-1 resize-none'
+              aria-label='Your response'
+              data-sentry-mask
+            />
+            <div className='flex flex-col gap-1'>
+              <Button
+                name='onboarding-chat-send'
+                variant='primary'
+                size='sm'
+                iconOnly
+                onClick={handleSend}
+                disabled={!input.trim() || loading || sending || deriving}
+                aria-label='Send message'
+              >
+                <Send className='size-4' />
+              </Button>
+            </div>
+          </div>
+        </div>
+      </Card>
+
+      {error && <Alert variant='error'>{error}</Alert>}
+
+      <div className='flex items-center justify-between'>
+        <Button
+          name='onboarding-skip-question'
+          variant='outline'
+          size='sm'
+          onClick={handleSkipQuestion}
+          disabled={loading || sending || deriving}
+        >
+          Skip this question
+        </Button>
+        <Button
+          name='onboarding-skip-conversation'
+          variant='ghost'
+          size='sm'
+          onClick={onSkip}
+          disabled={sending || deriving}
+        >
+          Skip for now
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/wyrdfold/src/app/_components/ConversationChatModal.tsx
+++ b/apps/wyrdfold/src/app/_components/ConversationChatModal.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { Modal } from '@danieljoffe.com/shared-ui/Modal';
+import ConversationChat from './ConversationChat';
+
+interface ConversationChatModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onComplete?: () => void;
+}
+
+export default function ConversationChatModal({
+  isOpen,
+  onClose,
+  onComplete,
+}: ConversationChatModalProps) {
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      size='lg'
+      title='Fill in profile details'
+    >
+      <ConversationChat
+        onComplete={() => {
+          onComplete?.();
+          onClose();
+        }}
+        onSkip={onClose}
+      />
+    </Modal>
+  );
+}

--- a/apps/wyrdfold/src/app/onboarding/CompletionScreen.tsx
+++ b/apps/wyrdfold/src/app/onboarding/CompletionScreen.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { CheckCircle, ArrowRight } from 'lucide-react';
+import { Card } from '@danieljoffe.com/shared-ui/Card';
+import { Text } from '@danieljoffe.com/shared-ui/Text';
+import { Heading } from '@danieljoffe.com/shared-ui/Heading';
+import Button from '@/components/Button';
+
+export default function CompletionScreen() {
+  return (
+    <div className='flex flex-col items-center gap-6'>
+      <Card padding='lg' className='w-full text-center'>
+        <div className='flex flex-col items-center gap-4 py-4'>
+          <div className='rounded-full bg-success/10 p-4'>
+            <CheckCircle className='size-12 text-success' aria-hidden />
+          </div>
+          <div>
+            <Heading variant='cardTitle' as='h2'>
+              You&apos;re all set!
+            </Heading>
+            <Text variant='body' className='mt-2 text-text-secondary'>
+              Your account is ready. Head to your targets to start tracking jobs
+              and generating tailored resumes.
+            </Text>
+          </div>
+        </div>
+      </Card>
+
+      <Button
+        name='onboarding-go-to-targets'
+        as='link'
+        href='/targets'
+        variant='primary'
+        size='lg'
+        className='w-full justify-center'
+      >
+        <span>Go to Targets</span>
+        <ArrowRight className='size-4' aria-hidden />
+      </Button>
+    </div>
+  );
+}

--- a/apps/wyrdfold/src/app/onboarding/JobUrlInput.tsx
+++ b/apps/wyrdfold/src/app/onboarding/JobUrlInput.tsx
@@ -1,0 +1,179 @@
+'use client';
+
+import { useState, useCallback, useEffect, useRef } from 'react';
+import { ExternalLink, CheckCircle, Briefcase } from 'lucide-react';
+import { Card } from '@danieljoffe.com/shared-ui/Card';
+import { Text } from '@danieljoffe.com/shared-ui/Text';
+import { Heading } from '@danieljoffe.com/shared-ui/Heading';
+import { Input } from '@danieljoffe.com/shared-ui/Input';
+import { Spinner } from '@danieljoffe.com/shared-ui/Spinner';
+import { Alert } from '@danieljoffe.com/shared-ui/Alert';
+import Button from '@/components/Button';
+
+export interface JobData {
+  postingId: string;
+  title: string | null;
+}
+
+interface JobUrlInputProps {
+  onComplete: (data?: JobData) => void;
+  onSkip: () => void;
+}
+
+interface ExtractedJob {
+  title: string | null;
+  company_name: string | null;
+  posting_id: string | null;
+}
+
+export default function JobUrlInput({ onComplete, onSkip }: JobUrlInputProps) {
+  const [url, setUrl] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [extracted, setExtracted] = useState<ExtractedJob | null>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+  // Cleanup timeout on unmount
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, []);
+
+  const handleSubmit = useCallback(
+    async (e: React.FormEvent) => {
+      e.preventDefault();
+      const trimmed = url.trim();
+      if (!trimmed) return;
+
+      setError(null);
+      setSubmitting(true);
+
+      try {
+        const res = await fetch('/api/jobs/manual', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ url: trimmed }),
+        });
+
+        if (!res.ok) {
+          const data = await res.json().catch(() => null);
+          throw new Error(
+            (data as Record<string, string> | null)?.detail ??
+              `Failed to add job (${res.status})`
+          );
+        }
+
+        const data = (await res.json()) as {
+          success: boolean;
+          posting_id: string | null;
+          extracted: { title: string | null; company_name: string | null };
+        };
+
+        setExtracted({
+          title: data.extracted?.title ?? null,
+          company_name: data.extracted?.company_name ?? null,
+          posting_id: data.posting_id,
+        });
+
+        const jobData = data.posting_id
+          ? { postingId: data.posting_id, title: data.extracted?.title ?? null }
+          : undefined;
+        timerRef.current = setTimeout(() => onComplete(jobData), 1500);
+      } catch (err) {
+        setError(
+          err instanceof Error
+            ? err.message
+            : 'Failed to add job. Please try again.'
+        );
+      } finally {
+        setSubmitting(false);
+      }
+    },
+    [url, onComplete]
+  );
+
+  return (
+    <div className='flex flex-col gap-6'>
+      <div className='text-center'>
+        <Heading variant='cardTitle' as='h2'>
+          Add your first job
+        </Heading>
+        <Text variant='caption' className='mt-1 text-text-secondary'>
+          Paste a job posting URL and we&apos;ll extract the details.
+        </Text>
+      </div>
+
+      {extracted ? (
+        <Card padding='lg'>
+          <div className='flex flex-col items-center gap-3 py-4'>
+            <CheckCircle className='size-12 text-success' aria-hidden />
+            <div className='text-center'>
+              <Text variant='body' className='font-medium'>
+                {extracted.title ?? 'Job added'}
+              </Text>
+              {extracted.company_name && (
+                <Text variant='caption' className='mt-1 text-text-secondary'>
+                  at {extracted.company_name}
+                </Text>
+              )}
+            </div>
+          </div>
+        </Card>
+      ) : (
+        <Card padding='lg'>
+          <form onSubmit={handleSubmit} className='flex flex-col gap-4'>
+            <div className='flex items-center gap-3'>
+              <div className='rounded-lg bg-surface-tertiary p-2'>
+                <Briefcase className='size-5 text-text-secondary' aria-hidden />
+              </div>
+              <div className='flex-1'>
+                <Input
+                  value={url}
+                  onChange={e => setUrl(e.target.value)}
+                  placeholder='https://jobs.example.com/posting/...'
+                  type='url'
+                  disabled={submitting}
+                  aria-label='Job posting URL'
+                />
+              </div>
+            </div>
+            <Button
+              name='onboarding-add-job'
+              variant='primary'
+              type='submit'
+              disabled={!url.trim() || submitting}
+              className='w-full justify-center'
+            >
+              {submitting ? (
+                <>
+                  <Spinner size='sm' aria-label='Adding job' />
+                  <span>Extracting job details...</span>
+                </>
+              ) : (
+                <>
+                  <ExternalLink className='size-4' aria-hidden />
+                  <span>Add job</span>
+                </>
+              )}
+            </Button>
+          </form>
+        </Card>
+      )}
+
+      {error && <Alert variant='error'>{error}</Alert>}
+
+      <div className='text-center'>
+        <Button
+          name='onboarding-skip-job'
+          variant='ghost'
+          size='sm'
+          onClick={onSkip}
+          disabled={submitting}
+        >
+          Skip for now
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/wyrdfold/src/app/onboarding/OnboardingWizard.tsx
+++ b/apps/wyrdfold/src/app/onboarding/OnboardingWizard.tsx
@@ -1,0 +1,130 @@
+'use client';
+
+import { useState, useCallback, useRef, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { ProgressBar } from '@danieljoffe.com/shared-ui/ProgressBar';
+import { Text } from '@danieljoffe.com/shared-ui/Text';
+import { Heading } from '@danieljoffe.com/shared-ui/Heading';
+import ConversationChat from '../_components/ConversationChat';
+import PathChooser from './PathChooser';
+import ResumeUploader from './ResumeUploader';
+import JobUrlInput, { type JobData } from './JobUrlInput';
+import TargetSuggestions from './TargetSuggestions';
+import CompletionScreen from './CompletionScreen';
+
+export type OnboardingPath = 'A' | 'B' | 'C';
+
+type Step =
+  | 'path-chooser'
+  | 'upload-resume'
+  | 'add-job'
+  | 'pick-targets'
+  | 'conversation'
+  | 'completion';
+
+const STEPS_BY_PATH: Record<OnboardingPath, Step[]> = {
+  A: ['path-chooser', 'upload-resume', 'add-job', 'pick-targets', 'completion'],
+  B: ['path-chooser', 'upload-resume', 'pick-targets', 'completion'],
+  C: ['path-chooser', 'conversation', 'pick-targets', 'completion'],
+};
+
+export default function OnboardingWizard() {
+  const router = useRouter();
+  const [currentStep, setCurrentStep] = useState<Step>('path-chooser');
+  const [selectedPath, setSelectedPath] = useState<OnboardingPath | null>(null);
+  const [jobData, setJobData] = useState<JobData | null>(null);
+  const stepRef = useRef<HTMLDivElement>(null);
+
+  const steps = selectedPath ? STEPS_BY_PATH[selectedPath] : ['path-chooser'];
+  const stepIndex = steps.indexOf(currentStep);
+  const totalSteps = steps.length;
+
+  // Move focus to the new step content on transition
+  useEffect(() => {
+    stepRef.current?.focus();
+  }, [currentStep]);
+
+  const goNext = useCallback(() => {
+    if (!selectedPath) return;
+    const stepsForPath = STEPS_BY_PATH[selectedPath];
+    const idx = stepsForPath.indexOf(currentStep);
+    if (idx < stepsForPath.length - 1) {
+      setCurrentStep(stepsForPath[idx + 1]);
+    }
+  }, [selectedPath, currentStep]);
+
+  const handlePathSelect = useCallback((path: OnboardingPath) => {
+    setSelectedPath(path);
+    const firstStep = STEPS_BY_PATH[path][1];
+    setCurrentStep(firstStep);
+  }, []);
+
+  const handleSkip = useCallback(() => {
+    router.push('/targets');
+  }, [router]);
+
+  return (
+    <div className='flex min-h-screen items-center justify-center bg-bg px-4 py-12'>
+      <div className='w-full max-w-2xl'>
+        {/* Header */}
+        <div className='mb-8 text-center'>
+          <Heading variant='hero' as='h1'>
+            Welcome to WyrdFold
+          </Heading>
+          <Text variant='body' className='mt-2 text-text-secondary'>
+            {currentStep === 'path-chooser'
+              ? 'How would you like to get started?'
+              : `Step ${stepIndex + 1} of ${totalSteps}`}
+          </Text>
+        </div>
+
+        {/* Progress bar */}
+        {selectedPath && currentStep !== 'completion' && (
+          <div className='mb-8'>
+            <ProgressBar
+              value={stepIndex + 1}
+              max={totalSteps}
+              size='sm'
+              aria-label={`Step ${stepIndex + 1} of ${totalSteps}`}
+            />
+          </div>
+        )}
+
+        {/* Step content — tabIndex={-1} allows programmatic focus */}
+        <div
+          ref={stepRef}
+          tabIndex={-1}
+          aria-label={`Onboarding step: ${currentStep.replace(/-/g, ' ')}`}
+          className='outline-none'
+        >
+          {currentStep === 'path-chooser' && (
+            <PathChooser onSelect={handlePathSelect} onSkip={handleSkip} />
+          )}
+          {currentStep === 'upload-resume' && (
+            <ResumeUploader onComplete={goNext} onSkip={handleSkip} />
+          )}
+          {currentStep === 'add-job' && (
+            <JobUrlInput
+              onComplete={data => {
+                if (data) setJobData(data);
+                goNext();
+              }}
+              onSkip={handleSkip}
+            />
+          )}
+          {currentStep === 'pick-targets' && (
+            <TargetSuggestions
+              onComplete={goNext}
+              onSkip={handleSkip}
+              jobData={jobData}
+            />
+          )}
+          {currentStep === 'conversation' && (
+            <ConversationChat onComplete={goNext} onSkip={handleSkip} />
+          )}
+          {currentStep === 'completion' && <CompletionScreen />}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/wyrdfold/src/app/onboarding/PathChooser.tsx
+++ b/apps/wyrdfold/src/app/onboarding/PathChooser.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import { FileText, Search, MessageCircle } from 'lucide-react';
+import { Card } from '@danieljoffe.com/shared-ui/Card';
+import { Heading } from '@danieljoffe.com/shared-ui/Heading';
+import { Text } from '@danieljoffe.com/shared-ui/Text';
+import Button from '@/components/Button';
+import type { OnboardingPath } from './OnboardingWizard';
+
+interface PathChooserProps {
+  onSelect: (path: OnboardingPath) => void;
+  onSkip: () => void;
+}
+
+const paths: {
+  id: OnboardingPath;
+  icon: typeof FileText;
+  title: string;
+  description: string;
+}[] = [
+  {
+    id: 'A',
+    icon: FileText,
+    title: 'I have a resume and a role in mind',
+    description:
+      'Upload your resume and paste a job URL to get a tailored resume right away.',
+  },
+  {
+    id: 'B',
+    icon: Search,
+    title: "I have a resume but I'm exploring roles",
+    description:
+      'Upload your resume and browse suggested job targets based on your experience.',
+  },
+  {
+    id: 'C',
+    icon: MessageCircle,
+    title: "I'm not sure where to start",
+    description:
+      "Answer a few questions and we'll build your master document from scratch.",
+  },
+];
+
+export default function PathChooser({ onSelect, onSkip }: PathChooserProps) {
+  return (
+    <div className='flex flex-col gap-4'>
+      {paths.map(({ id, icon: Icon, title, description }) => (
+        <button
+          key={id}
+          onClick={() => onSelect(id)}
+          className='text-left'
+          aria-label={title}
+        >
+          <Card className='transition-colors hover:border-brand-500 cursor-pointer'>
+            <div className='flex items-start gap-4'>
+              <div className='rounded-lg bg-surface-tertiary p-3'>
+                <Icon className='size-5 text-text-secondary' aria-hidden />
+              </div>
+              <div className='flex-1'>
+                <Heading variant='cardTitle' as='h2'>
+                  {title}
+                </Heading>
+                <Text variant='caption' className='mt-1 text-text-secondary'>
+                  {description}
+                </Text>
+              </div>
+            </div>
+          </Card>
+        </button>
+      ))}
+
+      <div className='mt-4 text-center'>
+        <Button
+          name='onboarding-skip'
+          variant='ghost'
+          size='sm'
+          onClick={onSkip}
+        >
+          Skip for now
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/wyrdfold/src/app/onboarding/ResumeUploader.tsx
+++ b/apps/wyrdfold/src/app/onboarding/ResumeUploader.tsx
@@ -1,0 +1,206 @@
+'use client';
+
+import { useState, useCallback, useRef, useEffect } from 'react';
+import { Upload, FileText, CheckCircle } from 'lucide-react';
+import { Card } from '@danieljoffe.com/shared-ui/Card';
+import { Text } from '@danieljoffe.com/shared-ui/Text';
+import { Heading } from '@danieljoffe.com/shared-ui/Heading';
+import { Spinner } from '@danieljoffe.com/shared-ui/Spinner';
+import { Alert } from '@danieljoffe.com/shared-ui/Alert';
+import Button from '@/components/Button';
+import { cn } from '@/lib/cn';
+
+const ACCEPTED_TYPES = [
+  'application/pdf',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+];
+const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB
+
+interface ResumeUploaderProps {
+  onComplete: () => void;
+  onSkip: () => void;
+}
+
+export default function ResumeUploader({
+  onComplete,
+  onSkip,
+}: ResumeUploaderProps) {
+  const [dragOver, setDragOver] = useState(false);
+  const [uploading, setUploading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [uploaded, setUploaded] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+  // Cleanup timeout on unmount
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, []);
+
+  const upload = useCallback(
+    async (file: File) => {
+      if (!ACCEPTED_TYPES.includes(file.type)) {
+        setError('Please upload a PDF or DOCX file.');
+        return;
+      }
+      if (file.size > MAX_FILE_SIZE) {
+        setError('File must be under 10 MB.');
+        return;
+      }
+
+      setError(null);
+      setUploading(true);
+
+      try {
+        const formData = new FormData();
+        formData.append('file', file);
+
+        const res = await fetch(
+          '/api/career/experience/upload-resume?auto_derive=true',
+          { method: 'POST', body: formData }
+        );
+
+        if (!res.ok) {
+          const data = await res.json().catch(() => null);
+          throw new Error(
+            (data as Record<string, string> | null)?.detail ??
+              `Upload failed (${res.status})`
+          );
+        }
+
+        setUploaded(true);
+        // Brief delay to show success state before advancing
+        timerRef.current = setTimeout(onComplete, 1200);
+      } catch (err) {
+        setError(
+          err instanceof Error
+            ? err.message
+            : 'Upload failed. Please try again.'
+        );
+      } finally {
+        setUploading(false);
+      }
+    },
+    [onComplete]
+  );
+
+  const handleDrop = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault();
+      setDragOver(false);
+      const file = e.dataTransfer.files[0];
+      if (file) upload(file);
+    },
+    [upload]
+  );
+
+  const handleFileChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0];
+      if (file) upload(file);
+    },
+    [upload]
+  );
+
+  return (
+    <div className='flex flex-col gap-6'>
+      <div className='text-center'>
+        <Heading variant='cardTitle' as='h2'>
+          Upload your resume
+        </Heading>
+        <Text variant='caption' className='mt-1 text-text-secondary'>
+          We&apos;ll parse it to build your master experience document.
+        </Text>
+      </div>
+
+      <Card
+        padding='lg'
+        className={cn(
+          'cursor-pointer border-dashed transition-colors',
+          dragOver && 'border-brand-500 bg-brand-500/5',
+          uploaded && 'border-success bg-success/5'
+        )}
+        onClick={() => !uploading && !uploaded && inputRef.current?.click()}
+        onDragOver={e => {
+          e.preventDefault();
+          setDragOver(true);
+        }}
+        onDragLeave={() => setDragOver(false)}
+        onDrop={handleDrop}
+        role='button'
+        tabIndex={0}
+        onKeyDown={e => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            if (!uploading && !uploaded) inputRef.current?.click();
+          }
+        }}
+        aria-label='Upload resume file'
+      >
+        <div
+          aria-live='polite'
+          className='flex flex-col items-center gap-3 py-4'
+        >
+          {uploading ? (
+            <>
+              <Spinner size='lg' aria-label='Uploading resume' />
+              <Text variant='body' className='text-text-secondary'>
+                Uploading and parsing your resume...
+              </Text>
+            </>
+          ) : uploaded ? (
+            <>
+              <CheckCircle className='size-12 text-success' aria-hidden />
+              <Text variant='body' className='text-success'>
+                Resume uploaded successfully!
+              </Text>
+            </>
+          ) : (
+            <>
+              <div className='rounded-full bg-surface-tertiary p-4'>
+                {dragOver ? (
+                  <FileText className='size-8 text-brand-500' aria-hidden />
+                ) : (
+                  <Upload className='size-8 text-text-tertiary' aria-hidden />
+                )}
+              </div>
+              <div className='text-center'>
+                <Text variant='body'>
+                  Drop your resume here or click to browse
+                </Text>
+                <Text variant='caption' className='mt-1 text-text-tertiary'>
+                  PDF or DOCX, up to 10 MB
+                </Text>
+              </div>
+            </>
+          )}
+        </div>
+      </Card>
+
+      <input
+        ref={inputRef}
+        type='file'
+        accept='.pdf,.docx'
+        onChange={handleFileChange}
+        className='hidden'
+        aria-hidden='true'
+      />
+
+      {error && <Alert variant='error'>{error}</Alert>}
+
+      <div className='text-center'>
+        <Button
+          name='onboarding-skip-upload'
+          variant='ghost'
+          size='sm'
+          onClick={onSkip}
+          disabled={uploading}
+        >
+          Skip for now
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/wyrdfold/src/app/onboarding/TargetSuggestions.tsx
+++ b/apps/wyrdfold/src/app/onboarding/TargetSuggestions.tsx
@@ -1,0 +1,419 @@
+'use client';
+
+import { useEffect, useState, useCallback, useRef } from 'react';
+import { CheckCircle, Target } from 'lucide-react';
+import { Badge } from '@danieljoffe.com/shared-ui/Badge';
+import { Card } from '@danieljoffe.com/shared-ui/Card';
+import { Text } from '@danieljoffe.com/shared-ui/Text';
+import { Heading } from '@danieljoffe.com/shared-ui/Heading';
+import { Spinner } from '@danieljoffe.com/shared-ui/Spinner';
+import { Alert } from '@danieljoffe.com/shared-ui/Alert';
+import Button from '@/components/Button';
+import { cn } from '@/lib/cn';
+import type {
+  JobTarget,
+  MatchedSuggestion,
+  MatchedSuggestions,
+} from '@/app/(app)/targets/types';
+import type { JobData } from './JobUrlInput';
+
+interface TargetSuggestionsProps {
+  onComplete: () => void;
+  onSkip: () => void;
+  jobData?: JobData | null;
+}
+
+export default function TargetSuggestions({
+  onComplete,
+  onSkip,
+  jobData,
+}: TargetSuggestionsProps) {
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [createdLabel, setCreatedLabel] = useState<string | null>(null);
+  const [suggestions, setSuggestions] = useState<MatchedSuggestion[]>([]);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [creating, setCreating] = useState(false);
+  const [createdCount, setCreatedCount] = useState(0);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, []);
+
+  // Path A: auto-create target from job posting
+  useEffect(() => {
+    if (!jobData) return;
+    const postingId = jobData.postingId;
+    let cancelled = false;
+
+    async function createFromPosting() {
+      try {
+        const res = await fetch(`/api/targets/from-posting/${postingId}`, {
+          method: 'POST',
+        });
+        if (!res.ok) throw new Error('Failed to create target');
+        const data = (await res.json()) as { label: string };
+        if (!cancelled) {
+          setCreatedLabel(data.label);
+          timerRef.current = setTimeout(onComplete, 2000);
+        }
+      } catch {
+        if (!cancelled) {
+          setError(
+            'Could not auto-create target. You can create one manually.'
+          );
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+
+    createFromPosting();
+    return () => {
+      cancelled = true;
+    };
+  }, [jobData, onComplete]);
+
+  // Paths B/C: fetch suggestions from LLM
+  useEffect(() => {
+    if (jobData) return;
+    let cancelled = false;
+
+    async function fetchSuggestions() {
+      try {
+        const res = await fetch('/api/targets/suggest', { method: 'POST' });
+        if (!res.ok) throw new Error('Failed to load suggestions');
+        const data = (await res.json()) as MatchedSuggestions;
+        if (!cancelled && data.matches?.length > 0) {
+          setSuggestions(data.matches);
+          // Pre-select all suggestions
+          setSelected(new Set(data.matches.map(m => m.suggestion.label)));
+        }
+      } catch {
+        if (!cancelled)
+          setError(
+            'Could not generate suggestions. You can create targets manually.'
+          );
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+
+    fetchSuggestions();
+    return () => {
+      cancelled = true;
+    };
+  }, [jobData]);
+
+  const toggleSelection = useCallback((label: string) => {
+    setSelected(prev => {
+      const next = new Set(prev);
+      if (next.has(label)) {
+        next.delete(label);
+      } else {
+        next.add(label);
+      }
+      return next;
+    });
+  }, []);
+
+  const handleCreateSelected = useCallback(async () => {
+    if (selected.size === 0) {
+      onComplete();
+      return;
+    }
+
+    setCreating(true);
+    let created = 0;
+
+    for (const match of suggestions) {
+      if (!selected.has(match.suggestion.label)) continue;
+      try {
+        let targetId: string;
+
+        if (match.is_new) {
+          const createRes = await fetch('/api/targets', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              label: match.suggestion.label,
+              description: match.suggestion.description,
+            }),
+          });
+          if (!createRes.ok) continue;
+          const createdTarget = (await createRes.json()) as JobTarget;
+          targetId = createdTarget.id;
+        } else {
+          targetId = match.matched_target!.id;
+        }
+
+        const linkRes = await fetch(`/api/targets/${targetId}/link`, {
+          method: 'POST',
+        });
+        if (linkRes.ok) created++;
+      } catch {
+        // Continue creating remaining targets
+      }
+    }
+
+    setCreatedCount(created);
+    setCreating(false);
+    timerRef.current = setTimeout(onComplete, 1500);
+  }, [selected, suggestions, onComplete]);
+
+  // Path A: auto-creation in progress or completed
+  if (jobData) {
+    if (loading) {
+      return (
+        <div className='flex flex-col items-center gap-4 py-12'>
+          <Spinner size='lg' aria-label='Creating target' />
+          <Text variant='body' className='text-text-secondary'>
+            Setting up a target from your job posting...
+          </Text>
+        </div>
+      );
+    }
+
+    if (createdLabel) {
+      return (
+        <div className='flex flex-col items-center gap-6'>
+          <Card padding='lg' className='w-full text-center'>
+            <div className='flex flex-col items-center gap-3 py-4'>
+              <CheckCircle className='size-12 text-success' aria-hidden />
+              <div>
+                <Text variant='body' className='font-medium'>
+                  Target created
+                </Text>
+                <Text variant='caption' className='mt-1 text-text-secondary'>
+                  {createdLabel}
+                </Text>
+              </div>
+            </div>
+          </Card>
+        </div>
+      );
+    }
+
+    // Error fallback — show manual flow below
+  }
+
+  // Paths B/C: suggestions or manual prompt
+  if (loading) {
+    return (
+      <div className='flex flex-col items-center gap-4 py-12'>
+        <Spinner size='lg' aria-label='Loading suggestions' />
+        <Text variant='body' className='text-text-secondary'>
+          Analyzing your experience...
+        </Text>
+      </div>
+    );
+  }
+
+  // Post-creation success
+  if (createdCount > 0) {
+    return (
+      <div className='flex flex-col items-center gap-6'>
+        <Card padding='lg' className='w-full text-center'>
+          <div className='flex flex-col items-center gap-3 py-4'>
+            <CheckCircle className='size-12 text-success' aria-hidden />
+            <div>
+              <Text variant='body' className='font-medium'>
+                {createdCount === 1
+                  ? '1 target created'
+                  : `${createdCount} targets created`}
+              </Text>
+            </div>
+          </div>
+        </Card>
+      </div>
+    );
+  }
+
+  // Suggestions available — show selectable cards
+  if (suggestions.length > 0) {
+    return (
+      <div className='flex flex-col gap-6'>
+        <div className='text-center'>
+          <Heading variant='cardTitle' as='h2'>
+            Suggested targets
+          </Heading>
+          <Text variant='caption' className='mt-1 text-text-secondary'>
+            Based on your experience, we suggest these role targets. Select the
+            ones you&apos;d like to track.
+          </Text>
+        </div>
+
+        <div className='flex flex-col gap-3'>
+          {suggestions.map(match => {
+            const { suggestion } = match;
+            const isSelected = selected.has(suggestion.label);
+            return (
+              <Card
+                key={suggestion.label}
+                padding='lg'
+                className={cn(
+                  'cursor-pointer transition-colors',
+                  isSelected
+                    ? 'border-brand-500 bg-brand-500/5'
+                    : 'hover:border-border-hover'
+                )}
+                onClick={() => toggleSelection(suggestion.label)}
+                role='checkbox'
+                aria-checked={isSelected}
+                tabIndex={0}
+                aria-label={suggestion.label}
+                onKeyDown={e => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    toggleSelection(suggestion.label);
+                  }
+                }}
+              >
+                <div className='flex items-start gap-4'>
+                  <div
+                    className={cn(
+                      'mt-0.5 flex size-5 shrink-0 items-center justify-center rounded border-2 transition-colors',
+                      isSelected
+                        ? 'border-brand-500 bg-brand-500'
+                        : 'border-border'
+                    )}
+                  >
+                    {isSelected && (
+                      <CheckCircle
+                        className='size-3.5 text-white'
+                        aria-hidden
+                      />
+                    )}
+                  </div>
+                  <div className='flex-1'>
+                    <div className='flex items-center gap-2'>
+                      <Text variant='body' className='font-medium'>
+                        {suggestion.label}
+                      </Text>
+                      {!match.is_new && (
+                        <Badge variant='default' size='sm'>
+                          Existing
+                        </Badge>
+                      )}
+                    </div>
+                    <Text
+                      variant='caption'
+                      className='mt-0.5 text-text-secondary'
+                    >
+                      {suggestion.description}
+                    </Text>
+                    {suggestion.core_skills.length > 0 && (
+                      <div className='mt-2 flex flex-wrap gap-1.5'>
+                        {suggestion.core_skills.map(skill => (
+                          <span
+                            key={skill}
+                            className='rounded-full bg-surface-tertiary px-2.5 py-0.5 text-xs text-text-secondary'
+                          >
+                            {skill}
+                          </span>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                </div>
+              </Card>
+            );
+          })}
+        </div>
+
+        {error && <Alert variant='error'>{error}</Alert>}
+
+        <div className='flex items-center justify-between'>
+          <Button
+            name='onboarding-skip-targets'
+            variant='ghost'
+            size='sm'
+            onClick={onSkip}
+          >
+            Skip for now
+          </Button>
+          <Button
+            name='onboarding-create-targets'
+            variant='primary'
+            size='sm'
+            onClick={handleCreateSelected}
+            disabled={creating}
+          >
+            {creating ? (
+              <>
+                <Spinner size='sm' aria-label='Creating targets' />
+                <span>Creating...</span>
+              </>
+            ) : selected.size === 0 ? (
+              'Continue without targets'
+            ) : selected.size === 1 ? (
+              'Create 1 target'
+            ) : (
+              `Create ${selected.size} targets`
+            )}
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  // No suggestions (error or empty OptimizedDoc) — fallback to manual prompt
+  return (
+    <div className='flex flex-col gap-6'>
+      <div className='text-center'>
+        <Heading variant='cardTitle' as='h2'>
+          Set up your job targets
+        </Heading>
+        <Text variant='caption' className='mt-1 text-text-secondary'>
+          Targets define the types of roles you&apos;re looking for. Create one
+          to start tracking jobs.
+        </Text>
+      </div>
+
+      {error && <Alert variant='error'>{error}</Alert>}
+
+      <Card
+        padding='lg'
+        className='cursor-pointer transition-colors hover:border-brand-500'
+        onClick={onComplete}
+        role='button'
+        tabIndex={0}
+        aria-label='Create your first target'
+        onKeyDown={e => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            onComplete();
+          }
+        }}
+      >
+        <div className='flex items-center gap-4'>
+          <div className='rounded-lg bg-surface-tertiary p-3'>
+            <Target className='size-5 text-text-secondary' aria-hidden />
+          </div>
+          <div className='flex-1'>
+            <Text variant='body' className='font-medium'>
+              Create your first target
+            </Text>
+            <Text variant='caption' className='mt-0.5 text-text-secondary'>
+              Define a role type, and we&apos;ll score and track matching jobs.
+            </Text>
+          </div>
+        </div>
+      </Card>
+
+      <div className='text-center'>
+        <Button
+          name='onboarding-skip-targets'
+          variant='ghost'
+          size='sm'
+          onClick={onSkip}
+        >
+          Skip for now
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/wyrdfold/src/app/onboarding/page.tsx
+++ b/apps/wyrdfold/src/app/onboarding/page.tsx
@@ -1,0 +1,21 @@
+import type { Metadata } from 'next';
+import { redirect } from 'next/navigation';
+import { createAuthServerClient } from '@/lib/supabase/auth-server';
+import OnboardingWizard from './OnboardingWizard';
+
+export const metadata: Metadata = {
+  title: 'Get Started',
+};
+
+export default async function OnboardingPage() {
+  const supabase = await createAuthServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect('/login');
+  }
+
+  return <OnboardingWizard />;
+}


### PR DESCRIPTION
## Summary

Brings **targets list, target detail (with reference JDs and scoring profile editor), and the onboarding wizard** across from `apps/root/src/app/fitted/`. Mostly mechanical — same files, hrefs adjusted (`/fitted/foo` → `/foo`), brand string updated, one TypeScript narrowing fix.

After this lands you can sign in → land on dashboard → click sidebar **Targets** to see your targets, drill into one, see reference JDs and the scoring profile editor. Or hit `/onboarding` to walk the wizard.

## What lit up

| Route | Source |
|---|---|
| `/targets` | targets list with create modal |
| `/targets/[id]` | target detail (reference JDs, scoring profile editor) |
| `/onboarding` | full wizard (path chooser → resume upload / job URL → target suggestions → completion) |

## Files (24, ~3624 LOC)

### Targets (15 files)
- `(app)/targets/{page,loading,types}.{tsx,ts}`
- `(app)/targets/{TargetsList,TargetCard,PendingTargetCard,CreateTargetModal}.tsx`
- `(app)/targets/[id]/{page,loading,TargetDetail,TargetDetailSkeleton,ReferenceJDList,AddReferenceJDModal,ScoringProfileEditor}.tsx`
- `(app)/targets/__tests__/types.spec.ts`

### Onboarding (7 files)
- `onboarding/{page,OnboardingWizard,PathChooser,ResumeUploader,JobUrlInput,TargetSuggestions,CompletionScreen}.tsx`

### Shared (2 files, sub-deps from `OnboardingWizard`)
- `_components/{ConversationChat,ConversationChatModal}.tsx`

## Adjustments

- **All hrefs** `/fitted/<route>` → `/<route>` via sed: `/fitted/{targets,jobs,onboarding,login,profile,insights,settings}` plus the bare `/fitted` → `/`.
- `TargetSuggestions.tsx`: import path `@/app/fitted/(app)/targets/types` → `@/app/(app)/targets/types`.
- `OnboardingWizard.tsx`: "Welcome to Fitted" → "Welcome to WyrdFold".
- `TargetSuggestions.tsx` Path A useEffect: hoist `jobData.postingId` into a const before the inner async closure. TypeScript couldn't narrow `jobData` across the closure boundary under `exactOptionalPropertyTypes`. The hoist captures the non-null value at the right time, and the closure uses the const.
- Internal function names left as `FittedTargetsPage`, etc. — not user-facing, less churn. Rename in 6.5 polish if desired.

## Routing notes

- **`/onboarding` is outside the `(app)` route group** — same as root. Onboarding has no sidebar (it's a wizard), but `proxy.ts` middleware still gates it (anything not `/login` or `/auth` needs auth).
- `/targets` and `/targets/[id]` are inside `(app)`, so they get the sidebar.
- `TargetSuggestions` Path A consumes `/api/targets/from-posting/[id]` (in BFF since Phase 4.3).
- `ResumeUploader` uses `/api/career/experience/upload-resume` (in BFF since Phase 4.2).

## Verification

- ✅ `pnpm nx lint wyrdfold` — 0 errors, 2 pre-existing warnings (non-null assertions in `ScoringProfileEditor` and `TargetSuggestions`, both carried over from root unchanged)
- ✅ `pnpm nx test wyrdfold` — passes (16 unit + 1 ported types spec)
- ✅ `pnpm nx build wyrdfold` — clean; new routes `/onboarding`, `/targets`, `/targets/[id]` register as dynamic (ƒ)
- ✅ `pnpm tsc --noEmit` — workspace clean

## Phase 6 progress

| Phase | Status |
|---|---|
| 6.1 | ✅ merged — auth shell + app layout |
| **6.2** | **(this PR)** — targets + onboarding |
| 6.3 | next — jobs core + insights |
| 6.4 | tailor (resume + cover letter) |
| 6.5 | profile + settings + polish + delete `root/fitted/` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)