### PR TITLE
feat(wyrdfold-api): cron-driven poller with retry-aware fetchers

### DIFF
--- a/apps/wyrdfold-api/app/config.py
+++ b/apps/wyrdfold-api/app/config.py
@@ -60,6 +60,13 @@ class Settings(BaseSettings):
     # should be the Next.js app URL; local dev typically `http://localhost:3000,http://localhost:3100`.
     cors_allowed_origins: str = ""
 
+    # In-process scheduled poller. Off by default so tests and ad-hoc dev
+    # processes don't trigger background fetches; ops opt-in via env var.
+    # Tick = how often the scheduler wakes up to look for due sources;
+    # actual per-source cadence is governed by ``sources.poll_interval_minutes``.
+    poll_scheduler_enabled: bool = False
+    poll_tick_minutes: int = Field(default=30, ge=1, le=1440)
+
     @property
     def cors_allowed_origins_list(self) -> list[str]:
         return [o.strip() for o in self.cors_allowed_origins.split(",") if o.strip()]

--- a/apps/wyrdfold-api/app/http_client.py
+++ b/apps/wyrdfold-api/app/http_client.py
@@ -4,9 +4,22 @@ Reuses TCP connections across ATS fetcher calls instead of creating
 a fresh client per request. Closed on app shutdown.
 """
 
+from __future__ import annotations
+
+import asyncio
+import logging
+import random
+from typing import Any, cast
+
 import httpx
 
+logger = logging.getLogger(__name__)
+
 _client: httpx.AsyncClient | None = None
+
+# Identifies us to third-party job-board APIs. Some boards (Workday in
+# particular) reject the default httpx UA outright.
+DEFAULT_USER_AGENT = "wyrdfold-jobs/1.0 (+https://wyrdfold.com)"
 
 
 def get_http_client() -> httpx.AsyncClient:
@@ -19,6 +32,7 @@ def get_http_client() -> httpx.AsyncClient:
                 max_keepalive_connections=10,
             ),
             follow_redirects=True,
+            headers={"User-Agent": DEFAULT_USER_AGENT},
         )
     return _client
 
@@ -28,3 +42,137 @@ async def close_http_client() -> None:
     if _client and not _client.is_closed:
         await _client.aclose()
     _client = None
+
+
+# ---- Retry helper ----------------------------------------------------------
+
+# 429 + 5xx are treated as transient and retried with exponential backoff.
+# Other 4xx (401/403/404/422) are returned to the caller without retry — the
+# caller decides whether to swallow (e.g. 404 = empty board) or surface.
+_RETRYABLE_STATUS = frozenset({408, 425, 429, 500, 502, 503, 504})
+
+
+class FetchExhaustedError(Exception):
+    """Raised by ``request_with_retry`` when all retry attempts fail.
+
+    Carries the last response (if any) and the last exception so callers
+    can inspect the failure mode without re-running the request.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        last_response: httpx.Response | None = None,
+        last_exception: Exception | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.last_response = last_response
+        self.last_exception = last_exception
+
+
+# Module-level sleep alias so tests can patch it without touching the
+# whole asyncio module. Production paths use ``asyncio.sleep`` directly.
+_sleep = asyncio.sleep
+
+
+async def request_with_retry(
+    method: str,
+    url: str,
+    *,
+    retries: int = 2,
+    backoff_base: float = 1.0,
+    backoff_cap: float = 8.0,
+    timeout: float | None = None,  # noqa: ASYNC109 — forwarded to httpx, not asyncio.timeout
+    **kwargs: Any,
+) -> httpx.Response:
+    """Issue an HTTP request with retries on transient failures.
+
+    Retries on network errors and on 408/425/429/5xx with exponential
+    backoff (``backoff_base * 2**attempt`` seconds, capped at
+    ``backoff_cap``, plus up to 250 ms of jitter). Honors ``Retry-After``
+    on 429 when the server provides it.
+
+    Returns the final ``httpx.Response`` (which may itself be a non-2xx
+    response if the status is non-retryable, e.g. 404). Raises
+    ``FetchExhaustedError`` only when retries are spent on a transient
+    failure, so callers don't have to distinguish "real 404" from "we
+    gave up after 3 tries."
+    """
+    last_response: httpx.Response | None = None
+    last_exc: Exception | None = None
+    client = get_http_client()
+
+    request_kwargs = dict(kwargs)
+    if timeout is not None:
+        request_kwargs["timeout"] = timeout
+
+    method_lower = method.lower()
+    method_func = getattr(client, method_lower, None)
+    if method_func is None:
+        raise ValueError(f"unsupported HTTP method: {method}")
+
+    for attempt in range(retries + 1):
+        try:
+            resp = await method_func(url, **request_kwargs)
+        except httpx.HTTPError as exc:
+            # ``HTTPError`` is the umbrella for transport failures
+            # (``TimeoutException``, ``NetworkError``, etc.). We never call
+            # ``raise_for_status`` ourselves, so ``HTTPStatusError`` doesn't
+            # reach this branch — non-2xx flows through the status-code check
+            # below.
+            last_exc = exc
+            last_response = None
+            if attempt == retries:
+                break
+            await _sleep(_backoff_seconds(attempt, backoff_base, backoff_cap))
+            continue
+
+        if resp.status_code not in _RETRYABLE_STATUS:
+            return cast(httpx.Response, resp)
+
+        last_response = resp
+        last_exc = None
+        if attempt == retries:
+            break
+
+        delay = _retry_after_seconds(resp) or _backoff_seconds(attempt, backoff_base, backoff_cap)
+        logger.warning(
+            "retrying %s %s after %s in %.2fs (attempt %d/%d)",
+            method,
+            url,
+            resp.status_code,
+            delay,
+            attempt + 1,
+            retries + 1,
+        )
+        await _sleep(delay)
+
+    raise FetchExhaustedError(
+        f"{method} {url} exhausted retries",
+        last_response=last_response,
+        last_exception=last_exc,
+    )
+
+
+def _backoff_seconds(attempt: int, base: float, cap: float) -> float:
+    raw: float = base * (2**attempt)
+    capped: float = raw if raw < cap else cap
+    jitter: float = random.uniform(0, 0.25)  # noqa: S311 — non-cryptographic jitter
+    return capped + jitter
+
+
+def _retry_after_seconds(resp: httpx.Response) -> float | None:
+    """Parse a ``Retry-After`` header. Honors integer-seconds form only.
+
+    HTTP-date form is ignored — it would need ``email.utils.parsedate_to_datetime``
+    and a clock comparison, and job-board APIs that send ``Retry-After`` use
+    the integer-seconds form in practice.
+    """
+    raw = resp.headers.get("retry-after")
+    if not raw:
+        return None
+    try:
+        return max(0.0, float(raw))
+    except ValueError:
+        return None

--- a/apps/wyrdfold-api/app/main.py
+++ b/apps/wyrdfold-api/app/main.py
@@ -25,6 +25,7 @@ from app.routers import (
     targets,
     user_profile,
 )
+from app.scheduler import start_scheduler_if_enabled
 from app.supabase_pool import close_supabase, init_supabase
 
 _log = logging.getLogger("app")
