### PR TITLE
ci(claude-review): soft-fail when the SDK action errors

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -24,7 +24,16 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
 
+      # Soft-fail: this review is advisory, not a merge gate. The most
+      # common failure mode is the Anthropic monthly API cap blocking the
+      # SDK call (the action exits with code 1, the job goes red, the PR
+      # shows a non-required failed check, the merge UI flips to UNSTABLE
+      # for no real reason). `continue-on-error: true` lets the job exit
+      # successfully even when the action errors. Trade-off: this also
+      # masks genuine action bugs — the workflow run history is the place
+      # to spot those.
       - uses: anthropics/claude-code-action@v1
+        continue-on-error: true
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_args: >-


### PR DESCRIPTION
## Summary

The Claude PR review is advisory, not a merge gate (\`ci-status\` is the required check). Today the most common failure mode is hitting the Anthropic monthly API cap — the action exits with code 1, the job goes red, the PR's merge state flips to UNSTABLE for no real reason. PR #660 is the current example.

Add \`continue-on-error: true\` to the action step so the job exits successfully regardless. The run history is still the place to look when reviews are mysteriously absent.

**Drafted** so the review workflow doesn't fire on this PR (\`pull_request: types: [ready_for_review]\`). Mark ready when you want to land it.

## Trade-off (called out explicitly)

This also masks genuine action bugs — e.g., a real crash in \`anthropics/claude-code-action@v1\` would now silently produce no review instead of a red check. Acceptable while review is non-blocking; revisit if/when you make it required (then \`continue-on-error\` should come off and quota issues should be handled differently).

## Once merged

To clear the existing red mark on PR #660: re-run the \`Claude PR Review\` workflow on that PR. \`pull_request\` events use the workflow file from the base branch (\`develop\`), so the re-run picks up the patched version. The action will still hit the quota error, but the job will now exit successfully.

## Test plan

- [x] YAML syntax valid (lint-staged Prettier ran on commit)
- [ ] Mark this PR ready when ready to merge — review should not fire because of the trigger filter, but if it does, it'll be the first run of the patched workflow on itself

🤖 Generated with [Claude Code](https://claude.com/claude-code)