### PR TITLE
chore(wyrdfold): label app as private beta and warn about data loss

### DIFF
--- a/apps/wyrdfold/src/app/(public)/layout.tsx
+++ b/apps/wyrdfold/src/app/(public)/layout.tsx
@@ -46,6 +46,24 @@ export default function PublicLayout({ children }: { children: ReactNode }) {
 
   return (
     <div className='min-h-screen flex flex-col bg-surface text-text-primary'>
+      {/* Beta strip — signals the app is pre-launch and data is not durable.
+          Public-pages-only on purpose: the (app) shell repeats this in the
+          dashboard nav so signed-in users don't lose the warning. */}
+      <div
+        role='status'
+        aria-live='polite'
+        className='border-b border-border bg-surface-elevated'
+      >
+        <div className='mx-auto w-full max-w-6xl px-4 py-2 md:px-6'>
+          <p className='text-xs md:text-sm text-text-secondary'>
+            <span className='font-semibold text-text-primary'>
+              Private beta.
+            </span>{' '}
+            WyrdFold is under active development — accounts and data may be
+            reset without notice while we iterate.
+          </p>
+        </div>
+      </div>
       <header className='border-b border-border'>
         <div className='mx-auto flex w-full max-w-6xl items-center justify-between px-4 py-4 md:px-6 md:py-5'>
           <Link
@@ -56,6 +74,12 @@ export default function PublicLayout({ children }: { children: ReactNode }) {
             <WyrdfoldLogo aria-label='WyrdFold' className='h-5 w-6' />
             <span className='text-base font-semibold tracking-tight text-text-primary'>
               WyrdFold
+            </span>
+            <span
+              className='ml-1 inline-flex items-center rounded-full border border-brand-300/40 bg-brand-300/10 px-2 py-0.5 font-mono text-[10px] uppercase tracking-wider text-brand-300'
+              aria-label='Private beta'
+            >
+              Beta
             </span>
           </Link>
           <Button

--- a/apps/wyrdfold/src/app/(public)/page.tsx
+++ b/apps/wyrdfold/src/app/(public)/page.tsx
@@ -7,6 +7,7 @@ import {
   Target,
   type LucideIcon,
 } from 'lucide-react';
+import { Alert } from '@danieljoffe.com/shared-ui/Alert';
 import { Card, CardContent } from '@danieljoffe.com/shared-ui/Card';
 import { Heading } from '@danieljoffe.com/shared-ui/Heading';
 import { Text } from '@danieljoffe.com/shared-ui/Text';
@@ -93,10 +94,13 @@ export default function WyrdfoldLandingPage() {
       {/* Hero */}
       <section className='py-16 md:py-24'>
         <div className='max-w-3xl'>
+          <span className='inline-flex items-center rounded-full border border-brand-300/40 bg-brand-300/10 px-3 py-1 font-mono text-xs uppercase tracking-wider text-brand-300'>
+            Private beta · invite-only
+          </span>
           <Heading
             variant='detail'
             as='h1'
-            className='text-balance text-text-primary'
+            className='mt-4 text-balance text-text-primary'
           >
             The search runs while you don&apos;t.
           </Heading>
@@ -128,6 +132,15 @@ export default function WyrdfoldLandingPage() {
               See how it works
             </Button>
           </div>
+          <Alert
+            variant='warning'
+            title='Heads up — this is a beta'
+            className='mt-8'
+          >
+            WyrdFold is invite-only and under active development. Schemas,
+            features, and accounts may change or be reset without notice. Don’t
+            rely on it as your only system of record while we iterate.
+          </Alert>
         </div>
 
         {/* Hero screenshot — optimized via scripts/optimize-covers.ts. */}
@@ -257,10 +270,14 @@ export default function WyrdfoldLandingPage() {
 
       {/* Footer CTA */}
       <section className='py-16 md:py-24 border-t border-border'>
-        <div className='flex flex-col items-center gap-6 text-center'>
+        <div className='flex flex-col items-center gap-4 text-center'>
           <Heading variant='section' as='h2' className='max-w-2xl text-balance'>
             You&apos;ll be authenticated in two clicks.
           </Heading>
+          <Text variant='body' as='p' className='max-w-xl text-text-secondary'>
+            Beta access is invite-only — bring an invited email address. Data
+            created during beta may be reset.
+          </Text>
           <Button
             name='wyrdfold-footer-sign-in'
             as='link'

--- a/apps/wyrdfold/src/app/login/MagicLinkForm.tsx
+++ b/apps/wyrdfold/src/app/login/MagicLinkForm.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { Mail, CheckCircle2 } from 'lucide-react';
+import { Alert } from '@danieljoffe.com/shared-ui/Alert';
 import { Heading } from '@danieljoffe.com/shared-ui/Heading';
 import { Text } from '@danieljoffe.com/shared-ui/Text';
 import {
@@ -165,6 +166,12 @@ export default function MagicLinkForm({ next }: MagicLinkFormProps) {
                 Two clicks: enter your email, click the link in your inbox.
               </Text>
             </div>
+
+            <Alert variant='warning' title='Private beta'>
+              WyrdFold is invite-only and under active development. By signing
+              in you accept that your account and data may be reset without
+              notice while we iterate.
+            </Alert>
 
             <form onSubmit={sendLink} className='w-full flex flex-col gap-3'>
               <div className='flex flex-col gap-1'>

--- a/apps/wyrdfold/src/app/login/__tests__/MagicLinkForm.spec.tsx
+++ b/apps/wyrdfold/src/app/login/__tests__/MagicLinkForm.spec.tsx
@@ -111,9 +111,11 @@ describe('MagicLinkForm — idle state', () => {
     );
     await user.click(screen.getByRole('button', { name: /send magic link/i }));
 
-    const alert = await screen.findByRole('alert');
-    expect(alert).toHaveTextContent(/rate limit exceeded/i);
-    expect(alert).toHaveAttribute('id', 'login-error');
+    // The persistent beta-warning Alert also exposes role='alert', so scope
+    // to the inline error by its id rather than picking the first alert.
+    const error = await screen.findByText(/rate limit exceeded/i);
+    expect(error).toHaveAttribute('role', 'alert');
+    expect(error).toHaveAttribute('id', 'login-error');
     expect(screen.getByRole('textbox', { name: /^email$/i })).toHaveAttribute(
       'aria-describedby',
       'login-error'


### PR DESCRIPTION
## Summary

WyrdFold is invite-only and pre-launch. Make that visible on every public surface so visitors understand that schemas, accounts, and data may be reset without notice while we iterate.

- **Public layout:** persistent beta strip above the header + a `Beta` pill next to the WyrdFold wordmark.
- **Landing page:** invite-only badge above the hero, warning Alert under the CTAs, qualifying line under the footer CTA so the \"two clicks\" promise doesn't read like open signup.
- **Login form (`/login`):** warning Alert above the form acknowledging that signing in accepts the data-reset risk. The `/login` page sits outside the `(public)` route group so the layout strip doesn't reach it — this is the explicit pre-signup warning the user asked for.
- **Test fix:** scope the existing error-rendering assertion to the inline error id. The new warning Alert also exposes `role='alert'`, so the unscoped `findByRole('alert')` became ambiguous.

## Test plan

- [x] `pnpm tsc --noEmit` clean
- [x] `pnpm nx test wyrdfold` — 376/376 pass
- [x] `pnpm nx lint wyrdfold` clean (existing warnings unrelated)
- [ ] Visual check on the Vercel preview: header strip + Beta pill render on `/`, hero Alert is visible, `/login` shows the warning callout above the form

🤖 Generated with [Claude Code](https://claude.com/claude-code)