@@ -40,8 +41,7 @@ def _validate_settings(s: Settings) -> None:
     """
     if not s.allowed_hosts_list:
         raise RuntimeError(
-            "ALLOWED_HOSTS must be set (comma-separated host allowlist). "
-            "Use '*' only in local dev."
+            "ALLOWED_HOSTS must be set (comma-separated host allowlist). Use '*' only in local dev."
         )
 
 
@@ -49,9 +49,12 @@ def _validate_settings(s: Settings) -> None:
 async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
     _validate_settings(settings)
     init_supabase()
+    scheduler = start_scheduler_if_enabled()
     try:
         yield
     finally:
+        if scheduler is not None:
+            scheduler.shutdown(wait=False)
         close_supabase()
         await close_http_client()
 
@@ -145,9 +148,7 @@ async def _unhandled_exception_handler(request: Request, exc: Exception) -> JSON
     _log.exception("unhandled exception on %s %s", request.method, request.url.path)
     is_production = settings.sentry_environment == "production"
     body: dict[str, str] = {
-        "detail": "Internal server error"
-        if is_production
-        else f"{type(exc).__name__}: {exc}",
+        "detail": "Internal server error" if is_production else f"{type(exc).__name__}: {exc}",
         "path": request.url.path,
     }
     return JSONResponse(status_code=500, content=body)

--- a/apps/wyrdfold-api/app/routers/poll.py
+++ b/apps/wyrdfold-api/app/routers/poll.py
@@ -4,13 +4,35 @@ from supabase import Client
 from app.cache import job_list_cache
 from app.dependencies import get_supabase, verify_api_key
 from app.models.schemas import PollResult
-from app.services.poller import poll_all_sources
+from app.services.poller import poll_all_sources, poll_due_sources
 
 router = APIRouter(tags=["poll"], dependencies=[Depends(verify_api_key)])
 
 
 @router.post("/poll", response_model=PollResult)
 async def trigger_poll(supabase: Client = Depends(get_supabase)) -> PollResult:
+    """Force-poll every enabled source. Ignores ``poll_interval_minutes``.
+
+    Use sparingly — this is the manual hammer. Routine polling should
+    go through ``/poll/due`` (or the in-process scheduler that calls
+    ``poll_due_sources`` directly).
+    """
     result = await poll_all_sources(supabase)
     job_list_cache.invalidate()
+    return result
+
+
+@router.post("/poll/due", response_model=PollResult)
+async def trigger_poll_due(supabase: Client = Depends(get_supabase)) -> PollResult:
+    """Poll only sources whose interval has elapsed.
+
+    Same authentication as ``/poll`` but cheap to call frequently —
+    sources that were polled recently are skipped. Mirrors what the
+    in-process scheduler does, exposed as an HTTP endpoint so external
+    cron callers (pg_cron, GitHub Actions) can drive it without
+    running APScheduler in the API.
+    """
+    result = await poll_due_sources(supabase)
+    if result.sources_polled > 0:
+        job_list_cache.invalidate()
     return result

--- a/apps/wyrdfold-api/app/scheduler.py
+++ b/apps/wyrdfold-api/app/scheduler.py
@@ -1,0 +1,98 @@
+"""In-process job scheduler for periodic polling.
+
+Wraps APScheduler's ``AsyncIOScheduler`` so the FastAPI lifespan can
+start/stop a single recurring job that calls ``poll_due_sources``.
+
+The scheduler is **off by default** — opt-in via the
+``POLL_SCHEDULER_ENABLED`` env var. Tests should leave it disabled so
+the lifespan stays deterministic; ops enable it on the production
+process. Any external cron driver (pg_cron, GitHub Actions) can call
+``POST /poll/due`` instead and reach the same code path.
+
+Single-instance assumption: APScheduler with ``max_instances=1`` and
+``coalesce=True`` is safe for a single FastAPI process. If we ever
+horizontally scale the API, swap this for an external trigger so we
+don't double-poll.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from apscheduler.schedulers.asyncio import AsyncIOScheduler  # type: ignore[import-untyped]
+from apscheduler.triggers.interval import IntervalTrigger  # type: ignore[import-untyped]
+
+from app.cache import job_list_cache
+from app.config import settings
+from app.services.poller import poll_due_sources
+from app.supabase_pool import get_supabase_pool
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+logger = logging.getLogger(__name__)
+
+
+async def _run_scheduled_poll() -> None:
+    """Tick body — fetch due sources and invalidate the list cache.
+
+    Errors are logged but never raised; APScheduler would otherwise
+    suppress and we'd lose the trace.
+    """
+    try:
+        client = get_supabase_pool()
+        if client is None:
+            logger.warning("scheduled poll skipped — supabase client not initialized")
+            return
+        result = await poll_due_sources(client)
+        if result.sources_polled > 0:
+            job_list_cache.invalidate()
+        logger.info(
+            "scheduled poll: polled=%d new=%d updated=%d archived=%d errors=%d",
+            result.sources_polled,
+            result.new_jobs,
+            result.updated_jobs,
+            result.archived_jobs,
+            len(result.errors),
+        )
+    except Exception:
+        logger.exception("scheduled poll raised")
+
+
+def build_scheduler(
+    *, tick_minutes: int, job_func: Callable[[], Awaitable[None]] = _run_scheduled_poll
+) -> AsyncIOScheduler:
+    """Construct a configured but unstarted scheduler.
+
+    ``coalesce=True`` collapses missed ticks into one (e.g. if the
+    process was paused). ``max_instances=1`` prevents two ticks from
+    running concurrently — the poll itself is async-concurrent, so a
+    second tick mid-fetch would just add contention.
+    """
+    scheduler = AsyncIOScheduler()
+    scheduler.add_job(
+        job_func,
+        IntervalTrigger(minutes=tick_minutes),
+        id="poll_due_sources",
+        max_instances=1,
+        coalesce=True,
+        replace_existing=True,
+    )
+    return scheduler
+
+
+def start_scheduler_if_enabled() -> AsyncIOScheduler | None:
+    """Build, start, and return the scheduler, or ``None`` when disabled.
+
+    Called from the FastAPI lifespan; the returned handle is what the
+    lifespan must shut down on exit.
+    """
+    if not settings.poll_scheduler_enabled:
+        logger.info("poll scheduler disabled (set POLL_SCHEDULER_ENABLED=true to enable)")
+        return None
+
+    scheduler = build_scheduler(tick_minutes=settings.poll_tick_minutes)
+    scheduler.start()
+    logger.info("poll scheduler started (tick every %d min)", settings.poll_tick_minutes)
+    return scheduler

--- a/apps/wyrdfold-api/app/services/ashby.py
+++ b/apps/wyrdfold-api/app/services/ashby.py
@@ -1,20 +1,25 @@
-import httpx
+import logging
 
-from app.http_client import get_http_client
+from app.http_client import FetchExhaustedError, request_with_retry
 from app.services.standard_job import StandardJob
+
+logger = logging.getLogger(__name__)
 
 ASHBY_BASE = "https://api.ashbyhq.com/posting-api/job-board"
 
 
 async def fetch_ashby_jobs(slug: str) -> list[StandardJob]:
     url = f"{ASHBY_BASE}/{slug}"
