### PR TITLE
fix(wyrdfold): use hasProse type guard so hasProfile flips after onboarding

### DIFF
--- a/apps/wyrdfold/src/app/(app)/dashboard/page.tsx
+++ b/apps/wyrdfold/src/app/(app)/dashboard/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import { fetchJsonFromWyrdfoldAPI } from '@/lib/api/proxy';
 import DashboardPage, { type DashboardInitial } from '../DashboardPage';
 import type { JobPosting } from '../jobs/types';
+import { hasProse, type ProseResponse } from '../profile/types';
 import type { UserTargetWithTarget } from '../targets/types';
 
 export const metadata: Metadata = {
@@ -19,13 +20,14 @@ const PIPELINE_STATUSES = ['new', 'saved', 'resume_draft', 'applied'] as const;
 
 export default async function WyrdfoldDashboard() {
   // ``hasProfile`` checks whether the user has authored prose at all —
-  // the underlying signal that "they've started onboarding." Earlier
-  // versions used ``/experience/gap-health`` for this, but that route
-  // returns a synthetic 200 body (``{gap_pct: 100, tier: 'red', gaps:
-  // [...content.empty]}``) for users with no content, so the truthiness
-  // check incorrectly flagged invited guests as already-onboarded and
-  // sent them to the "no active targets" branch instead of the
-  // onboarding CTA.
+  // the underlying signal that "they've started onboarding." The
+  // upstream ``/experience/prose`` endpoint returns ``{prose: null}``
+  // when empty and the bare ``ProseDoc`` (``{id, content, ...}``) when
+  // populated — two shapes for the same response. ``hasProse`` is the
+  // type-guard from ``profile/types`` that handles both correctly.
+  // A naive ``proseRes?.prose != null`` check matched only the empty
+  // case and silently treated every populated response as ``no profile``,
+  // sending users back to the onboarding CTA after they'd onboarded.
   const [topRes, proseRes, targetsRes, ...countResponses] = await Promise.all([
     fetchJsonFromWyrdfoldAPI<JobsListResponse>('/jobs', {
       searchParams: new URLSearchParams({
@@ -35,7 +37,7 @@ export default async function WyrdfoldDashboard() {
         page_size: '5',
       }),
     }),
-    fetchJsonFromWyrdfoldAPI<{ prose: unknown }>('/experience/prose'),
+    fetchJsonFromWyrdfoldAPI<ProseResponse>('/experience/prose'),
     fetchJsonFromWyrdfoldAPI<{ targets: UserTargetWithTarget[] }>(
       '/targets/mine'
     ),
@@ -55,7 +57,7 @@ export default async function WyrdfoldDashboard() {
   const initial: DashboardInitial = {
     topMatches: topRes?.postings ?? [],
     counts,
-    hasProfile: proseRes?.prose != null,
+    hasProfile: proseRes != null && hasProse(proseRes),
     hasActiveTargets:
       targetsRes?.targets?.some(t => t.user_target.is_active) ?? false,
   };

--- a/apps/wyrdfold/src/app/(app)/targets/page.tsx
+++ b/apps/wyrdfold/src/app/(app)/targets/page.tsx
@@ -7,6 +7,7 @@ import { Card, CardContent } from '@danieljoffe.com/shared-ui/Card';
 import { Skeleton } from '@danieljoffe.com/shared-ui/Skeleton';
 import Button from '@/components/Button';
 import { fetchJsonFromWyrdfoldAPI } from '@/lib/api/proxy';
+import { hasProse, type ProseResponse } from '../profile/types';
 import TargetsList from './TargetsList';
 import type { UserTargetWithTarget } from './types';
 
@@ -41,10 +42,13 @@ async function TargetsLoader() {
     fetchJsonFromWyrdfoldAPI<{ targets: UserTargetWithTarget[] }>(
       '/targets/mine'
     ),
-    fetchJsonFromWyrdfoldAPI<{ prose: unknown }>('/experience/prose'),
+    fetchJsonFromWyrdfoldAPI<ProseResponse>('/experience/prose'),
   ]);
   const initialTargets = targetsRes?.targets ?? [];
-  const hasProfile = proseRes?.prose != null;
+  // ``/experience/prose`` returns ``{prose: null}`` when empty and the
+  // bare ``ProseDoc`` when populated — ``hasProse`` is the type guard
+  // that handles both.
+  const hasProfile = proseRes != null && hasProse(proseRes);
 
   if (!hasProfile && initialTargets.length === 0) {
     return <NoProfileZeroState />;


### PR DESCRIPTION
## Summary

Real bug found while smoke-testing the full onboarding round-trip: after completing the conversation wizard and creating two targets, the dashboard kept showing the **"Build your profile"** CTA forever, even though prose version 6 (2,231 chars) was sitting in the DB and the API was returning it cleanly.

Root cause: \`/experience/prose\` deliberately returns **two response shapes**:

| Case      | Shape                                                       |
|-----------|-------------------------------------------------------------|
| Empty     | \`{prose: null}\`                                            |
| Populated | \`{id, user_id, version, content, created_at}\` (bare ProseDoc) |

The codebase already encodes this via \`ProseResponse = ProseDoc | {prose: null}\` and a \`hasProse\` type guard in \`profile/types.ts\`. **My PRs #670 and #672 introduced a naive \`proseRes?.prose != null\` check** on the dashboard and \`/targets\` respectively. That check matches only the empty branch:

- Empty: \`{prose: null}.prose\` is \`null\`, \`null != null\` → \`false\` ✓
- Populated: \`{id, content, ...}.prose\` is \`undefined\`, \`undefined != null\` → \`false\` ✗

So both pages permanently treated populated profiles as "no profile."

## Fix

- \`apps/wyrdfold/src/app/(app)/dashboard/page.tsx\` — annotate as \`ProseResponse\`, use \`hasProse(proseRes)\`
- \`apps/wyrdfold/src/app/(app)/targets/page.tsx\` — same pattern

TypeScript now narrows correctly through the type guard. The existing \`profile/types.spec.ts\` covers both branches of \`hasProse\`, so this is caught at compile time for any future consumer that uses the wrong annotation.

## Test plan

- [x] Verified in the browser: completed onboarding → dashboard now renders pipeline stats (0/0/0/0 + "No new matches" message) instead of the onboarding CTA
- [x] Verified \`/targets\` no longer false-positives onto "Build your profile first"
- [x] \`pnpm tsc --noEmit\` clean
- [x] \`pnpm nx test wyrdfold\` — 381/381

🤖 Generated with [Claude Code](https://claude.com/claude-code)