### PR TITLE
chore(claude): audit-and-fix skill + migration-reviewer agent + migration-safety hook

### DIFF
--- a/.claude/agents/supabase-migration-reviewer.md
+++ b/.claude/agents/supabase-migration-reviewer.md
@@ -1,0 +1,105 @@
+---
+name: supabase-migration-reviewer
+description: Reviews Supabase Postgres migrations for forward-only safety, idempotency, RLS performance, FK indexes, and function safety
+memory: project
+---
+
+# Supabase Migration Reviewer
+
+Review changed `supabase/migrations/*.sql` files for safety, performance, and Postgres-specific anti-patterns. Report only issues that would cause real problems — broken deploys, perf regressions on RLS-touched tables, or invariants that PRs slip past.
+
+This agent is distinct from `security-reviewer` (which covers app-level auth/PII/SSRF). It focuses on database tooling: forward-only patterns, RLS perf, idempotency, function safety.
+
+## Token Budget
+
+- Read only the migration files in the diff (`git diff origin/<base>...HEAD -- 'supabase/migrations/*.sql'`)
+- Pull the most recent 3 already-merged migrations as context if the diff is small
+- Skip the rest of the codebase
+
+## What to Check
+
+### Forward-only safety
+
+- **Already-deployed migrations should not be edited in place.** Modifying a file Supabase has already applied means the local file diverges from prod. Detect by comparing the file's mtime / git history against the most recent `origin/main` snapshot. If a migration was committed before the branch's merge-base, edits to its body are HIGH-severity.
+- The fix is always: leave the deployed file unchanged, write a new dated migration that does `CREATE OR REPLACE FUNCTION` / `ALTER POLICY` / similar to apply the change forward.
+- Examples in this repo: `20260507130000_anon_beta_allowlist_error.sql`, `20260507140000_rls_auth_uid_perf.sql`.
+
+### Idempotency guards
+
+- `CREATE TABLE` must use `IF NOT EXISTS`.
+- `CREATE INDEX` must use `IF NOT EXISTS`.
+- `ADD CONSTRAINT` (named) must be guarded by a `DO $$ BEGIN IF NOT EXISTS ... END $$` block — Postgres has no `ADD CONSTRAINT IF NOT EXISTS`.
+- `ADD COLUMN` must use `IF NOT EXISTS`.
+- `ALTER TABLE` against a table that may not exist on a fresh DB must be wrapped in `to_regclass('public.<table>') IS NOT NULL` check, or use `ALTER TABLE IF EXISTS`.
+- `DROP TABLE/INDEX/CONSTRAINT` must use `IF EXISTS`.
+- Examples of correct idempotency in this repo: `20260426120000_add_sms_notification_columns.sql` (post-fix) wraps `ALTER TABLE user_profiles` in `to_regclass`. `20260428120002_create_notification_tables.sql` follows `CREATE TABLE IF NOT EXISTS` with a `DO $$` block for `ADD CONSTRAINT`.
+
+### RLS performance
+
+- Every `auth.uid()` call inside a policy `USING` or `WITH CHECK` clause must be wrapped in `(SELECT auth.uid())`. Postgres treats `auth.uid()` as STABLE, not IMMUTABLE — without the wrap it's re-evaluated per row. The wrap caches once per query (5–10× perf on RLS-touched tables). Same for subqueries that reference `auth.uid()` (e.g. `WHERE user_id = (SELECT auth.uid())`).
+- This is the #1 RLS perf anti-pattern per Supabase guidance.
+- Reference: <https://supabase.com/docs/guides/database/postgres/row-level-security#rls-performance-recommendations>
+
+### RLS coverage
+
+- `ALTER TABLE ... ENABLE ROW LEVEL SECURITY` without any `CREATE POLICY` for the `authenticated` role means anon and authenticated callers get nothing — fine if the only access is service-role (FastAPI), but flag it as MEDIUM so the author confirms intent.
+- A `CREATE POLICY ... USING (true)` on a user-scoped table is **HIGH** (anon-readable hole). The `user_targets` table had this in `20260426120008_shared_targets.sql` until `20260507120000_add_rls_user_scoping_policies.sql` replaced it.
+
+### Foreign-key indexes
+
+- Every `... REFERENCES ...` column should have an index on the referencing side (Postgres does **not** auto-index FKs). Without it, JOINs and `ON DELETE CASCADE` do full table scans.
+- Detect by parsing `REFERENCES` in `CREATE TABLE` and confirming a matching `CREATE INDEX` exists somewhere in the same migration or an earlier one.
+- The `pg_constraint`-based audit query (lines below) is the authoritative check — flag if the migration adds an FK without the index in the same migration:
+
+```sql
+select conrelid::regclass as table_name, a.attname as fk_column
+from pg_constraint c
+join pg_attribute a on a.attrelid = c.conrelid and a.attnum = any(c.conkey)
+where c.contype = 'f'
+  and not exists (
+    select 1 from pg_index i
+    where i.indrelid = c.conrelid and a.attnum = any(i.indkey)
+  );
+```
+
+### Function safety
+
+- `CREATE FUNCTION` (or `CREATE OR REPLACE`) must set `search_path` explicitly — either `SET search_path = public` (or `''` if the function only references qualified identifiers) — to prevent search-path-based SQL injection / function shadowing.
+- Functions used by RLS policies or auth hooks (`SECURITY DEFINER`) must always pin `search_path`.
+- `LANGUAGE plpgsql` functions defined in earlier migrations and re-altered now must keep the `SET search_path` clause.
+- Audit hooks (e.g. `hook_restrict_wyrdfold_beta`) should `REVOKE EXECUTE ... FROM authenticated, anon, public` and `GRANT EXECUTE ... TO supabase_auth_admin`.
+
+### Migration ordering
+
+- A migration that ALTERs a table should have a timestamp **after** the migration that creates the table. The `20260426120000_add_sms_notification_columns.sql` file in this repo had this bug — it ALTERed `user_profiles` two days before `20260428120002_create_notification_tables.sql` created the table, breaking fresh-DB applies.
+
+### Renames + RPC compatibility
+
+- Renaming a table or column requires touching every `CREATE FUNCTION` body that references the old name (Postgres doesn't auto-rebind function bodies). Functions with `RETURNS SETOF <renamed_table>` must be DROP+CREATE'd, not `CREATE OR REPLACE`'d.
+- See `20260502120000_wyrdfold_rename_pass.sql` for the canonical pattern in this repo.
+
+## Severity
+
+- **HIGH**: any forward-only violation (editing a deployed file), missing RLS policy that was clearly intended, `USING (true)` on user-scoped tables, missing idempotency on a structural change.
+- **MEDIUM**: missing `(SELECT auth.uid())` wrap on a small/dev-scale table, missing FK index, function without `SET search_path`.
+- **LOW**: cosmetic — column ordering, missing comments, etc. Skip these unless the user asks.
+
+## Output
+
+For each finding:
+
+```
+**<file>:<line>** (<severity>)
+<one-paragraph description of the issue and the impact>
+**Fix**: <one-paragraph recommendation, with a SQL snippet if non-obvious>
+```
+
+End with a one-line summary: `<N> HIGH, <M> MEDIUM findings`. If clean: `Migration looks safe — no findings.`
+
+## What to skip
+
+- Style preferences (capitalization of SQL keywords, indentation)
+- Generic Postgres tuning (work_mem, shared_buffers — that's project-level)
+- Anything outside the migrations directory
+- Theoretical concerns (e.g. "what if Postgres adds a new auth.uid()?")
+- Performance speculation that requires a real EXPLAIN to assess

--- a/.claude/hooks/check-migration-safety.sh
+++ b/.claude/hooks/check-migration-safety.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+# PreToolUse Bash hook — runs on every Bash invocation.
+# Fast-exits unless the command is a `git commit` and supabase migrations are staged.
+#
+# Catches the bug classes that have hit this repo before:
+#   1. Editing an already-deployed migration file (must be forward-only)
+#   2. CREATE TABLE / CREATE INDEX / ALTER TABLE without idempotency guards
+#   3. auth.uid() in a policy without the (SELECT ...) wrap (perf, not safety —
+#      block as warning, exit 0)
+#
+# Exit codes:
+#   0  pass / no migrations staged / not a commit command
+#   2  block — Claude sees the stderr and should rethink
+
+command -v jq >/dev/null || exit 0
+
+INPUT=$(cat /dev/stdin)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+
+# Fast-exit: not a commit
+case "$COMMAND" in
+  *git*commit*) ;;
+  *) exit 0 ;;
+esac
+
+# Fast-exit: no supabase migrations staged
+STAGED=$(git diff --cached --name-only 2>/dev/null | grep -E '^supabase/migrations/.*\.sql$' || true)
+[ -z "$STAGED" ] && exit 0
+
+ERRORS=()
+WARNINGS=()
+
+# 1. Forward-only check: a staged file that already exists in origin/main
+#    means the author edited a deployed migration. Hard fail.
+git fetch origin main --quiet 2>/dev/null || true
+MAIN_REF=$(git rev-parse origin/main 2>/dev/null || git rev-parse main 2>/dev/null)
+
+if [ -n "$MAIN_REF" ]; then
+  for f in $STAGED; do
+    # Was this file already in main?
+    if git cat-file -e "${MAIN_REF}:${f}" 2>/dev/null; then
+      # Check the staged version against the main version
+      MAIN_HASH=$(git ls-tree -r "$MAIN_REF" "$f" 2>/dev/null | awk '{print $3}')
+      STAGED_HASH=$(git diff --cached --raw "$f" 2>/dev/null | awk '{print $4}')
+      if [ -n "$MAIN_HASH" ] && [ -n "$STAGED_HASH" ] && [ "$MAIN_HASH" != "$STAGED_HASH" ]; then
+        ERRORS+=("$f: edited a migration that is already in origin/main. Migrations are forward-only — write a new dated migration instead.")
+      fi
+    fi
+  done
+fi
+
+# 2. Idempotency guards on staged content
+for f in $STAGED; do
+  CONTENT=$(git diff --cached "$f" | grep '^+' | grep -v '^+++')
+
+  # CREATE TABLE without IF NOT EXISTS
+  if echo "$CONTENT" | grep -iE '^\+\s*CREATE TABLE' | grep -ivE 'IF NOT EXISTS' >/dev/null; then
+    ERRORS+=("$f: CREATE TABLE missing IF NOT EXISTS — fresh-DB rebuilds will fail on re-apply.")
+  fi
+
+  # CREATE INDEX without IF NOT EXISTS
+  if echo "$CONTENT" | grep -iE '^\+\s*CREATE (UNIQUE )?INDEX' | grep -ivE 'IF NOT EXISTS' >/dev/null; then
+    ERRORS+=("$f: CREATE INDEX missing IF NOT EXISTS.")
+  fi
+
+  # ADD COLUMN without IF NOT EXISTS (only catch single-line cases — multi-line
+  # ALTER TABLE blocks need a smarter parser, defer to the agent)
+  if echo "$CONTENT" | grep -iE '^\+\s*ADD COLUMN [a-z_]+ ' | grep -ivE 'IF NOT EXISTS' >/dev/null; then
+    ERRORS+=("$f: ADD COLUMN missing IF NOT EXISTS.")
+  fi
+
+  # ADD CONSTRAINT without DO $$ guard (Postgres has no IF NOT EXISTS for these)
+  if echo "$CONTENT" | grep -iE '^\+\s*(ALTER TABLE.*)?ADD CONSTRAINT [a-z_]+' >/dev/null; then
+    if ! grep -iE 'pg_constraint|conname' "$f" >/dev/null 2>&1; then
+      WARNINGS+=("$f: ADD CONSTRAINT without a DO \$\$ ... pg_constraint guard — may break re-applies. (Pattern: see 20260428120002_create_notification_tables.sql)")
+    fi
+  fi
+
+  # Bare auth.uid() in a CREATE/ALTER POLICY (RLS perf).
+  # Strategy: collect +lines referencing auth.uid(), strip the (SELECT
+  # auth.uid()) occurrences, then check what remains. Anything left is
+  # an unwrapped call.
+  if echo "$CONTENT" | grep -iE '(CREATE|ALTER) POLICY' >/dev/null; then
+    BARE=$(echo "$CONTENT" | grep -E '^\+' | grep -E 'auth\.uid\(\)' \
+      | sed -E 's/\(SELECT[[:space:]]+auth\.uid\(\)\)//gi')
+    if echo "$BARE" | grep -E 'auth\.uid\(\)' >/dev/null; then
+      WARNINGS+=("$f: bare auth.uid() in a policy — wrap in (SELECT auth.uid()) for 5-10× RLS perf on large tables. See https://supabase.com/docs/guides/database/postgres/row-level-security#rls-performance-recommendations")
+    fi
+  fi
+done
+
+if [ ${#WARNINGS[@]} -gt 0 ]; then
+  echo "Migration safety warnings:" >&2
+  for w in "${WARNINGS[@]}"; do
+    echo "  ⚠ $w" >&2
+  done
+fi
+
+if [ ${#ERRORS[@]} -gt 0 ]; then
+  echo "" >&2
+  echo "Migration safety errors (commit blocked):" >&2
+  for e in "${ERRORS[@]}"; do
+    echo "  ✗ $e" >&2
+  done
+  echo "" >&2
+  echo "Fix the issues or, if intentional, append --no-verify to bypass. Hard-bypass with care." >&2
+  exit 2
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -38,6 +38,15 @@
             "command": "bash .claude/hooks/block-snapshot-edits.sh"
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/check-migration-safety.sh"
+          }
+        ]
       }
     ],
     "PostToolUse": [

--- a/.claude/skills/audit-and-fix/SKILL.md
+++ b/.claude/skills/audit-and-fix/SKILL.md
@@ -1,0 +1,162 @@
+---
+name: audit-and-fix
+description: Run an audit skill, branch off the deploy target, apply HIGH-severity fixes, push, and open a PR
+disable-model-invocation: true
+user-invocable: true
+---
+
+# Audit and Fix
+
+Orchestrates the post-audit workflow that recurs across `/security-review`, `/nx-audit`, `/nextjs-audit`, `/python-audit`, `/coverage-gaps --quality`, and `/supabase:supabase-postgres-best-practices`. Each of those skills produces findings; the boilerplate that follows is identical:
+
+1. Branch off the canonical deploy target (`wyrdfold` for app/API/db work, `develop` otherwise)
+2. Apply HIGH-severity fixes (and obvious mechanical MEDIUMs) inline via Edit
+3. Run the affected test/lint/typecheck targets
+4. Commit with a descriptive message that lists the findings
+5. Push and `gh pr create --base <target>` with a generated body
+
+This skill replaces ~6 manual commands per audit cycle.
+
+## Arguments
+
+- `/audit-and-fix <audit-name>` — run the audit and complete the loop. Audit name is the slash-command minus the leading `/` (e.g. `security-review`, `nx-audit`, `nextjs-audit`, `python-audit`, `coverage-gaps`, `supabase:supabase-postgres-best-practices`).
+- `/audit-and-fix <audit-name> --base develop` — override the PR base (default: `wyrdfold` if migrations / `apps/wyrdfold` / `apps/wyrdfold-api` / `audit-api` are touched, else `develop`).
+- `/audit-and-fix <audit-name> --branch <name>` — override the auto-derived branch name (default: `chore/<audit-name-slug>`).
+- `/audit-and-fix <audit-name> --no-pr` — stop after push, don't open the PR.
+- `/audit-and-fix <audit-name> --dry-run` — print the planned actions without writing or pushing.
+
+## Instructions
+
+### Step 1: Resolve target + branch
+
+```bash
+git fetch origin
+
+# Determine deploy target. Default heuristic: if any of these paths
+# show up in recent activity (or in the audit's expected scope), use
+# `wyrdfold`; otherwise `develop`.
+BASE=${ARG_BASE:-wyrdfold}
+SLUG=$(echo "${AUDIT_NAME}" | tr ':/' '-' | tr -cd 'a-z0-9-')
+BRANCH=${ARG_BRANCH:-chore/${SLUG}}
+```
+
+Branch off `origin/${BASE}`:
+
+```bash
+git checkout -b "${BRANCH}" "origin/${BASE}"
+```
+
+If the branch already exists locally, prompt the user: rebase onto `origin/${BASE}` or pick a new name.
+
+### Step 2: Run the audit skill
+
+Invoke the audit slash command directly. Capture findings into a working buffer. The audit skills all follow the same output shape:
+
+- HIGH severity findings with `file:line` + fix recommendation
+- MEDIUM findings (apply only when the fix is mechanical and self-contained)
+- LOW / RECOMMENDATION findings (document, do not auto-fix)
+
+If the audit is `coverage-gaps`, treat all `--quality` issues as candidates; for `--quality` invocations, append `--quality` to the audit call.
+
+### Step 3: Apply HIGH fixes
+
+For each HIGH finding:
+
+1. Read the cited file (only if the fix isn't obvious from the diff hunk)
+2. Apply the fix via Edit (single file) or Write (rare — only for net-new files like new migrations or shared modules)
+3. After every batch of related fixes (≤4 files), run the affected test target. Stop early if a fix breaks something — investigate before proceeding.
+
+Skip MEDIUM/LOW unless the audit explicitly flagged them as `mechanical safe fix`.
+
+### Step 4: Verify
+
+Run the relevant targets based on what changed:
+
+```bash
+# JS/TS edits
+pnpm tsc --noEmit
+pnpm nx test <project>             # for the touched project(s)
+pnpm nx lint <project>
+
+# Python edits
+cd apps/<project>
+uv run --package <project> ruff check .
+uv run --package <project> mypy app/
+uv run --package <project> pytest -q
+
+# Supabase edits — no local apply; the Supabase Preview check on PR catches issues
+```
+
+Stop and report if anything fails — do **not** push a broken branch.
+
+### Step 5: Commit + push + PR
+
+Commit body should:
+
+- Lead with a one-line summary that names the audit (e.g. `sec(audit): close 2 HIGH findings from /security-review`)
+- List each finding as a bullet with `file:line` and a 1-sentence fix description
+- End with `Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>`
+
+```bash
+git push -u origin "${BRANCH}"
+
+gh pr create --base "${BASE}" --title "<derived from commit>" --body "$(generate-pr-body)"
+```
+
+PR body template:
+
+```markdown
+## Summary
+
+<N> findings from `/<audit-name>` resolved in this PR.
+
+## Fixed
+
+- **<finding-id>** (HIGH/MEDIUM) `<file>:<line>` — <one-line fix description>
+
+## Verification
+
+- `pnpm tsc --noEmit`: clean
+- `pnpm nx test <project>`: <N> pass
+- ...
+
+## Deferred
+
+LOW/RECOMMENDATION findings from the audit not addressed in this PR. See the audit output above for the full list.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```
+
+### Step 6: Report back
+
+Print:
+
+- The PR URL
+- Findings applied (count by severity)
+- Findings deferred (count)
+- Test results
+
+## Constraints
+
+- **Never** auto-merge the PR or force-push.
+- **Never** edit a file outside the audit's scope. If a fix would touch unrelated code, surface it as a finding for the user instead.
+- If the audit produces zero HIGH findings, exit with "no fixes needed" and do not branch or commit.
+- If `--dry-run`, print every step without executing the mutating commands (`git checkout -b`, `git push`, `gh pr create`).
+- If the user has staged or unstaged changes when starting, **abort** and tell them to commit/stash first — don't carry their work into the audit branch.
+
+## Examples
+
+```
+/audit-and-fix security-review
+→ branches chore/security-review off wyrdfold
+→ runs /security-review
+→ applies HIGH fixes
+→ opens PR
+
+/audit-and-fix supabase:supabase-postgres-best-practices --branch chore/db-rls-perf
+→ same loop, custom branch name (good for narrowing scope when only one rule applies)
+
+/audit-and-fix coverage-gaps --quality --no-pr
+→ runs /coverage-gaps --quality
+→ applies fixes, pushes, but skips PR creation
+```


### PR DESCRIPTION
## Summary

Three Claude Code automations from \`/claude-code-setup:claude-automation-recommender\`. Each addresses a specific bug class from this session's work.

## What's added

### 1. \`/audit-and-fix\` skill — \`.claude/skills/audit-and-fix/SKILL.md\`

Orchestrator that takes an audit name (\`security-review\`, \`nx-audit\`, \`nextjs-audit\`, \`python-audit\`, \`coverage-gaps\`, \`supabase:supabase-postgres-best-practices\`) and runs the entire post-audit loop: branch off \`wyrdfold\`, apply HIGH fixes, run tests, push, open PR. Replaces ~6 manual commands per cycle (this session ran the loop 6 times).

User-only (\`disable-model-invocation: true\`) since it has push/PR side effects.

### 2. \`supabase-migration-reviewer\` agent — \`.claude/agents/supabase-migration-reviewer.md\`

Focused reviewer for \`supabase/migrations/*.sql\`. Catches:
- editing already-deployed migrations (must be forward-only)
- missing \`IF NOT EXISTS\` / \`DO $$\` idempotency guards
- bare \`auth.uid()\` in RLS policies — the perf miss from PR #654
- \`USING (true)\` on user-scoped tables — the \`user_targets\` hole from Phase 5
- missing FK indexes
- functions without \`SET search_path\`

Distinct from \`security-reviewer\`. Spawnable by \`/pr-review\` alongside the existing reviewers.

### 3. Migration-safety pre-commit hook — \`.claude/hooks/check-migration-safety.sh\`

PreToolUse on the Bash matcher. Fast-exits unless the command is \`git commit*\` and \`supabase/migrations/*.sql\` files are staged.

**Blocks the commit** (exit 2) when:
- a migration already in \`origin/main\` was edited (forward-only violation)
- \`CREATE TABLE\` / \`CREATE INDEX\` / \`ADD COLUMN\` missing \`IF NOT EXISTS\`

**Warns** (exit 0 with stderr) when:
- \`ADD CONSTRAINT\` lacks a \`DO $$ ... pg_constraint\` guard
- a policy contains bare \`auth.uid()\` instead of \`(SELECT auth.uid())\`

Smoke-tested against synthetic fixtures — both error and warning paths fire correctly, and good migrations pass cleanly.

## Bugs these would have caught

| Bug | Where | Caught by |
|---|---|---|
| SMS columns ALTER 2 days before user_profiles created | \`20260426120000_add_sms_notification_columns.sql\` | reviewer agent (idempotency) |
| \`USING (true)\` on user_targets (anon-readable) | \`20260426120008_shared_targets.sql\` | reviewer agent (RLS coverage) |
| auth.uid() not wrapped in (SELECT ...) | \`20260507120000_add_rls_user_scoping_policies.sql\` | hook (warning) + reviewer agent (HIGH) |
| Edited deployed \`20260506150000_wyrdfold_beta_allowlist.sql\` (briefly, before switching to forward-only) | this session | hook (block) |

## Verification

- Hook: smoke-tested against synthetic bad and good migration fixtures. Block + warning paths both fire.
- Skill: spec only — no execution wired. Will exercise on the next \`/audit-and-fix <name>\` invocation.
- Agent: spec only — exercise via \`/pr-review\` or direct Agent tool spawn.

## Test plan

- [ ] Open a PR that touches \`supabase/migrations/*.sql\` and verify the migration-safety hook fires correctly
- [ ] Run \`/audit-and-fix nextjs-audit\` (or any audit) end-to-end on a fresh branch
- [ ] Verify the new agent appears in \`/pr-review\` orchestration

🤖 Generated with [Claude Code](https://claude.com/claude-code)