-    client = get_http_client()
     try:
-        resp = await client.get(url)
-        if resp.status_code == 404:
-            return []
-        resp.raise_for_status()
-    except httpx.HTTPError:
+        resp = await request_with_retry("GET", url)
+    except FetchExhaustedError as exc:
+        logger.warning("ashby fetch exhausted retries for %s: %s", slug, exc)
+        return []
+
+    if resp.status_code == 404:
+        return []
+    if resp.status_code >= 400:
+        logger.warning("ashby %s returned %d for %s", slug, resp.status_code, url)
         return []
 
     data = resp.json()

--- a/apps/wyrdfold-api/app/services/firecrawl.py
+++ b/apps/wyrdfold-api/app/services/firecrawl.py
@@ -1,10 +1,8 @@
 import hashlib
 import logging
 
-import httpx
-
 from app.config import settings
-from app.http_client import get_http_client
+from app.http_client import FetchExhaustedError, request_with_retry
 from app.services.standard_job import StandardJob
 
 logger = logging.getLogger(__name__)
@@ -78,9 +76,9 @@ async def fetch_firecrawl_jobs(careers_url: str) -> list[StandardJob]:
         logger.warning("FIRECRAWL_API_KEY not set — skipping crawl source %s", careers_url)
         return []
 
-    client = get_http_client()
     try:
