### PR TITLE
feat(wyrdfold): set onboarding expectations with recruiter framing

### DIFF
--- a/apps/wyrdfold/src/app/onboarding/CompletionScreen.tsx
+++ b/apps/wyrdfold/src/app/onboarding/CompletionScreen.tsx
@@ -22,6 +22,10 @@ export default function CompletionScreen() {
               Your account is ready. Head to your targets to start tracking jobs
               and generating tailored resumes.
             </Text>
+            <Text variant='caption' className='mt-3 text-text-tertiary'>
+              WyrdFold sharpens as you mark which jobs you&apos;d actually apply
+              to. A few rounds in, the matches start finding you.
+            </Text>
           </div>
         </div>
       </Card>

--- a/apps/wyrdfold/src/app/onboarding/OnboardingWizard.tsx
+++ b/apps/wyrdfold/src/app/onboarding/OnboardingWizard.tsx
@@ -80,6 +80,16 @@ export default function OnboardingWizard() {
               ? 'How would you like to get started?'
               : `Step ${stepIndex + 1} of ${totalSteps}`}
           </Text>
+          {currentStep === 'path-chooser' && (
+            <Text
+              variant='caption'
+              className='mt-3 max-w-md text-text-tertiary'
+            >
+              Think of WyrdFold like a new recruiter you&apos;re onboarding. The
+              first scores will be rough — the more context you feed it, the
+              sharper it gets.
+            </Text>
+          )}
         </div>
 
         {/* Progress bar */}


### PR DESCRIPTION
## Summary

WyrdFold's first matches are necessarily rough — the scoring profile sharpens as users feed it resumes, targets, and signal about which jobs they'd actually apply to. New users who expect day-one magic bounce; users who expect to *onboard* the system invest. Set that expectation up front and at the end of the wizard.

- **`OnboardingWizard.tsx`** — adds a one-line caption under the path-chooser subtitle: *\"Think of WyrdFold like a new recruiter you're onboarding. The first scores will be rough — the more context you feed it, the sharper it gets.\"* Renders only on the path-chooser step so the in-flow steps stay clean.
- **`CompletionScreen.tsx`** — adds a forward-looking caption after the existing supporting copy: *\"WyrdFold sharpens as you mark which jobs you'd actually apply to. A few rounds in, the matches start finding you.\"*

Adapted from [santifer/career-ops](https://github.com/santifer/career-ops)'s *\"think of it as onboarding a new recruiter — the first week they need to learn about you, then they become invaluable\"* framing (MIT-licensed).

## Test plan

- [x] \`pnpm tsc --noEmit\` clean
- [x] \`pnpm nx test wyrdfold -- --testPathPatterns=onboarding\` — 46/46 pass
- [x] Every test-asserted string preserved (\"Welcome to WyrdFold\", \"How would you like to get started?\", \"all set\", \"head to your targets to start tracking jobs\", path-card titles, \"Skip for now\", \"Go to Targets\")
- [ ] Visual check on Vercel preview: caption renders below subtitle on path-chooser, doesn't appear on subsequent steps; completion screen shows the second caption

🤖 Generated with [Claude Code](https://claude.com/claude-code)