### PR TITLE
perf(wyrdfold): stream /targets shell, suspend only the data section

### DIFF
--- a/apps/wyrdfold/src/app/(app)/targets/TargetsList.tsx
+++ b/apps/wyrdfold/src/app/(app)/targets/TargetsList.tsx
@@ -272,16 +272,8 @@ export default function TargetsList({ initialTargets }: TargetsListProps) {
 
   return (
     <div className='flex flex-col gap-6'>
-      <div className='flex items-start justify-between gap-3'>
-        <div>
-          <Heading variant='hero' as='h1'>
-            Targets
-          </Heading>
-          <Text variant='body' className='mt-1 text-text-secondary'>
-            Role profiles you score new jobs against
-          </Text>
-        </div>
-        {hasContent && (
+      {hasContent && (
+        <div className='flex justify-end'>
           <Button
             name='target-create'
             variant='primary'
@@ -293,8 +285,8 @@ export default function TargetsList({ initialTargets }: TargetsListProps) {
           >
             <Plus className='size-4' aria-hidden />
           </Button>
-        )}
-      </div>
+        </div>
+      )}
 
       {!hasContent ? (
         <Card>

--- a/apps/wyrdfold/src/app/(app)/targets/loading.tsx
+++ b/apps/wyrdfold/src/app/(app)/targets/loading.tsx
@@ -1,12 +1,21 @@
+import { Heading } from '@danieljoffe.com/shared-ui/Heading';
+import { Text } from '@danieljoffe.com/shared-ui/Text';
 import { Card, CardContent } from '@danieljoffe.com/shared-ui/Card';
 import { Skeleton } from '@danieljoffe.com/shared-ui/Skeleton';
 
 export default function FittedTargetsLoading() {
   return (
     <div className='flex flex-col gap-6' aria-label='Loading targets'>
-      <div className='flex items-center justify-between'>
-        <Skeleton width={120} height={28} />
-        <Skeleton variant='rectangular' width={110} height={36} />
+      <div>
+        <Heading variant='hero' as='h1'>
+          Targets
+        </Heading>
+        <Text variant='body' className='mt-1 text-text-secondary'>
+          Role profiles you score new jobs against
+        </Text>
+      </div>
+      <div className='flex justify-end'>
+        <Skeleton variant='rectangular' width={36} height={36} />
       </div>
       <div className='grid gap-4 sm:grid-cols-2 lg:grid-cols-3'>
         {Array.from({ length: 3 }).map((_, i) => (

--- a/apps/wyrdfold/src/app/(app)/targets/page.tsx
+++ b/apps/wyrdfold/src/app/(app)/targets/page.tsx
@@ -1,4 +1,9 @@
+import { Suspense } from 'react';
 import type { Metadata } from 'next';
+import { Heading } from '@danieljoffe.com/shared-ui/Heading';
+import { Text } from '@danieljoffe.com/shared-ui/Text';
+import { Card, CardContent } from '@danieljoffe.com/shared-ui/Card';
+import { Skeleton } from '@danieljoffe.com/shared-ui/Skeleton';
 import { fetchJsonFromWyrdfoldAPI } from '@/lib/api/proxy';
 import TargetsList from './TargetsList';
 import type { UserTargetWithTarget } from './types';
@@ -7,11 +12,53 @@ export const metadata: Metadata = {
   title: 'Targets',
 };
 
-export default async function FittedTargetsPage() {
+export default function FittedTargetsPage() {
+  return (
+    <div className='flex flex-col gap-6'>
+      <div>
+        <Heading variant='hero' as='h1'>
+          Targets
+        </Heading>
+        <Text variant='body' className='mt-1 text-text-secondary'>
+          Role profiles you score new jobs against
+        </Text>
+      </div>
+      <Suspense fallback={<TargetsCardsSkeleton />}>
+        <TargetsLoader />
+      </Suspense>
+    </div>
+  );
+}
+
+async function TargetsLoader() {
   const res = await fetchJsonFromWyrdfoldAPI<{
     targets: UserTargetWithTarget[];
   }>('/targets/mine');
   const initialTargets = res?.targets ?? [];
-
   return <TargetsList initialTargets={initialTargets} />;
+}
+
+function TargetsCardsSkeleton() {
+  return (
+    <div className='flex flex-col gap-6' aria-label='Loading targets'>
+      <div className='flex justify-end'>
+        <Skeleton variant='rectangular' width={36} height={36} />
+      </div>
+      <div className='grid gap-4 sm:grid-cols-2 lg:grid-cols-3'>
+        {Array.from({ length: 3 }).map((_, i) => (
+          <Card key={i} padding='none'>
+            <CardContent className='flex flex-col gap-2.5 p-4'>
+              <Skeleton width='70%' size='sm' />
+              <hr className='-mx-4 border-border' />
+              <Skeleton variant='text' lines={3} />
+              <hr className='-mx-4 border-border' />
+              <div className='flex justify-end'>
+                <Skeleton width={60} size='sm' />
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary

Server log on a real \`/targets\` request: \`200 in 57s (compile: 3.9s, proxy.ts: 4.2s, render: 49s)\`. The 49s render was a single \`await fetchJsonFromWyrdfoldAPI('/targets/mine')\` blocking the entire page — including the heading — behind upstream latency. The user saw \`(app)/targets/loading.tsx\` for the full duration.

This PR moves the static shell out of the data path:

- **\`page.tsx\`** is now synchronous. It renders \`<Heading>Targets</Heading>\` + the descriptive text, then a \`<Suspense fallback={<TargetsCardsSkeleton />}>\` wrapping an async \`<TargetsLoader>\`. Next can flush the heading immediately; only the cards section is suspended on the upstream.
- **\`TargetsList\`** drops its heading + description block. The create button (still \`hasContent\`-gated) moves above the cards on its own right-aligned row.
- **\`loading.tsx\`** mirrors the new shell so the compile→render handoff doesn't flash. Real heading text + the same cards skeleton.

## What this does and doesn't fix

- ✅ User sees the heading the moment compile completes — they know where they landed.
- ✅ Sets up the pattern for the same fix on \`/jobs\` and \`/\` (dashboard).
- ❌ Does **not** make wyrdfold-api faster. The 49s upstream wait is a separate problem (likely single-worker uvicorn + RSC fetch storm from sidebar prefetch). Fixes for that:
  - Run wyrdfold-api with \`--workers 4\`.
  - Investigate why \`/targets/mine\` was 49s when an earlier call to the same endpoint from \`/jobs\` was 287ms — possibly cold-cache, queueing, or a runaway query.
  - Consider \`prefetch={false}\` on sidebar links in dev to stop the prefetch storm.

## Test plan

- [x] \`nx test wyrdfold\` — all passing
- [x] \`nx build wyrdfold\` — clean
- [x] \`pnpm tsc --noEmit\` — no new errors
- [x] \`eslint\` — only the pre-existing \`match.matched_target!\` warning
- [ ] Manual: load \`/targets\` cold, confirm heading appears before cards (cards-skeleton shows in their place)
- [ ] Manual: with no targets, empty state still renders
- [ ] Manual: create target via modal still works (button moved location, but interaction unchanged)