-        resp = await client.post(
+        resp = await request_with_retry(
+            "POST",
             FIRECRAWL_SCRAPE_URL,
             headers={
                 "Authorization": f"Bearer {api_key}",
@@ -98,8 +96,8 @@ async def fetch_firecrawl_jobs(careers_url: str) -> list[StandardJob]:
             },
             timeout=120.0,
         )
-    except httpx.HTTPError:
-        logger.exception("Firecrawl request failed for %s", careers_url)
+    except FetchExhaustedError as exc:
+        logger.warning("firecrawl fetch exhausted retries for %s: %s", careers_url, exc)
         return []
 
     if resp.status_code != 200:

--- a/apps/wyrdfold-api/app/services/greenhouse.py
+++ b/apps/wyrdfold-api/app/services/greenhouse.py
@@ -1,20 +1,25 @@
-import httpx
+import logging
 
-from app.http_client import get_http_client
+from app.http_client import FetchExhaustedError, request_with_retry
 from app.services.standard_job import StandardJob
+
+logger = logging.getLogger(__name__)
 
 GREENHOUSE_BASE = "https://boards-api.greenhouse.io/v1/boards"
 
 
 async def fetch_board_jobs(board_token: str) -> list[StandardJob]:
     url = f"{GREENHOUSE_BASE}/{board_token}/jobs?content=true"
-    client = get_http_client()
     try:
-        resp = await client.get(url)
-        if resp.status_code == 404:
-            return []
-        resp.raise_for_status()
-    except httpx.HTTPError:
+        resp = await request_with_retry("GET", url)
+    except FetchExhaustedError as exc:
+        logger.warning("greenhouse fetch exhausted retries for %s: %s", board_token, exc)
+        return []
+
+    if resp.status_code == 404:
+        return []
+    if resp.status_code >= 400:
+        logger.warning("greenhouse %s returned %d for %s", board_token, resp.status_code, url)
         return []
 
     data = resp.json()

--- a/apps/wyrdfold-api/app/services/jsonld.py
+++ b/apps/wyrdfold-api/app/services/jsonld.py
@@ -1,11 +1,12 @@
 import json
+import logging
 import re
 from html.parser import HTMLParser
 
-import httpx
-
-from app.http_client import get_http_client
+from app.http_client import FetchExhaustedError, request_with_retry
 from app.services.standard_job import StandardJob
+
+logger = logging.getLogger(__name__)
 
 
 class _JsonLdExtractor(HTMLParser):
@@ -143,12 +144,14 @@ def _format_salary(posting: dict[str, object]) -> str | None:
 
 async def fetch_jsonld_jobs(careers_url: str) -> list[StandardJob]:
     """Fetch a careers page and extract jobs from JSON-LD markup."""
-    client = get_http_client()
     try:
-        resp = await client.get(careers_url)
-        if resp.status_code != 200:
-            return []
-    except httpx.HTTPError:
+        resp = await request_with_retry("GET", careers_url)
+    except FetchExhaustedError as exc:
+        logger.warning("jsonld fetch exhausted retries for %s: %s", careers_url, exc)
+        return []
+
+    if resp.status_code != 200:
+        logger.warning("jsonld %s returned %d for %s", careers_url, resp.status_code, careers_url)
         return []
 
     postings = _extract_jobs(resp.text)

--- a/apps/wyrdfold-api/app/services/lever.py
+++ b/apps/wyrdfold-api/app/services/lever.py
@@ -1,20 +1,25 @@
-import httpx
+import logging
 
-from app.http_client import get_http_client
+from app.http_client import FetchExhaustedError, request_with_retry
 from app.services.standard_job import StandardJob
+
+logger = logging.getLogger(__name__)
 
 LEVER_BASE = "https://api.lever.co/v0/postings"
 
 
 async def fetch_lever_jobs(company: str) -> list[StandardJob]:
     url = f"{LEVER_BASE}/{company}?mode=json"
-    client = get_http_client()
     try:
-        resp = await client.get(url)
-        if resp.status_code == 404:
-            return []
-        resp.raise_for_status()
-    except httpx.HTTPError:
+        resp = await request_with_retry("GET", url)
+    except FetchExhaustedError as exc:
+        logger.warning("lever fetch exhausted retries for %s: %s", company, exc)
+        return []
+
+    if resp.status_code == 404:
+        return []
+    if resp.status_code >= 400:
+        logger.warning("lever %s returned %d for %s", company, resp.status_code, url)
         return []
 
     data = resp.json()

--- a/apps/wyrdfold-api/app/services/poller.py
+++ b/apps/wyrdfold-api/app/services/poller.py
@@ -4,7 +4,7 @@ import asyncio
 import contextlib
 import logging
 from collections.abc import Callable, Coroutine
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import Any, cast
 
 from supabase import Client
@@ -656,6 +656,89 @@ async def poll_all_sources(supabase: Client) -> PollResult:
         if s["error"]:
             result.errors.append(s["error"])
 
+    return result
+
+
+# ---- Due-source polling (cron entry point) ---------------------------------
+
+
+# Fallback interval used when a source row predates the
+# `poll_interval_minutes` column or has it set to NULL for any reason.
+DEFAULT_POLL_INTERVAL_MINUTES = 240
+
+
+def _is_due(source: dict[str, Any], now: datetime) -> bool:
+    """Return True if the source should be polled this tick.
+
+    A source is due when it has never been polled or when its
+    ``last_polled_at + poll_interval_minutes`` is in the past.
+    """
+    last = source.get("last_polled_at")
+    if not last:
+        return True
+
+    interval_min = source.get("poll_interval_minutes") or DEFAULT_POLL_INTERVAL_MINUTES
+    try:
+        last_dt = (
+            datetime.fromisoformat(last.replace("Z", "+00:00"))
+            if isinstance(last, str)
+            else last
+        )
+    except (TypeError, ValueError):
+        # Unparseable timestamp — treat as never-polled rather than
+        # silently skipping the row forever.
+        return True
+
+    return last_dt + timedelta(minutes=int(interval_min)) <= now
+
+
+def filter_due_sources(
+    sources: list[dict[str, Any]], *, now: datetime | None = None
+) -> list[dict[str, Any]]:
+    """Pure helper for the due-filter — extracted so tests don't need Supabase."""
+    moment = now or datetime.now(UTC)
+    return [s for s in sources if _is_due(s, moment)]
+
+
+async def poll_due_sources(supabase: Client) -> PollResult:
+    """Poll only the sources whose interval has elapsed.
+
+    Same shape as ``poll_all_sources`` but skips sources that were
+    polled recently. Designed to be called from a frequent cron tick
+    (e.g. every 30 min) without re-hammering boards that have a longer
+    configured cadence.
+    """
+    sources_query = supabase.table("sources").select("*").eq("enabled", True)
+    sources_resp = await asyncio.to_thread(sources_query.execute)
+    all_enabled = cast(list[dict[str, Any]], sources_resp.data or [])
+
+    due = filter_due_sources(all_enabled)
+    if not due:
+        return PollResult(
+            sources_polled=0, new_jobs=0, updated_jobs=0, archived_jobs=0, errors=[]
+        )
+
+    optimized_doc = await asyncio.to_thread(get_latest_optimized, supabase, None)
+
+    semaphore = asyncio.Semaphore(POLL_CONCURRENCY)
+
+    async def _worker(source: dict[str, Any]) -> dict[str, Any]:
+        async with semaphore:
+            return await _poll_one_source(source, supabase, optimized_doc)
+
+    summaries = await asyncio.gather(*(_worker(s) for s in due))
+
+    result = PollResult(
+        sources_polled=0, new_jobs=0, updated_jobs=0, archived_jobs=0, errors=[]
+    )
+    for s in summaries:
+        if s["polled"]:
+            result.sources_polled += 1
+        result.new_jobs += s["new"]
+        result.updated_jobs += s["updated"]
+        result.archived_jobs += s["archived"]
+        if s["error"]:
+            result.errors.append(s["error"])
     return result
 
 

--- a/apps/wyrdfold-api/app/services/smartrecruiters.py
+++ b/apps/wyrdfold-api/app/services/smartrecruiters.py
@@ -1,7 +1,9 @@
-import httpx
+import logging
 
-from app.http_client import get_http_client
+from app.http_client import FetchExhaustedError, request_with_retry
 from app.services.standard_job import StandardJob
+
+logger = logging.getLogger(__name__)
 
 SMARTRECRUITERS_BASE = "https://api.smartrecruiters.com/v1/companies"
 
@@ -9,13 +11,16 @@ SMARTRECRUITERS_BASE = "https://api.smartrecruiters.com/v1/companies"
 async def fetch_smartrecruiters_jobs(company_id: str) -> list[StandardJob]:
     """Fetch jobs from SmartRecruiters' public Posting API."""
     url = f"{SMARTRECRUITERS_BASE}/{company_id}/postings"
-    client = get_http_client()
     try:
-        resp = await client.get(url)
-        if resp.status_code == 404:
-            return []
-        resp.raise_for_status()
-    except httpx.HTTPError:
+        resp = await request_with_retry("GET", url)
+    except FetchExhaustedError as exc:
+        logger.warning("smartrecruiters fetch exhausted retries for %s: %s", company_id, exc)
+        return []
+
+    if resp.status_code == 404:
+        return []
+    if resp.status_code >= 400:
+        logger.warning("smartrecruiters %s returned %d for %s", company_id, resp.status_code, url)
         return []
 
     data = resp.json()

--- a/apps/wyrdfold-api/app/services/workday.py
+++ b/apps/wyrdfold-api/app/services/workday.py
@@ -1,9 +1,12 @@
-import httpx
+import logging
 
-from app.http_client import get_http_client
+from app.http_client import FetchExhaustedError, request_with_retry
 from app.services.standard_job import StandardJob
 
+logger = logging.getLogger(__name__)
+
 MAX_JOBS = 200
+PAGE_SIZE = 20
 
 
 async def fetch_workday_jobs(board_token: str) -> list[StandardJob]:
@@ -19,24 +22,37 @@ async def fetch_workday_jobs(board_token: str) -> list[StandardJob]:
     base_url, tenant, site = parts
     url = f"{base_url}/wday/cxs/{tenant}/{site}/jobs"
 
-    client = get_http_client()
     all_jobs: list[StandardJob] = []
     offset = 0
 
     while offset < MAX_JOBS:
         try:
-            resp = await client.post(
+            resp = await request_with_retry(
+                "POST",
                 url,
                 json={
                     "appliedFacets": {},
-                    "limit": 20,
+                    "limit": PAGE_SIZE,
                     "offset": offset,
                     "searchText": "",
                 },
             )
-            if resp.status_code != 200:
-                return all_jobs
-        except httpx.HTTPError:
+        except FetchExhaustedError as exc:
+            logger.warning(
+                "workday fetch exhausted retries for %s (offset %d): %s",
+                board_token,
+                offset,
+                exc,
+            )
+            return all_jobs
+
+        if resp.status_code != 200:
+            logger.warning(
+                "workday %s returned %d at offset %d",
+                board_token,
+                resp.status_code,
+                offset,
+            )
             return all_jobs
 
         data = resp.json()
@@ -59,7 +75,7 @@ async def fetch_workday_jobs(board_token: str) -> list[StandardJob]:
             )
 
         total = data.get("total", 0)
-        offset += 20
+        offset += PAGE_SIZE
         if offset >= total:
             break
 

--- a/apps/wyrdfold-api/pyproject.toml
+++ b/apps/wyrdfold-api/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
   "voyageai>=0.3",
   "twilio>=9.0",
   "sentry-sdk[fastapi]>=2.19",
+  "apscheduler>=3.11",
 ]
 
 [dependency-groups]

--- a/apps/wyrdfold-api/tests/conftest.py
+++ b/apps/wyrdfold-api/tests/conftest.py
@@ -22,6 +22,25 @@ def _clear_caches():
 
 
 @pytest.fixture(autouse=True)
