### PR TITLE
fix(wyrdfold-api): route job status ownership check through scores (status updates were 404'ing)

### DIFF
--- a/apps/wyrdfold-api/app/routers/status.py
+++ b/apps/wyrdfold-api/app/routers/status.py
@@ -25,13 +25,21 @@ router = APIRouter(
 def _assert_user_owns_posting(
     supabase: Client, posting_id: str, user_id: str
 ) -> dict[str, Any]:
-    """Return the posting row only if the caller is linked (via user_targets)
-    to the target the posting belongs to. 404 on either missing or unowned —
-    don't leak existence of postings outside the user's targets.
+    """Return ``{status, target_id}`` for the posting only if the caller is
+    linked (via ``user_targets``) to at least one target that has scored
+    this posting. 404 on either missing or unowned — don't leak existence
+    of postings outside the user's targets.
+
+    Ownership is derived through the ``scores`` table (the poller writes
+    ``scores`` rows keyed by ``(job_posting_id, target_id)``). The
+    ``jobs.target_id`` column is **not** populated by the poller — it's
+    a vestigial pre-shared-targets column — so checking it as the source
+    of truth always 404s on real postings.
     """
+    # 1. Confirm the posting exists.
     posting_resp = (
         supabase.table("jobs")
-        .select("status, target_id")
+        .select("status")
         .eq("id", posting_id)
         .single()
         .execute()
@@ -39,21 +47,39 @@ def _assert_user_owns_posting(
     if not posting_resp.data:
         raise HTTPException(status_code=404, detail="Posting not found")
     posting = cast(dict[str, Any], posting_resp.data)
-    target_id = posting.get("target_id")
-    if not target_id:
-        # Pre-shared-targets postings without a target — unreachable through
-        # the multi-tenant UI; treat as not-found rather than implicit-allow.
-        raise HTTPException(status_code=404, detail="Posting not found")
-    link = (
+
+    # 2. Get the caller's active+inactive target ids (auth boundary, not a
+    # filter — the user can act on jobs even from a deactivated target).
+    user_targets_resp = (
         supabase.table("user_targets")
         .select("target_id")
         .eq("user_id", user_id)
-        .eq("target_id", target_id)
+        .execute()
+    )
+    user_target_ids = {
+        cast(dict[str, Any], r)["target_id"]
+        for r in user_targets_resp.data or []
+    }
+    if not user_target_ids:
+        raise HTTPException(status_code=404, detail="Posting not found")
+
+    # 3. Confirm at least one of the user's targets has a score row for
+    # this posting. If so, the user is allowed to mutate its status.
+    score_resp = (
+        supabase.table("scores")
+        .select("target_id")
+        .eq("job_posting_id", posting_id)
+        .in_("target_id", list(user_target_ids))
         .limit(1)
         .execute()
     )
-    if not link.data:
+    rows = cast(list[dict[str, Any]], score_resp.data or [])
+    if not rows:
         raise HTTPException(status_code=404, detail="Posting not found")
+
+    # Surface the owning target_id so callers can scope cache invalidation
+    # to it (same shape the old query exposed via ``jobs.target_id``).
+    posting["target_id"] = rows[0]["target_id"]
     return posting
 
 

--- a/apps/wyrdfold-api/tests/test_routers_status.py
+++ b/apps/wyrdfold-api/tests/test_routers_status.py
@@ -29,13 +29,30 @@ def _build_supabase(
 ) -> MagicMock:
     """Mock supabase chain for status + delete routes.
 
-    Status uses `_assert_user_owns_posting` which:
-      1. table("jobs").select(...).eq("id", id).single().execute()
-      2. table("user_targets").select(...).eq.eq.limit(1).execute()
-    Delete uses the jobs router's own `_assert_user_owns_posting` which
-    differs slightly: it uses .limit(1) instead of .single(). Mock both.
+    Status uses ``_assert_user_owns_posting`` which:
+      1. ``table("jobs").select("status").eq("id", id).single().execute()``
+      2. ``table("user_targets").select("target_id").eq("user_id", uid).execute()``
+      3. ``table("scores").select("target_id").eq("job_posting_id", id).in_("target_id", [...]).limit(1).execute()``
+
+    The old shape went via ``jobs.target_id`` directly; this version
+    routes ownership through the ``scores`` table since the poller
+    doesn't populate ``jobs.target_id``.
+
+    Delete uses the jobs router's own ``_assert_user_owns_posting``
+    (still on the old shape today — ``jobs.target_id`` + .limit(1)).
+    Mock both.
     """
     sb = MagicMock()
+    # Status route returns ``{status}`` from the jobs query. Delete route
+    # still uses the legacy shape with ``jobs.target_id`` inline.
+    posting_status_only = (
+        # The status route only reads ``status`` off the row. Default to
+        # ``"new"`` when callers don't supply one (e.g. delete-path tests
+        # that don't care about status semantics).
+        {"status": posting_data.get("status", "new"), "id": "abc"}
+        if posting_data is not None
+        else None
+    )
     posting_with_target = (
         {**posting_data, "target_id": _TEST_TARGET_ID, "id": "abc"}
         if posting_data is not None
@@ -46,11 +63,11 @@ def _build_supabase(
         t = MagicMock()
         if name == "jobs":
             sel = t.select.return_value
-            # status.py uses .single().execute()
+            # status.py uses .single().execute() — selects just ``status``
             sel.eq.return_value.single.return_value.execute.return_value = _Resp(
-                posting_with_target
+                posting_status_only
             )
-            # jobs.py delete/get use .limit(1).execute()
+            # jobs.py delete/get use .limit(1).execute() — still selects target_id
             sel.eq.return_value.limit.return_value.execute.return_value = _Resp(
                 [posting_with_target] if posting_with_target else None
             )
@@ -61,13 +78,25 @@ def _build_supabase(
                 [posting_with_target] if posting_with_target else None
             )
         elif name == "user_targets":
-            link_data = (
+            # Status route: ``.select("target_id").eq("user_id", uid).execute()``
+            t.select.return_value.eq.return_value.execute.return_value = _Resp(
+                [{"target_id": _TEST_TARGET_ID}] if owns_posting else []
+            )
+            # Legacy delete-path chain (kept for jobs.py compatibility).
+            t.select.return_value.eq.return_value.eq.return_value.limit.return_value.execute.return_value = _Resp(
                 [{"target_id": _TEST_TARGET_ID}]
                 if owns_posting and posting_with_target
                 else []
             )
-            t.select.return_value.eq.return_value.eq.return_value.limit.return_value.execute.return_value = _Resp(
-                link_data
+        elif name == "scores":
+            # Status route: ``.eq("job_posting_id", id).in_("target_id", [...]).limit(1).execute()``
+            score_rows = (
+                [{"target_id": _TEST_TARGET_ID}]
+                if owns_posting and posting_with_target
+                else []
+            )
+            t.select.return_value.eq.return_value.in_.return_value.limit.return_value.execute.return_value = _Resp(
+                score_rows
             )
         elif name == "status_log":
             t.insert.return_value.execute.return_value = _Resp(None)


### PR DESCRIPTION
## Summary

The status-update flow (Save / Applied / Rejected / etc.) was returning **404 \`Posting not found\`** for every call. Status badges in \`/jobs\` never updated; nothing in the pipeline (saved jobs / applications / status_log) could be populated.

Root cause is the **same dead-column issue PR #670 already fixed** in the \`/jobs\` list endpoint: \`_assert_user_owns_posting\` was reading \`jobs.target_id\` to determine which target a posting belongs to — but **the poller never populates that column**. It lives on \`scores\`, keyed by \`(job_posting_id, target_id)\`. Every real posting hit the \`if not target_id\` branch and got 404'd.

## Fix

Derive ownership through \`scores\`:

1. Confirm the posting exists (just \`jobs.status\`).
2. Read the caller's \`user_targets\` rows.
3. Look for any \`scores\` row matching \`(job_posting_id, target_id IN user_targets)\`.

A match means the user is allowed to mutate the posting's status. The matched \`target_id\` is exposed back on the returned dict so the route can still scope cache invalidation to it (same contract as the old \`jobs.target_id\` read).

## Verification

Discovered by walking the full onboarding → target activation → /jobs → status update path in chrome-devtools against Railway dev. With the old code, \`POST /jobs/{id}/status\` returned \`{detail: "Posting not found"}\`. With this patch (run locally), it succeeds and the posting's status flips correctly.

## Test plan

- [x] Updated mock in \`test_routers_status.py\` to model the new \`user_targets\` + \`scores\` query chain (instead of the old \`jobs.target_id\` inline read). Existing delete-path mocking is preserved unchanged — delete still uses the legacy shape inside \`jobs.py\` (separate fix later).
- [x] All 8 status-router tests pass
- [x] Full wyrdfold-api suite: 844/844
- [x] \`ruff check\` + \`mypy --strict\` clean
- [ ] After Railway redeploys, verify status mutations land in the DB and \`status_log\` gains entries

## Follow-up (out of scope)

- \`jobs.py\` has its own \`_assert_user_owns_posting\` (used by DELETE and the per-posting GET). It still uses the \`jobs.target_id\` shape. Same root-cause migration applies — but the failure mode wasn't observed in this smoke walk, so leaving it for a focused follow-up rather than expanding this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)