### PR TITLE
ci: auto-deploy WyrdFold preview on develop merges

### DIFF
--- a/.github/workflows/deploy-develop.yml
+++ b/.github/workflows/deploy-develop.yml
@@ -1,0 +1,40 @@
+name: Deploy Develop
+
+on:
+  push:
+    branches: [develop]
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+  deployments: write
+
+concurrency:
+  group: develop-deploy
+  cancel-in-progress: true
+
+jobs:
+  wyrdfold-preview:
+    name: WyrdFold Preview
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    environment:
+      name: preview-wyrdfold
+      url: ${{ steps.deploy.outputs.url }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: ./.github/actions/vercel-deploy
+        id: deploy
+        with:
+          vercel-token: ${{ secrets.VERCEL_TOKEN }}
+          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
+          vercel-project-id: ${{ secrets.VERCEL_WYRDFOLD_PROJECT_ID }}
+
+      - name: Summary
+        run: echo "### WyrdFold preview deployed to ${{ steps.deploy.outputs.url }}" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Deploy failed
+        if: failure()
+        run: echo "### WyrdFold preview deploy failed — [view logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/deploy-develop.yml` that fires on `push: develop` (every PR merge into develop) plus manual `workflow_dispatch`.
- Deploys a WyrdFold preview via the existing `./.github/actions/vercel-deploy` composite — same install / pull / build / deploy --prebuilt pipeline already used by \`ci-preview.yml\` and \`deploy-production.yml\`.
- Surfaces the preview URL via the `preview-wyrdfold` GitHub deployment environment (one-click from the commit view) and the workflow run summary.

## Why

Vercel's native Git integration either wasn't configured for develop or stopped firing — last auto-preview on develop was 4 days ago, so the recent email-template merge (#662), seed-sources (#660), and onboarding-recruiter-framing (#659) all shipped without a preview to smoke-test. This closes that gap with explicit-config visibility.

Pattern matches the rest of the workflows folder:
- `ci-preview.yml` — preview deploy on PRs into main
- `deploy-production.yml` — manual production deploy from main
- **`deploy-develop.yml` (new)** — auto preview deploy on develop merges

## ⚠️ Required before merge

Add a new repo secret:

- **Name**: `VERCEL_WYRDFOLD_PROJECT_ID`
- **Value**: `prj_Yq9LgOO8sEjXxPOXIU5fIC3PjQUS`

(Confirmed via \`vercel project inspect wyrdfold-com\` — that's the wyrdfold-com project owned by `danieljoffe-work`.)

The workflow will fail on first run without this secret. Existing secrets `VERCEL_TOKEN` and `VERCEL_ORG_ID` are reused.

## Test plan

- [ ] Add `VERCEL_WYRDFOLD_PROJECT_ID` secret at https://github.com/danieljoffe/danieljoffe.com/settings/secrets/actions.
- [ ] Merge this PR into develop.
- [ ] Confirm the `Deploy Develop` workflow fires on the merge commit and the `WyrdFold Preview` job posts a URL via deployment status + run summary.
- [ ] Open the preview URL and confirm `https://<preview>.vercel.app/logo.png` returns 200 (or 401 from Vercel deployment protection — that's expected).
- [ ] Trigger a manual run via `gh workflow run deploy-develop.yml --ref develop` to verify `workflow_dispatch` works.

## Out of scope (future work)

- Auto-deploy `danieljoffe-com` (root site) and `ui-danieljoffe-com` (Storybook) on develop merges. Easy to add as additional jobs in this same workflow if desired — left out for now since the immediate need was wyrdfold for beta-invite testing.
- Path filters (only deploy when \`apps/wyrdfold/**\` changed). Could shave runtime, but at the cost of complexity. Worth revisiting if develop merge volume increases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)