+def _no_retry_sleep(monkeypatch):
+    """Skip retry backoff in tests.
+
+    The shared HTTP helper retries on 429/5xx/transport errors with
+    exponential backoff. In production that's seconds of sleep per
+    failure; in tests that's seconds of pointless wall-clock time.
+    Patch the module-level sleep alias to an immediate no-op.
+    """
+
+    async def _instant(_seconds: float) -> None:
+        return None
+
+    import app.http_client as http_mod
+
+    monkeypatch.setattr(http_mod, "_sleep", _instant)
+    yield
+
+
+@pytest.fixture(autouse=True)
 def _bypass_ssrf_dns(monkeypatch):
     """Make every hostname resolve to a public address for unit tests.
 

--- a/apps/wyrdfold-api/tests/test_http_retry.py
+++ b/apps/wyrdfold-api/tests/test_http_retry.py
@@ -1,0 +1,129 @@
+"""Tests for the shared HTTP retry helper."""
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+from app.http_client import (
+    DEFAULT_USER_AGENT,
+    FetchExhaustedError,
+    get_http_client,
+    request_with_retry,
+)
+
+
+def _resp(status_code: int, *, headers: dict[str, str] | None = None) -> MagicMock:
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = status_code
+    resp.headers = headers or {}
+    return resp
+
+
+@pytest.mark.asyncio
+async def test_returns_response_on_first_success(mock_http_client: Any) -> None:
+    mock_http_client.get = AsyncMock(return_value=_resp(200))
+    resp = await request_with_retry("GET", "https://example.com")
+    assert resp.status_code == 200
+    assert mock_http_client.get.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_passes_through_non_retryable_4xx(mock_http_client: Any) -> None:
+    """403/404 are returned to the caller without retry — caller decides."""
+    mock_http_client.get = AsyncMock(return_value=_resp(404))
+    resp = await request_with_retry("GET", "https://example.com")
+    assert resp.status_code == 404
+    assert mock_http_client.get.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_retries_on_5xx_then_succeeds(mock_http_client: Any) -> None:
+    mock_http_client.get = AsyncMock(side_effect=[_resp(503), _resp(502), _resp(200)])
+    resp = await request_with_retry("GET", "https://example.com", retries=2)
+    assert resp.status_code == 200
+    assert mock_http_client.get.await_count == 3
+
+
+@pytest.mark.asyncio
+async def test_exhausts_retries_on_persistent_5xx(mock_http_client: Any) -> None:
+    mock_http_client.get = AsyncMock(return_value=_resp(503))
+    with pytest.raises(FetchExhaustedError) as excinfo:
+        await request_with_retry("GET", "https://example.com", retries=2)
+    assert excinfo.value.last_response is not None
+    assert excinfo.value.last_response.status_code == 503
+    assert mock_http_client.get.await_count == 3
+
+
+@pytest.mark.asyncio
+async def test_retries_on_429(mock_http_client: Any) -> None:
+    mock_http_client.get = AsyncMock(side_effect=[_resp(429), _resp(200)])
+    resp = await request_with_retry("GET", "https://example.com", retries=1)
+    assert resp.status_code == 200
+    assert mock_http_client.get.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_retries_on_transport_error(mock_http_client: Any) -> None:
+    mock_http_client.get = AsyncMock(side_effect=[httpx.ConnectError("nope"), _resp(200)])
+    resp = await request_with_retry("GET", "https://example.com", retries=1)
+    assert resp.status_code == 200
+    assert mock_http_client.get.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_exhausts_on_persistent_transport_error(mock_http_client: Any) -> None:
+    mock_http_client.get = AsyncMock(side_effect=httpx.TimeoutException("slow"))
+    with pytest.raises(FetchExhaustedError) as excinfo:
+        await request_with_retry("GET", "https://example.com", retries=1)
+    assert excinfo.value.last_exception is not None
+    assert excinfo.value.last_response is None
+
+
+@pytest.mark.asyncio
+async def test_post_method_dispatches_correctly(mock_http_client: Any) -> None:
+    mock_http_client.post = AsyncMock(return_value=_resp(200))
+    resp = await request_with_retry("POST", "https://example.com", json={"x": 1})
+    assert resp.status_code == 200
+    mock_http_client.post.assert_awaited_once_with("https://example.com", json={"x": 1})
+
+
+@pytest.mark.asyncio
+async def test_default_user_agent_set_on_client() -> None:
+    """Job-board APIs (especially Workday) reject default httpx UA — verify
+    our shared client always sends a recognizable identity.
+
+    Closes and resets the singleton so the real client isn't left bound
+    to this test's event loop (which would leak ``"Event loop is closed"``
+    errors into the next async test).
+    """
+    import app.http_client as http_mod
+
+    saved = http_mod._client
+    http_mod._client = None
+    try:
+        client = get_http_client()
+        assert client.headers.get("User-Agent") == DEFAULT_USER_AGENT
+        await client.aclose()
+    finally:
+        http_mod._client = saved
+
+
+@pytest.mark.asyncio
+async def test_unsupported_method_raises_value_error(mock_http_client: Any) -> None:
+    """Defensive: typo in method name fails fast instead of silently
+    falling back to MagicMock's auto-attribute behavior."""
+    # MagicMock auto-creates attributes, so we need a strict mock to
+    # exercise the missing-method branch. Spec the client to httpx.AsyncClient.
+    import app.http_client as http_mod
+
+    strict = MagicMock(spec=httpx.AsyncClient)
+    strict.is_closed = False
+    original = http_mod._client
+    http_mod._client = strict
+    try:
+        with pytest.raises(ValueError, match="unsupported HTTP method"):
+            await request_with_retry("BREW", "https://example.com")
+    finally:
+        http_mod._client = original

