### PR TITLE
chore(tests): query-pattern hygiene + axe coverage

### DIFF
--- a/apps/root-e2e/src/audit-report.spec.ts
+++ b/apps/root-e2e/src/audit-report.spec.ts
@@ -145,8 +145,10 @@ if (E2E_SCAN_ID) {
     test('network error shows network error message', async ({ page }) => {
       await page.route('**/api/leads/capture', route => route.abort());
 
+      const captureRequest = page.waitForRequest('**/api/leads/capture');
       await fillInput(page.getByLabel('Email address'), 'test@example.com');
       await page.getByRole('button', { name: 'Get full report' }).click();
+      await captureRequest;
 
       await expect(
         page.getByText('Network error. Please try again.')

--- a/apps/root-e2e/src/audit-scan.spec.ts
+++ b/apps/root-e2e/src/audit-scan.spec.ts
@@ -129,8 +129,10 @@ test.describe('audit scan page - form validation', () => {
       name: /audit this site|starting scan/i,
     });
 
+    const scanRequest = page.waitForRequest('**/api/audit/scan');
     await fillInput(input, VALID_AUDIT_URL);
     await button.click();
+    await scanRequest;
 
     await expect(input).toBeDisabled();
     await expect(
@@ -302,8 +304,10 @@ test.describe('audit scan page - error handling', () => {
   test('network error shows network error message', async ({ page }) => {
     await page.route('**/api/audit/scan', route => route.abort());
 
+    const scanRequest = page.waitForRequest('**/api/audit/scan');
     await fillInput(page.getByLabel('Website URL'), VALID_AUDIT_URL);
     await page.getByRole('button', { name: 'Audit this site' }).click();
+    await scanRequest;
 
     await expect(
       page.getByText('Network error. Please try again.')
@@ -359,8 +363,10 @@ test.describe('audit scan page - accessibility', () => {
     // Hang the request to keep submitting state
     await page.route('**/api/audit/scan', async () => undefined);
 
+    const scanRequest = page.waitForRequest('**/api/audit/scan');
     await fillInput(page.getByLabel('Website URL'), VALID_AUDIT_URL);
     await page.getByRole('button', { name: 'Audit this site' }).click();
+    await scanRequest;
 
     await expect(
       page.getByRole('button', { name: /starting scan/i })

--- a/apps/root/src/components/BreadCrumbs.spec.tsx
+++ b/apps/root/src/components/BreadCrumbs.spec.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
+import { axe, toHaveNoViolations } from 'jest-axe';
 import type { NavLink } from '@/types/base';
 import BreadCrumbs from './BreadCrumbs';
+
+expect.extend(toHaveNoViolations);
 
 // Mock next/navigation
 const mockUsePathname = jest.fn();
@@ -78,5 +81,11 @@ describe('BreadCrumbs', () => {
       <BreadCrumbs items={null as unknown as NavLink[]} />
     );
     expect(container.firstChild).toBeNull();
+  });
+
+  test('has no accessibility violations', async () => {
+    mockUsePathname.mockReturnValue('/about');
+    const { container } = render(<BreadCrumbs items={items} />);
+    expect(await axe(container)).toHaveNoViolations();
   });
 });

--- a/apps/root/src/components/Footer/__tests__/index.spec.tsx
+++ b/apps/root/src/components/Footer/__tests__/index.spec.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
+import { axe, toHaveNoViolations } from 'jest-axe';
 import Footer from '../index';
+
+expect.extend(toHaveNoViolations);
 
 // Mock next/link to render a real <a>
 jest.mock('next/link', () => {
@@ -67,5 +70,10 @@ describe('Footer', () => {
     render(<Footer />);
     expect(screen.getByText('Browse the design system')).toBeInTheDocument();
     expect(screen.getByText('ui.danieljoffe.com')).toBeInTheDocument();
+  });
+
+  it('has no accessibility violations', async () => {
+    const { container } = render(<Footer />);
+    expect(await axe(container)).toHaveNoViolations();
   });
 });

--- a/apps/root/src/components/kit/Pagination.spec.tsx
+++ b/apps/root/src/components/kit/Pagination.spec.tsx
@@ -1,6 +1,9 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { axe, toHaveNoViolations } from 'jest-axe';
 import { Pagination } from './Pagination';
+
+expect.extend(toHaveNoViolations);
 
 describe('Pagination', () => {
   it('returns null when there is only one page', () => {
@@ -72,5 +75,17 @@ describe('Pagination', () => {
 
     await user.click(screen.getByRole('button', { name: 'Next' }));
     expect(onPageChange).toHaveBeenCalledWith(3);
+  });
+
+  it('has no accessibility violations', async () => {
+    const { container } = render(
+      <Pagination
+        page={2}
+        totalPages={5}
+        onPageChange={jest.fn()}
+        namePrefix='jobs'
+      />
+    );
+    expect(await axe(container)).toHaveNoViolations();
   });
 });

--- a/apps/root/src/components/kit/PostCard.spec.tsx
+++ b/apps/root/src/components/kit/PostCard.spec.tsx
@@ -1,8 +1,11 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { axe, toHaveNoViolations } from 'jest-axe';
 import { analytics } from '@/lib/analytics';
 import type { PostThumbnail } from '@/types/postTypes';
 import { PostCard } from './PostCard';
+
+expect.extend(toHaveNoViolations);
 
 jest.mock('@/lib/analytics', () => ({
   analytics: {
@@ -53,6 +56,8 @@ describe('PostCard', () => {
   });
 
   it('renders a company logo image when the logo prop is supplied', () => {
+    // CompanyLogo uses alt='' (decorative) — no accessible name, so we
+    // can't query by role. Match the rendered <img src=...> directly.
     const { container } = render(
       <PostCard post={makePost()} logo='/images/acme.png' />
     );
@@ -67,5 +72,10 @@ describe('PostCard', () => {
     await user.click(screen.getByRole('link'));
     expect(analytics.blogClick).toHaveBeenCalledWith('my-post');
     expect(analytics.projectClick).not.toHaveBeenCalled();
+  });
+
+  it('has no accessibility violations', async () => {
+    const { container } = render(<PostCard post={makePost()} />);
+    expect(await axe(container)).toHaveNoViolations();
   });
 });

--- a/apps/root/src/components/kit/PostPagination.spec.tsx
+++ b/apps/root/src/components/kit/PostPagination.spec.tsx
@@ -1,6 +1,9 @@
 import { render, screen } from '@testing-library/react';
+import { axe, toHaveNoViolations } from 'jest-axe';
 import type { PostPaginationData } from '@/data/contentOrder';
 import { PostPagination } from './PostPagination';
+
+expect.extend(toHaveNoViolations);
 
 const pagination: PostPaginationData = {
   prev: {
@@ -31,5 +34,10 @@ describe('PostPagination', () => {
     const next = screen.getByRole('link', { name: /next: next post/i });
     expect(next).toHaveAttribute('href', '/blog/next-post');
     expect(next).toHaveTextContent('Next Post');
+  });
+
+  it('has no accessibility violations', async () => {
+    const { container } = render(<PostPagination pagination={pagination} />);
+    expect(await axe(container)).toHaveNoViolations();
   });
 });

--- a/apps/root/src/components/kit/__tests__/TableOfContents.spec.tsx
+++ b/apps/root/src/components/kit/__tests__/TableOfContents.spec.tsx
@@ -1,5 +1,8 @@
 import { render, screen, fireEvent, act } from '@testing-library/react';
+import { axe, toHaveNoViolations } from 'jest-axe';
 import { TableOfContents } from '../TableOfContents';
+
+expect.extend(toHaveNoViolations);
 
 // Mock useFocusTrap
 jest.mock('@/hooks/useFocusTrap', () => ({
@@ -102,13 +105,9 @@ describe('TableOfContents', () => {
     await act(() => Promise.resolve());
 
     // The heading text appears both in the DOM heading and the TOC button.
-    // Click the TOC button (role=button), not the heading element.
-    const tocButtons = screen.getAllByRole('button');
-    const introButton = tocButtons.find(
-      btn => btn.textContent === 'Introduction'
-    );
-    expect(introButton).toBeDefined();
-    fireEvent.click(introButton!);
+    // `getByRole('button', { name })` throws if missing — implicit assertion.
+    const introButton = screen.getByRole('button', { name: 'Introduction' });
+    fireEvent.click(introButton);
 
     expect(scrollIntoViewMock).toHaveBeenCalledWith(
       expect.objectContaining({ behavior: 'smooth' })
@@ -168,5 +167,11 @@ describe('TableOfContents', () => {
     expect(
       screen.getByRole('button', { name: /open table of contents/i })
     ).toBeInTheDocument();
+  });
+
+  it('has no accessibility violations (desktop)', async () => {
+    const { container: wrapper } = render(<TableOfContents desktop />);
+    await act(() => Promise.resolve());
+    expect(await axe(wrapper)).toHaveNoViolations();
   });
 });

--- a/libs/shared/ui/src/lib/Breadcrumb.spec.tsx
+++ b/libs/shared/ui/src/lib/Breadcrumb.spec.tsx
@@ -1,5 +1,8 @@
 import { render, screen } from '@testing-library/react';
+import { axe, toHaveNoViolations } from 'jest-axe';
 import { Breadcrumb } from './Breadcrumb';
+
+expect.extend(toHaveNoViolations);
 
 describe('Breadcrumb', () => {
   const items = [
@@ -53,5 +56,10 @@ describe('Breadcrumb', () => {
   it('renders as a nav element', () => {
     render(<Breadcrumb items={items} />);
     expect(screen.getByRole('navigation')).toBeInTheDocument();
+  });
+
+  it('has no accessibility violations', async () => {
+    const { container } = render(<Breadcrumb items={items} />);
+    expect(await axe(container)).toHaveNoViolations();
   });
 });

--- a/libs/shared/ui/src/lib/CTACard.spec.tsx
+++ b/libs/shared/ui/src/lib/CTACard.spec.tsx
@@ -1,5 +1,8 @@
 import { render, screen } from '@testing-library/react';
+import { axe, toHaveNoViolations } from 'jest-axe';
 import { CTACard } from './CTACard';
+
+expect.extend(toHaveNoViolations);
 
 describe('CTACard', () => {
   it('renders heading', () => {
@@ -26,7 +29,9 @@ describe('CTACard', () => {
         <button>Click me</button>
       </CTACard>
     );
-    expect(screen.getByText('Click me')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Click me' })
+    ).toBeInTheDocument();
   });
 
   it('applies custom className', () => {
@@ -36,5 +41,14 @@ describe('CTACard', () => {
       </CTACard>
     );
     expect(container.firstChild).toHaveClass('mt-8');
+  });
+
+  it('has no accessibility violations', async () => {
+    const { container } = render(
+      <CTACard heading='Get Started' description='Description'>
+        <button>CTA</button>
+      </CTACard>
+    );
+    expect(await axe(container)).toHaveNoViolations();
   });
 });

--- a/libs/shared/ui/src/lib/Dropdown.spec.tsx
+++ b/libs/shared/ui/src/lib/Dropdown.spec.tsx
@@ -86,7 +86,7 @@ describe('Dropdown', () => {
       />
     );
     fireEvent.click(screen.getByText('Menu'));
-    expect(screen.getByText('Disabled').closest('button')).toHaveAttribute(
+    expect(screen.getByRole('menuitem', { name: 'Disabled' })).toHaveAttribute(
       'aria-disabled',
       'true'
     );
@@ -95,7 +95,7 @@ describe('Dropdown', () => {
   it('applies danger styles to danger items', () => {
     render(<Dropdown trigger={<span>Menu</span>} items={items} />);
     fireEvent.click(screen.getByText('Menu'));
-    expect(screen.getByText('Delete').closest('button')).toHaveClass(
+    expect(screen.getByRole('menuitem', { name: 'Delete' })).toHaveClass(
       'text-error'
     );
   });
@@ -118,7 +118,7 @@ describe('Dropdown', () => {
   it('applies focus-visible ring classes on menu items', () => {
     render(<Dropdown trigger={<span>Menu</span>} items={items} />);
     fireEvent.click(screen.getByText('Menu'));
-    const editButton = screen.getByText('Edit').closest('button')!;
+    const editButton = screen.getByRole('menuitem', { name: 'Edit' });
     expect(editButton.className).toContain('focus-visible:ring-2');
   });
 

--- a/libs/shared/ui/src/lib/Sidebar.spec.tsx
+++ b/libs/shared/ui/src/lib/Sidebar.spec.tsx
@@ -39,7 +39,7 @@ describe('Sidebar', () => {
 
   it('highlights active item', () => {
     render(<Sidebar items={items} activeId='home' />);
-    expect(screen.getByText('Home').closest('button')).toHaveClass(
+    expect(screen.getByRole('button', { name: 'Home' })).toHaveClass(
       'bg-brand-50'
     );
   });
@@ -103,14 +103,14 @@ describe('Sidebar', () => {
 
   it('applies focus-visible ring classes on sidebar buttons', () => {
     render(<Sidebar items={items} />);
-    const homeButton = screen.getByText('Home').closest('button')!;
+    const homeButton = screen.getByRole('button', { name: 'Home' });
     expect(homeButton.className).toContain('focus-visible:ring-2');
   });
 
   it('applies focus-visible ring classes on child items', () => {
     render(<Sidebar items={items} />);
-    fireEvent.click(screen.getByText('Projects'));
-    const childButton = screen.getByText('Project A').closest('button')!;
+    fireEvent.click(screen.getByRole('button', { name: 'Projects' }));
+    const childButton = screen.getByRole('button', { name: 'Project A' });
     expect(childButton.className).toContain('focus-visible:ring-2');
   });
 

--- a/libs/shared/ui/src/lib/ThemeProvider.spec.tsx
+++ b/libs/shared/ui/src/lib/ThemeProvider.spec.tsx
@@ -103,7 +103,7 @@ describe('ThemeProvider', () => {
       </ThemeProvider>
     );
     await act(async () => {
-      screen.getByText('Set Dark').click();
+      screen.getByRole('button', { name: 'Set Dark' }).click();
     });
     expect(localStorage.getItem('theme')).toBe('dark');
   });
@@ -119,7 +119,7 @@ describe('ThemeProvider', () => {
       await new Promise(r => setTimeout(r, 0));
     });
     await act(async () => {
-      screen.getByText('Toggle').click();
+      screen.getByRole('button', { name: 'Toggle' }).click();
     });
     expect(screen.getByTestId('dark')).toHaveTextContent('yes');
   });
@@ -132,7 +132,7 @@ describe('ThemeProvider', () => {
       </ThemeProvider>
     );
     await act(async () => {
-      screen.getByText('Set Dark').click();
+      screen.getByRole('button', { name: 'Set Dark' }).click();
     });
     expect(document.documentElement.classList.contains('dark')).toBe(true);
   });
@@ -146,7 +146,7 @@ describe('ThemeProvider', () => {
       </ThemeProvider>
     );
     await act(async () => {
-      screen.getByText('Set Light').click();
+      screen.getByRole('button', { name: 'Set Light' }).click();
     });
     expect(document.documentElement.classList.contains('dark')).toBe(false);
   });

--- a/libs/shared/ui/src/lib/Tooltip.spec.tsx
+++ b/libs/shared/ui/src/lib/Tooltip.spec.tsx
@@ -25,7 +25,7 @@ describe('Tooltip', () => {
   });
 
   it('renders tooltip element with content', () => {
-    const { container } = render(
+    render(
       <Tooltip content='Tooltip text'>
         <button>Hover me</button>
       </Tooltip>
@@ -36,7 +36,7 @@ describe('Tooltip', () => {
   });
 
   it('tooltip is hidden by default', () => {
-    const { container } = render(
+    render(
       <Tooltip content='Tooltip text'>
         <button>Hover me</button>
       </Tooltip>
@@ -46,7 +46,7 @@ describe('Tooltip', () => {
   });
 
   it('shows tooltip after delay on mouse enter', () => {
-    const { container } = render(
+    render(
       <Tooltip content='Tooltip text' delay={200}>
         <button>Hover me</button>
       </Tooltip>
@@ -64,7 +64,7 @@ describe('Tooltip', () => {
   });
 
   it('hides tooltip on mouse leave', () => {
-    const { container } = render(
+    render(
       <Tooltip content='Tooltip text' delay={200}>
         <button>Hover me</button>
       </Tooltip>
@@ -84,7 +84,7 @@ describe('Tooltip', () => {
   });
 
   it('does not show tooltip if mouse leaves before delay', () => {
-    const { container } = render(
+    render(
       <Tooltip content='Tooltip text' delay={200}>
         <button>Hover me</button>
       </Tooltip>
@@ -108,7 +108,7 @@ describe('Tooltip', () => {
   });
 
   it('shows tooltip on focus', () => {
-    const { container } = render(
+    render(
       <Tooltip content='Tooltip text' delay={200}>
         <button>Hover me</button>
       </Tooltip>
@@ -126,7 +126,7 @@ describe('Tooltip', () => {
   });
 
   it('hides tooltip on blur', () => {
-    const { container } = render(
+    render(
       <Tooltip content='Tooltip text' delay={200}>
         <button>Hover me</button>
       </Tooltip>
@@ -146,7 +146,7 @@ describe('Tooltip', () => {
   });
 
   it('hides tooltip on Escape key', () => {
-    const { container } = render(
+    render(
       <Tooltip content='Tooltip text' delay={200}>
         <button>Hover me</button>
       </Tooltip>
@@ -166,7 +166,7 @@ describe('Tooltip', () => {
   });
 
   it('applies top position with offset and centering by default', () => {
-    const { container } = render(
+    render(
       <Tooltip content='Tooltip text'>
         <button>Hover me</button>
       </Tooltip>
@@ -176,7 +176,7 @@ describe('Tooltip', () => {
   });
 
   it('applies bottom position with offset and centering', () => {
-    const { container } = render(
+    render(
       <Tooltip content='Tooltip text' position='bottom'>
         <button>Hover me</button>
       </Tooltip>
@@ -186,7 +186,7 @@ describe('Tooltip', () => {
   });
 
   it('applies left position with offset and centering', () => {
-    const { container } = render(
+    render(
       <Tooltip content='Tooltip text' position='left'>
         <button>Hover me</button>
       </Tooltip>
@@ -196,7 +196,7 @@ describe('Tooltip', () => {
   });
 
   it('applies right position with offset and centering', () => {
-    const { container } = render(
+    render(
       <Tooltip content='Tooltip text' position='right'>
         <button>Hover me</button>
       </Tooltip>
@@ -206,7 +206,7 @@ describe('Tooltip', () => {
   });
 
   it('uses custom delay', () => {
-    const { container } = render(
+    render(
       <Tooltip content='Tooltip text' delay={500}>
         <button>Hover me</button>
       </Tooltip>
@@ -271,7 +271,7 @@ describe('Tooltip', () => {
   });
 
   it('sets aria-hidden="true" on tooltip when not visible', () => {
-    const { container } = render(
+    render(
       <Tooltip content='Tooltip text'>
         <button>Hover me</button>
       </Tooltip>
@@ -281,7 +281,7 @@ describe('Tooltip', () => {
   });
 
   it('sets aria-hidden="false" on tooltip when visible', () => {
-    const { container } = render(
+    render(
       <Tooltip content='Tooltip text' delay={200}>
         <button>Hover me</button>
       </Tooltip>

--- a/libs/shared/ui/src/lib/Tooltip.spec.tsx
+++ b/libs/shared/ui/src/lib/Tooltip.spec.tsx
@@ -30,7 +30,7 @@ describe('Tooltip', () => {
         <button>Hover me</button>
       </Tooltip>
     );
-    const tooltip = container.querySelector('[role="tooltip"]');
+    const tooltip = screen.getByRole('tooltip', { hidden: true });
     expect(tooltip).toBeInTheDocument();
     expect(screen.getByText('Tooltip text')).toBeInTheDocument();
   });
@@ -41,7 +41,7 @@ describe('Tooltip', () => {
         <button>Hover me</button>
       </Tooltip>
     );
-    const tooltip = container.querySelector('[role="tooltip"]');
+    const tooltip = screen.getByRole('tooltip', { hidden: true });
     expect(tooltip).toHaveClass('opacity-0');
   });
 
@@ -59,7 +59,7 @@ describe('Tooltip', () => {
       jest.advanceTimersByTime(200);
     });
 
-    const tooltip = container.querySelector('[role="tooltip"]');
+    const tooltip = screen.getByRole('tooltip', { hidden: true });
     expect(tooltip).toHaveClass('opacity-100');
   });
 
@@ -79,7 +79,7 @@ describe('Tooltip', () => {
 
     fireEvent.mouseLeave(trigger);
 
-    const tooltip = container.querySelector('[role="tooltip"]');
+    const tooltip = screen.getByRole('tooltip', { hidden: true });
     expect(tooltip).toHaveClass('opacity-0');
   });
 
@@ -103,7 +103,7 @@ describe('Tooltip', () => {
       jest.advanceTimersByTime(100);
     });
 
-    const tooltip = container.querySelector('[role="tooltip"]');
+    const tooltip = screen.getByRole('tooltip', { hidden: true });
     expect(tooltip).toHaveClass('opacity-0');
   });
 
@@ -121,7 +121,7 @@ describe('Tooltip', () => {
       jest.advanceTimersByTime(200);
     });
 
-    const tooltip = container.querySelector('[role="tooltip"]');
+    const tooltip = screen.getByRole('tooltip', { hidden: true });
     expect(tooltip).toHaveClass('opacity-100');
   });
 
@@ -141,7 +141,7 @@ describe('Tooltip', () => {
 
     fireEvent.blur(trigger);
 
-    const tooltip = container.querySelector('[role="tooltip"]');
+    const tooltip = screen.getByRole('tooltip', { hidden: true });
     expect(tooltip).toHaveClass('opacity-0');
   });
 
@@ -161,7 +161,7 @@ describe('Tooltip', () => {
 
     fireEvent.keyDown(trigger, { key: 'Escape' });
 
-    const tooltip = container.querySelector('[role="tooltip"]');
+    const tooltip = screen.getByRole('tooltip', { hidden: true });
     expect(tooltip).toHaveClass('opacity-0');
   });
 
@@ -171,7 +171,7 @@ describe('Tooltip', () => {
         <button>Hover me</button>
       </Tooltip>
     );
-    const tooltip = container.querySelector('[role="tooltip"]');
+    const tooltip = screen.getByRole('tooltip', { hidden: true });
     expect(tooltip).toHaveClass('bottom-full', 'mb-2', '-translate-x-1/2');
   });
 
@@ -181,7 +181,7 @@ describe('Tooltip', () => {
         <button>Hover me</button>
       </Tooltip>
     );
-    const tooltip = container.querySelector('[role="tooltip"]');
+    const tooltip = screen.getByRole('tooltip', { hidden: true });
     expect(tooltip).toHaveClass('top-full', 'mt-2', '-translate-x-1/2');
   });
 
@@ -191,7 +191,7 @@ describe('Tooltip', () => {
         <button>Hover me</button>
       </Tooltip>
     );
-    const tooltip = container.querySelector('[role="tooltip"]');
+    const tooltip = screen.getByRole('tooltip', { hidden: true });
     expect(tooltip).toHaveClass('right-full', 'mr-2', '-translate-y-1/2');
   });
 
@@ -201,7 +201,7 @@ describe('Tooltip', () => {
         <button>Hover me</button>
       </Tooltip>
     );
-    const tooltip = container.querySelector('[role="tooltip"]');
+    const tooltip = screen.getByRole('tooltip', { hidden: true });
     expect(tooltip).toHaveClass('left-full', 'ml-2', '-translate-y-1/2');
   });
 
@@ -213,7 +213,7 @@ describe('Tooltip', () => {
     );
 
     const trigger = screen.getByRole('button');
-    const tooltip = container.querySelector('[role="tooltip"]');
+    const tooltip = screen.getByRole('tooltip', { hidden: true });
 
     fireEvent.mouseEnter(trigger);
 
@@ -257,7 +257,7 @@ describe('Tooltip', () => {
         <button>Hover me</button>
       </Tooltip>
     );
-    const tooltip = container.querySelector('[role="tooltip"]');
+    const tooltip = screen.getByRole('tooltip', { hidden: true });
     const trigger = container.querySelector('[role="presentation"]');
     const button = screen.getByRole('button', { name: 'Hover me' });
 
@@ -276,7 +276,7 @@ describe('Tooltip', () => {
         <button>Hover me</button>
       </Tooltip>
     );
-    const tooltip = container.querySelector('[role="tooltip"]');
+    const tooltip = screen.getByRole('tooltip', { hidden: true });
     expect(tooltip).toHaveAttribute('aria-hidden', 'true');
   });
 
@@ -294,7 +294,7 @@ describe('Tooltip', () => {
       jest.advanceTimersByTime(200);
     });
 
-    const tooltip = container.querySelector('[role="tooltip"]');
+    const tooltip = screen.getByRole('tooltip', { hidden: true });
     expect(tooltip).toHaveAttribute('aria-hidden', 'false');
   });
 


### PR DESCRIPTION
## Summary

Quality fixes from \`/coverage-gaps --quality\` — query patterns + axe coverage gaps. Coverage itself is at 100% across shared-ui / kit / app components / hooks (verified by \`/coverage-gaps\` first), so this PR is purely about test resilience.

## Changes

### Tooltip getByRole migration (1 file, 18 lines)

Replaced \`container.querySelector('[role=\"tooltip\"]')\` with \`screen.getByRole('tooltip', { hidden: true })\` throughout. The tooltip element is always in the DOM but toggles \`aria-hidden\` — \`{ hidden: true }\` keeps the query consistent across both states.

### closest('button') → getByRole (3 files)

\`screen.getByText('X').closest('button')\` patterns replaced with \`screen.getByRole('button'/'menuitem', { name: 'X' })\` in:
- \`Sidebar.spec.tsx\` — 3 instances
- \`Dropdown.spec.tsx\` — 3 instances (items render as \`role='menuitem'\`, not 'button' — caught the mistake on first run)
- \`ThemeProvider.spec.tsx\` — 4 instances of \`getByText('Set Dark').click()\` for in-test buttons

### axe coverage on 8 interactive specs

Added \`expect(await axe(container)).toHaveNoViolations()\` smoke to:
- shared-ui: CTACard, Breadcrumb
- app: BreadCrumbs, Footer
- kit: Pagination, PostCard, PostPagination, TableOfContents

Skipped:
- \`KeyboardShortcuts.spec.tsx\` — renders nothing visible (axe N/A)
- \`Nav/Links.spec.tsx\` — tests constants, no DOM

### TableOfContents toBeDefined → getByRole

\`tocButtons.find(...)\` + \`toBeDefined()\` → direct \`screen.getByRole('button', { name: 'Introduction' })\` (RTL throws on miss; assertion is implicit).

### E2E waitForRequest (4 tests, 2 files)

Tests using \`page.route\` to abort/hang requests now wait on the request explicitly. Previously these tests asserted UI state but never verified the component called the API. If the call ever stopped firing, the tests would still pass against the unhit mock.

- \`audit-scan.spec.ts\`: 3 tests (disabled-while-submitting, network error, button text changes)
- \`audit-report.spec.ts\`: 1 test (network error)

## Verification

- shared-ui: **754 tests pass**
- root: **1024 tests pass**
- typecheck clean

## Findings reviewed but not changed

- \`PostCard.spec.tsx:60\` and \`CompanyLogo.spec.tsx:19\` \`expect(img).not.toBeNull()\` — initially flagged as redundant, but \`container.querySelector\` returns null on no-match (doesn't throw), so the assertion is a meaningful guard. CompanyLogo uses \`alt=''\` (decorative) so role-based queries aren't an option. Left as-is with an explanatory comment.
- \`Section.spec.tsx\`, \`Skeleton.spec.tsx\`, \`Table.spec.tsx\` \`querySelector\` for class/structure checks — no semantic role exists for those queries; acceptable.
- \`PageContainer.spec.tsx\` heavy \`getByTestId\` — PageContainer is a layout primitive without semantic roles; test IDs are justified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)