### PR TITLE
perf(wyrdfold): fetch dashboard data in RSC instead of useEffect

### DIFF
--- a/apps/wyrdfold/src/app/(app)/DashboardPage.tsx
+++ b/apps/wyrdfold/src/app/(app)/DashboardPage.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
 import Link from 'next/link';
 import {
   ArrowRight,
@@ -15,18 +14,15 @@ import {
 import { Badge } from '@danieljoffe.com/shared-ui/Badge';
 import { Card, CardContent } from '@danieljoffe.com/shared-ui/Card';
 import { Heading } from '@danieljoffe.com/shared-ui/Heading';
-import { Skeleton } from '@danieljoffe.com/shared-ui/Skeleton';
 import { Text } from '@danieljoffe.com/shared-ui/Text';
 import Button from '@/components/Button';
-import { useToast } from '@/state/Toast/ToastProvider';
 import type { JobPosting } from './jobs/types';
-import type { UserTargetWithTarget } from './targets/types';
 
-interface JobsListResponse {
-  postings: JobPosting[];
-  total: number;
-  page: number;
-  page_size: number;
+export interface DashboardInitial {
+  topMatches: JobPosting[];
+  counts: Record<string, number>;
+  hasProfile: boolean;
+  hasActiveTargets: boolean;
 }
 
 interface PipelineStat {
@@ -71,82 +67,12 @@ function scoreBadgeVariant(score: number): 'success' | 'brand' | 'default' {
 
 // -- Component ----------------------------------------------------------------
 
-export default function DashboardPage() {
-  const [loading, setLoading] = useState(true);
-  const [topMatches, setTopMatches] = useState<JobPosting[]>([]);
-  const [counts, setCounts] = useState<Record<string, number>>({});
-  const [hasProfile, setHasProfile] = useState<boolean>(false);
-  const [hasActiveTargets, setHasActiveTargets] = useState<boolean>(false);
-  const { toast } = useToast();
+interface DashboardPageProps {
+  initial: DashboardInitial;
+}
 
-  const fetchData = useCallback(async () => {
-    try {
-      const [topRes, healthRes, targetsRes, ...countResponses] =
-        await Promise.all([
-          fetch('/api/jobs?status=new&sort=score&order=desc&page_size=5'),
-          fetch('/api/career/experience/gap-health'),
-          fetch('/api/targets/mine'),
-          ...PIPELINE_STATS.map(s =>
-            fetch(`/api/jobs?status=${s.status}&page_size=1`)
-          ),
-        ]);
-
-      if (topRes.ok) {
-        const data = (await topRes.json()) as JobsListResponse;
-        setTopMatches(data.postings ?? []);
-      }
-
-      if (healthRes.ok) {
-        setHasProfile(true);
-      }
-
-      if (targetsRes.ok) {
-        const { targets } = (await targetsRes.json()) as {
-          targets: UserTargetWithTarget[];
-        };
-        setHasActiveTargets(targets.some(t => t.user_target.is_active));
-      }
-
-      const newCounts: Record<string, number> = {};
-      await Promise.all(
-        countResponses.map(async (res, i) => {
-          if (res.ok) {
-            const data = (await res.json()) as JobsListResponse;
-            const stat = PIPELINE_STATS[i];
-            if (stat) newCounts[stat.status] = data.total ?? 0;
-          }
-        })
-      );
-      setCounts(newCounts);
-    } catch {
-      toast({ variant: 'error', title: 'Failed to load dashboard data' });
-    } finally {
-      setLoading(false);
-    }
-  }, [toast]);
-
-  useEffect(() => {
-    fetchData();
-  }, [fetchData]);
-
-  // -- Loading state ----------------------------------------------------------
-
-  if (loading) {
-    return (
-      <div className='flex flex-col gap-6'>
-        <div>
-          <Skeleton variant='text' size='lg' className='w-32' />
-          <Skeleton variant='text' className='mt-2 w-56' />
-        </div>
-        <div className='grid grid-cols-2 gap-3 sm:grid-cols-4'>
-          {[0, 1, 2, 3].map(i => (
-            <Skeleton key={i} variant='rectangular' height={88} />
-          ))}
-        </div>
-        <Skeleton variant='rectangular' height={320} />
-      </div>
-    );
-  }
+export default function DashboardPage({ initial }: DashboardPageProps) {
+  const { topMatches, counts, hasProfile, hasActiveTargets } = initial;
 
   // -- Zero state -------------------------------------------------------------
 

--- a/apps/wyrdfold/src/app/(app)/page.tsx
+++ b/apps/wyrdfold/src/app/(app)/page.tsx
@@ -1,10 +1,56 @@
 import type { Metadata } from 'next';
-import DashboardPage from './DashboardPage';
+import { fetchJsonFromWyrdfoldAPI } from '@/lib/api/proxy';
+import DashboardPage, { type DashboardInitial } from './DashboardPage';
+import type { JobPosting } from './jobs/types';
+import type { UserTargetWithTarget } from './targets/types';
 
 export const metadata: Metadata = {
   title: 'Dashboard',
 };
 
-export default function WyrdfoldDashboard() {
-  return <DashboardPage />;
+interface JobsListResponse {
+  postings: JobPosting[];
+  total: number;
+  page: number;
+  page_size: number;
+}
+
+const PIPELINE_STATUSES = ['new', 'saved', 'resume_draft', 'applied'] as const;
+
+export default async function WyrdfoldDashboard() {
+  const [topRes, healthRes, targetsRes, ...countResponses] = await Promise.all([
+    fetchJsonFromWyrdfoldAPI<JobsListResponse>('/jobs', {
+      searchParams: new URLSearchParams({
+        status: 'new',
+        sort: 'score',
+        order: 'desc',
+        page_size: '5',
+      }),
+    }),
+    fetchJsonFromWyrdfoldAPI<unknown>('/experience/gap-health'),
+    fetchJsonFromWyrdfoldAPI<{ targets: UserTargetWithTarget[] }>(
+      '/targets/mine'
+    ),
+    ...PIPELINE_STATUSES.map(status =>
+      fetchJsonFromWyrdfoldAPI<JobsListResponse>('/jobs', {
+        searchParams: new URLSearchParams({ status, page_size: '1' }),
+      })
+    ),
+  ]);
+
+  const counts: Record<string, number> = {};
+  countResponses.forEach((res, i) => {
+    const status = PIPELINE_STATUSES[i];
+    if (status) counts[status] = res?.total ?? 0;
+  });
+
+  const initial: DashboardInitial = {
+    topMatches: topRes?.postings ?? [],
+    counts,
+    hasProfile: healthRes !== null,
+    hasActiveTargets:
+      targetsRes?.targets?.some(t => t.user_target.is_active) ?? false,
+  };
+
+  return <DashboardPage initial={initial} />;
 }

--- a/apps/wyrdfold/src/lib/api/proxy.ts
+++ b/apps/wyrdfold/src/lib/api/proxy.ts
@@ -29,6 +29,45 @@ export async function getAccessToken(): Promise<string | null> {
   }
 }
 
+/**
+ * Server-side JSON GET to wyrdfold-api for use in Server Components.
+ * Returns null on auth failure, network error, or non-OK status — the
+ * caller should fall back to defaults (empty list, "no data" state).
+ *
+ * Bypasses the /api/* route handler so the page doesn't pay an extra
+ * client→Next round-trip; data streams inline with the RSC payload.
+ */
+export async function fetchJsonFromWyrdfoldAPI<T>(
+  path: string,
+  options: { searchParams?: URLSearchParams; timeoutMs?: number } = {}
+): Promise<T | null> {
+  const { searchParams, timeoutMs = DEFAULT_TIMEOUT_MS } = options;
+
+  const accessToken = await getAccessToken();
+  if (accessToken === null) return null;
+
+  const qs = searchParams ? `?${searchParams.toString()}` : '';
+  const url = `${apiBaseUrl()}${path}${qs}`;
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const res = await fetch(url, {
+      method: 'GET',
+      headers: { Authorization: `Bearer ${accessToken}` },
+      signal: controller.signal,
+      cache: 'no-store',
+    });
+    if (!res.ok) return null;
+    return (await res.json()) as T;
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 function unauthorized(): NextResponse {
   return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 }


### PR DESCRIPTION
## Summary

`DashboardPage` was a \`'use client'\` component that mounted, then fired 7 parallel \`fetch('/api/...')\` calls in \`useEffect\`. Each call hopped browser → \`/api/*\` route handler → middleware → \`wyrdfold-api\` → DB, and the user stared at a skeleton until all 7 resolved.

This PR moves the initial data fetch to the \`(app)/page.tsx\` server component:

- **New helper** \`fetchJsonFromWyrdfoldAPI<T>(path, options)\` in \`lib/api/proxy.ts\`. Server-only GET to wyrdfold-api with the Supabase JWT, returns \`null\` on auth failure / network error / non-OK so callers fall back to defaults. Bypasses the \`/api/*\` route handler so the page doesn't pay an extra client → Next round-trip.
- **\`page.tsx\`** is now an async server component. Fires the same 7 calls (top matches, gap-health, targets/mine, plus 4 status counts) in \`Promise.all\`, builds a \`DashboardInitial\` shape, and passes it to \`<DashboardPage initial={...} />\`. Data streams inline with the RSC payload.
- **\`DashboardPage.tsx\`** drops \`useEffect\`, \`useToast\`, and the in-component \`loading\` state. It now just consumes the \`initial\` prop and renders. The loading skeleton in \`(app)/loading.tsx\` still covers the actual fetch latency on initial nav.

## Why

This addresses the original \"requests take a long time to resolve\" complaint that #1 (sidebar prefetch) and #634 (drop redundant auth call) didn't cover. The dashboard's data path is now: route render → wyrdfold-api → done. No waterfall after HTML arrives.

## Test plan

- [x] \`nx test wyrdfold\` — 26/26 passing
- [x] \`nx build wyrdfold\` — clean (route shows as ƒ Dynamic)
- [x] \`pnpm tsc --noEmit\` — no new errors
- [x] \`eslint\` — clean
- [ ] Manual: load \`/\` while signed in, verify the four count tiles + top matches render without a skeleton flash
- [ ] Manual: load \`/\` with no profile yet → zero state renders directly
- [ ] Manual: load \`/\` with a wyrdfold-api outage → no white-screen; falls back to zero state (acceptable degraded UX)