### PR TITLE
sec: audit-api SSRF + magic-link cookie + anti-enum beta error

### DIFF
--- a/apps/audit-api/app/schemas.py
+++ b/apps/audit-api/app/schemas.py
@@ -4,6 +4,8 @@ from urllib.parse import urlparse
 
 from pydantic import BaseModel, Field, field_validator
 
+from app.services.ssrf_guard import assert_safe_host
+
 _BLOCKED_HOSTNAMES = {
     "localhost",
     "metadata.google.internal",
@@ -30,7 +32,14 @@ class RunScanRequest(BaseModel):
         try:
             ip = ip_address(host)
         except ValueError:
-            pass
+            # Hostname is not a literal IP — DNS-resolve and reject if any
+            # resolved address falls in a disallowed range. Without this,
+            # `metadata.evil.com → 169.254.169.254` would slip past the
+            # literal-IP block and Lighthouse would scan internal infra.
+            try:
+                assert_safe_host(host)
+            except ValueError as exc:
+                raise ValueError("url host is not allowed") from exc
         else:
             if (
                 ip.is_private

--- a/apps/audit-api/app/services/ssrf_guard.py
+++ b/apps/audit-api/app/services/ssrf_guard.py
@@ -1,0 +1,81 @@
+"""SSRF defense for outbound URL fetches.
+
+Mirror of `apps/wyrdfold-api/app/services/validate.py` (the SSRF half).
+Lighthouse + axe scan a user-supplied URL via headless Chromium / a Node
+subprocess — without resolving the hostname here, an attacker can pass a
+real DNS name like ``metadata.evil.com`` that resolves to
+``169.254.169.254`` (cloud metadata) or any RFC1918 / loopback address,
+and the scan response would echo back internal infrastructure content.
+
+The Pydantic validator on `RunScanRequest` already blocks raw IP literals
+and three hardcoded hostnames, but DNS resolution is the missing layer.
+
+Note: this does not protect against DNS rebinding (the resolver may
+return a different IP between this check and the Lighthouse subprocess
+opening the socket). Full mitigation requires pinning the resolved IP
+at request time.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import logging
+import socket
+
+logger = logging.getLogger(__name__)
+
+
+def _is_disallowed_address(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
+    """Return True if *ip* falls in any range we refuse to fetch from."""
+    if ip.is_loopback or ip.is_link_local or ip.is_private:
+        return True
+    if ip.is_multicast or ip.is_unspecified or ip.is_reserved:
+        return True
+    # IPv4-mapped (::ffff:x.x.x.x) and IPv4-compat IPv6 — re-check the
+    # embedded v4 against the v4 ranges. Short-circuit narrows to v6.
+    return (
+        isinstance(ip, ipaddress.IPv6Address)
+        and ip.ipv4_mapped is not None
+        and _is_disallowed_address(ip.ipv4_mapped)
+    )
+
+
+def _resolve_addresses(
+    hostname: str,
+) -> list[ipaddress.IPv4Address | ipaddress.IPv6Address]:
+    """Resolve *hostname* to all addresses (A + AAAA). Empty on failure."""
+    try:
+        infos = socket.getaddrinfo(hostname, None)
+    except socket.gaierror:
+        return []
+    seen: set[str] = set()
+    out: list[ipaddress.IPv4Address | ipaddress.IPv6Address] = []
+    for info in infos:
+        sockaddr = info[4]
+        addr_str = str(sockaddr[0])
+        if addr_str in seen:
+            continue
+        seen.add(addr_str)
+        try:
+            out.append(ipaddress.ip_address(addr_str))
+        except ValueError:
+            continue
+    return out
+
+
+def assert_safe_host(hostname: str) -> None:
+    """Raise ValueError if *hostname* resolves to a disallowed address.
+
+    Call this before any outbound fetch of a user-supplied URL.
+    """
+    addrs = _resolve_addresses(hostname)
+    if not addrs:
+        raise ValueError(f"hostname did not resolve: {hostname}")
+    for addr in addrs:
+        if _is_disallowed_address(addr):
+            logger.warning(
+                "ssrf_block: %s resolved to disallowed address %s", hostname, addr
+            )
+            raise ValueError(
+                f"hostname {hostname} resolves to a disallowed address ({addr})"
+            )

--- a/apps/wyrdfold/src/app/login/MagicLinkForm.tsx
+++ b/apps/wyrdfold/src/app/login/MagicLinkForm.tsx
@@ -33,20 +33,29 @@ const RESEND_COOLDOWN_S = 30;
  * (production), dropping `next` and breaking dev login. The cookie sits
  * alongside the request, the callback reads it after exchanging the
  * code, then clears it.
+ *
+ * `secure` is set when the page is served over HTTPS so the cookie
+ * isn't sent in cleartext on any non-HSTS preview/dev host. Skipped
+ * on plain http://localhost in dev.
  */
 function stashNextInCookie(next: string): void {
-  document.cookie = `${NEXT_COOKIE}=${encodeURIComponent(next)}; max-age=${NEXT_COOKIE_MAX_AGE_S}; path=/; samesite=lax`;
+  const secure =
+    typeof window !== 'undefined' && window.location.protocol === 'https:'
+      ? '; secure'
+      : '';
+  document.cookie = `${NEXT_COOKIE}=${encodeURIComponent(next)}; max-age=${NEXT_COOKIE_MAX_AGE_S}; path=/; samesite=lax${secure}`;
 }
 
 // Wyrdfold is invite-only during the beta. The login form sends
 // `shouldCreateUser: false`, so non-invited emails get rejected by GoTrue
-// (or by the before-user-created hook) with one of these messages. Translate
-// to copy that hints at the invite gate without leaking which path failed.
+// (or by the before-user-created hook) with one of these messages. The
+// hook now mirrors GoTrue's "User not found" string verbatim so the two
+// paths are indistinguishable on the wire (anti-enumeration). Translate
+// to copy that hints at the invite gate without naming the gate.
 function friendlyAuthError(message: string): string {
   const lower = message.toLowerCase();
   if (
     lower.includes('signups not allowed') ||
-    lower.includes('not on the wyrdfold beta list') ||
     lower.includes('user not found')
   ) {
     return "This email isn't on the beta list yet. If you think it should be, reply to your invitation.";

--- a/supabase/migrations/20260507130000_anon_beta_allowlist_error.sql
+++ b/supabase/migrations/20260507130000_anon_beta_allowlist_error.sql
@@ -1,0 +1,48 @@
+-- Anonymize the beta-allowlist rejection so it's indistinguishable from
+-- GoTrue's standard "user not found" path. Combined with
+-- `shouldCreateUser: false` on the magic-link form, both paths now
+-- produce identical responses — an attacker polling the OTP endpoint
+-- with candidate emails can no longer enumerate the invite list.
+--
+-- The client-side `friendlyAuthError` in MagicLinkForm.tsx already maps
+-- both error strings to the same UI copy, so the user-facing experience
+-- is unchanged.
+--
+-- Surfaced by Phase 5 follow-up security review (M2).
+
+CREATE OR REPLACE FUNCTION public.hook_restrict_wyrdfold_beta(event jsonb)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  user_email text;
+BEGIN
+  user_email := lower(event->'user'->>'email');
+
+  IF user_email IS NULL THEN
+    RETURN jsonb_build_object(
+      'error', jsonb_build_object(
+        'message', 'Email is required to sign up.',
+        'http_code', 400
+      )
+    );
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM public.wyrdfold_beta_invites
+    WHERE lower(email) = user_email
+  ) THEN
+    -- Match GoTrue's standard "user not found" error verbatim.
+    RETURN jsonb_build_object(
+      'error', jsonb_build_object(
+        'message', 'User not found',
+        'http_code', 400
+      )
+    );
+  END IF;
+
+  RETURN '{}'::jsonb;
+END;
+$$;


### PR DESCRIPTION
## Summary

Follow-up security review on the current \`wyrdfold\` tip (\`99ed3347\`, post-Phase-5). Phase 5 cleared the major P0s (cross-tenant leak, JWT logging, e2e config, wyrdfold-api SSRF, RLS scoping). This pass found **2 HIGH + 1 MEDIUM** that the prior review didn't cover.

## Findings + fixes

### HIGH

**H1 — audit-api SSRF defense bypassable via DNS** \`apps/audit-api/app/schemas.py\`

\`RunScanRequest\` validator blocked raw IP literals and three hardcoded hostnames (\`localhost\`, \`metadata.google.internal\`, \`metadata.goog\`) but didn't resolve DNS. A hostname like \`metadata.evil.com\` resolving to \`169.254.169.254\` (cloud metadata), \`127.0.0.1\`, or any RFC1918 address would pass validation, and Lighthouse / axe would scan internal infra and echo the response back in the scan record.

**Fix**: New \`apps/audit-api/app/services/ssrf_guard.py\` ports \`assert_safe_host()\` from \`wyrdfold-api\`. Called from the Pydantic validator on non-IP hostnames. Blocks loopback / link-local (incl. AWS/GCP metadata) / RFC1918 / multicast / reserved / IPv4-mapped IPv6.

**H2 — magic-link \`next\` cookie missing Secure flag** \`apps/wyrdfold/src/app/login/MagicLinkForm.tsx\`

The \`wyrdfold_login_next\` cookie was set without \`; secure\`, so on any non-HSTS preview / dev host it'd ride in cleartext. \`safeNext()\` in the callback constrains the value to same-origin relative paths so it's not a direct open redirect, but the cookie still leaks behavioral intent.

**Fix**: Add \`; secure\` when the page is served over HTTPS (skipped on \`http://localhost\` in dev).

### MEDIUM

**M2 — beta-allowlist enumeration via error string** \`supabase/migrations/20260507130000_anon_beta_allowlist_error.sql\`

The \`hook_restrict_wyrdfold_beta\` function returned \`'This email is not on the wyrdfold beta list.'\` for allowlist misses, while a non-invited / non-beta email returns GoTrue's standard \`'User not found'\`. An attacker polling the OTP endpoint with candidate emails could enumerate the entire invite list by inspecting the wire-level error.

**Fix**: Forward-only migration does \`CREATE OR REPLACE\` on the hook function, returning \`'User not found'\` verbatim. Both paths now indistinguishable on the wire. Client-side \`friendlyAuthError\` mapping updated to match — UI copy is unchanged.

The original deployed migration \`20260506150000_wyrdfold_beta_allowlist.sql\` is left untouched.

## Reviewed clean (no changes)

- \`wyrdfold-api/services/validate.py\` SSRF coverage
- JWT JWKS verification (both apps), \`hmac.compare_digest\` for API keys
- RLS migration \`20260507120000_add_rls_user_scoping_policies.sql\` — replaces \`USING(true)\` hole on \`user_targets\`
- \`shouldCreateUser: false\` on signInWithOtp prevents ghost-account creation
- All PII inputs masked with \`data-sentry-mask\`
- No \`dangerouslySetInnerHTML\` in wyrdfold src
- No secrets logged in either Python service or Next.js
- Lighthouse subprocess uses \`create_subprocess_exec\` (no shell) — no command injection
- BFF API routes (\`apps/wyrdfold/src/app/api/**\`) all forward JWT to FastAPI — auth centralized
- \`MagicLinkForm.tsx\` callback prefers cookie \`next\` over query — \`safeNext()\` correctness verified

## Still-open items (not in this PR — Phase-5 deferred)

- Rate limiting on Next.js BFF + FastAPI services (P1-Sec from Phase 5). Login form relies on Supabase OTP throttling; \`/run-scan\` and \`/targets/from-url\` have no app-level rate limit.
- M1 — auth callback prefers a client-set cookie value over query \`next\`. Bounded by \`safeNext()\` correctness; could sign the cookie with HMAC for defense-in-depth. Lower priority.
- M3 — CSP \`script-src\` includes \`https:\` alongside \`'strict-dynamic'\`. Modern browsers ignore \`https:\`; legacy fallback. OWASP recommends dropping \`https:\` if you accept the legacy-no-script result.

## Verification

- audit-api: ruff ✓, mypy strict ✓, **62 tests pass**
- wyrdfold: typecheck clean, **376 tests pass**

## Test plan

- [ ] CI green
- [ ] Manual: \`/run-scan\` rejects \`http://hostname-resolving-to-169.254.169.254/\` with 422
- [ ] Manual: magic-link cookie shows \`Secure\` attribute in DevTools when on prod URL
- [ ] Manual: non-allowlisted email gets the same wire-level error as a truly-non-existent account

🤖 Generated with [Claude Code](https://claude.com/claude-code)