### PR TITLE
fix(wyrdfold): magic-link button stuck disabled with autofilled email

### DIFF
--- a/apps/wyrdfold/src/app/login/MagicLinkForm.tsx
+++ b/apps/wyrdfold/src/app/login/MagicLinkForm.tsx
@@ -192,6 +192,13 @@ export default function MagicLinkForm({ next }: MagicLinkFormProps) {
                     placeholder='you@example.com'
                     value={email}
                     onChange={e => setEmail(e.target.value)}
+                    // Password managers and browser autofill sometimes set the
+                    // DOM .value without firing React's synthetic onChange, so
+                    // the field appears filled but `email` stays '' and the
+                    // submit button stays disabled. Re-sync on blur covers the
+                    // common autofill paths (Chrome/1Password set on focus
+                    // change).
+                    onBlur={e => setEmail(e.target.value)}
                     aria-describedby={
                       formState === 'error' ? 'login-error' : undefined
                     }

--- a/apps/wyrdfold/src/app/login/__tests__/MagicLinkForm.spec.tsx
+++ b/apps/wyrdfold/src/app/login/__tests__/MagicLinkForm.spec.tsx
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom';
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import MagicLinkForm from '../MagicLinkForm';
 
@@ -49,6 +49,27 @@ describe('MagicLinkForm — idle state', () => {
     expect(
       screen.getByRole('button', { name: /send magic link/i })
     ).toBeDisabled();
+  });
+
+  it('re-syncs state on blur so password-manager autofill enables submit', () => {
+    // Password managers (1Password, Chrome) sometimes set the input's
+    // .value via the DOM without firing a synthetic React onChange,
+    // leaving `email` state empty and the button disabled. Simulate
+    // that by mutating .value directly, then verify onBlur catches it.
+    render(<MagicLinkForm next={undefined} />);
+
+    const email = screen.getByRole('textbox', {
+      name: /^email$/i,
+    }) as HTMLInputElement;
+    const button = screen.getByRole('button', { name: /send magic link/i });
+
+    expect(button).toBeDisabled();
+
+    // Direct DOM mutation — bypasses React's onChange the way autofill does.
+    email.value = 'autofilled@example.com';
+    fireEvent.blur(email);
+
+    expect(button).toBeEnabled();
   });
 
   it('does not submit when the input is empty (HTML5 required)', async () => {


### PR DESCRIPTION
## Summary

When a password manager or browser autofill fills the email field on the login form, the input's DOM \`.value\` is set without firing React's synthetic \`onChange\`, so the controlled \`email\` state stays empty and the submit button never enables. Visually the field looks filled — the button is just stuck.

Adds an \`onBlur={e => setEmail(e.target.value)}\` handler that re-syncs state when focus leaves the field, which covers the common autofill paths (1Password fills on focus change; Chrome autofill fires on blur).

Repros on \`http://127.0.0.1:3100/login\` with any browser-managed credential.

## Test plan

- [x] New regression test mutates \`input.value\` directly and asserts the button enables on \`fireEvent.blur\` (mirrors how autofill bypasses onChange)
- [x] All 13 \`MagicLinkForm\` tests pass
- [x] Workspace typecheck clean
- [ ] Manual: load \`/login\`, let 1Password/Chrome autofill the email, click outside the field — submit button should enable

🤖 Generated with [Claude Code](https://claude.com/claude-code)