### PR TITLE
perf(wyrdfold): fetch /targets list in RSC, drop client targets useEffect

### DIFF
--- a/apps/wyrdfold/src/app/(app)/targets/TargetsList.tsx
+++ b/apps/wyrdfold/src/app/(app)/targets/TargetsList.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { Plus, Sparkles } from 'lucide-react';
 import { Badge } from '@danieljoffe.com/shared-ui/Badge';
@@ -8,7 +8,6 @@ import { Heading } from '@danieljoffe.com/shared-ui/Heading';
 import { Spinner } from '@danieljoffe.com/shared-ui/Spinner';
 import { Text } from '@danieljoffe.com/shared-ui/Text';
 import { Card, CardContent } from '@danieljoffe.com/shared-ui/Card';
-import { Skeleton } from '@danieljoffe.com/shared-ui/Skeleton';
 import Button from '@/components/Button';
 import { useToast } from '@/state/Toast/ToastProvider';
 import TargetCard from './TargetCard';
@@ -30,13 +29,19 @@ interface PendingTarget {
   label: string;
 }
 
-export default function TargetsList() {
-  const [targets, setTargets] = useState<UserTargetWithTarget[]>([]);
-  const [loading, setLoading] = useState(true);
+interface TargetsListProps {
+  initialTargets: UserTargetWithTarget[];
+}
+
+export default function TargetsList({ initialTargets }: TargetsListProps) {
+  const [targets, setTargets] =
+    useState<UserTargetWithTarget[]>(initialTargets);
   const [modalOpen, setModalOpen] = useState(false);
   const { toast } = useToast();
   const router = useRouter();
 
+  // Re-fetch after mutating actions (activate/deactivate/delete) so the cards
+  // pick up server-derived state (fit score, activation status, etc.).
   const fetchTargets = useCallback(async () => {
     try {
       const res = await fetch('/api/targets/mine');
@@ -47,14 +52,8 @@ export default function TargetsList() {
       setTargets(targets);
     } catch {
       toast({ variant: 'error', title: 'Failed to load targets' });
-    } finally {
-      setLoading(false);
     }
   }, [toast]);
-
-  useEffect(() => {
-    fetchTargets();
-  }, [fetchTargets]);
 
   const handleActivate = useCallback(
     async (id: string) => {
@@ -268,32 +267,6 @@ export default function TargetsList() {
     },
     [toast]
   );
-
-  if (loading) {
-    return (
-      <div className='flex flex-col gap-6' aria-label='Loading targets'>
-        <div className='flex items-center justify-between'>
-          <Skeleton width={120} height={28} />
-          <Skeleton variant='rectangular' width={110} height={36} />
-        </div>
-        <div className='grid gap-4 sm:grid-cols-2 lg:grid-cols-3'>
-          {Array.from({ length: 3 }).map((_, i) => (
-            <Card key={i} padding='none'>
-              <CardContent className='flex flex-col gap-2.5 p-4'>
-                <Skeleton width='70%' size='sm' />
-                <hr className='-mx-4 border-border' />
-                <Skeleton variant='text' lines={3} />
-                <hr className='-mx-4 border-border' />
-                <div className='flex justify-end'>
-                  <Skeleton width={60} size='sm' />
-                </div>
-              </CardContent>
-            </Card>
-          ))}
-        </div>
-      </div>
-    );
-  }
 
   const hasContent = targets.length > 0 || pendingTargets.length > 0;
 

--- a/apps/wyrdfold/src/app/(app)/targets/page.tsx
+++ b/apps/wyrdfold/src/app/(app)/targets/page.tsx
@@ -1,10 +1,17 @@
 import type { Metadata } from 'next';
+import { fetchJsonFromWyrdfoldAPI } from '@/lib/api/proxy';
 import TargetsList from './TargetsList';
+import type { UserTargetWithTarget } from './types';
 
 export const metadata: Metadata = {
   title: 'Targets',
 };
 
-export default function FittedTargetsPage() {
-  return <TargetsList />;
+export default async function FittedTargetsPage() {
+  const res = await fetchJsonFromWyrdfoldAPI<{
+    targets: UserTargetWithTarget[];
+  }>('/targets/mine');
+  const initialTargets = res?.targets ?? [];
+
+  return <TargetsList initialTargets={initialTargets} />;
 }


### PR DESCRIPTION
## Summary

\`TargetsList\` mounted, then fired \`/api/targets/mine\` in \`useEffect\` to populate the cards — same pattern as the dashboard / jobs work. The user saw a 3-card skeleton until the fetch resolved.

This PR moves the initial fetch to \`/targets/page.tsx\`:

- Server component calls \`fetchJsonFromWyrdfoldAPI<{ targets }>('/targets/mine')\` and passes \`initialTargets\` to \`<TargetsList>\`. Cards stream inline with the RSC payload.
- \`TargetsList\` takes \`initialTargets\` as a required prop and seeds \`useState\` from it.
- \`fetchTargets\` stays as a re-fetch helper for activate / deactivate / delete actions (still needs to be client-side since it runs after a mutation).
- Drops the loading skeleton block, the \`loading\` state, and the initial-load \`useEffect\`.

## Test plan

- [x] \`nx test wyrdfold\` — all passing
- [x] \`nx build wyrdfold\` — clean
- [x] \`pnpm tsc --noEmit\` — no new errors
- [x] \`eslint\` — only a pre-existing warning on \`match.matched_target!\` in \`handleAddSuggestion\` (unchanged)
- [ ] Manual: load \`/targets\`, cards render directly without a skeleton flash
- [ ] Manual: activate/deactivate/delete a target → list refetches and reflects new state
- [ ] Manual: create a target via the modal → optimistic insert + toast still works
- [ ] Manual: with no targets → empty state renders directly