--- a/apps/wyrdfold-api/tests/test_poll_due.py
+++ b/apps/wyrdfold-api/tests/test_poll_due.py
@@ -1,0 +1,188 @@
+"""Tests for the due-source filter and the cron-driven poll endpoint."""
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services.poller import (
+    DEFAULT_POLL_INTERVAL_MINUTES,
+    filter_due_sources,
+    poll_due_sources,
+)
+
+
+def _src(
+    *,
+    last_polled_at: str | None = None,
+    poll_interval_minutes: int | None = 240,
+    enabled: bool = True,
+    company: str = "Test Co",
+) -> dict[str, Any]:
+    return {
+        "id": f"src-{company}",
+        "company_name": company,
+        "board_token": company.lower(),
+        "provider": "greenhouse",
+        "enabled": enabled,
+        "last_polled_at": last_polled_at,
+        "poll_interval_minutes": poll_interval_minutes,
+    }
+
+
+def test_never_polled_is_due() -> None:
+    src = _src(last_polled_at=None)
+    assert filter_due_sources([src]) == [src]
+
+
+def test_recently_polled_is_not_due() -> None:
+    just_now = datetime.now(UTC).isoformat()
+    src = _src(last_polled_at=just_now, poll_interval_minutes=240)
+    assert filter_due_sources([src]) == []
+
+
+def test_polled_past_interval_is_due() -> None:
+    long_ago = (datetime.now(UTC) - timedelta(hours=5)).isoformat()
+    src = _src(last_polled_at=long_ago, poll_interval_minutes=240)
+    assert filter_due_sources([src]) == [src]
+
+
+def test_per_source_interval_honored() -> None:
+    """A source with a tight 30-min interval should be due after 35 min,
+    while a 4-hour source should not."""
+    thirty_five_min_ago = (datetime.now(UTC) - timedelta(minutes=35)).isoformat()
+    fast = _src(
+        last_polled_at=thirty_five_min_ago,
+        poll_interval_minutes=30,
+        company="Fast",
+    )
+    slow = _src(
+        last_polled_at=thirty_five_min_ago,
+        poll_interval_minutes=240,
+        company="Slow",
+    )
+    due = filter_due_sources([fast, slow])
+    assert due == [fast]
+
+
+def test_null_interval_falls_back_to_default() -> None:
+    """Forward-compat: rows that predate the interval column shouldn't
+    silently never get polled."""
+    long_ago = (
+        datetime.now(UTC) - timedelta(minutes=DEFAULT_POLL_INTERVAL_MINUTES + 5)
+    ).isoformat()
+    src = _src(last_polled_at=long_ago, poll_interval_minutes=None)
+    assert filter_due_sources([src]) == [src]
+
+
+def test_unparseable_timestamp_treated_as_never_polled() -> None:
+    """A garbage timestamp shouldn't cause a row to be skipped forever."""
+    src = _src(last_polled_at="not-a-date", poll_interval_minutes=60)
+    assert filter_due_sources([src]) == [src]
+
+
+def test_z_suffix_iso_timestamp_parses() -> None:
+    """Supabase returns ISO timestamps with a 'Z' suffix; ensure we
+    handle both 'Z' and '+00:00' forms identically."""
+    long_ago = "2020-01-01T00:00:00Z"
+    src = _src(last_polled_at=long_ago, poll_interval_minutes=60)
+    assert filter_due_sources([src]) == [src]
+
+
+# ---- end-to-end: poll_due_sources with mocked supabase ---------------------
+
+
+def _supabase_returning(rows: list[dict[str, Any]]) -> MagicMock:
+    """Build a Supabase-table-builder mock that returns ``rows`` from
+    .select(...).eq(...).execute(). Only the chain used by
+    poll_due_sources is stubbed — everything else stays a MagicMock."""
+    table = MagicMock()
+    select = MagicMock()
+    eq = MagicMock()
+    response = MagicMock()
+    response.data = rows
+    eq.execute.return_value = response
+    select.eq.return_value = eq
+    table.select.return_value = select
+
+    supabase = MagicMock()
+    supabase.table.return_value = table
+    return supabase
+
+
+@pytest.mark.asyncio
+async def test_poll_due_sources_skips_when_nothing_due() -> None:
+    just_now = datetime.now(UTC).isoformat()
+    supabase = _supabase_returning([_src(last_polled_at=just_now, poll_interval_minutes=240)])
+    with (
+        patch("app.services.poller.get_latest_optimized") as get_opt,
+        patch("app.services.poller._poll_one_source") as poll_one,
+    ):
+        get_opt.return_value = None
+        result = await poll_due_sources(supabase)
+
+    assert result.sources_polled == 0
+    poll_one.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_poll_due_sources_polls_only_due_rows() -> None:
+    long_ago = (datetime.now(UTC) - timedelta(hours=5)).isoformat()
+    just_now = datetime.now(UTC).isoformat()
+
+    due = _src(last_polled_at=long_ago, poll_interval_minutes=240, company="Due Co")
+    fresh = _src(last_polled_at=just_now, poll_interval_minutes=240, company="Fresh Co")
+    supabase = _supabase_returning([due, fresh])
+
+    with (
+        patch("app.services.poller.get_latest_optimized") as get_opt,
+        patch("app.services.poller._poll_one_source", new_callable=AsyncMock) as poll_one,
+    ):
+        get_opt.return_value = None
+        poll_one.return_value = {
+            "polled": True,
+            "new": 2,
+            "updated": 1,
+            "archived": 0,
+            "error": None,
+        }
+        result = await poll_due_sources(supabase)
+
+    assert poll_one.await_count == 1
+    polled_source = poll_one.await_args.args[0]
+    assert polled_source["company_name"] == "Due Co"
+    assert result.sources_polled == 1
+    assert result.new_jobs == 2
+    assert result.updated_jobs == 1
+
+
+@pytest.mark.asyncio
+async def test_poll_due_sources_aggregates_errors() -> None:
+    long_ago = (datetime.now(UTC) - timedelta(hours=5)).isoformat()
+    supabase = _supabase_returning(
+        [
+            _src(last_polled_at=long_ago, company="A"),
+            _src(last_polled_at=long_ago, company="B"),
+        ]
+    )
+
+    with (
+        patch("app.services.poller.get_latest_optimized") as get_opt,
+        patch("app.services.poller._poll_one_source", new_callable=AsyncMock) as poll_one,
+    ):
+        get_opt.return_value = None
+        poll_one.side_effect = [
+            {"polled": True, "new": 0, "updated": 0, "archived": 0, "error": None},
+            {
+                "polled": False,
+                "new": 0,
+                "updated": 0,
+                "archived": 0,
+                "error": "B: poll failed",
+            },
+        ]
+        result = await poll_due_sources(supabase)
+
+    assert result.sources_polled == 1
+    assert result.errors == ["B: poll failed"]

--- a/apps/wyrdfold-api/tests/test_scheduler.py
+++ b/apps/wyrdfold-api/tests/test_scheduler.py
@@ -1,0 +1,96 @@
+"""Tests for the in-process APScheduler wiring."""
+
+from unittest.mock import patch
+
+import pytest
+
+from app.scheduler import build_scheduler, start_scheduler_if_enabled
+
+
+def test_build_scheduler_registers_single_job() -> None:
+    """``build_scheduler`` configures but does not start — verify the job
+    is registered without needing a running event loop."""
+
+    async def _noop() -> None:
+        return None
+
+    scheduler = build_scheduler(tick_minutes=15, job_func=_noop)
+    jobs = scheduler.get_jobs()
+    assert len(jobs) == 1
+    assert jobs[0].id == "poll_due_sources"
+
+
+def test_start_scheduler_returns_none_when_disabled() -> None:
+    """Default settings have the scheduler off — verify nothing starts."""
+    with patch("app.scheduler.settings") as mock_settings:
+        mock_settings.poll_scheduler_enabled = False
+        result = start_scheduler_if_enabled()
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_start_scheduler_returns_running_handle_when_enabled() -> None:
+    """AsyncIOScheduler binds to the running loop, so this test has to
+    be async — production calls it from inside the FastAPI lifespan."""
+    with patch("app.scheduler.settings") as mock_settings:
+        mock_settings.poll_scheduler_enabled = True
+        mock_settings.poll_tick_minutes = 30
+        scheduler = start_scheduler_if_enabled()
+
+    assert scheduler is not None
+    try:
+        assert scheduler.running is True
+        assert len(scheduler.get_jobs()) == 1
+    finally:
+        scheduler.shutdown(wait=False)
+
+
+@pytest.mark.asyncio
+async def test_run_scheduled_poll_invokes_due_poller_with_pool_client() -> None:
+    """The tick body must pull the singleton supabase client and pass it
+    to ``poll_due_sources``. Easy to break by accident — guard it."""
+    from app.models.schemas import PollResult
+    from app.scheduler import _run_scheduled_poll
+
+    fake_client = object()
+    fake_result = PollResult(
+        sources_polled=1, new_jobs=2, updated_jobs=0, archived_jobs=0, errors=[]
+    )
+
+    with (
+        patch("app.scheduler.get_supabase_pool", return_value=fake_client),
+        patch("app.scheduler.poll_due_sources", autospec=True) as mock_poll,
+    ):
+        mock_poll.return_value = fake_result
+        await _run_scheduled_poll()
+
+    mock_poll.assert_awaited_once_with(fake_client)
+
+
+@pytest.mark.asyncio
+async def test_run_scheduled_poll_skips_when_supabase_uninitialized() -> None:
+    """If Supabase env isn't configured, ``get_supabase_pool`` returns
+    None — the tick should log+skip instead of crashing."""
+    from app.scheduler import _run_scheduled_poll
+
+    with (
+        patch("app.scheduler.get_supabase_pool", return_value=None),
+        patch("app.scheduler.poll_due_sources", autospec=True) as mock_poll,
+    ):
+        await _run_scheduled_poll()
+
+    mock_poll.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_run_scheduled_poll_swallows_exceptions() -> None:
+    """APScheduler swallows exceptions from job bodies silently — that's
+    a debugging trap. The tick must log and return cleanly itself."""
+    from app.scheduler import _run_scheduled_poll
+
+    with (
+        patch("app.scheduler.get_supabase_pool", return_value=object()),
+        patch("app.scheduler.poll_due_sources", side_effect=RuntimeError("kaboom")),
+    ):
+        # Must not raise.
+        await _run_scheduled_poll()

