### PR TITLE
fix(wyrdfold): allow 127.0.0.1 as a dev origin (fixes broken hydration)

### DIFF
--- a/apps/wyrdfold/next.config.mjs
+++ b/apps/wyrdfold/next.config.mjs
@@ -27,6 +27,14 @@ const nextConfig = {
   nx: {},
   pageExtensions: ['js', 'jsx', 'ts', 'tsx'],
   devIndicators: false,
+  // Next 16 blocks cross-origin requests to internal dev endpoints
+  // (HMR WebSocket, /__nextjs_font/*, etc.) by default — and the
+  // built-in allow list is only `localhost` / `*.localhost`. Loading
+  // the dev server from `127.0.0.1` hits 403s on those internals,
+  // which breaks hydration on the page and leaves SSR HTML stuck.
+  // Allow both forms so either hostname works.
+  // Ref: node_modules/next/dist/server/lib/router-utils/block-cross-site-dev.js
+  allowedDevOrigins: ['127.0.0.1'],
   experimental: {
     optimizePackageImports: ['lucide-react', 'recharts'],
     webpackBuildWorker: !isTest && !isCI,


### PR DESCRIPTION
## Summary

Loading the wyrdfold dev server from \`http://127.0.0.1:3000\` (instead of \`localhost\`) leaves the page stuck with the SSR HTML and no React event listeners. Visible symptoms: the magic-link submit button ignores typing, password-manager autofill doesn't help, the page can't be interacted with at all.

Root cause: **Next.js 16 ships a default cross-origin block for internal dev resources**, and its built-in allow list only includes \`localhost\` and \`*.localhost\` — see \`node_modules/next/dist/server/lib/router-utils/block-cross-site-dev.js:79\`. From \`127.0.0.1\`:

- \`/__nextjs_font/geist-latin.woff2\` → **403** (visible in the browser console)
- HMR WebSocket → \`ERR_INVALID_HTTP_RESPONSE\` (the dev server returns 403 to the upgrade)
- A subsequent hydration mismatch on the rendered tree → React aborts hydration → SSR HTML stays in place with no event handlers

Confirmed via chrome-devtools: before the fix the input/button had **zero React internals attached** (\`Object.getOwnPropertyNames\` returned no \`__react*\` keys); after the fix, hydration completes and the button enables on input.

The Supabase auth config already names \`127.0.0.1\` (\`supabase/config.toml\` site_url), so it's the natural hostname to land on — this change keeps that path working.

## Test plan

- [x] Repro on \`http://127.0.0.1:3000/login\`: button disabled, console shows 403 + WebSocket failure, React internals missing
- [x] Apply fix, reload: React hydrates, typing in the email field enables the button
- [x] \`localhost:3000\` still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)