### PR TITLE
fix(db): pin search_path on insights_score_stats and insights_trends

### DIFF
--- a/supabase/migrations/20260420140000_create_insights_score_stats_fn.sql
+++ b/supabase/migrations/20260420140000_create_insights_score_stats_fn.sql
@@ -21,6 +21,7 @@ RETURNS TABLE (
 )
 LANGUAGE sql
 STABLE
+SET search_path = public
 AS $$
   SELECT
     ROUND(AVG(score_performance)::numeric, 1) AS avg_performance,

--- a/supabase/migrations/20260420150000_create_insights_trends_fn.sql
+++ b/supabase/migrations/20260420150000_create_insights_trends_fn.sql
@@ -17,6 +17,7 @@ RETURNS TABLE (
 )
 LANGUAGE sql
 STABLE
+SET search_path = public
 AS $$
   SELECT
     date_trunc(bucket_interval, completed_at) AS bucket_start,

--- a/supabase/migrations/20260420180000_guard_insights_function_inputs.sql
+++ b/supabase/migrations/20260420180000_guard_insights_function_inputs.sql
@@ -17,6 +17,7 @@ RETURNS TABLE (
 )
 LANGUAGE plpgsql
 STABLE
+SET search_path = public
 AS $$
 BEGIN
   IF bucket_interval NOT IN ('week', 'month') THEN
@@ -67,6 +68,7 @@ RETURNS TABLE (
 )
 LANGUAGE plpgsql
 STABLE
+SET search_path = public
 AS $$
 BEGIN
   IF period_days IS NOT NULL AND (period_days < 1 OR period_days > 365) THEN

--- a/supabase/migrations/20260506140000_pin_insights_fn_search_path.sql
+++ b/supabase/migrations/20260506140000_pin_insights_fn_search_path.sql
@@ -1,0 +1,11 @@
+-- Pin search_path on the two insights functions to clear Supabase database
+-- linter rule 0011 (function_search_path_mutable). The function definitions
+-- in 20260420140000, 20260420150000, and 20260420180000 were updated inline
+-- so a fresh `pnpm db:reset` produces clean functions; this ALTER catches
+-- existing remote state where those migrations already ran.
+--
+-- search_path = public is sufficient: pg_catalog is implicitly first, and
+-- both functions reference only `public.scans` plus pg_catalog primitives.
+
+ALTER FUNCTION public.insights_score_stats(int) SET search_path = public;
+ALTER FUNCTION public.insights_trends(text, int) SET search_path = public;


### PR DESCRIPTION
## Summary

Production's Supabase database linter flags `public.insights_score_stats` and `public.insights_trends` with rule 0011 (`function_search_path_mutable`). Both are defined in this repo without an explicit `search_path`, so they inherit the caller's role-mutable value.

This PR adds `SET search_path = public` to both function definitions:

- Updates the original source migrations (`20260420140000_*`, `20260420150000_*`) and the later `20260420180000_guard_insights_function_inputs.sql` (which `CREATE OR REPLACE`s both with bounds checks) so a fresh `pnpm db:reset` produces clean functions.
- Adds `20260506140000_pin_insights_fn_search_path.sql` — a small `ALTER FUNCTION` migration to clear the warning on existing remote state where the prior migrations already ran.

`search_path = public` is sufficient: `pg_catalog` is implicitly first, and both functions reference only `public.scans` plus `pg_catalog` primitives (`AVG`, `ROUND`, `COALESCE`, `date_trunc`, `NOW`, `RAISE`).

The three `security_definer_view` ERRORs surfaced alongside these warnings on production are not addressed here — they're already fixed by PR #643 and will clear when `wyrdfold` lands on `main`.

## Test plan

- [ ] `pnpm db:push` applies cleanly against the linked Supabase project
- [ ] Re-run the database linter — the two `function_search_path_mutable` warnings on `insights_score_stats` and `insights_trends` are gone
- [ ] `/api/audit/insights/scores` and `/api/audit/insights/trends` still respond correctly (functions unchanged in behaviour)

https://claude.ai/code/session_01XN5tZMudekCtyA2y5AUMzm

---
_Generated by [Claude Code](https://claude.ai/code/session_01XN5tZMudekCtyA2y5AUMzm)_