### PR TITLE
fix(wyrdfold): fail-fast on missing LLM creds + surface upstream detail in chat

### DIFF
--- a/apps/wyrdfold-api/app/main.py
+++ b/apps/wyrdfold-api/app/main.py
@@ -45,6 +45,27 @@ def _validate_settings(s: Settings) -> None:
             "ALLOWED_HOSTS must be set (comma-separated host allowlist). Use '*' only in local dev."
         )
 
+    # If the operator selected the real Anthropic provider but didn't
+    # configure a key, every LLM-backed request will 500 mid-call with
+    # an opaque SDK ``TypeError`` ("Could not resolve authentication
+    # method") — and nothing surfaces that misconfig until the first
+    # user tries to onboard, derive a target, score a job, etc. Fail
+    # the lifespan instead so the deploy logs make the cause obvious.
+    if s.llm_provider == "anthropic" and not s.anthropic_api_key:
+        raise RuntimeError(
+            "LLM_PROVIDER=anthropic but ANTHROPIC_API_KEY is unset. "
+            "Either set ANTHROPIC_API_KEY or switch LLM_PROVIDER=mock."
+        )
+
+    # Same shape for Voyage embeddings — when the real provider is
+    # selected without a key, embedding generation will explode partway
+    # through a request flow (re-derive, conversation, etc.).
+    if s.embeddings_provider == "voyage" and not s.voyage_api_key:
+        raise RuntimeError(
+            "EMBEDDINGS_PROVIDER=voyage but VOYAGE_API_KEY is unset. "
+            "Either set VOYAGE_API_KEY or switch EMBEDDINGS_PROVIDER=mock."
+        )
+
 
 @asynccontextmanager
 async def lifespan(_app: FastAPI) -> AsyncIterator[None]:

--- a/apps/wyrdfold/src/app/_components/ConversationChat.tsx
+++ b/apps/wyrdfold/src/app/_components/ConversationChat.tsx
@@ -21,6 +21,30 @@ interface Message {
   content: string;
 }
 
+/**
+ * Extract a usable error message from a failing response. The wyrdfold
+ * proxy forwards upstream FastAPI errors as ``{detail: "..."}`` — when
+ * that's present and string-shaped, surface it so the toast can name
+ * the actual cause (e.g. "No experience profile found", "LLM provider
+ * misconfigured") instead of the generic fallback. Outside non-prod
+ * envs FastAPI returns a generic "Internal server error", which is
+ * also fine to surface.
+ */
+async function extractErrorDetail(
+  res: Response,
+  fallback: string
+): Promise<string> {
+  try {
+    const body = (await res.clone().json()) as { detail?: unknown };
+    if (typeof body.detail === 'string' && body.detail.trim()) {
+      return body.detail;
+    }
+  } catch {
+    /* non-JSON body or stream already consumed — fall through */
+  }
+  return fallback;
+}
+
 export default function ConversationChat({
   onComplete,
   onSkip,
@@ -99,7 +123,11 @@ export default function ConversationChat({
         }),
       });
 
-      if (!res.ok) throw new Error('Failed to send message');
+      if (!res.ok) {
+        throw new Error(
+          await extractErrorDetail(res, 'Failed to send message')
+        );
+      }
 
       const data = (await res.json()) as {
         assistant_message: string;
@@ -117,7 +145,14 @@ export default function ConversationChat({
         const deriveRes = await fetch('/api/career/experience/derive', {
           method: 'POST',
         });
-        if (!deriveRes.ok) throw new Error('Failed to build master document');
+        if (!deriveRes.ok) {
+          throw new Error(
+            await extractErrorDetail(
+              deriveRes,
+              'Failed to build master document'
+            )
+          );
+        }
         setDeriving(false);
 
         setTimeout(onComplete, 800);
@@ -159,7 +194,11 @@ export default function ConversationChat({
         }),
       });
 
-      if (!res.ok) throw new Error('Failed to skip question');
+      if (!res.ok) {
+        throw new Error(
+          await extractErrorDetail(res, 'Failed to skip question')
+        );
+      }
 
       const data = (await res.json()) as {
         assistant_message: string;
@@ -176,7 +215,14 @@ export default function ConversationChat({
         const deriveRes = await fetch('/api/career/experience/derive', {
           method: 'POST',
         });
-        if (!deriveRes.ok) throw new Error('Failed to build master document');
+        if (!deriveRes.ok) {
+          throw new Error(
+            await extractErrorDetail(
+              deriveRes,
+              'Failed to build master document'
+            )
+          );
+        }
         setDeriving(false);
         setTimeout(onComplete, 800);
       }


### PR DESCRIPTION
## Summary

Follow-up to #672 from continued smoke testing. While walking the onboarding conversation against Railway dev (which had \`LLM_PROVIDER=anthropic\` set but \`ANTHROPIC_API_KEY\` unset), every conversation turn returned a 500 from the Anthropic SDK:

\`\`\`
TypeError: "Could not resolve authentication method. Expected either api_key or auth_token to be set..."
\`\`\`

And the UI just said **"Failed to send message"** — no breadcrumb to the underlying misconfig. Two fixes, one on each side of the stack.

## Findings & fixes

### 1. wyrdfold-api: fail-fast on missing LLM/embeddings creds
**File:** \`apps/wyrdfold-api/app/main.py\`

\`_validate_settings\` now refuses to boot when:
- \`LLM_PROVIDER=anthropic\` AND \`ANTHROPIC_API_KEY\` is empty
- \`EMBEDDINGS_PROVIDER=voyage\` AND \`VOYAGE_API_KEY\` is empty

The lifespan throws a clear \`RuntimeError\` naming the missing env var so deploy logs catch the misconfig at startup instead of every authenticated request 500-ing mid-LLM-call.

Verified manually by booting with \`env LLM_PROVIDER=anthropic ANTHROPIC_API_KEY= ...\` — startup aborts with: \`LLM_PROVIDER=anthropic but ANTHROPIC_API_KEY is unset. Either set ANTHROPIC_API_KEY or switch LLM_PROVIDER=mock.\`

### 2. wyrdfold UI: surface upstream FastAPI \`detail\` in onboarding chat
**File:** \`apps/wyrdfold/src/app/_components/ConversationChat.tsx\`

Added \`extractErrorDetail(res, fallback)\` helper that pulls the \`{detail: "..."}\` payload the wyrdfold proxy already forwards from upstream FastAPI. Threaded it through all three error sites (send, skip, derive). The toast now reads e.g. \`"Internal server error"\` or \`"No experience profile found — complete onboarding first"\` instead of the generic \`"Failed to send message"\`.

Same shape as the \`/targets\` modal's existing error handling (#672). Worth promoting to a shared utility eventually — leaving that to a follow-up so this PR stays narrow.

## Test plan

- [x] \`uv run --package wyrdfold-api pytest\` — 844/844
- [x] \`pnpm nx test wyrdfold\` — 381/381
- [x] \`ruff check . && mypy app\` — both clean
- [x] Workspace \`tsc --noEmit\` — clean
- [x] Manual: API refuses to boot with the right RuntimeError when ANTHROPIC_API_KEY is unset
- [ ] After Railway redeploys with \`ANTHROPIC_API_KEY\` set, confirm onboarding conversation completes a full turn without 500
- [ ] If a future LLM error fires (rate limit, model deprecation), confirm the detail surfaces in the toast

🤖 Generated with [Claude Code](https://claude.com/claude-code)