### PR TITLE
fix(wyrdfold): keep /api/* sessions fresh by routing them through proxy middleware

### DIFF
--- a/apps/wyrdfold/src/proxy.ts
+++ b/apps/wyrdfold/src/proxy.ts
@@ -84,6 +84,17 @@ export async function proxy(request: NextRequest) {
 
   const { pathname, search } = request.nextUrl;
 
+  // API routes handle their own 401s (returning JSON, not redirecting), so
+  // we deliberately don't run the redirect-to-/login dance here. Letting
+  // the middleware run is what makes ``getUser()`` above fire — its side
+  // effect is refreshing the access token via the cookie adapter when the
+  // current one is expiring, which keeps every authenticated /api/* call
+  // from 401-ing the moment the session crosses the JWT TTL.
+  if (pathname.startsWith('/api/')) {
+    supabaseResponse.headers.set('Content-Security-Policy', cspValue);
+    return supabaseResponse;
+  }
+
   // Public marketing landing page. Signed-in users get sent to the dashboard
   // so they don't see the marketing pitch; everyone else can view it.
   if (pathname === '/') {
@@ -123,11 +134,18 @@ export async function proxy(request: NextRequest) {
 export const config = {
   matcher: [
     {
-      // Bypass: API routes, Next internals, favicons, manifest/robots/sitemap,
-      // and the /public/images directory (public-page assets like the hero
-      // screenshot are served from here and must not require auth).
+      // Bypass: Next internals, favicons, manifest/robots/sitemap, and the
+      // /public/images directory (public-page assets like the hero screenshot
+      // are served from here and must not require auth).
+      //
+      // ``/api/*`` is intentionally NOT bypassed — the middleware's
+      // ``auth.getUser()`` call is what refreshes the access token via the
+      // cookie adapter, and skipping it on /api/* causes every authenticated
+      // route handler to ship a stale token to wyrdfold-api after the JWT
+      // TTL elapses. The handler for /api/* exits early in ``proxy()`` so
+      // route handlers keep their own 401 contract.
       source:
-        '/((?!api|_next/static|_next/image|favicon|images/|site\\.webmanifest|robots\\.txt|sitemap\\.xml).*)',
+        '/((?!_next/static|_next/image|favicon|images/|site\\.webmanifest|robots\\.txt|sitemap\\.xml).*)',
     },
   ],
 };


### PR DESCRIPTION
## Summary

Authenticated /api/* routes were 401-ing exactly one JWT TTL into a session. Logs showed a clean burst of 200s for ~8 minutes followed abruptly by 401s on every endpoint:

\`\`\`
01:25:00 GET /jobs status=200
01:25:00 GET /experience/gap-health status=200
…
01:33:19 GET /jobs HTTP/1.1" 401 Unauthorized
\`\`\`

Root cause: the middleware matcher excluded \`/api/*\`, so the proxy's \`supabase.auth.getUser()\` call — which is what the @supabase/ssr cookie adapter hooks to **refresh the access token** — never fired for client-initiated API calls. Server-side fetches from \`page.tsx\` (which do hit the middleware) stayed healthy, so the symptom looked path-specific. \`getAccessToken()\` in \`lib/api/proxy.ts\` reads tokens via \`getSession()\`, which doesn't validate or refresh, so the route handler shipped a stale JWT to wyrdfold-api and Railway rejected it.

## Change

- Drop \`api|\` from the middleware matcher exclusion (\`apps/wyrdfold/src/proxy.ts:148\`).
- Add an \`/api/*\` branch in \`proxy()\` that returns the Supabase-attached response without the redirect-to-/login dance, so route handlers keep their JSON 401 contract. The middleware's only contribution on /api/* is the refresh side effect plus the shared CSP header.

Trade-off: every /api/* call now does an extra Supabase round-trip (~50–100 ms). Acceptable for a private beta; revisit with \`getClaims()\` (Supabase 2.50+) for local JWT validation if/when that matters.

## Test plan

- [x] \`pnpm tsc --noEmit\` clean
- [x] \`pnpm nx test wyrdfold\` — 376 passing
- [ ] Manual: sign in, leave the tab idle past the JWT TTL (default 1 h), refresh /jobs and /profile — both should populate without re-login

🤖 Generated with [Claude Code](https://claude.com/claude-code)