### PR TITLE
fix(wyrdfold): kick off /activate for each onboarded target so jobs start polling

### DIFF
--- a/apps/wyrdfold/src/app/onboarding/TargetSuggestions.tsx
+++ b/apps/wyrdfold/src/app/onboarding/TargetSuggestions.tsx
@@ -153,7 +153,22 @@ export default function TargetSuggestions({
         const linkRes = await fetch(`/api/targets/${targetId}/link`, {
           method: 'POST',
         });
-        if (linkRes.ok) created++;
+        if (!linkRes.ok) continue;
+        created++;
+
+        // Fire the activation pipeline (derive scoring profile → poll
+        // sources → mark ready) without awaiting. Onboarded targets
+        // were previously left at ``activation_status=idle`` because the
+        // wizard only ran create+link, so no jobs got polled until the
+        // user manually clicked Activate on /targets. Fire-and-forget
+        // keeps the wizard responsive; failures will surface on /jobs
+        // (still-idle target = no postings) rather than block the
+        // completion step. Catch and swallow to avoid an unhandled
+        // promise rejection — the user can re-activate from /targets if
+        // the kickoff was lost.
+        void fetch(`/api/targets/${targetId}/activate`, {
+          method: 'POST',
+        }).catch(() => undefined);
       } catch {
         // Continue creating remaining targets
       }

--- a/apps/wyrdfold/src/app/onboarding/__tests__/TargetSuggestions.spec.tsx
+++ b/apps/wyrdfold/src/app/onboarding/__tests__/TargetSuggestions.spec.tsx
@@ -247,6 +247,62 @@ describe('TargetSuggestions — Path B/C (no jobData)', () => {
     });
   });
 
+  it('kicks off /activate for each created target so jobs start polling', async () => {
+    // Regression test for the "onboarded targets stuck at activation_status=idle"
+    // bug. Without the activate kickoff, the derive→poll pipeline never runs
+    // and the user lands at /jobs with no postings — even after a full
+    // onboarding round-trip.
+    fetchMock.mockImplementation((url: string) => {
+      // /suggest returns two new suggestions
+      if (typeof url === 'string' && url.endsWith('/api/targets/suggest')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            matches: [
+              makeSuggestion('Frontend Engineer', true, null),
+              makeSuggestion('Backend Engineer', true, null),
+            ],
+          }),
+        });
+      }
+      // /api/targets POST returns the created target with an id
+      if (typeof url === 'string' && url === '/api/targets') {
+        return Promise.resolve({
+          ok: true,
+          json: async () =>
+            makeTarget({ id: `t-${Math.random().toString(36).slice(2, 6)}` }),
+        });
+      }
+      // /link POST succeeds
+      // /activate POST succeeds — but we only care that it was CALLED.
+      return Promise.resolve({ ok: true, json: async () => ({}) });
+    });
+
+    const user = userEvent.setup();
+    render(<TargetSuggestions onComplete={jest.fn()} onSkip={jest.fn()} />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('heading', { level: 2, name: /suggested targets/i })
+      ).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('button', { name: /create 2 targets/i }));
+
+    // After create+link, /activate must fire for both targets — the bug
+    // was that this call was missing, leaving the activation pipeline
+    // (derive → poll) un-kicked.
+    await waitFor(() => {
+      const activateCalls = fetchMock.mock.calls.filter(
+        ([url, init]: [string, RequestInit | undefined]) =>
+          typeof url === 'string' &&
+          /\/api\/targets\/[^/]+\/activate$/.test(url) &&
+          init?.method === 'POST'
+      );
+      expect(activateCalls.length).toBe(2);
+    });
+  });
+
   it('invokes onSkip when "Skip for now" is clicked from the manual fallback', async () => {
     fetchMock.mockResolvedValueOnce({
       ok: true,


### PR DESCRIPTION
## Summary

Onboarded targets were stuck at \`activation_status=idle\` because the \`TargetSuggestions\` wizard only ran **create + link** — never the **activate** call that triggers the derive→poll pipeline.

User-visible symptom: complete the conversation wizard with two target picks, land on \`/jobs\`, see **zero postings**. The manual-create path on \`/targets\` doesn't have this bug because each \`TargetCard\` exposes an explicit Activate button. The wizard exits straight to the dashboard with no equivalent affordance.

## Fix

After a successful \`/link\`, fire \`POST /api/targets/{id}/activate\` fire-and-forget. The activation pipeline runs as a \`BackgroundTask\` on the API side:

1. \`activation_status=deriving\` — derives the target's scoring profile + search keywords from the user's experience via LLM
2. \`activation_status=polling\` — runs \`poll_sources_for_target()\` to populate scored jobs
3. \`activation_status=ready\` — UI can now render scored postings

The wizard doesn't need to await — failures will surface on \`/jobs\` as a still-idle target (no postings) rather than block the completion step. Wrapped in \`.catch(() => undefined)\` to avoid an unhandled promise rejection if the kickoff itself fails.

## Verified end-to-end

Against Railway dev with a fresh onboarding round-trip:

- Completed conversation wizard → 2 target picks → "Create 2 targets" clicked
- Both targets transitioned \`idle → deriving → ready\` in ~12s
- \`/jobs\` populated:
  - **Senior Frontend Infrastructure Engineer**: 73 scored postings, top score 81 (LaunchDarkly Full Stack Engineer)
  - **Staff Full-Stack Engineer**: 49 scored postings, top score 68 (Postman Staff SWE)

## Test plan

- [x] New regression test asserts \`POST /api/targets/{id}/activate\` is called for each created target
- [x] \`pnpm tsc --noEmit\` clean
- [x] \`pnpm nx test wyrdfold\` — 382/382 (was 381 + 1 new)
- [x] Full end-to-end smoke validated above

🤖 Generated with [Claude Code](https://claude.com/claude-code)