### PR TITLE
chore(audit-api): align with wyrdfold-api conventions

### DIFF
--- a/apps/audit-api/app/dependencies.py
+++ b/apps/audit-api/app/dependencies.py
@@ -1,10 +1,13 @@
 import hmac
+import logging
 
 import jwt
 from fastapi import Depends, HTTPException, Request, Security
 from fastapi.security import APIKeyHeader
 
 from app.config import Settings, settings
+
+logger = logging.getLogger(__name__)
 
 api_key_header = APIKeyHeader(name="x-api-key", auto_error=False)
 
@@ -75,8 +78,15 @@ def verify_api_key_or_session(
                     algorithms=["HS256"],
                     options={"require": ["exp", "sub"]},
                 )
-            except jwt.PyJWTError:
-                pass
+            except jwt.PyJWTError as exc:
+                # Log decode failures so spikes of invalid tokens are
+                # visible in observability — silent swallow is a
+                # detection blind spot. Mirrors the wyrdfold-api pattern.
+                logger.warning(
+                    "auth_jwt_decode_failed path=%s reason=%s",
+                    request.url.path,
+                    exc,
+                )
             else:
                 if payload.get("sub") == "tools-admin":
                     return "session"

--- a/apps/audit-api/app/main.py
+++ b/apps/audit-api/app/main.py
@@ -1,7 +1,9 @@
+import logging
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.responses import JSONResponse
 from starlette.middleware.trustedhost import TrustedHostMiddleware
 
 from app.config import settings
@@ -10,6 +12,8 @@ from app.routers import run_scan as run_scan_router
 from app.schemas import HealthResponse
 from app.services.browser_pool import get_browser_pool
 from app.services.scan_queue import get_queue
+
+_log = logging.getLogger("app")
 
 if not settings.allowed_hosts_list:
     raise RuntimeError(
@@ -42,6 +46,31 @@ app.add_middleware(
     TrustedHostMiddleware,
     allowed_hosts=settings.allowed_hosts_list,
 )
+
+
+@app.exception_handler(Exception)
+async def _unhandled_exception_handler(request: Request, exc: Exception) -> JSONResponse:
+    """Log full traceback and return a JSON 500.
+
+    Without this, Starlette's default handler returns plain-text
+    "Internal Server Error", which trips JSON-only callers (the Next.js
+    BFF). Verbose detail is gated on non-production environments —
+    production gets a generic body so SQL fragments, file paths, or
+    secrets in stringified exceptions don't leak. Mirrors the
+    wyrdfold-api pattern.
+    """
+    if isinstance(exc, HTTPException):
+        raise exc
+
+    _log.exception("unhandled exception on %s %s", request.method, request.url.path)
+    is_production = settings.sentry_environment == "production"
+    body: dict[str, str] = {
+        "detail": "Internal server error"
+        if is_production
+        else f"{type(exc).__name__}: {exc}",
+        "path": request.url.path,
+    }
+    return JSONResponse(status_code=500, content=body)
 
 
 @app.get("/health", response_model=HealthResponse)

--- a/apps/audit-api/app/routers/run_scan.py
+++ b/apps/audit-api/app/routers/run_scan.py
@@ -1,13 +1,17 @@
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, status
 
 from app.dependencies import verify_api_key
 from app.schemas import RunScanRequest, RunScanResponse
 from app.services.scan_queue import ScanJob, ScanQueue, get_queue
 
-router = APIRouter()
+router = APIRouter(tags=["scan"])
 
 
-@router.post("/run-scan", response_model=RunScanResponse)
+@router.post(
+    "/run-scan",
+    response_model=RunScanResponse,
+    status_code=status.HTTP_202_ACCEPTED,
+)
 async def run_scan_endpoint(
     body: RunScanRequest,
     _: str = Depends(verify_api_key),

--- a/apps/audit-api/tests/test_run_scan_route.py
+++ b/apps/audit-api/tests/test_run_scan_route.py
@@ -66,7 +66,8 @@ def test_run_scan_enqueues_job_and_returns_accepted() -> None:
                     "device_mode": "desktop",
                 },
             )
-        assert response.status_code == 200
+        # 202 Accepted — scan is queued for async processing, not completed.
+        assert response.status_code == 202
         assert response.json() == {"status": "accepted", "scan_id": "s1"}
         mock_enqueue.assert_awaited_once()
         enqueued: ScanJob = mock_enqueue.await_args.args[0]


### PR DESCRIPTION
## Summary

Three small alignment fixes surfaced by \`/python-audit\` — patterns wyrdfold-api adopted in Phase 5 that audit-api hadn't picked up.

## Changes

- **JWT decode logging** (\`apps/audit-api/app/dependencies.py\`): \`verify_api_key_or_session\` was swallowing \`jwt.PyJWTError\` silently. Now logs \`auth_jwt_decode_failed\` at WARNING with path + reason so spikes of invalid tokens are visible in observability. Mirrors wyrdfold-api P0-Sec-2.
- **202 Accepted on \`POST /run-scan\`** (\`apps/audit-api/app/routers/run_scan.py\`): the endpoint enqueues an async scan job — 202 matches the semantic. Added \`tags=[\"scan\"]\` for OpenAPI grouping while there.
- **Global exception handler** (\`apps/audit-api/app/main.py\`): without it, Starlette returned plain-text \"Internal Server Error\" on uncaught exceptions, tripping JSON-only callers (the Next.js BFF). Added the same handler wyrdfold-api uses, with prod/dev gated detail leak protection.

## Verification

- audit-api: \`ruff check\` ✓, \`mypy --strict\` ✓, **61 tests pass** (one assertion updated for the 202 status)
- wyrdfold-api: 775 tests pass (untouched)

## Test plan

- [ ] CI lint/typecheck/test pass
- [ ] Manual: hit \`POST /run-scan\` with valid api-key, verify 202 response and queue job lands
- [ ] Manual: invalid Bearer token now produces a WARNING log line

## Findings reported as recommendations (not applied)

- \`audit-api/app/config.py\` could use typed \`SettingsConfigDict\` instead of dict \`model_config\` (cosmetic, both apps)
- \`pyproject.toml\` could \`extend-select = [\"PTH\", \"ASYNC\"]\` for path/async hygiene (both apps)
- mypy could enable \`warn_unreachable = true\` (both apps)
- Settings \`admin_session_secret\` 32-char check is in the dependency layer; could move to a Pydantic validator

These are nice-to-haves, not bugs — left as backlog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)