--- a/apps/wyrdfold-api/tests/test_workday.py
+++ b/apps/wyrdfold-api/tests/test_workday.py
@@ -1,4 +1,5 @@
-from unittest.mock import AsyncMock, MagicMock, patch
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
 
 import httpx
 import pytest
@@ -6,55 +7,51 @@ import pytest
 from app.services.workday import fetch_workday_jobs
 
 
-def _make_resp(status: int, json_data: object) -> MagicMock:
-    resp = MagicMock()
+def _make_resp(status: int, json_data: dict[str, Any] | None = None) -> MagicMock:
+    resp = MagicMock(spec=httpx.Response)
     resp.status_code = status
-    resp.json.return_value = json_data
+    resp.json.return_value = json_data or {}
+    resp.headers = {}
     return resp
 
 
 @pytest.mark.asyncio
-async def test_invalid_token_format():
+async def test_invalid_token_format() -> None:
     result = await fetch_workday_jobs("bad-token")
     assert result == []
 
 
 @pytest.mark.asyncio
-async def test_valid_response():
-    mock_client = AsyncMock()
-    mock_client.post.return_value = _make_resp(
-        200,
-        {
-            "total": 2,
-            "jobPostings": [
-                {
-                    "externalPath": "job/abc123",
-                    "title": "Software Engineer",
-                    "locationsText": "San Francisco, CA",
-                    "descriptionTeaser": "Build things",
-                    "postedOn": "2026-04-01",
-                    "bulletFields": ["abc123"],
-                },
-                {
-                    "externalPath": "job/def456",
-                    "title": "Product Manager",
-                    "locationsText": "Remote",
-                    "descriptionTeaser": "Manage things",
-                    "postedOn": "2026-04-02",
-                    "bulletFields": ["def456"],
-                },
-            ],
-        },
+async def test_valid_response(mock_http_client: Any) -> None:
+    mock_http_client.post = AsyncMock(
+        return_value=_make_resp(
+            200,
+            {
+                "total": 2,
+                "jobPostings": [
+                    {
+                        "externalPath": "job/abc123",
+                        "title": "Software Engineer",
+                        "locationsText": "San Francisco, CA",
+                        "descriptionTeaser": "Build things",
+                        "postedOn": "2026-04-01",
+                        "bulletFields": ["abc123"],
+                    },
+                    {
+                        "externalPath": "job/def456",
+                        "title": "Product Manager",
+                        "locationsText": "Remote",
+                        "descriptionTeaser": "Manage things",
+                        "postedOn": "2026-04-02",
+                        "bulletFields": ["def456"],
+                    },
+                ],
+            },
+        )
     )
-    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-    mock_client.__aexit__ = AsyncMock(return_value=False)
 
-    with patch(
-        "app.services.workday.httpx.AsyncClient",
-        return_value=mock_client,
-    ):
-        token = "https://salesforce.wd12.myworkdayjobs.com|salesforce|External"
-        jobs = await fetch_workday_jobs(token)
+    token = "https://salesforce.wd12.myworkdayjobs.com|salesforce|External"
+    jobs = await fetch_workday_jobs(token)
 
     assert len(jobs) == 2
     assert jobs[0].title == "Software Engineer"
@@ -64,34 +61,16 @@ async def test_valid_response():
 
 
 @pytest.mark.asyncio
-async def test_404_returns_empty():
-    mock_client = AsyncMock()
-    mock_client.post.return_value = _make_resp(404, {})
-    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-    mock_client.__aexit__ = AsyncMock(return_value=False)
-
-    with patch(
-        "app.services.workday.httpx.AsyncClient",
-        return_value=mock_client,
-    ):
-        token = "https://example.wd5.myworkdayjobs.com|example|Site"
-        jobs = await fetch_workday_jobs(token)
-
+async def test_404_returns_empty(mock_http_client: Any) -> None:
+    mock_http_client.post = AsyncMock(return_value=_make_resp(404))
+    token = "https://example.wd5.myworkdayjobs.com|example|Site"
+    jobs = await fetch_workday_jobs(token)
     assert jobs == []
 
 
 @pytest.mark.asyncio
-async def test_network_error():
-    mock_client = AsyncMock()
-    mock_client.post.side_effect = httpx.HTTPError("timeout")
-    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-    mock_client.__aexit__ = AsyncMock(return_value=False)
-
-    with patch(
-        "app.services.workday.httpx.AsyncClient",
-        return_value=mock_client,
-    ):
-        token = "https://example.wd5.myworkdayjobs.com|example|Site"
-        jobs = await fetch_workday_jobs(token)
-
+async def test_network_error(mock_http_client: Any) -> None:
+    mock_http_client.post = AsyncMock(side_effect=httpx.HTTPError("timeout"))
+    token = "https://example.wd5.myworkdayjobs.com|example|Site"
+    jobs = await fetch_workday_jobs(token)
     assert jobs == []

--- a/supabase/migrations/20260508120000_sources_poll_interval_minutes.sql
+++ b/supabase/migrations/20260508120000_sources_poll_interval_minutes.sql
@@ -1,0 +1,40 @@
+-- Per-source polling cadence for the scheduled poller.
+--
+-- The cron-driven poller (`poll_due_sources`) ticks frequently (e.g.
+-- every 30 min) but only re-fetches a given source once per its
+-- configured interval. Keeps the API gentle on Greenhouse/Lever/etc.
+-- while still surfacing new jobs without manual triggers, and lets us
+-- raise the interval for expensive crawl-based sources (Firecrawl).
+--
+-- Default 240 minutes (4 hours) matches the audit-tier cadence for
+-- most ATS APIs. Bound is wide-open (5 min .. 1 week) so operators
+-- can dial individual rows up or down without another migration.
+
+ALTER TABLE public.sources
+  ADD COLUMN IF NOT EXISTS poll_interval_minutes integer NOT NULL DEFAULT 240;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'sources_poll_interval_minutes_check'
+      AND conrelid = 'public.sources'::regclass
+  ) THEN
+    ALTER TABLE public.sources
+      ADD CONSTRAINT sources_poll_interval_minutes_check
+      CHECK (poll_interval_minutes BETWEEN 5 AND 10080);
+  END IF;
+END
+$$;
+
+COMMENT ON COLUMN public.sources.poll_interval_minutes IS
+  'Minimum minutes between polls of this source. Used by poll_due_sources.';
+
+-- Composite index supports the "find sources due to be polled" query:
+--   SELECT * FROM sources WHERE enabled AND
+--   (last_polled_at IS NULL OR last_polled_at + interval ... <= now())
+-- The filter is applied client-side (per-row interval makes a pure-SQL
+-- predicate awkward), but indexing on (enabled, last_polled_at) lets
+-- the initial fetch skip disabled rows efficiently.
+CREATE INDEX IF NOT EXISTS idx_sources_enabled_last_polled
+  ON public.sources(enabled, last_polled_at);

