### PR TITLE
chore(wyrdfold): add vercel.json (cron + cache headers)

### DIFF
--- a/apps/wyrdfold/vercel.json
+++ b/apps/wyrdfold/vercel.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "nextjs",
+  "headers": [
+    {
+      "source": "/_next/static/css/(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        }
+      ]
+    }
+  ],
+  "crons": [
+    {
+      "path": "/api/jobs/poll",
+      "schedule": "0 9 * * *"
+    }
+  ]
+}


### PR DESCRIPTION
Mirrors apps/root/vercel.json shape:
- `framework: nextjs`
- Long-term cache headers on `/_next/static/css/*`
- Cron for `/api/jobs/poll` daily at 09:00 UTC (Vercel Cron auto-attaches `Authorization: Bearer $CRON_SECRET`; the BFF poll route already accepts that path from Phase 4.5)

Required for Vercel deploy of the wyrdfold BFF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)