### PR TITLE
perf(wyrdfold): drop redundant supabase.auth.getUser() in (app)/layout

### DIFF
--- a/apps/wyrdfold/src/app/(app)/layout.tsx
+++ b/apps/wyrdfold/src/app/(app)/layout.tsx
@@ -1,25 +1,13 @@
 import type { ReactNode } from 'react';
-import { redirect } from 'next/navigation';
-import { createAuthServerClient } from '@/lib/supabase/auth-server';
 import WyrdfoldSidebar from './WyrdfoldSidebar';
 
-/**
- * Server-side auth backstop for /(app)/* routes. The proxy.ts middleware
- * already redirects unauthenticated requests, but Next.js Router Cache can
- * replay a previously-rendered RSC payload on client-side nav before the
- * middleware runs. Re-checking the session here means any cached payload
- * still has to pass an authenticated render — no auth, no shell.
- */
-export default async function AppLayout({ children }: { children: ReactNode }) {
-  const supabase = await createAuthServerClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
+// Auth gating for /(app)/* lives entirely in proxy.ts middleware, which runs
+// on every matched request (including RSC navigations) and redirects to
+// /login when there's no session. Re-doing supabase.auth.getUser() here would
+// mean two network round-trips per page render, which serializes the shell
+// behind a Supabase call that the middleware already made.
 
-  if (!user) {
-    redirect('/login');
-  }
-
+export default function AppLayout({ children }: { children: ReactNode }) {
   return (
     <div className='flex min-h-screen'>
       <WyrdfoldSidebar />


### PR DESCRIPTION
## Summary

- `apps/wyrdfold/src/app/(app)/layout.tsx` was calling `supabase.auth.getUser()` and redirecting on no user before rendering the shell. The `proxy.ts` middleware already does this for every `(app)/*` request (see `proxy.ts:94-100`), so this was a second Supabase token-validation round-trip per navigation, serialized on the render path.
- The comment justified it as a "Router Cache replay" backstop. That reasoning doesn't hold: the layout runs at *render* time, not at *cache-replay* time. Once an authenticated payload is in the Router Cache, replaying it doesn't re-execute the layout. The protection is the same one middleware already provides — never *render* an unauthed payload in the first place.
- Drop the call (and the `createAuthServerClient` import). The layout becomes synchronous, Next streams the shell immediately, and there's only one Supabase auth check per nav (in middleware).

## Context

Part of investigating "wyrdfold app feels unresponsive on route changes." Stacked alongside #633 (Link prefetch in the sidebar). Independent file, independent PR.

## Test plan

- [x] \`nx test wyrdfold\` — 26/26 passing
- [x] \`pnpm tsc --noEmit -p apps/wyrdfold/tsconfig.json\` — clean for this file
- [x] \`eslint\` — clean
- [ ] Manual: sign out, hit \`/jobs\` directly — middleware redirects to \`/login?next=/jobs\` (unchanged)
- [ ] Manual: with valid session, navigate between \`(app)/*\` routes and confirm shell renders without the previous auth-call latency
- [ ] Manual: with an expired/revoked JWT, request \`/\` — middleware should still redirect to \`/login\`