--- a/uv.lock
+++ b/uv.lock
@@ -210,6 +210,18 @@ wheels = [
 ]
 
 [[package]]
+name = "apscheduler"
+version = "3.11.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tzlocal" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/07/12/3e4389e5920b4c1763390c6d371162f3784f86f85cd6d6c1bfe68eef14e2/apscheduler-3.11.2.tar.gz", hash = "sha256:2a9966b052ec805f020c8c4c3ae6e6a06e24b1bf19f2e11d91d8cca0473eef41", size = 108683, upload-time = "2025-12-22T00:39:34.884Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/64/2e54428beba8d9992aa478bb8f6de9e4ecaa5f8f513bcfd567ed7fb0262d/apscheduler-3.11.2-py3-none-any.whl", hash = "sha256:ce005177f741409db4e4dd40a7431b76feb856b9dd69d57e0da49d6715bfd26d", size = 64439, upload-time = "2025-12-22T00:39:33.303Z" },
+]
+
+[[package]]
 name = "attrs"
 version = "26.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3008,6 +3020,27 @@ wheels = [
 ]
 
 [[package]]
+name = "tzdata"
+version = "2026.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254, upload-time = "2026-04-24T15:22:08.651Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321, upload-time = "2026-04-24T15:22:05.876Z" },
+]
+
+[[package]]
+name = "tzlocal"
+version = "5.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/2e/c14812d3d4d9cd1773c6be938f89e5735a1f11a9f184ac3639b93cef35d5/tzlocal-5.3.1.tar.gz", hash = "sha256:cceffc7edecefea1f595541dbd6e990cb1ea3d19bf01b2809f362a03dd7921fd", size = 30761, upload-time = "2025-03-05T21:17:41.549Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/14/e2a54fabd4f08cd7af1c07030603c3356b74da07f7cc056e600436edfa17/tzlocal-5.3.1-py3-none-any.whl", hash = "sha256:eb1a66c3ef5847adf7a834f1be0800581b683b5608e74f86ecbcef8ab91bb85d", size = 18026, upload-time = "2025-03-05T21:17:39.857Z" },
+]
+
+[[package]]
 name = "urllib3"
 version = "2.6.3"
 source = { registry = "https://pypi.org/simple" }
@@ -3272,6 +3305,7 @@ version = "0.1.0"
 source = { virtual = "apps/wyrdfold-api" }
 dependencies = [
     { name = "anthropic" },
+    { name = "apscheduler" },
     { name = "beautifulsoup4" },
     { name = "bleach" },
     { name = "fastapi" },
@@ -3301,6 +3335,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "anthropic", specifier = ">=0.40" },
+    { name = "apscheduler", specifier = ">=3.11" },
     { name = "beautifulsoup4", specifier = ">=4.13" },
     { name = "bleach", specifier = ">=6.2" },
     { name = "fastapi", specifier = ">=0.115" },


### PR DESCRIPTION
## Summary

Replaces manual \`/poll\` triggering with a scheduled, due-source-aware poller, and hardens every provider fetcher against transient failures (zero retries / no UA today, per the audit). Inspired by `santifer/career-ops/scan.mjs` for the per-source-isolation + concurrency-bounded patterns; this codebase already had broader provider coverage.

### Cron host: APScheduler in-process

Lives in the FastAPI lifespan — single ticker calls `poll_due_sources` directly. Off by default; ops opt in via `POLL_SCHEDULER_ENABLED=true`. `max_instances=1` + `coalesce=True` keep it sane on a single API instance.

If you'd rather drive scheduling externally (Supabase pg_cron via pg_net, or GitHub Actions cron), `POST /poll/due` mirrors the same code path — flip the env var off and call the endpoint instead. `POST /poll` is preserved as the "force everything" hammer.

### Per-source cadence

`sources.poll_interval_minutes` (default 240, range 5–10080). Cheap ATS APIs (Greenhouse) can poll fast; Firecrawl-backed sources can be set to once a day. The scheduler ticks every `POLL_TICK_MINUTES` (default 30) but only re-fetches sources past their interval.

### Reliability across providers

Per the audit, **every** fetcher was one-shot, used the bare httpx UA (Workday outright rejects it), and silently collapsed all errors to `[]` — including 429s, so a rate-limit storm was invisible. Now:

- Shared `request_with_retry` with exponential backoff on 408/425/429/5xx + transport errors, honors `Retry-After`, raises a typed `FetchExhaustedError` when spent.
- Default `User-Agent: wyrdfold-jobs/1.0 (+https://wyrdfold.com)` on the shared client.
- All seven providers (greenhouse, lever, ashby, workday, smartrecruiters, jsonld, firecrawl) migrated; their `404 → []` semantics are preserved.

EU Greenhouse boards (career-ops's bonus pattern) are deferred since the current source seed is US-focused.

### Tests

- `test_http_retry.py` — success / non-retryable 4xx / 429 / 5xx-then-success / exhausted retries / transport error / POST dispatch / UA / unsupported method
- `test_poll_due.py` — pure due-filter (NULL last_polled, per-row interval, NULL interval fallback, unparseable timestamp, ISO `Z` form) + end-to-end `poll_due_sources` with mocked Supabase
- `test_scheduler.py` — disabled/enabled lifecycle, tick body invokes `poll_due_sources` with the pool client, swallows exceptions, skips cleanly when Supabase isn't initialized

Full suite: 801/801 pass. `ruff check` + `mypy strict` clean.

## Test plan

- [ ] Apply migration `20260508120000_sources_poll_interval_minutes.sql` against the dev Supabase.
- [ ] Verify `poll_interval_minutes` default of 240 is set on existing rows.
- [ ] Hit `POST /poll/due` once (operator API key) — confirm only sources past their interval are fetched.
- [ ] Set `POLL_SCHEDULER_ENABLED=true` + `POLL_TICK_MINUTES=5` in a staging env; confirm the scheduler logs each tick and `last_polled_at` updates only for due rows.
- [ ] Force a 429 / 5xx response from a test board (or temporarily blackhole one in DNS) and confirm the helper retries with backoff and the source surfaces in the `errors` array instead of disappearing silently.
- [ ] Confirm `POST /poll` (the existing endpoint) still force-polls every enabled source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)