### PR TITLE
fix(wyrdfold): smoke-test findings — /targets profile gate, status code, toast a11y

### DIFF
--- a/apps/wyrdfold-api/app/routers/targets.py
+++ b/apps/wyrdfold-api/app/routers/targets.py
@@ -178,8 +178,13 @@ async def create_target_from_manual(
     """
     doc = optimized.get_latest(supabase, user_id=user_id)
     if doc is None:
+        # 422 (Unprocessable Entity): the route exists and the request is
+        # well-formed, but a business precondition (an experience profile
+        # to derive against) isn't met. 404 was misleading — it implied
+        # the endpoint didn't exist, and the UI couldn't distinguish from
+        # a genuine misrouted call.
         raise HTTPException(
-            status_code=404,
+            status_code=422,
             detail="No experience profile found — complete onboarding first",
         )
     return await from_input.from_manual(
@@ -214,8 +219,9 @@ async def create_target_from_url(
     """
     doc = optimized.get_latest(supabase, user_id=user_id)
     if doc is None:
+        # Precondition (profile exists) not met — see /from-manual for rationale.
         raise HTTPException(
-            status_code=404,
+            status_code=422,
             detail="No experience profile found — complete onboarding first",
         )
 
@@ -266,7 +272,8 @@ async def suggest(
     """
     doc = optimized.get_latest(supabase, user_id=user_id)
     if doc is None:
-        raise HTTPException(status_code=404, detail="No experience profile found")
+        # Precondition (profile exists) not met — see /from-manual for rationale.
+        raise HTTPException(status_code=422, detail="No experience profile found")
 
     matched, result = await suggest_and_match(
         supabase, llm, payload=doc.payload, user_id=user_id
@@ -427,7 +434,8 @@ async def derive_target_profile(
 
     doc = optimized.get_latest(supabase, user_id=user_id)
     if doc is None:
-        raise HTTPException(status_code=404, detail="No experience profile found")
+        # Precondition (profile exists) not met — see /from-manual for rationale.
+        raise HTTPException(status_code=422, detail="No experience profile found")
 
     derived, result = await derive_profile_from_label(
         llm, label=target.label, payload=doc.payload

--- a/apps/wyrdfold/src/app/(app)/targets/page.tsx
+++ b/apps/wyrdfold/src/app/(app)/targets/page.tsx
@@ -1,9 +1,11 @@
 import { Suspense } from 'react';
 import type { Metadata } from 'next';
+import { ArrowRight, Sparkles } from 'lucide-react';
 import { Heading } from '@danieljoffe.com/shared-ui/Heading';
 import { Text } from '@danieljoffe.com/shared-ui/Text';
 import { Card, CardContent } from '@danieljoffe.com/shared-ui/Card';
 import { Skeleton } from '@danieljoffe.com/shared-ui/Skeleton';
+import Button from '@/components/Button';
 import { fetchJsonFromWyrdfoldAPI } from '@/lib/api/proxy';
 import TargetsList from './TargetsList';
 import type { UserTargetWithTarget } from './types';
@@ -31,11 +33,60 @@ export default function FittedTargetsPage() {
 }
 
 async function TargetsLoader() {
-  const res = await fetchJsonFromWyrdfoldAPI<{
-    targets: UserTargetWithTarget[];
-  }>('/targets/mine');
-  const initialTargets = res?.targets ?? [];
+  // Target creation depends on having an experience profile — the API
+  // uses it to derive the scoring profile. Fetch both in parallel so we
+  // can short-circuit to the onboarding CTA when no prose doc exists,
+  // sparing the user a dead-end submit that just toasts an error.
+  const [targetsRes, proseRes] = await Promise.all([
+    fetchJsonFromWyrdfoldAPI<{ targets: UserTargetWithTarget[] }>(
+      '/targets/mine'
+    ),
+    fetchJsonFromWyrdfoldAPI<{ prose: unknown }>('/experience/prose'),
+  ]);
+  const initialTargets = targetsRes?.targets ?? [];
+  const hasProfile = proseRes?.prose != null;
+
+  if (!hasProfile && initialTargets.length === 0) {
+    return <NoProfileZeroState />;
+  }
+
   return <TargetsList initialTargets={initialTargets} />;
+}
+
+function NoProfileZeroState() {
+  return (
+    <Card>
+      <CardContent className='flex flex-col items-center gap-4 py-12'>
+        <Sparkles className='size-12 text-text-tertiary' aria-hidden />
+        <Text variant='body' as='p' className='text-center max-w-md'>
+          Build your profile first — we use it to derive each target's scoring
+          profile, so targets can't be created until there's prose to draw from.
+        </Text>
+        <div className='flex items-center gap-3'>
+          <Button
+            name='targets-go-profile'
+            variant='primary'
+            size='sm'
+            as='link'
+            href='/profile'
+          >
+            <span>Set up profile</span>
+            <ArrowRight className='size-4' aria-hidden />
+          </Button>
+          <Button
+            name='targets-start-onboarding'
+            variant='outline'
+            size='sm'
+            as='link'
+            href='/onboarding'
+          >
+            <Sparkles className='size-4' aria-hidden />
+            <span>Start with AI</span>
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
 }
 
 function TargetsCardsSkeleton() {

--- a/apps/wyrdfold/src/state/Toast/ToastProvider.tsx
+++ b/apps/wyrdfold/src/state/Toast/ToastProvider.tsx
@@ -64,7 +64,18 @@ export function ToastProvider({ children }: { children: ReactNode }) {
   return (
     <ToastContext.Provider value={{ toast: addToast }}>
       {children}
-      <div className='fixed bottom-20 right-4 z-100 flex flex-col gap-2 max-w-sm'>
+      {/*
+        Container is the ARIA live region: ``aria-live="polite"`` queues
+        announcements after the user's current speech, and ``role="status"``
+        marks the region semantically. Without this, toasted errors were
+        invisible to screen readers — the visual feedback was the only signal.
+      */}
+      <div
+        role='status'
+        aria-live='polite'
+        aria-atomic='false'
+        className='fixed bottom-20 right-4 z-100 flex flex-col gap-2 max-w-sm'
+      >
         {toasts.map(t => {
           const Icon = icons[t.variant];
           return (

--- a/apps/wyrdfold/src/state/Toast/__tests__/ToastProvider.spec.tsx
+++ b/apps/wyrdfold/src/state/Toast/__tests__/ToastProvider.spec.tsx
@@ -1,0 +1,42 @@
+import '@testing-library/jest-dom';
+import { act, render, screen } from '@testing-library/react';
+import { ToastProvider, useToast } from '../ToastProvider';
+
+function ToastTrigger({ title }: { title: string }) {
+  const { toast } = useToast();
+  return (
+    <button type='button' onClick={() => toast({ variant: 'error', title })}>
+      Trigger
+    </button>
+  );
+}
+
+describe('ToastProvider — accessibility', () => {
+  it('exposes the live region as role="status" with aria-live="polite"', () => {
+    render(
+      <ToastProvider>
+        <div>child</div>
+      </ToastProvider>
+    );
+    // The live region exists even when no toasts are present so screen
+    // readers attach a listener before the first announcement.
+    const liveRegion = screen.getByRole('status');
+    expect(liveRegion).toHaveAttribute('aria-live', 'polite');
+    expect(liveRegion).toHaveAttribute('aria-atomic', 'false');
+  });
+
+  it('renders toast titles inside the live region so they get announced', () => {
+    render(
+      <ToastProvider>
+        <ToastTrigger title='No experience profile found' />
+      </ToastProvider>
+    );
+
+    act(() => {
+      screen.getByText('Trigger').click();
+    });
+
+    const liveRegion = screen.getByRole('status');
+    expect(liveRegion).toHaveTextContent('No experience profile found');
+  });
+});


### PR DESCRIPTION
## Summary

Three findings from interactively walking the empty-state user flows (post-DB-wipe, post-#671-merge). Bundled together because all three surface the same underlying problem: a user with no experience profile is allowed to attempt actions that depend on having one, hits a confusing error, and has no obvious recovery path.

## Findings & fixes

### 1. API: `404 → 422` on missing-profile precondition
**File:** `apps/wyrdfold-api/app/routers/targets.py`

Four target endpoints (`/from-manual`, `/from-url`, `/suggest`, `/{id}/derive`) returned **HTTP 404** when the user hadn't built an experience profile yet. 404 implies "no such route/resource" — but the route exists and the request is well-formed; only the business precondition isn't met. Switched to **422 Unprocessable Entity**, which matches PostgREST/FastAPI conventions for validation/precondition failures.

UI behavior unchanged for valid sessions — the toast still surfaces the `detail` message verbatim.

### 2. UI: `/targets` now gates on profile existence
**File:** `apps/wyrdfold/src/app/(app)/targets/page.tsx`

Previously: a user with no profile could click **Create Target**, fill the modal, submit, get a toast, and end up at the same empty state — a dead-end submit cycle. Worth fixing because the toast was the only feedback that the action couldn't succeed, and the page didn't redirect anywhere.

Now: the page checks `/experience/prose` alongside `/targets/mine`; if no prose exists AND no targets exist, render a **Build your profile first** zero-state with CTAs to `/profile` or `/onboarding`. Mirrors the same pattern dashboard uses (PR #670).

### 3. A11y: toast container is now an ARIA live region
**File:** `apps/wyrdfold/src/state/Toast/ToastProvider.tsx`

The container had no `role` or `aria-live`, so screen readers never announced toasted feedback — the visible card was the only signal. Added `role="status"` + `aria-live="polite"` + `aria-atomic="false"`. New spec (`ToastProvider.spec.tsx`) covers both attributes and content propagation through the live region.

## Not fixed (observed but out of scope)

- **Next.js 16 turbopack dev-mode RSC cache hiccup**: first navigation to a page often serves stale content (e.g. modal won't open because the client never hydrated; old copy shows because the RSC payload is stale). Hard reload reliably resolves it. Reproduces every time I navigate via a sidebar link, but never on hard reload. Likely worth filing upstream once I confirm it doesn't repro in a production build.

## Test plan

- [x] Verified `/targets` shows the new "Build your profile first" CTA when no prose exists (browser)
- [x] Verified the toast role/live attributes are in the rendered DOM (browser + new spec)
- [x] Verified the 422 status code is what callers receive
- [x] Wyrdfold tests: **381/381** (was 379, +2 new toast specs)
- [x] Wyrdfold-api tests: **844/844**
- [x] `ruff` + `mypy --strict` clean, workspace `tsc` clean
- [ ] Manual: after this lands and Railway redeploys, hit `/api/targets/from-manual` from a profile-less account and verify the toast still surfaces the message under the new 422

🤖 Generated with [Claude Code](https://claude.com/claude-code)