### PR TITLE
feat(wyrdfold): gate magic-link login behind beta invite allowlist

### DIFF
--- a/apps/wyrdfold/package.json
+++ b/apps/wyrdfold/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "build": "next build",
     "dev": "next dev",
+    "invite-beta": "tsx scripts/invite-beta-tester.ts",
     "start": "next start"
   },
   "dependencies": {

--- a/apps/wyrdfold/scripts/invite-beta-tester.ts
+++ b/apps/wyrdfold/scripts/invite-beta-tester.ts
@@ -1,0 +1,58 @@
+/**
+ * Invite a beta tester to the wyrdfold app.
+ *
+ * Inserts the email into public.wyrdfold_beta_invites first so the
+ * before-user-created auth hook (hook_restrict_wyrdfold_beta) lets the
+ * subsequent admin invite through. Then calls the GoTrue admin API to send
+ * the invitation email, which seeds the auth.users row.
+ *
+ * Usage:
+ *   SUPABASE_URL=... \
+ *   SUPABASE_SERVICE_ROLE_KEY=... \
+ *   pnpm --filter @danieljoffe.com/wyrdfold invite-beta tester@example.com
+ */
+
+import { createClient } from '@supabase/supabase-js';
+
+const REDIRECT_TO = 'https://wyrdfold.com/auth/callback';
+
+async function main(): Promise<void> {
+  const rawEmail = process.argv[2];
+  if (!rawEmail) {
+    throw new Error('Usage: pnpm invite-beta <email>');
+  }
+  const email = rawEmail.trim().toLowerCase();
+
+  const url = process.env.SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !serviceRoleKey) {
+    throw new Error(
+      'SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY must be set in the environment.'
+    );
+  }
+
+  const admin = createClient(url, serviceRoleKey, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+
+  const { error: insertErr } = await admin
+    .from('wyrdfold_beta_invites')
+    .upsert({ email });
+  if (insertErr) {
+    throw new Error(`Failed to upsert allowlist row: ${insertErr.message}`);
+  }
+
+  const { data, error } = await admin.auth.admin.inviteUserByEmail(email, {
+    redirectTo: REDIRECT_TO,
+  });
+  if (error) {
+    throw new Error(`inviteUserByEmail failed: ${error.message}`);
+  }
+
+  console.log(`Invited ${data.user?.email ?? email}`);
+}
+
+main().catch(err => {
+  console.error(err instanceof Error ? err.message : err);
+  process.exit(1);
+});

--- a/apps/wyrdfold/src/app/login/MagicLinkForm.tsx
+++ b/apps/wyrdfold/src/app/login/MagicLinkForm.tsx
@@ -37,6 +37,22 @@ function stashNextInCookie(next: string): void {
   document.cookie = `${NEXT_COOKIE}=${encodeURIComponent(next)}; max-age=${NEXT_COOKIE_MAX_AGE_S}; path=/; samesite=lax`;
 }
 
+// Wyrdfold is invite-only during the beta. The login form sends
+// `shouldCreateUser: false`, so non-invited emails get rejected by GoTrue
+// (or by the before-user-created hook) with one of these messages. Translate
+// to copy that hints at the invite gate without leaking which path failed.
+function friendlyAuthError(message: string): string {
+  const lower = message.toLowerCase();
+  if (
+    lower.includes('signups not allowed') ||
+    lower.includes('not on the wyrdfold beta list') ||
+    lower.includes('user not found')
+  ) {
+    return "This email isn't on the beta list yet. If you think it should be, reply to your invitation.";
+  }
+  return message;
+}
+
 export default function MagicLinkForm({ next }: MagicLinkFormProps) {
   const [email, setEmail] = useState('');
   const [formState, setFormState] = useState<FormState>('idle');
@@ -64,11 +80,12 @@ export default function MagicLinkForm({ next }: MagicLinkFormProps) {
       email,
       options: {
         emailRedirectTo: `${window.location.origin}/auth/callback`,
+        shouldCreateUser: false,
       },
     });
 
     if (authError) {
-      setError(authError.message);
+      setError(friendlyAuthError(authError.message));
       setFormState('error');
     } else {
       setFormState('sent');

--- a/supabase/migrations/20260506150000_wyrdfold_beta_allowlist.sql
+++ b/supabase/migrations/20260506150000_wyrdfold_beta_allowlist.sql
@@ -1,0 +1,61 @@
+-- Beta allowlist for the wyrdfold app. Populated by the invite script before
+-- the admin invite call so the before-user-created auth hook lets the email
+-- through. Combined with `shouldCreateUser: false` on the magic-link form, no
+-- account can be created for an email that isn't in this table.
+--
+-- Service-role only: RLS is enabled with no anon/authenticated policies. The
+-- hook function reads the table via the supabase_auth_admin grant.
+
+CREATE TABLE public.wyrdfold_beta_invites (
+  email text PRIMARY KEY,
+  invited_at timestamptz NOT NULL DEFAULT now(),
+  accepted_at timestamptz
+);
+
+ALTER TABLE public.wyrdfold_beta_invites ENABLE ROW LEVEL SECURITY;
+
+-- Auth hook called by GoTrue before every user-creation request. Receives the
+-- event as jsonb (shape documented at
+-- https://supabase.com/docs/guides/auth/auth-hooks/before-user-created-hook).
+-- Returns {} to allow, {error: {message, http_code}} to reject. Email is
+-- lowercased on both sides so the comparison is case-insensitive.
+CREATE OR REPLACE FUNCTION public.hook_restrict_wyrdfold_beta(event jsonb)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  user_email text;
+BEGIN
+  user_email := lower(event->'user'->>'email');
+
+  IF user_email IS NULL THEN
+    RETURN jsonb_build_object(
+      'error', jsonb_build_object(
+        'message', 'Email is required to sign up.',
+        'http_code', 400
+      )
+    );
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM public.wyrdfold_beta_invites
+    WHERE lower(email) = user_email
+  ) THEN
+    RETURN jsonb_build_object(
+      'error', jsonb_build_object(
+        'message', 'This email is not on the wyrdfold beta list.',
+        'http_code', 403
+      )
+    );
+  END IF;
+
+  RETURN '{}'::jsonb;
+END;
+$$;
+
+GRANT ALL ON TABLE public.wyrdfold_beta_invites TO supabase_auth_admin;
+GRANT EXECUTE ON FUNCTION public.hook_restrict_wyrdfold_beta TO supabase_auth_admin;
+REVOKE EXECUTE ON FUNCTION public.hook_restrict_wyrdfold_beta
+  FROM authenticated, anon, public;


### PR DESCRIPTION
## Summary

Locks down the wyrdfold magic-link login to a beta invite allowlist so the app can run with a controlled tester pool.

### Two layers, server-enforced

1. **`before-user-created` Auth Hook + allowlist table** — new migration `supabase/migrations/20260506150000_wyrdfold_beta_allowlist.sql` adds `public.wyrdfold_beta_invites` (RLS on, service-role only) and `hook_restrict_wyrdfold_beta(event jsonb) returns jsonb`. The hook rejects any user-creation request whose email isn't in the allowlist with a 403. Granted to `supabase_auth_admin`, revoked from `public/anon/authenticated`, `SET search_path = public`.

2. **Client `shouldCreateUser: false`** — `MagicLinkForm.tsx` sends the flag so non-invited emails get rejected by GoTrue without ever attempting account creation. The error message is mapped to friendly copy via a small `friendlyAuthError` helper that catches the GoTrue `Signups not allowed for otp` / `User not found` / `not on the wyrdfold beta list` variants.

### Invite flow

`apps/wyrdfold/scripts/invite-beta-tester.ts` (runnable via `pnpm --filter @danieljoffe.com/wyrdfold invite-beta <email>`):

1. Reads `SUPABASE_URL` + `SUPABASE_SERVICE_ROLE_KEY` from env (no client bundling).
2. Upserts the email into `wyrdfold_beta_invites` so the hook lets the next step through.
3. Calls `supabase.auth.admin.inviteUserByEmail(email, { redirectTo: 'https://wyrdfold.com/auth/callback' })`, which sends the Supabase invite email and seeds `auth.users`.

### Manual step after merge

The `before-user-created` hook needs to be **enabled** at **Authentication → Hooks** in the Supabase dashboard once the migration applies. Settings:

- Hook type: Postgres function
- Schema: `public`
- Function: `hook_restrict_wyrdfold_beta`

The function itself ships in this PR; only the hook registration is dashboard-side.

[Source: Before User Created Hook | Supabase Docs](https://supabase.com/docs/guides/auth/auth-hooks/before-user-created-hook)
[Source: Passwordless email logins | Supabase Docs](https://supabase.com/docs/guides/auth/auth-email-passwordless)

## Test plan

- [ ] `pnpm db:push` applies cleanly against the linked Supabase project
- [ ] Enable the `before-user-created` hook in the dashboard
- [ ] Submit a non-invited email on `/login` → see "isn't on the beta list" copy, no `auth.users` row created
- [ ] `pnpm --filter @danieljoffe.com/wyrdfold invite-beta you@yourdomain.com` → invite email arrives
- [ ] Click the invite link → land on `/auth/callback` → session established, magic-link login works on subsequent attempts

https://claude.ai/code/session_01XN5tZMudekCtyA2y5AUMzm

---
_Generated by [Claude Code](https://claude.ai/code/session_01XN5tZMudekCtyA2y5AUMzm)_