### PR TITLE
fix(wyrdfold-e2e): unblock CI by stubbing Supabase env vars in webServer

### DIFF
--- a/apps/wyrdfold-e2e/playwright.config.ts
+++ b/apps/wyrdfold-e2e/playwright.config.ts
@@ -20,6 +20,16 @@ export default defineConfig({
     url: baseURL,
     reuseExistingServer: !process.env['CI'],
     cwd: workspaceRoot,
+    // proxy.ts hard-401s when these are absent. The smoke specs run with no
+    // auth cookie, so getUser() returns null without ever calling out to the
+    // dummy URL — the values just need to be present strings. Real Supabase
+    // creds stay in Vercel/CI secrets for environments that exercise auth.
+    env: {
+      NEXT_PUBLIC_SUPABASE_URL:
+        process.env['NEXT_PUBLIC_SUPABASE_URL'] ?? 'http://127.0.0.1:0',
+      NEXT_PUBLIC_SUPABASE_ANON_ID:
+        process.env['NEXT_PUBLIC_SUPABASE_ANON_ID'] ?? 'e2e-placeholder',
+    },
   },
   // CI-Chromium-only matches root-e2e and avoids 90% noise from running
   // Firefox + WebKit headless against an auth+SSE stack with zero specs.


### PR DESCRIPTION
## Summary

`apps/wyrdfold-e2e` has been failing on every PR — both specs in `login.spec.ts` time out:

```
Locator: getByRole('heading', { name: 'Sign in', level: 1 })
Expected: visible
Error: element(s) not found

Expected pattern: /\/login(\?.*)?$/
Received string:  "http://localhost:3100/dashboard"
```

## Root cause

`apps/wyrdfold/src/proxy.ts` hard-401s when `NEXT_PUBLIC_SUPABASE_URL` or `NEXT_PUBLIC_SUPABASE_ANON_ID` are missing:

```ts
if (!supabaseUrl || !anonKey) {
  return new NextResponse('Supabase configuration missing', { status: 401 });
}
```

CI doesn't provide those env vars to the dev server that Playwright spins up. So:
- `/login` → 401 body (no `Sign in` h1)
- `/dashboard` → 401 body (URL stays at `/dashboard` instead of redirecting)

Both failures look like app/test bugs but are pure env-config holes.

## Fix

Set placeholder values in the `webServer.env` block of `apps/wyrdfold-e2e/playwright.config.ts`. The proxy then runs normally; for an unauthenticated browser context there's no JWT cookie, so `auth.getUser()` returns `null` without needing a working Supabase URL, and the public `/login` route renders + the unauthenticated redirect logic works.

```ts
env: {
  NEXT_PUBLIC_SUPABASE_URL:
    process.env['NEXT_PUBLIC_SUPABASE_URL'] ?? 'http://127.0.0.1:0',
  NEXT_PUBLIC_SUPABASE_ANON_ID:
    process.env['NEXT_PUBLIC_SUPABASE_ANON_ID'] ?? 'e2e-placeholder',
},
```

Real Supabase keys (Vercel/CI secrets) take precedence when present, so any future spec that needs a real auth round-trip can opt in by setting those env vars in the workflow.

## Why not provide real keys in CI?

These specs are smoke checks: "does the public login route render?" and "does the unauthenticated redirect work?". Neither exercises Supabase. Plumbing real keys + a test user into CI for a smoke suite is over-investment; revisit when we add the launch-suite specs called out in `audit/findings phase 5`.

## Test plan

- [x] Local: `pnpm nx run wyrdfold-e2e:e2e` → **2 passed (11.9s)**
- [x] Pre-commit typecheck green across 6 projects (5/6 from R2 cache)
- [ ] CI on this PR: `wyrdfold-e2e` step passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)