### PR TITLE
feat(wyrdfold): port profile + settings (Phase 6.5)

### DIFF
--- a/apps/wyrdfold/src/app/(app)/profile/ProfilePage.tsx
+++ b/apps/wyrdfold/src/app/(app)/profile/ProfilePage.tsx
@@ -1,0 +1,784 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { FileText, Layers, RefreshCw, Sparkles, Upload } from 'lucide-react';
+import { Alert } from '@danieljoffe.com/shared-ui/Alert';
+import { Badge } from '@danieljoffe.com/shared-ui/Badge';
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from '@danieljoffe.com/shared-ui/Card';
+import { Heading } from '@danieljoffe.com/shared-ui/Heading';
+import { ProgressBar } from '@danieljoffe.com/shared-ui/ProgressBar';
+import { Skeleton } from '@danieljoffe.com/shared-ui/Skeleton';
+import { Spinner } from '@danieljoffe.com/shared-ui/Spinner';
+import { Text } from '@danieljoffe.com/shared-ui/Text';
+import Button from '@/components/Button';
+import { consumeSse } from '@/lib/consumeSse';
+import { parsePartialJson } from '@/lib/parsePartialJson';
+import { useToast } from '@/state/Toast/ToastProvider';
+import ConversationChatModal from '../../_components/ConversationChatModal';
+import type {
+  Gap,
+  GapHealthResult,
+  GapTier,
+  OptimizedDoc,
+  OptimizedPayload,
+  OptimizedResponse,
+  Outcome,
+  ProseDoc,
+  ProseResponse,
+  Role,
+  Skill,
+} from './types';
+import {
+  GAP_KIND_LABELS,
+  GAP_KIND_WEIGHTS,
+  hasOptimized,
+  hasProse,
+} from './types';
+
+// -- Helpers ------------------------------------------------------------------
+
+function formatDateRange(start: string, end: string | null): string {
+  const fmt = (iso: string) => {
+    const d = new Date(iso);
+    if (Number.isNaN(d.getTime())) return iso;
+    return d.toLocaleDateString(undefined, { year: 'numeric', month: 'short' });
+  };
+  return end
+    ? `${fmt(start)} \u2013 ${fmt(end)}`
+    : `${fmt(start)} \u2013 Present`;
+}
+
+function gapBadgeVariant(kind: string): 'error' | 'warning' | 'default' {
+  const w = GAP_KIND_WEIGHTS[kind] ?? 0;
+  if (w >= 3) return 'error';
+  if (w >= 1) return 'warning';
+  return 'default';
+}
+
+function tierToProgressVariant(tier: GapTier): 'error' | 'accent' | 'success' {
+  if (tier === 'red') return 'error';
+  if (tier === 'yellow') return 'accent';
+  return 'success';
+}
+
+function tierToBadgeVariant(tier: GapTier): 'error' | 'warning' | 'success' {
+  if (tier === 'red') return 'error';
+  if (tier === 'yellow') return 'warning';
+  return 'success';
+}
+
+// Mid-stream the parser may produce role/skill/outcome objects that have only
+// some fields populated. Use a permissive shape so the render can guard each
+// field rather than asserting Role/Skill/Outcome exactness on a partial parse.
+type DisplayPayload = {
+  summary: string | null;
+  roles: Partial<Role>[];
+  skills: Partial<Skill>[];
+  outcomes: Partial<Outcome>[];
+};
+
+const ACCEPTED_TYPES = [
+  'application/pdf',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+];
+const MAX_FILE_SIZE = 10 * 1024 * 1024;
+
+// -- Component ----------------------------------------------------------------
+
+export default function ProfilePage() {
+  const [loading, setLoading] = useState(true);
+  const [optimized, setOptimized] = useState<OptimizedDoc | null>(null);
+  const [gapHealth, setGapHealth] = useState<GapHealthResult | null>(null);
+  const [prose, setProse] = useState<ProseDoc | null>(null);
+  const [chatOpen, setChatOpen] = useState(false);
+  const [uploading, setUploading] = useState(false);
+  const [deriving, setDeriving] = useState(false);
+  const [streamingPayload, setStreamingPayload] =
+    useState<Partial<OptimizedPayload> | null>(null);
+  const [draft, setDraft] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [consolidating, setConsolidating] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  // Track the server's known content so autosave only fires on actual edits and
+  // doesn't overwrite mid-typing when fetchData refreshes the prose state.
+  const lastSavedProseRef = useRef<string | null>(null);
+  const { toast } = useToast();
+
+  const fetchData = useCallback(async () => {
+    try {
+      const [optRes, ghRes, proseRes] = await Promise.all([
+        fetch('/api/career/experience/optimized'),
+        fetch('/api/career/experience/gap-health'),
+        fetch('/api/career/experience/prose'),
+      ]);
+
+      if (optRes.ok) {
+        const body = (await optRes.json()) as OptimizedResponse;
+        setOptimized(hasOptimized(body) ? body : null);
+      }
+
+      if (ghRes.ok) {
+        setGapHealth((await ghRes.json()) as GapHealthResult);
+      }
+
+      if (proseRes.ok) {
+        const body = (await proseRes.json()) as ProseResponse;
+        setProse(hasProse(body) ? body : null);
+      }
+    } catch {
+      toast({ variant: 'error', title: 'Failed to load profile data' });
+    } finally {
+      setLoading(false);
+    }
+  }, [toast]);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  // Sync the editable draft with the server-known prose, but skip when the
+  // user has unsaved local edits — autosave will catch up on its own debounce.
+  useEffect(() => {
+    if (loading) return;
+    if (
+      lastSavedProseRef.current !== null &&
+      draft !== lastSavedProseRef.current
+    ) {
+      return;
+    }
+    const content = prose?.content ?? '';
+    if (content === lastSavedProseRef.current) return;
+    setDraft(content);
+    lastSavedProseRef.current = content;
+  }, [loading, prose, draft]);
+
+  // Autosave the master document 800ms after the user stops typing.
+  useEffect(() => {
+    if (loading) return;
+    if (lastSavedProseRef.current === null) return;
+    if (saving || deriving) return;
+    if (draft === lastSavedProseRef.current) return;
+    if (!draft.trim()) return;
+
+    const handle = setTimeout(async () => {
+      setSaving(true);
+      try {
+        const res = await fetch('/api/career/experience/prose', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ content: draft }),
+        });
+        if (!res.ok) {
+          const data = await res.json().catch(() => null);
+          throw new Error(
+            (data as Record<string, string> | null)?.detail ??
+              `Save failed (${res.status})`
+          );
+        }
+        lastSavedProseRef.current = draft;
+        toast({ variant: 'success', title: 'Master document saved' });
+        await fetchData();
+      } catch (err) {
+        toast({
+          variant: 'error',
+          title: err instanceof Error ? err.message : 'Failed to save',
+        });
+      } finally {
+        setSaving(false);
+      }
+    }, 800);
+    return () => clearTimeout(handle);
+  }, [draft, loading, saving, deriving, fetchData, toast]);
+
+  const handleUpload = useCallback(
+    async (file: File) => {
+      if (!ACCEPTED_TYPES.includes(file.type)) {
+        toast({ variant: 'error', title: 'Please upload a PDF or DOCX file' });
+        return;
+      }
+      if (file.size > MAX_FILE_SIZE) {
+        toast({ variant: 'error', title: 'File must be under 10 MB' });
+        return;
+      }
+
+      setUploading(true);
+      try {
+        const formData = new FormData();
+        formData.append('file', file);
+        const res = await fetch(
+          '/api/career/experience/upload-resume?auto_derive=true',
+          { method: 'POST', body: formData }
+        );
+        if (!res.ok) {
+          const data = await res.json().catch(() => null);
+          throw new Error(
+            (data as Record<string, string> | null)?.detail ??
+              `Upload failed (${res.status})`
+          );
+        }
+        toast({ variant: 'success', title: 'Resume uploaded and processed' });
+        await fetchData();
+      } catch (err) {
+        toast({
+          variant: 'error',
+          title: err instanceof Error ? err.message : 'Upload failed',
+        });
+      } finally {
+        setUploading(false);
+      }
+    },
+    [fetchData, toast]
+  );
+
+  const handleFileChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0];
+      if (file) handleUpload(file);
+      e.target.value = '';
+    },
+    [handleUpload]
+  );
+
+  const handleDerive = useCallback(async () => {
+    setDeriving(true);
+    setStreamingPayload(null);
+    let buffered = '';
+    let cached = false;
+    try {
+      const res = await fetch('/api/career/experience/derive/stream', {
+        method: 'POST',
+      });
+      if (!res.ok) throw new Error('Derive failed');
+
+      let streamError: string | null = null;
+      await consumeSse(res, (event, data) => {
+        if (event === 'delta') {
+          const text = (data as { text?: string }).text ?? '';
+          buffered += text;
+          const parsed = parsePartialJson<Partial<OptimizedPayload>>(buffered);
+          if (parsed) setStreamingPayload(parsed);
+        } else if (event === 'done') {
+          const payload = data as { doc: OptimizedDoc; cached?: boolean };
+          setOptimized(payload.doc);
+          cached = Boolean(payload.cached);
+        } else if (event === 'error') {
+          streamError =
+            (data as { detail?: string }).detail ?? 'derive stream error';
+        }
+      });
+
+      if (streamError) throw new Error(streamError);
+
+      toast({
+        variant: cached ? 'info' : 'success',
+        title: cached
+          ? 'Profile already up to date'
+          : 'Profile re-derived from experience',
+      });
+      await fetchData();
+    } catch {
+      toast({ variant: 'error', title: 'Failed to re-derive profile' });
+    } finally {
+      setDeriving(false);
+      setStreamingPayload(null);
+    }
+  }, [fetchData, toast]);
+
+  const handleConsolidate = useCallback(async () => {
+    setConsolidating(true);
+    try {
+      const res = await fetch('/api/career/experience/prose/consolidate', {
+        method: 'POST',
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => null);
+        throw new Error(
+          (data as Record<string, string> | null)?.detail ??
+            `Consolidate failed (${res.status})`
+        );
+      }
+      const body = (await res.json()) as {
+        no_op: boolean;
+        chars_before: number;
+        chars_after: number;
+      };
+      if (body.no_op) {
+        toast({
+          variant: 'info',
+          title: 'No duplicates found in master document',
+        });
+      } else {
+        const removed = body.chars_before - body.chars_after;
+        toast({
+          variant: 'success',
+          title: `Consolidated — removed ${removed.toLocaleString()} characters of duplicate content`,
+        });
+      }
+      await fetchData();
+    } catch (err) {
+      toast({
+        variant: 'error',
+        title: err instanceof Error ? err.message : 'Consolidate failed',
+      });
+    } finally {
+      setConsolidating(false);
+    }
+  }, [fetchData, toast]);
+
+  const fileInput = (
+    <input
+      ref={fileInputRef}
+      type='file'
+      accept='.pdf,.docx'
+      onChange={handleFileChange}
+      className='hidden'
+      aria-hidden='true'
+    />
+  );
+
+  // -- Loading state ----------------------------------------------------------
+
+  if (loading) {
+    return (
+      <div className='flex flex-col gap-6'>
+        <div>
+          <Skeleton variant='text' size='lg' className='w-32' />
+          <Skeleton variant='text' className='mt-2 w-56' />
+        </div>
+        <Skeleton variant='rectangular' height={140} />
+        <Skeleton variant='rectangular' height={200} />
+        <Skeleton variant='rectangular' height={200} />
+      </div>
+    );
+  }
+
+  // -- Zero state -------------------------------------------------------------
+
+  if (!optimized && !prose) {
+    return (
+      <div className='flex flex-col gap-6'>
+        <div>
+          <Heading variant='hero' as='h1'>
+            Profile
+          </Heading>
+          <Text variant='body' className='mt-1 text-text-secondary'>
+            Your master experience document and derived skills
+          </Text>
+        </div>
+
+        <Card>
+          <CardContent className='flex flex-col items-center gap-4 py-12'>
+            <Upload className='size-12 text-text-tertiary' aria-hidden />
+            <Text variant='body' as='p' className='text-center'>
+              Upload your resume to build your master experience document.
+            </Text>
+            <div className='flex items-center gap-3'>
+              <Button
+                name='profile-upload-resume'
+                variant='primary'
+                size='sm'
+                onClick={() => fileInputRef.current?.click()}
+                disabled={uploading}
+              >
+                {uploading ? (
+                  <>
+                    <Spinner size='sm' aria-label='Uploading' />
+                    <span>Uploading...</span>
+                  </>
+                ) : (
+                  <>
+                    <Upload className='size-4' aria-hidden />
+                    <span>Upload Resume</span>
+                  </>
+                )}
+              </Button>
+              <Button
+                name='profile-start-conversation'
+                variant='outline'
+                size='sm'
+                as='link'
+                href='/onboarding'
+              >
+                <Sparkles className='size-4' aria-hidden />
+                <span>Start with AI</span>
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+
+        {fileInput}
+      </div>
+    );
+  }
+
+  // -- Main layout ------------------------------------------------------------
+
+  // While streaming, render parsed-so-far fields with empty defaults; this lets
+  // the user see the resume materialize instead of staring at a spinner. Once
+  // the `done` event lands, we swap back to the persisted optimized doc.
+  const payload: DisplayPayload | undefined = streamingPayload
+    ? {
+        summary: streamingPayload.summary ?? null,
+        roles: (streamingPayload.roles ?? []) as Partial<Role>[],
+        skills: (streamingPayload.skills ?? []) as Partial<Skill>[],
+        outcomes: (streamingPayload.outcomes ?? []) as Partial<Outcome>[],
+      }
+    : optimized?.payload;
+  const roleGapRefs = new Set(
+    gapHealth?.gaps
+      .filter(g => g.ref && g.kind.startsWith('role.'))
+      .map(g => g.ref) ?? []
+  );
+
+  return (
+    <div className='flex flex-col gap-6'>
+      <div>
+        <Heading variant='hero' as='h1'>
+          Profile
+        </Heading>
+        <Text variant='body' className='mt-1 text-text-secondary'>
+          Your master experience document and derived skills
+        </Text>
+      </div>
+
+      {deriving && (
+        <Alert variant='info' aria-live='polite'>
+          <div className='flex items-center gap-2'>
+            <Spinner size='sm' aria-label='Generating' />
+            <span>
+              Generating profile from your master document — fields below update
+              as they stream in. Editing is locked until generation completes.
+            </span>
+          </div>
+        </Alert>
+      )}
+
+      {/* Document Health */}
+      {gapHealth && (
+        <Card>
+          <CardHeader>
+            <div className='flex items-center justify-between'>
+              <CardTitle>Document Health</CardTitle>
+              <Badge variant={tierToBadgeVariant(gapHealth.tier)} size='sm'>
+                {Math.round(100 - gapHealth.gap_pct)}%
+              </Badge>
+            </div>
+          </CardHeader>
+          <CardContent>
+            <ProgressBar
+              value={Math.round(100 - gapHealth.gap_pct)}
+              variant={tierToProgressVariant(gapHealth.tier)}
+              size='sm'
+              aria-label='Document completeness'
+            />
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Master Document */}
+      <Card>
+        <CardHeader>
+          <div className='flex items-center justify-between gap-3'>
+            <CardTitle>
+              <FileText className='mr-2 inline size-5' aria-hidden />
+              Master Document
+            </CardTitle>
+            <div className='flex items-center gap-2'>
+              {saving && (
+                <Text
+                  as='span'
+                  variant='meta'
+                  className='inline-flex items-center gap-1'
+                  aria-live='polite'
+                >
+                  <Spinner size='sm' aria-label='Saving' />
+                  <span>Saving…</span>
+                </Text>
+              )}
+              {prose && (
+                <Text variant='meta' as='span'>
+                  v{prose.version} &middot;{' '}
+                  {new Date(prose.created_at).toLocaleDateString()}
+                </Text>
+              )}
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent className='flex flex-col gap-3'>
+          <div className='flex flex-wrap items-center gap-2'>
+            <Button
+              name='profile-upload'
+              variant='outline'
+              size='sm'
+              onClick={() => fileInputRef.current?.click()}
+              disabled={uploading}
+            >
+              {uploading ? (
+                <>
+                  <Spinner size='sm' aria-label='Uploading' />
+                  <span>Uploading...</span>
+                </>
+              ) : (
+                <>
+                  <Upload className='size-4' aria-hidden />
+                  <span>Upload Resume</span>
+                </>
+              )}
+            </Button>
+            <Button
+              name='profile-consolidate-prose'
+              variant='outline'
+              size='sm'
+              onClick={handleConsolidate}
+              disabled={consolidating || !prose}
+              title='Merge duplicate sections from past resume uploads'
+            >
+              {consolidating ? (
+                <>
+                  <Spinner size='sm' aria-label='Consolidating' />
+                  <span>Consolidating...</span>
+                </>
+              ) : (
+                <>
+                  <Layers className='size-4' aria-hidden />
+                  <span>Consolidate</span>
+                </>
+              )}
+            </Button>
+          </div>
+          <textarea
+            value={draft}
+            onChange={e => setDraft(e.target.value)}
+            className='min-h-[300px] w-full rounded-md border border-border bg-surface-primary p-3 font-mono text-sm text-text-primary focus:border-brand focus:outline-none focus:ring-1 focus:ring-brand'
+            placeholder='Paste or type your master experience document here...'
+            data-sentry-mask
+          />
+        </CardContent>
+      </Card>
+
+      {/* Experience */}
+      {payload && payload.roles.length > 0 && (
+        <Card aria-busy={deriving || undefined}>
+          <CardHeader>
+            <div className='flex items-center justify-between gap-2'>
+              <CardTitle>Experience</CardTitle>
+              <Button
+                name='profile-derive'
+                variant='outline'
+                size='sm'
+                iconOnly
+                aria-label='Re-derive profile from master document'
+                className='rounded-full'
+                onClick={handleDerive}
+                disabled={deriving}
+              >
+                {deriving ? (
+                  <Spinner size='sm' aria-label='Re-deriving' />
+                ) : (
+                  <RefreshCw className='size-4' aria-hidden />
+                )}
+              </Button>
+            </div>
+          </CardHeader>
+          <CardContent className='flex flex-col divide-y divide-border'>
+            {payload.roles.map((role, idx) => {
+              const outcomeCount =
+                payload.outcomes.filter(o => o.role_ref === role.id).length +
+                (role.outcome_refs?.length ?? 0);
+              const hasGap = role.id ? roleGapRefs.has(role.id) : false;
+              const dateRange =
+                role.start !== undefined
+                  ? formatDateRange(role.start, role.end ?? null)
+                  : '';
+              const skills = role.skills ?? [];
+
+              return (
+                <div
+                  key={role.id ?? `role-${idx}`}
+                  className='flex flex-col gap-2 py-3 first:pt-0 last:pb-0'
+                >
+                  <div className='flex items-start justify-between gap-2'>
+                    <div>
+                      <Text variant='body' className='font-medium'>
+                        {role.title ?? ''}
+                      </Text>
+                      <Text variant='caption' className='text-text-secondary'>
+                        {role.company ?? ''}
+                        {role.company && dateRange ? ' · ' : ''}
+                        {dateRange}
+                      </Text>
+                    </div>
+                    <div className='flex shrink-0 items-center gap-1.5'>
+                      {outcomeCount > 0 && (
+                        <Badge variant='brand' size='sm'>
+                          {outcomeCount}{' '}
+                          {outcomeCount === 1 ? 'outcome' : 'outcomes'}
+                        </Badge>
+                      )}
+                      {hasGap && (
+                        <Badge variant='warning' size='sm'>
+                          Has gaps
+                        </Badge>
+                      )}
+                    </div>
+                  </div>
+                  {role.summary && (
+                    <Text variant='caption' className='text-text-secondary'>
+                      {role.summary}
+                    </Text>
+                  )}
+                  {skills.length > 0 && (
+                    <div className='flex flex-wrap gap-1'>
+                      {skills.map(skill => (
+                        <Badge key={skill} variant='default' size='sm'>
+                          {skill}
+                        </Badge>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Skills */}
+      {payload && payload.skills.length > 0 && (
+        <Card aria-busy={deriving || undefined}>
+          <CardHeader>
+            <CardTitle>Skills</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className='grid gap-3 sm:grid-cols-2 lg:grid-cols-3'>
+              {payload.skills.map((skill, idx) => {
+                const evidenceCount = skill.evidence_refs?.length ?? 0;
+                return (
+                  <div
+                    key={skill.name ?? `skill-${idx}`}
+                    className='flex items-center justify-between rounded-md border border-border px-3 py-2'
+                  >
+                    <Text variant='body' className='text-sm'>
+                      {skill.name ?? ''}
+                    </Text>
+                    {evidenceCount > 0 ? (
+                      <Badge variant='default' size='sm'>
+                        {evidenceCount} evidence
+                      </Badge>
+                    ) : (
+                      <Badge variant='error' size='sm'>
+                        No evidence
+                      </Badge>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Gaps */}
+      {gapHealth && gapHealth.gaps.length > 0 && (
+        <GapsList
+          gaps={gapHealth.gaps}
+          tier={gapHealth.tier}
+          onOpenChat={() => setChatOpen(true)}
+        />
+      )}
+
+      {fileInput}
+
+      <ConversationChatModal
+        isOpen={chatOpen}
+        onClose={() => setChatOpen(false)}
+        onComplete={fetchData}
+      />
+    </div>
+  );
+}
+
+// -- Sub-components -----------------------------------------------------------
+
+function GapsList({
+  gaps,
+  tier,
+  onOpenChat,
+}: {
+  gaps: Gap[];
+  tier: GapTier;
+  onOpenChat: () => void;
+}) {
+  const visible = gaps.slice(0, 10);
+  const count = gaps.length;
+  const cta = (
+    <Button
+      name='profile-answer-questions'
+      variant='outline'
+      size='sm'
+      onClick={onOpenChat}
+    >
+      <Sparkles className='size-4' aria-hidden />
+      <span>
+        Answer {count} {count === 1 ? 'question' : 'questions'} to fill gaps
+      </span>
+    </Button>
+  );
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className='flex items-center justify-between'>
+          <CardTitle>Gaps to Fill</CardTitle>
+          <Badge variant='default' size='sm'>
+            {count} {count === 1 ? 'gap' : 'gaps'}
+          </Badge>
+        </div>
+      </CardHeader>
+      <CardContent className='flex flex-col gap-4'>
+        <div className='flex flex-col divide-y divide-border'>
+          {visible.map((gap, i) => (
+            <div
+              key={`${gap.kind}-${gap.ref}-${i}`}
+              className='flex items-start gap-3 py-2.5 first:pt-0 last:pb-0'
+            >
+              <Badge
+                variant={gapBadgeVariant(gap.kind)}
+                size='sm'
+                className='shrink-0 mt-0.5'
+              >
+                {GAP_KIND_LABELS[gap.kind] ?? gap.kind}
+              </Badge>
+              <Text variant='caption' className='text-text-secondary'>
+                {gap.context}
+              </Text>
+            </div>
+          ))}
+          {gaps.length > 10 && (
+            <Text variant='caption' className='pt-2 text-text-tertiary'>
+              +{gaps.length - 10} more gaps
+            </Text>
+          )}
+        </div>
+        {tier === 'red' ? (
+          <Alert variant='warning'>
+            <div className='flex flex-col items-start gap-2'>
+              <span>
+                Critical gaps detected. Generated resumes will be missing
+                outcomes and metrics until you fill them in.
+              </span>
+              {cta}
+            </div>
+          </Alert>
+        ) : (
+          cta
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/wyrdfold/src/app/(app)/profile/loading.tsx
+++ b/apps/wyrdfold/src/app/(app)/profile/loading.tsx
@@ -1,0 +1,55 @@
+import { Card, CardContent, CardHeader } from '@danieljoffe.com/shared-ui/Card';
+import { Skeleton } from '@danieljoffe.com/shared-ui/Skeleton';
+
+export default function ProfileLoading() {
+  return (
+    <div className='flex flex-col gap-6' aria-label='Loading profile'>
+      {/* Heading + subtitle */}
+      <div>
+        <Skeleton variant='text' size='lg' className='w-32' />
+        <Skeleton variant='text' className='mt-2 w-56' />
+      </div>
+
+      {/* Document Health card */}
+      <Card>
+        <CardHeader>
+          <div className='flex items-center justify-between'>
+            <Skeleton width={140} height={20} />
+            <Skeleton variant='rectangular' width={56} height={20} />
+          </div>
+        </CardHeader>
+        <CardContent>
+          <Skeleton variant='rectangular' height={8} />
+        </CardContent>
+      </Card>
+
+      {/* Master Document card */}
+      <Card>
+        <CardHeader>
+          <div className='flex items-center justify-between gap-3'>
+            <Skeleton width={180} height={20} />
+            <Skeleton width={90} height={14} />
+          </div>
+        </CardHeader>
+        <CardContent className='flex flex-col gap-3'>
+          <div className='flex flex-wrap gap-2'>
+            <Skeleton variant='rectangular' width={140} height={32} />
+            <Skeleton variant='rectangular' width={160} height={32} />
+          </div>
+          <Skeleton variant='rectangular' height={200} />
+        </CardContent>
+      </Card>
+
+      {/* Optimized profile card */}
+      <Card>
+        <CardHeader>
+          <Skeleton width={160} height={20} />
+        </CardHeader>
+        <CardContent className='flex flex-col gap-3'>
+          <Skeleton variant='text' lines={2} />
+          <Skeleton variant='rectangular' height={120} />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/wyrdfold/src/app/(app)/profile/page.tsx
+++ b/apps/wyrdfold/src/app/(app)/profile/page.tsx
@@ -1,0 +1,10 @@
+import type { Metadata } from 'next';
+import ProfilePage from './ProfilePage';
+
+export const metadata: Metadata = {
+  title: 'Profile',
+};
+
+export default function FittedProfile() {
+  return <ProfilePage />;
+}

--- a/apps/wyrdfold/src/app/(app)/profile/types.ts
+++ b/apps/wyrdfold/src/app/(app)/profile/types.ts
@@ -1,0 +1,105 @@
+// TypeScript mirror of the Pydantic shapes in apps/job-api/app/models/experience.py
+// and apps/job-api/app/models/conversation.py.
+
+export interface Outcome {
+  description: string;
+  metric: string | null;
+  value: string | null;
+  role_ref: string | null;
+}
+
+export interface Role {
+  id: string;
+  company: string;
+  title: string;
+  start: string;
+  end: string | null;
+  summary: string | null;
+  skills: string[];
+  outcome_refs: string[];
+}
+
+export interface Skill {
+  name: string;
+  evidence_refs: string[];
+  years: number | null;
+}
+
+export interface OptimizedPayload {
+  summary: string | null;
+  roles: Role[];
+  skills: Skill[];
+  outcomes: Outcome[];
+}
+
+export interface ProseDoc {
+  id: string;
+  user_id: string | null;
+  version: number;
+  content: string;
+  created_at: string;
+}
+
+// API returns either the record or `{ prose: null }` when empty.
+export type ProseResponse = ProseDoc | { prose: null };
+
+export function hasProse(value: ProseResponse): value is ProseDoc {
+  return 'id' in value;
+}
+
+export type OptimizedDocSource = 'llm' | 'user_edit';
+
+export interface OptimizedDoc {
+  id: string;
+  user_id: string | null;
+  prose_doc_id: string | null;
+  version: number;
+  payload: OptimizedPayload;
+  markdown_view: string | null;
+  source: OptimizedDocSource;
+  created_at: string;
+}
+
+// API returns either the record or `{ optimized: null }` when empty.
+export type OptimizedResponse = OptimizedDoc | { optimized: null };
+
+export type GapTier = 'red' | 'yellow' | 'green';
+
+export interface Gap {
+  kind: string;
+  ref: string;
+  priority: number;
+  context: string;
+}
+
+export interface GapHealthResult {
+  gap_pct: number;
+  tier: GapTier;
+  gaps: Gap[];
+  total_weight: number;
+  gap_weight: number;
+}
+
+export function hasOptimized(value: OptimizedResponse): value is OptimizedDoc {
+  return 'id' in value;
+}
+
+// -- Gap labels ---------------------------------------------------------------
+
+export const GAP_KIND_LABELS: Record<string, string> = {
+  'role.missing_outcomes': 'Missing outcomes',
+  'outcome.missing_metric': 'Missing metric',
+  'role.missing_summary': 'Missing summary',
+  'role.missing_end_date': 'Missing end date',
+  'skill.missing_evidence': 'Missing evidence',
+  'content.empty': 'No content',
+};
+
+export const GAP_KIND_WEIGHTS: Record<string, number> = {
+  'role.missing_outcomes': 5,
+  'outcome.missing_metric': 3,
+  'role.missing_summary': 2,
+  'role.missing_end_date': 1,
+  'skill.missing_evidence': 1,
+  'content.empty': 0,
+};

--- a/apps/wyrdfold/src/app/(app)/settings/SettingsPage.tsx
+++ b/apps/wyrdfold/src/app/(app)/settings/SettingsPage.tsx
@@ -1,0 +1,615 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from '@danieljoffe.com/shared-ui/Card';
+import { Heading } from '@danieljoffe.com/shared-ui/Heading';
+import { Input } from '@danieljoffe.com/shared-ui/Input';
+import { Skeleton } from '@danieljoffe.com/shared-ui/Skeleton';
+import { Spinner } from '@danieljoffe.com/shared-ui/Spinner';
+import { Switch } from '@danieljoffe.com/shared-ui/Switch';
+import { Text } from '@danieljoffe.com/shared-ui/Text';
+import { useToast } from '@/state/Toast/ToastProvider';
+
+const AUTOSAVE_DEBOUNCE_MS = 800;
+
+async function extractFastApiError(res: Response): Promise<string | null> {
+  if (res.ok) return null;
+  try {
+    const body = (await res.clone().json()) as { detail?: unknown };
+    if (Array.isArray(body.detail)) {
+      const first = body.detail[0] as { msg?: string } | undefined;
+      if (first?.msg) return first.msg.replace(/^Value error,\s*/, '');
+    } else if (typeof body.detail === 'string') {
+      return body.detail;
+    }
+  } catch {
+    // not JSON / no body — fall through
+  }
+  return null;
+}
+
+interface NotificationPreferences {
+  job_notifications_enabled: boolean;
+  job_score_threshold: number;
+  sms_notifications_enabled: boolean;
+  sms_score_threshold: number;
+  sms_daily_limit: number;
+  phone_number: string | null;
+  email: string | null;
+  email_available: boolean;
+  sms_available: boolean;
+}
+
+interface IdentityFields {
+  name: string | null;
+  email: string | null;
+  phone_number: string | null;
+  location: string | null;
+  linkedin_url: string | null;
+  website_url: string | null;
+}
+
+type Section = 'profile' | 'email' | 'sms';
+
+function profileSig(fields: {
+  name: string;
+  email: string;
+  phone_number: string;
+  location: string;
+  linkedin_url: string;
+  website_url: string;
+}): string {
+  return JSON.stringify(fields);
+}
+
+function emailSig(enabled: boolean, threshold: number): string {
+  return JSON.stringify({
+    job_notifications_enabled: enabled,
+    job_score_threshold: threshold,
+  });
+}
+
+function smsSig(
+  enabled: boolean,
+  threshold: number,
+  dailyLimit: number,
+  phone: string | null
+): string {
+  return JSON.stringify({
+    sms_notifications_enabled: enabled,
+    sms_score_threshold: threshold,
+    sms_daily_limit: dailyLimit,
+    phone_number: phone,
+  });
+}
+
+function SavingIndicator({ active }: { active: boolean }) {
+  if (!active) return null;
+  return (
+    <Text
+      as='span'
+      variant='meta'
+      className='inline-flex items-center gap-1'
+      aria-live='polite'
+    >
+      <Spinner size='sm' aria-label='Saving' />
+      <span>Saving…</span>
+    </Text>
+  );
+}
+
+export default function SettingsPage() {
+  const [loading, setLoading] = useState(true);
+  const [savingSection, setSavingSection] = useState<Section | null>(null);
+  const [prefs, setPrefs] = useState<NotificationPreferences | null>(null);
+  const { toast } = useToast();
+
+  // Form state
+  const [emailEnabled, setEmailEnabled] = useState(false);
+  const [emailThreshold, setEmailThreshold] = useState('100');
+  const [smsEnabled, setSmsEnabled] = useState(false);
+  const [smsThreshold, setSmsThreshold] = useState('100');
+  const [smsDailyLimit, setSmsDailyLimit] = useState('5');
+  const [phoneNumber, setPhoneNumber] = useState('');
+
+  // Profile identity (F3-A): contact info used for resume + cover-letter headers.
+  const [identityName, setIdentityName] = useState('');
+  const [identityEmail, setIdentityEmail] = useState('');
+  const [identityPhone, setIdentityPhone] = useState('');
+  const [identityLocation, setIdentityLocation] = useState('');
+  const [identityLinkedin, setIdentityLinkedin] = useState('');
+  const [identityWebsite, setIdentityWebsite] = useState('');
+
+  // Server-known signatures — autosave fires only when local state diverges.
+  // Failed-sigs prevent retry-loops when the server rejects a value.
+  const lastProfileSigRef = useRef<string | null>(null);
+  const lastEmailSigRef = useRef<string | null>(null);
+  const lastSmsSigRef = useRef<string | null>(null);
+  const lastFailedProfileSigRef = useRef<string | null>(null);
+  const lastFailedEmailSigRef = useRef<string | null>(null);
+  const lastFailedSmsSigRef = useRef<string | null>(null);
+
+  const fetchPrefs = useCallback(async () => {
+    try {
+      const [prefsRes, identityRes] = await Promise.all([
+        fetch('/api/profile/notifications'),
+        fetch('/api/profile/identity'),
+      ]);
+      if (prefsRes.ok) {
+        const data = (await prefsRes.json()) as NotificationPreferences;
+        setPrefs(data);
+        setEmailEnabled(data.job_notifications_enabled);
+        setEmailThreshold(String(data.job_score_threshold));
+        setSmsEnabled(data.sms_notifications_enabled);
+        setSmsThreshold(String(data.sms_score_threshold));
+        setSmsDailyLimit(String(data.sms_daily_limit));
+        setPhoneNumber(data.phone_number ?? '');
+        lastEmailSigRef.current = emailSig(
+          data.job_notifications_enabled,
+          data.job_score_threshold
+        );
+        lastSmsSigRef.current = smsSig(
+          data.sms_notifications_enabled,
+          data.sms_score_threshold,
+          data.sms_daily_limit,
+          data.phone_number ?? null
+        );
+      }
+      if (identityRes.ok) {
+        const data = (await identityRes.json()) as IdentityFields;
+        setIdentityName(data.name ?? '');
+        setIdentityEmail(data.email ?? '');
+        setIdentityPhone(data.phone_number ?? '');
+        setIdentityLocation(data.location ?? '');
+        setIdentityLinkedin(data.linkedin_url ?? '');
+        setIdentityWebsite(data.website_url ?? '');
+        lastProfileSigRef.current = profileSig({
+          name: (data.name ?? '').trim(),
+          email: (data.email ?? '').trim(),
+          phone_number: (data.phone_number ?? '').trim(),
+          location: (data.location ?? '').trim(),
+          linkedin_url: (data.linkedin_url ?? '').trim(),
+          website_url: (data.website_url ?? '').trim(),
+        });
+      }
+    } catch {
+      toast({
+        variant: 'error',
+        title: 'Failed to load settings',
+      });
+    } finally {
+      setLoading(false);
+    }
+  }, [toast]);
+
+  useEffect(() => {
+    fetchPrefs();
+  }, [fetchPrefs]);
+
+  // -- Save handlers ----------------------------------------------------------
+
+  const handleSaveProfile = useCallback(async () => {
+    const trimmed = {
+      name: identityName.trim(),
+      email: identityEmail.trim(),
+      phone_number: identityPhone.trim(),
+      location: identityLocation.trim(),
+      linkedin_url: identityLinkedin.trim(),
+      website_url: identityWebsite.trim(),
+    };
+    const sig = profileSig(trimmed);
+    setSavingSection('profile');
+    try {
+      const res = await fetch('/api/profile/identity', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(trimmed),
+      });
+      if (!res.ok) {
+        const message =
+          (await extractFastApiError(res)) ?? 'Failed to save profile';
+        toast({ variant: 'error', title: message });
+        lastFailedProfileSigRef.current = sig;
+        return;
+      }
+      const data = (await res.json()) as IdentityFields;
+      // Re-sync from server response so normalized values (e.g. E.164 phone)
+      // replace the typed input.
+      setIdentityName(data.name ?? '');
+      setIdentityEmail(data.email ?? '');
+      setIdentityPhone(data.phone_number ?? '');
+      setIdentityLocation(data.location ?? '');
+      setIdentityLinkedin(data.linkedin_url ?? '');
+      setIdentityWebsite(data.website_url ?? '');
+      lastProfileSigRef.current = profileSig({
+        name: (data.name ?? '').trim(),
+        email: (data.email ?? '').trim(),
+        phone_number: (data.phone_number ?? '').trim(),
+        location: (data.location ?? '').trim(),
+        linkedin_url: (data.linkedin_url ?? '').trim(),
+        website_url: (data.website_url ?? '').trim(),
+      });
+      lastFailedProfileSigRef.current = null;
+      toast({ variant: 'success', title: 'Profile saved' });
+    } catch {
+      toast({ variant: 'error', title: 'Failed to save profile' });
+      lastFailedProfileSigRef.current = sig;
+    } finally {
+      setSavingSection(null);
+    }
+  }, [
+    identityName,
+    identityEmail,
+    identityPhone,
+    identityLocation,
+    identityLinkedin,
+    identityWebsite,
+    toast,
+  ]);
+
+  const handleSaveEmail = useCallback(async () => {
+    const threshold = parseInt(emailThreshold, 10) || 100;
+    const sig = emailSig(emailEnabled, threshold);
+    setSavingSection('email');
+    try {
+      const res = await fetch('/api/profile/notifications', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          job_notifications_enabled: emailEnabled,
+          job_score_threshold: threshold,
+        }),
+      });
+      if (!res.ok) {
+        const message =
+          (await extractFastApiError(res)) ?? 'Failed to save email settings';
+        toast({ variant: 'error', title: message });
+        lastFailedEmailSigRef.current = sig;
+        return;
+      }
+      const data = (await res.json()) as NotificationPreferences;
+      setPrefs(data);
+      setEmailEnabled(data.job_notifications_enabled);
+      setEmailThreshold(String(data.job_score_threshold));
+      lastEmailSigRef.current = emailSig(
+        data.job_notifications_enabled,
+        data.job_score_threshold
+      );
+      lastFailedEmailSigRef.current = null;
+      toast({ variant: 'success', title: 'Email settings saved' });
+    } catch {
+      toast({ variant: 'error', title: 'Failed to save email settings' });
+      lastFailedEmailSigRef.current = sig;
+    } finally {
+      setSavingSection(null);
+    }
+  }, [emailEnabled, emailThreshold, toast]);
+
+  const handleSaveSms = useCallback(async () => {
+    const trimmedPhone = phoneNumber.trim();
+    const threshold = parseInt(smsThreshold, 10) || 100;
+    const dailyLimit = parseInt(smsDailyLimit, 10) || 5;
+    const sig = smsSig(smsEnabled, threshold, dailyLimit, trimmedPhone || null);
+    setSavingSection('sms');
+    try {
+      const body: Record<string, unknown> = {
+        sms_notifications_enabled: smsEnabled,
+        sms_score_threshold: threshold,
+        sms_daily_limit: dailyLimit,
+      };
+      if (trimmedPhone) {
+        body.phone_number = trimmedPhone;
+      }
+      const res = await fetch('/api/profile/notifications', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) {
+        const message =
+          (await extractFastApiError(res)) ?? 'Failed to save SMS settings';
+        toast({ variant: 'error', title: message });
+        lastFailedSmsSigRef.current = sig;
+        return;
+      }
+      const data = (await res.json()) as NotificationPreferences;
+      setPrefs(data);
+      setSmsEnabled(data.sms_notifications_enabled);
+      setSmsThreshold(String(data.sms_score_threshold));
+      setSmsDailyLimit(String(data.sms_daily_limit));
+      setPhoneNumber(data.phone_number ?? '');
+      lastSmsSigRef.current = smsSig(
+        data.sms_notifications_enabled,
+        data.sms_score_threshold,
+        data.sms_daily_limit,
+        data.phone_number ?? null
+      );
+      lastFailedSmsSigRef.current = null;
+      toast({ variant: 'success', title: 'SMS settings saved' });
+    } catch {
+      toast({ variant: 'error', title: 'Failed to save SMS settings' });
+      lastFailedSmsSigRef.current = sig;
+    } finally {
+      setSavingSection(null);
+    }
+  }, [smsEnabled, smsThreshold, smsDailyLimit, phoneNumber, toast]);
+
+  // -- Autosave effects -------------------------------------------------------
+
+  useEffect(() => {
+    if (lastProfileSigRef.current === null) return;
+    if (savingSection === 'profile') return;
+    const sig = profileSig({
+      name: identityName.trim(),
+      email: identityEmail.trim(),
+      phone_number: identityPhone.trim(),
+      location: identityLocation.trim(),
+      linkedin_url: identityLinkedin.trim(),
+      website_url: identityWebsite.trim(),
+    });
+    if (sig === lastProfileSigRef.current) return;
+    if (sig === lastFailedProfileSigRef.current) return;
+    const handle = setTimeout(() => {
+      handleSaveProfile();
+    }, AUTOSAVE_DEBOUNCE_MS);
+    return () => clearTimeout(handle);
+  }, [
+    identityName,
+    identityEmail,
+    identityPhone,
+    identityLocation,
+    identityLinkedin,
+    identityWebsite,
+    savingSection,
+    handleSaveProfile,
+  ]);
+
+  useEffect(() => {
+    if (lastEmailSigRef.current === null) return;
+    if (savingSection === 'email') return;
+    const sig = emailSig(emailEnabled, parseInt(emailThreshold, 10) || 100);
+    if (sig === lastEmailSigRef.current) return;
+    if (sig === lastFailedEmailSigRef.current) return;
+    const handle = setTimeout(() => {
+      handleSaveEmail();
+    }, AUTOSAVE_DEBOUNCE_MS);
+    return () => clearTimeout(handle);
+  }, [emailEnabled, emailThreshold, savingSection, handleSaveEmail]);
+
+  useEffect(() => {
+    if (lastSmsSigRef.current === null) return;
+    if (savingSection === 'sms') return;
+    const sig = smsSig(
+      smsEnabled,
+      parseInt(smsThreshold, 10) || 100,
+      parseInt(smsDailyLimit, 10) || 5,
+      phoneNumber.trim() || null
+    );
+    if (sig === lastSmsSigRef.current) return;
+    if (sig === lastFailedSmsSigRef.current) return;
+    const handle = setTimeout(() => {
+      handleSaveSms();
+    }, AUTOSAVE_DEBOUNCE_MS);
+    return () => clearTimeout(handle);
+  }, [
+    smsEnabled,
+    smsThreshold,
+    smsDailyLimit,
+    phoneNumber,
+    savingSection,
+    handleSaveSms,
+  ]);
+
+  const emailAvailable = prefs?.email_available ?? false;
+  const smsAvailable = prefs?.sms_available ?? false;
+
+  if (loading) {
+    return (
+      <div className='flex flex-col gap-6'>
+        <div>
+          <Skeleton variant='text' size='lg' className='w-32' />
+          <Skeleton variant='text' className='mt-2 w-56' />
+        </div>
+        <Skeleton variant='rectangular' height={300} />
+        <Skeleton variant='rectangular' height={250} />
+      </div>
+    );
+  }
+
+  return (
+    <div className='flex flex-col gap-6'>
+      <div>
+        <Heading variant='hero' as='h1'>
+          Settings
+        </Heading>
+        <Text variant='body' className='mt-1 text-text-secondary'>
+          Notification preferences and alerts
+        </Text>
+      </div>
+
+      {/* Profile (resume + cover-letter contact info) */}
+      <Card>
+        <CardHeader>
+          <div className='flex items-center justify-between gap-3'>
+            <CardTitle>Profile</CardTitle>
+            <SavingIndicator active={savingSection === 'profile'} />
+          </div>
+        </CardHeader>
+        <CardContent className='flex flex-col gap-4'>
+          <Text variant='caption' className='text-text-secondary'>
+            Used as the contact header on every generated resume and cover
+            letter. Name is required before you can generate.
+          </Text>
+          <div className='grid gap-4 sm:grid-cols-2'>
+            <Input
+              label='Name'
+              value={identityName}
+              onChange={e => setIdentityName(e.target.value)}
+              placeholder='Full name'
+              autoComplete='name'
+              required
+              data-sentry-mask
+            />
+            <Input
+              label='Email'
+              type='email'
+              value={identityEmail}
+              onChange={e => setIdentityEmail(e.target.value)}
+              placeholder='name@example.com'
+              autoComplete='email'
+              inputMode='email'
+              data-sentry-mask
+            />
+            <Input
+              label='Phone'
+              type='tel'
+              value={identityPhone}
+              onChange={e => setIdentityPhone(e.target.value)}
+              placeholder='+1 555 555 5555'
+              autoComplete='tel'
+              inputMode='tel'
+              data-sentry-mask
+            />
+            <Input
+              label='Location'
+              value={identityLocation}
+              onChange={e => setIdentityLocation(e.target.value)}
+              placeholder='City, State'
+              autoComplete='address-level2'
+              data-sentry-mask
+            />
+            <Input
+              label='LinkedIn URL'
+              type='url'
+              value={identityLinkedin}
+              onChange={e => setIdentityLinkedin(e.target.value)}
+              placeholder='https://linkedin.com/in/username'
+              autoComplete='url'
+              inputMode='url'
+              data-sentry-mask
+            />
+            <Input
+              label='Website'
+              type='url'
+              value={identityWebsite}
+              onChange={e => setIdentityWebsite(e.target.value)}
+              placeholder='https://example.com'
+              autoComplete='url'
+              inputMode='url'
+              data-sentry-mask
+            />
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Email Notifications */}
+      <Card>
+        <CardHeader>
+          <div className='flex flex-wrap items-center justify-between gap-3'>
+            <div className='flex items-center gap-3'>
+              <CardTitle>Email Notifications</CardTitle>
+              <SavingIndicator active={savingSection === 'email'} />
+            </div>
+            <Switch
+              checked={emailEnabled && emailAvailable}
+              onChange={setEmailEnabled}
+              label='Enabled'
+              disabled={!emailAvailable}
+            />
+          </div>
+        </CardHeader>
+        <CardContent className='flex flex-col gap-4'>
+          <Text variant='caption' className='text-text-secondary'>
+            Get email alerts when new jobs score above your threshold. Powered
+            by Resend.
+          </Text>
+          {!emailAvailable && (
+            <Text variant='meta' className='text-text-tertiary'>
+              Email notifications are unavailable until the operator configures
+              the email provider credentials.
+            </Text>
+          )}
+          {prefs?.email && (
+            <Text variant='meta' className='text-text-tertiary'>
+              Sending to: {prefs.email}
+            </Text>
+          )}
+          <div className='max-w-xs'>
+            <Input
+              label='Score threshold'
+              type='number'
+              value={emailThreshold}
+              onChange={e => setEmailThreshold(e.target.value)}
+              helperText='Minimum job score to trigger an email alert (0-200)'
+              disabled={!emailEnabled || !emailAvailable}
+            />
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* SMS Notifications */}
+      <Card>
+        <CardHeader>
+          <div className='flex flex-wrap items-center justify-between gap-3'>
+            <div className='flex items-center gap-3'>
+              <CardTitle>SMS Notifications</CardTitle>
+              <SavingIndicator active={savingSection === 'sms'} />
+            </div>
+            <Switch
+              checked={smsEnabled && smsAvailable}
+              onChange={setSmsEnabled}
+              label='Enabled'
+              disabled={!smsAvailable}
+            />
+          </div>
+        </CardHeader>
+        <CardContent className='flex flex-col gap-4'>
+          <Text variant='caption' className='text-text-secondary'>
+            Get text messages for high-scoring jobs with a deep link to view and
+            act immediately. Powered by Twilio.
+          </Text>
+          {!smsAvailable && (
+            <Text variant='meta' className='text-text-tertiary'>
+              SMS notifications are unavailable until the operator configures
+              Twilio credentials.
+            </Text>
+          )}
+          <div className='grid gap-4 sm:grid-cols-2 lg:grid-cols-3'>
+            <Input
+              label='Phone number'
+              type='tel'
+              value={phoneNumber}
+              onChange={e => setPhoneNumber(e.target.value)}
+              placeholder='+1 555 555 5555'
+              helperText='Include country code'
+              autoComplete='tel'
+              inputMode='tel'
+              disabled={!smsEnabled || !smsAvailable}
+            />
+            <Input
+              label='Score threshold'
+              type='number'
+              value={smsThreshold}
+              onChange={e => setSmsThreshold(e.target.value)}
+              helperText='Minimum score for SMS (0-200)'
+              disabled={!smsEnabled || !smsAvailable}
+            />
+            <Input
+              label='Daily limit'
+              type='number'
+              value={smsDailyLimit}
+              onChange={e => setSmsDailyLimit(e.target.value)}
+              helperText='Max texts per day (1-50)'
+              disabled={!smsEnabled || !smsAvailable}
+            />
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/wyrdfold/src/app/(app)/settings/loading.tsx
+++ b/apps/wyrdfold/src/app/(app)/settings/loading.tsx
@@ -1,0 +1,49 @@
+import { Card, CardContent, CardHeader } from '@danieljoffe.com/shared-ui/Card';
+import { Skeleton } from '@danieljoffe.com/shared-ui/Skeleton';
+
+export default function SettingsLoading() {
+  return (
+    <div className='flex flex-col gap-6' aria-label='Loading settings'>
+      {/* Heading + subtitle */}
+      <div>
+        <Skeleton variant='text' size='lg' className='w-32' />
+        <Skeleton variant='text' className='mt-2 w-56' />
+      </div>
+
+      {/* Profile section */}
+      <Card>
+        <CardHeader>
+          <Skeleton width={120} height={20} />
+        </CardHeader>
+        <CardContent className='flex flex-col gap-4'>
+          <Skeleton width='80%' size='sm' />
+          <div className='grid gap-4 sm:grid-cols-2'>
+            {Array.from({ length: 6 }).map((_, i) => (
+              <div key={i} className='flex flex-col gap-1'>
+                <Skeleton width={80} size='sm' />
+                <Skeleton variant='rectangular' height={36} />
+              </div>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Email notifications section */}
+      <Card>
+        <CardHeader>
+          <div className='flex items-center justify-between gap-3'>
+            <Skeleton width={160} height={20} />
+            <Skeleton variant='rectangular' width={80} height={24} />
+          </div>
+        </CardHeader>
+        <CardContent className='flex flex-col gap-4'>
+          <Skeleton width='70%' size='sm' />
+          <div className='max-w-xs flex flex-col gap-1'>
+            <Skeleton width={120} size='sm' />
+            <Skeleton variant='rectangular' height={36} />
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/wyrdfold/src/app/(app)/settings/page.tsx
+++ b/apps/wyrdfold/src/app/(app)/settings/page.tsx
@@ -1,0 +1,10 @@
+import type { Metadata } from 'next';
+import SettingsPage from './SettingsPage';
+
+export const metadata: Metadata = {
+  title: 'Settings',
+};
+
+export default function FittedSettings() {
+  return <SettingsPage />;
+}

--- a/apps/wyrdfold/src/lib/consumeSse.ts
+++ b/apps/wyrdfold/src/lib/consumeSse.ts
@@ -1,0 +1,62 @@
+/**
+ * Minimal Server-Sent Events reader for `fetch` Responses.
+ *
+ * The browser's native EventSource only supports GET, so we hand-roll a
+ * reader for our POST-based SSE endpoints. Frames are delimited by a
+ * blank line; each frame may contain `event:` and one or more `data:`
+ * lines (per the SSE spec). We dispatch each completed frame through
+ * the handler with the JSON-decoded data payload.
+ */
+export async function consumeSse(
+  response: Response,
+  handler: (event: string, data: unknown) => void,
+  options: { signal?: AbortSignal } = {}
+): Promise<void> {
+  if (!response.body) {
+    throw new Error('Response has no body');
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+
+  const onAbort = () => {
+    reader.cancel().catch(() => {
+      /* already closed */
+    });
+  };
+  options.signal?.addEventListener('abort', onAbort);
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+
+      const frames = buffer.split('\n\n');
+      buffer = frames.pop() ?? '';
+
+      for (const frame of frames) {
+        if (!frame.trim()) continue;
+        let eventName = 'message';
+        const dataLines: string[] = [];
+        for (const line of frame.split('\n')) {
+          if (line.startsWith('event: ')) {
+            eventName = line.slice('event: '.length);
+          } else if (line.startsWith('data: ')) {
+            dataLines.push(line.slice('data: '.length));
+          }
+        }
+        if (dataLines.length === 0) continue;
+        const raw = dataLines.join('\n');
+        try {
+          handler(eventName, JSON.parse(raw));
+        } catch {
+          /* malformed frame — skip rather than abort the stream */
+        }
+      }
+    }
+  } finally {
+    options.signal?.removeEventListener('abort', onAbort);
+  }
+}

--- a/apps/wyrdfold/src/lib/parsePartialJson.ts
+++ b/apps/wyrdfold/src/lib/parsePartialJson.ts
@@ -1,0 +1,112 @@
+/**
+ * Best-effort partial-JSON parser for streaming LLM responses.
+ *
+ * Anthropic emits JSON one chunk at a time. After each chunk we'd like to
+ * render whatever fields have completed so far — but the buffer is almost
+ * never valid JSON mid-stream (open string, dangling key, half-typed array
+ * element, etc). This walker patches up the common cases so the buffer
+ * parses to "the longest valid prefix":
+ *
+ *   1. Close any open string (drop a trailing dangling `\` first).
+ *   2. Trim trailing whitespace + comma (dangling field separator).
+ *   3. If the buffer ends with `:` (key without value), append `null`.
+ *   4. Close any open `{` / `[` in stack order.
+ *
+ * If that still fails (typically because we're mid-key, e.g. `{"rol`),
+ * fall back to slicing off everything after the last top-level comma and
+ * trying again. Returns `null` when no usable prefix can be recovered;
+ * callers should hold their previously-parsed state until the next chunk.
+ */
+export function parsePartialJson<T = unknown>(buffer: string): T | null {
+  if (!buffer) return null;
+
+  try {
+    return JSON.parse(buffer) as T;
+  } catch {
+    /* fall through */
+  }
+
+  const closed = closeOpenStructures(buffer);
+  try {
+    return JSON.parse(closed) as T;
+  } catch {
+    /* fall through */
+  }
+
+  const truncated = truncateAtLastTopLevelComma(buffer);
+  if (truncated !== null) {
+    try {
+      return JSON.parse(closeOpenStructures(truncated)) as T;
+    } catch {
+      /* give up */
+    }
+  }
+
+  return null;
+}
+
+function closeOpenStructures(buffer: string): string {
+  const stack: string[] = [];
+  let inString = false;
+  let escape = false;
+
+  for (let i = 0; i < buffer.length; i++) {
+    const ch = buffer[i];
+    if (escape) {
+      escape = false;
+      continue;
+    }
+    if (ch === '\\') {
+      if (inString) escape = true;
+      continue;
+    }
+    if (ch === '"') {
+      inString = !inString;
+      continue;
+    }
+    if (inString) continue;
+    if (ch === '{') stack.push('}');
+    else if (ch === '[') stack.push(']');
+    else if (ch === '}' || ch === ']') stack.pop();
+  }
+
+  let candidate = buffer;
+  if (inString) {
+    if (candidate.endsWith('\\')) candidate = candidate.slice(0, -1);
+    candidate += '"';
+  }
+  candidate = candidate.replace(/[\s,]+$/, '');
+  if (/:\s*$/.test(candidate)) candidate += ' null';
+
+  while (stack.length > 0) candidate += stack.pop();
+  return candidate;
+}
+
+function truncateAtLastTopLevelComma(buffer: string): string | null {
+  let depth = 0;
+  let inString = false;
+  let escape = false;
+  let cutoff = -1;
+
+  for (let i = 0; i < buffer.length; i++) {
+    const ch = buffer[i];
+    if (escape) {
+      escape = false;
+      continue;
+    }
+    if (ch === '\\') {
+      if (inString) escape = true;
+      continue;
+    }
+    if (ch === '"') {
+      inString = !inString;
+      continue;
+    }
+    if (inString) continue;
+    if (ch === '{' || ch === '[') depth++;
+    else if (ch === '}' || ch === ']') depth--;
+    else if (ch === ',' && depth === 1) cutoff = i;
+  }
+
+  return cutoff > 0 ? buffer.slice(0, cutoff) : null;
+}


### PR DESCRIPTION
## Summary

**Final UI port phase for the `(app)` tree.** Brings the **profile** (career identity + preference editor with conversation refinement) and **settings** (notification preferences) pages across from `apps/root/src/app/fitted/`.

After this lands, **every sidebar link in `WyrdfoldSidebar` resolves to a real page**. The `(app)` tree is feature-complete for parity with root's fitted UI.

## What lit up

| Route | Source |
|---|---|
| `/profile` | career identity (name, contact, links) + experience editor with conversational refinement (SSE-streamed derivation) |
| `/settings` | notification preferences (email + SMS gates) |

## Files (9, ~1850 LOC)

### Profile
- `(app)/profile/{page,loading,ProfilePage,types}.{tsx,ts}`

### Settings
- `(app)/settings/{page,loading,SettingsPage}.tsx`

### Shared lib (sub-deps from `ProfilePage`)
- `src/lib/consumeSse.ts` — SSE byte-stream → JSON event iterator
- `src/lib/parsePartialJson.ts` — resilient parser for streaming JSON

## Adjustments

- All `/fitted/*` hrefs → `/*` via sed (same pattern as 6.2–6.4).
- **Zero code-level adjustments needed beyond the URL rewrites** — third clean port in a row.
- Internal function names left as-is.

## Routing notes

- `/profile` consumes:
  - `GET/PATCH /api/profile/identity` (Phase 4.5)
  - `GET/POST /api/career/experience/{prose,turns,gap-health,optimized,preferences}` (Phase 4.2)
  - `POST /api/career/experience/derive/stream` — **SSE streaming via `proxyStreamingToWyrdfoldAPI`** (Phase 4.1)
  - `POST /api/career/experience/conversation/{turn,next-probe,reset}` (Phase 4.2)
- `/settings` consumes:
  - `GET/PATCH /api/profile/notifications` (Phase 4.5, with the BFF's `email_available` defense-in-depth)
- Both inside `(app)`, sidebar visible.

## What's NOT in this PR

- **Deletion of `apps/root/src/app/fitted/*`** — separate sub-PR after this lands and the user verifies the wyrdfold UI works end-to-end. Splitting deletes from new-file work keeps the diff readable.
- **E2E smoke spec for `wyrdfold-e2e`** — defer until the UI port is smoked manually first; there's value in writing the e2e against the real flow rather than guessing at it.
- **Lighthouse pass** on `(app)` routes — defer until prod deploy.

## Verification

- ✅ `pnpm nx lint wyrdfold` — 0 errors, 4 warnings (pre-existing)
- ✅ `pnpm nx test wyrdfold` — passes
- ✅ `pnpm nx build wyrdfold` — clean; `/profile` and `/settings` register dynamic
- ✅ `pnpm tsc --noEmit` — workspace clean

## Phase 6 progress — UI port complete

| Phase | Status | Files | LOC |
|---|---|---|---|
| 6.1 | ✅ merged | 21 | ~1238 |
| 6.2 | ✅ merged | 24 | ~3624 |
| 6.3 | ✅ merged | 40 | ~5316 |
| 6.4 | ✅ merged | 4 | ~1380 |
| **6.5** | **(this PR)** | 9 | ~1850 |
| **Total** | | **~98 files** | **~13,400 LOC** |

After this lands, you'll want a follow-up cleanup PR to delete `apps/root/src/app/fitted/*` (no longer referenced from anywhere now that wyrdfold owns the UI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)