### PR TITLE
perf(db): wrap auth.uid() in (SELECT ...) across all RLS policies

### DIFF
--- a/supabase/migrations/20260507140000_rls_auth_uid_perf.sql
+++ b/supabase/migrations/20260507140000_rls_auth_uid_perf.sql
@@ -1,0 +1,105 @@
+-- Wrap `auth.uid()` calls in `(SELECT auth.uid())` across every RLS
+-- policy added in 20260507120000_add_rls_user_scoping_policies.sql.
+--
+-- Postgres treats `auth.uid()` as STABLE (not IMMUTABLE), so without
+-- the wrap it gets re-evaluated per row during policy enforcement. With
+-- a `(SELECT ...)` subquery the planner caches the value once per query.
+-- Per Supabase RLS performance guidance the wrap is "100x+ faster on
+-- large tables" — and even on small tables it's free. Same fix for
+-- subqueries that reference `auth.uid()` from inside the WHERE clause.
+--
+-- Reference: https://supabase.com/docs/guides/database/postgres/row-level-security#rls-performance-recommendations
+--
+-- Forward-only — uses ALTER POLICY to swap the expressions in place.
+-- The original migration's policy bodies stay readable; only the
+-- runtime expressions change.
+
+-- user_targets (TEXT user_id — keeps the ::text cast)
+ALTER POLICY "Users access their own user_targets"
+  ON user_targets
+  USING ((SELECT auth.uid())::text = user_id)
+  WITH CHECK ((SELECT auth.uid())::text = user_id);
+
+-- user_profiles
+ALTER POLICY "Users access their own profile"
+  ON user_profiles
+  USING ((SELECT auth.uid()) = user_id)
+  WITH CHECK ((SELECT auth.uid()) = user_id);
+
+-- llm_costs (SELECT only — no WITH CHECK needed)
+ALTER POLICY "Users read their own llm_costs"
+  ON llm_costs
+  USING ((SELECT auth.uid()) = user_id);
+
+-- documents
+ALTER POLICY "Users access their own documents"
+  ON documents
+  USING ((SELECT auth.uid()) = user_id)
+  WITH CHECK ((SELECT auth.uid()) = user_id);
+
+-- analyses (SELECT only)
+ALTER POLICY "Users read their own analyses"
+  ON analyses
+  USING ((SELECT auth.uid()) = user_id);
+
+-- experience_* tables
+ALTER POLICY "Users access their own experience_prose_docs"
+  ON experience_prose_docs
+  USING ((SELECT auth.uid()) = user_id)
+  WITH CHECK ((SELECT auth.uid()) = user_id);
+
+ALTER POLICY "Users access their own experience_optimized_docs"
+  ON experience_optimized_docs
+  USING ((SELECT auth.uid()) = user_id)
+  WITH CHECK ((SELECT auth.uid()) = user_id);
+
+ALTER POLICY "Users access their own experience_conversation_turns"
+  ON experience_conversation_turns
+  USING ((SELECT auth.uid()) = user_id)
+  WITH CHECK ((SELECT auth.uid()) = user_id);
+
+ALTER POLICY "Users access their own experience_preferences"
+  ON experience_preferences
+  USING ((SELECT auth.uid()) = user_id)
+  WITH CHECK ((SELECT auth.uid()) = user_id);
+
+-- experience_chunks (subquery on parent doc)
+ALTER POLICY "Users access experience_chunks for their own docs"
+  ON experience_chunks
+  USING (
+    optimized_doc_id IN (
+      SELECT id FROM experience_optimized_docs
+      WHERE user_id = (SELECT auth.uid())
+    )
+  )
+  WITH CHECK (
+    optimized_doc_id IN (
+      SELECT id FROM experience_optimized_docs
+      WHERE user_id = (SELECT auth.uid())
+    )
+  );
+
+-- batch_runs (SELECT only)
+ALTER POLICY "Users read their own batch_runs"
+  ON batch_runs
+  USING ((SELECT auth.uid()) = user_id);
+
+-- uploaded_resumes
+ALTER POLICY "Users access their own uploaded_resumes"
+  ON uploaded_resumes
+  USING ((SELECT auth.uid()) = user_id)
+  WITH CHECK ((SELECT auth.uid()) = user_id);
+
+-- document_versions (subquery on parent document)
+ALTER POLICY "Users access document_versions for their own documents"
+  ON document_versions
+  USING (
+    resume_id IN (
+      SELECT id FROM documents WHERE user_id = (SELECT auth.uid())
+    )
+  )
+  WITH CHECK (
+    resume_id IN (
+      SELECT id FROM documents WHERE user_id = (SELECT auth.uid())
+    )
+  );


