### PR TITLE
perf(wyrdfold): fetch /jobs targets in RSC, drop client targets useEffect

### DIFF
--- a/apps/wyrdfold/src/app/(app)/jobs/JobsList.tsx
+++ b/apps/wyrdfold/src/app/(app)/jobs/JobsList.tsx
@@ -3,19 +3,17 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { Heading } from '@danieljoffe.com/shared-ui/Heading';
-import { Skeleton } from '@danieljoffe.com/shared-ui/Skeleton';
 import { Spinner } from '@danieljoffe.com/shared-ui/Spinner';
 import { Text } from '@danieljoffe.com/shared-ui/Text';
 import { Card, CardContent } from '@danieljoffe.com/shared-ui/Card';
 import Button from '@/components/Button';
 import { useToast } from '@/state/Toast/ToastProvider';
 import { cn } from '@/lib/cn';
-import type { UserTargetWithTarget } from '../targets/types';
 import BatchActionBar from './BatchActionBar';
 import JobsListView from './JobsListView';
 import type { JobPosting, JobsFilterState } from './types';
 
-interface TargetTab {
+export interface TargetTab {
   id: string;
   label: string;
 }
@@ -38,12 +36,14 @@ interface JobsListProps {
   targetId: string | undefined;
   initialStatus?: string;
   initialMinScore?: string;
+  initialTargets: TargetTab[];
 }
 
 export default function JobsList({
   targetId,
   initialStatus,
   initialMinScore,
+  initialTargets,
 }: JobsListProps) {
   const [filters, setFilters] = useState<JobsFilterState>(() => {
     const base = targetId ? TARGET_FILTERS : INITIAL_FILTERS;
@@ -61,8 +61,6 @@ export default function JobsList({
   >(undefined);
   const [exporting, setExporting] = useState(false);
   const [visiblePostings, setVisiblePostings] = useState<JobPosting[]>([]);
-  const [targets, setTargets] = useState<TargetTab[]>([]);
-  const [targetsLoading, setTargetsLoading] = useState(true);
   const [activeTargetId, setActiveTargetId] = useState<string | undefined>(
     targetId
   );
@@ -72,34 +70,7 @@ export default function JobsList({
   const { toast } = useToast();
   const router = useRouter();
 
-  // Fetch targets for tab bar — uses the per-user link so tabs reflect
-  // what THIS user has active, not what's globally active across users.
-  useEffect(() => {
-    async function fetchTargets() {
-      try {
-        const res = await fetch('/api/targets/mine');
-        if (!res.ok) return;
-        const { targets } = (await res.json()) as {
-          targets: UserTargetWithTarget[];
-        };
-        const activeTargets: TargetTab[] = targets
-          .filter(t => t.user_target.is_active)
-          .map(t => ({ id: t.target.id, label: t.target.label }));
-        setTargets(activeTargets);
-        if (targetId && !activeTargets.some(t => t.id === targetId)) {
-          // URL target is not active for this user — redirect to All Jobs
-          setActiveTargetId(undefined);
-          setFilters(INITIAL_FILTERS);
-          router.replace('/jobs', { scroll: false });
-        }
-      } catch {
-        // Non-critical — tabs just won't show
-      } finally {
-        setTargetsLoading(false);
-      }
-    }
-    fetchTargets();
-  }, [targetId]);
+  const targets = initialTargets;
 
   // Check target activation status when switching tabs
   useEffect(() => {
@@ -358,13 +329,7 @@ export default function JobsList({
         </Text>
       </div>
 
-      {targetsLoading ? (
-        <div className='flex gap-1 border-b border-border pb-px'>
-          {Array.from({ length: 3 }).map((_, i) => (
-            <Skeleton key={i} variant='rectangular' width={90} height={36} />
-          ))}
-        </div>
-      ) : targets.length === 0 ? (
+      {targets.length === 0 ? (
         <Card>
           <CardContent className='flex flex-col items-center gap-3 py-12'>
             <Text variant='body' as='p'>

--- a/apps/wyrdfold/src/app/(app)/jobs/page.tsx
+++ b/apps/wyrdfold/src/app/(app)/jobs/page.tsx
@@ -1,5 +1,8 @@
 import type { Metadata } from 'next';
-import JobsList from './JobsList';
+import { redirect } from 'next/navigation';
+import { fetchJsonFromWyrdfoldAPI } from '@/lib/api/proxy';
+import type { UserTargetWithTarget } from '../targets/types';
+import JobsList, { type TargetTab } from './JobsList';
 import { JOB_STATUSES, type JobStatus } from './types';
 
 export const metadata: Metadata = {
@@ -30,11 +33,26 @@ export default async function FittedJobsPage({
       ? String(parsedMinScore)
       : '';
 
+  const targetsRes = await fetchJsonFromWyrdfoldAPI<{
+    targets: UserTargetWithTarget[];
+  }>('/targets/mine');
+  const initialTargets: TargetTab[] = (targetsRes?.targets ?? [])
+    .filter(t => t.user_target.is_active)
+    .map(t => ({ id: t.target.id, label: t.target.label }));
+
+  // If the URL points to a target this user doesn't have active, drop the
+  // filter rather than rendering an empty list. Server-side redirect avoids
+  // a render → effect → client redirect waterfall.
+  if (targetId && !initialTargets.some(t => t.id === targetId)) {
+    redirect('/jobs');
+  }
+
   return (
     <JobsList
       targetId={targetId}
       initialStatus={initialStatus}
       initialMinScore={initialMinScore}
+      initialTargets={initialTargets}
     />
   );
 }


### PR DESCRIPTION
## Summary

\`JobsList\` was a \`'use client'\` component that mounted, then fired \`/api/targets/mine\` in \`useEffect\` to populate the tab bar — gating the entire jobs shell behind a 3-tab skeleton until the fetch resolved. Worse, when the URL pointed to a target the user no longer had active, the redirect happened only **after** the client-side fetch finished (render → effect → fetch → \`router.replace\`).

This PR moves both to the \`/jobs\` server component:

- **\`page.tsx\`** calls \`fetchJsonFromWyrdfoldAPI<{ targets }>('/targets/mine')\` alongside the search-params parsing — no separate browser round-trip.
- The invalid-\`targetId\` redirect is now \`redirect('/jobs')\` server-side, so it fires before any HTML is sent. No client-side flash.
- **\`JobsList\`** takes \`initialTargets: TargetTab[]\` as a required prop, drops \`targetsLoading\` / \`setTargets\` state and the targets-fetching effect.

The postings list inside \`JobsListView\` still uses its existing client-side \`useAdminTableFetch\` hook for paging / sort / filter reactivity — out of scope for this change.

## Test plan

- [x] \`nx test wyrdfold\` — 26/26 passing
- [x] \`nx build wyrdfold\` — clean
- [x] \`pnpm tsc --noEmit\` — no new errors
- [x] \`eslint\` — only pre-existing warnings on unchanged lines
- [ ] Manual: load \`/jobs\` and verify the tab bar renders immediately without a skeleton flash
- [ ] Manual: load \`/jobs?target=\` with a stale/inactive target id → server-side redirect to \`/jobs\`
- [ ] Manual: with no active targets → empty state renders directly
- [ ] Manual: tab switching, batch generate / export / delete still work