### PR TITLE
chore(wyrdfold): add turbopack: {} block for parity with apps/root

### DIFF
--- a/apps/wyrdfold/next.config.mjs
+++ b/apps/wyrdfold/next.config.mjs
@@ -129,6 +129,13 @@ const nextConfig = {
     ];
     return config;
   },
+  // Turbopack uses the package.json `exports` field directly, so workspace
+  // resolution works via the `default` condition (the built dist) rather
+  // than the custom `@danieljoffe.com/source` condition wired up in the
+  // webpack block above. No SVG-as-component loader rules are needed since
+  // wyrdfold imports SVG icons via lucide-react components, not file imports.
+  // Block is here for parity with apps/root/next.config.mjs.
+  turbopack: {},
 
   productionBrowserSourceMaps: false,
 };


### PR DESCRIPTION
## Summary

\`apps/root/next.config.mjs\` declares a \`turbopack:\` block alongside its \`webpack:\` block — making it explicit that the app is configured for both bundlers. \`apps/wyrdfold/next.config.mjs\` only had \`webpack:\`, which read like webpack-only even though the app actually runs on Turbopack in dev and build (neither nx target overrides to \`--webpack\`).

This adds an empty \`turbopack: {}\` block with a comment explaining there's nothing wyrdfold-specific to put there:

- Workspace package resolution falls through to the \`default\` condition in shared-ui's \`exports\` (the built dist), so the custom \`@danieljoffe.com/source\` condition wired up in the webpack block doesn't have a Turbopack equivalent that's needed.
- No SVG-as-React-component loader rules are needed (icons come from \`lucide-react\`, not file imports).

No behavior change — purely structural parity so the bundler intent is visible in the config.

## Context

Came out of debugging a wyrdfold dev slowdown that turned out to be a stale \`.next\` cache, not a config problem. Worth keeping the parity change anyway since it makes wyrdfold's bundler story line up with root's.

## Test plan

- [x] \`pnpm tsc --noEmit -p apps/wyrdfold/tsconfig.json\` — clean
- [x] No runtime behavior change to verify