### PR DESCRIPTION
## Summary

HIGH-impact perf finding from \`/supabase:supabase-postgres-best-practices\`. The RLS policies added in \`20260507120000_add_rls_user_scoping_policies.sql\` (13 of them) call \`auth.uid() = user_id\` directly. Postgres treats \`auth.uid()\` as STABLE, not IMMUTABLE — without a wrap, the function is re-evaluated **per row** during policy enforcement. With \`(SELECT auth.uid())\` the planner caches the value once per query.

Per [Supabase docs](https://supabase.com/docs/guides/database/postgres/row-level-security#rls-performance-recommendations):

> Wrap auth.uid() in SELECT — 100x+ faster on large tables.

## Fix

Forward-only \`ALTER POLICY\` pass over all 13 policies. New migration: \`20260507140000_rls_auth_uid_perf.sql\`.

| Table | Policy | Op |
|---|---|---|
| \`user_targets\` | Users access their own user_targets | FOR ALL (TEXT user_id, keeps ::text cast) |
| \`user_profiles\` | Users access their own profile | FOR ALL |
| \`llm_costs\` | Users read their own llm_costs | FOR SELECT |
| \`documents\` | Users access their own documents | FOR ALL |
| \`analyses\` | Users read their own analyses | FOR SELECT |
| \`experience_prose_docs\` | … own experience_prose_docs | FOR ALL |
| \`experience_optimized_docs\` | … own experience_optimized_docs | FOR ALL |
| \`experience_conversation_turns\` | … own experience_conversation_turns | FOR ALL |
| \`experience_preferences\` | … own experience_preferences | FOR ALL |
| \`experience_chunks\` | … chunks for own docs | subquery on parent |
| \`batch_runs\` | Users read their own batch_runs | FOR SELECT |
| \`uploaded_resumes\` | … own uploaded_resumes | FOR ALL |
| \`document_versions\` | … document_versions for own docs | subquery on parent |

The wrap inside subqueries (\`experience_chunks\`, \`document_versions\`) also caches \`auth.uid()\` — the planner can hoist the constant before the join.

## Other rules verified clean (no changes needed)

- **\`schema-foreign-key-indexes\`**: every \`user_id\` column referenced by an RLS policy is indexed (verified across \`llm_cost_log\`, \`job_analyses\`, \`tailored_resumes\`, \`resume_uploads\`, \`batch_jobs\`, \`experience_*\`, \`user_targets\`; \`user_profiles\` has UNIQUE which creates an index).
- **\`schema-constraints\`**: workspace already uses \`DO $$ … IF NOT EXISTS … ALTER TABLE ADD CONSTRAINT\` for idempotency.
- **\`monitor-pg-stat-statements\`**: enabled by \`20260430120000_enable_pg_stat_statements.sql\`.

## Deferred (lower-impact, larger blast radius)

- **\`data-pagination\`**: \`get_target_jobs\` RPC uses \`LIMIT/OFFSET\`. Cursor-based would be faster on deep pages but the BFF callers (\`apps/wyrdfold-api/app/routers/jobs.py\`) would need a contract change. Out of scope for an RLS-perf PR.
- **\`schema-data-types\`**: \`user_targets.user_id TEXT\` (vs UUID) is a legacy sentinel for the \`__system__\` / \`tools-admin\` rows. Migration would touch every reader.
- **\`query-covering-indexes\` / \`query-partial-indexes\`**: opportunistic — wait for \`pg_stat_statements\` data after launch to target real hot paths.

## Test plan

- [ ] Supabase Preview migration check passes (forward-only, no schema break)
- [ ] Manual: \`EXPLAIN ANALYZE\` on a \`SELECT * FROM documents WHERE user_id = auth.uid()\` after migration shows InitPlan caching the function call

🤖 Generated with [Claude Code](https://claude.com/claude-code)