### PR TITLE
fix(wyrdfold): job detail GET projects description_html + analysis errors stop blaming the description

### DIFF
--- a/apps/wyrdfold-api/app/routers/jobs.py
+++ b/apps/wyrdfold-api/app/routers/jobs.py
@@ -66,6 +66,12 @@ _JP_SELECT_COLS = (
     "greenhouse_updated_at, first_seen_at, created_at"
 )
 
+# Detail-view projection — adds ``description_html`` (and anything else
+# that's too heavy for list pages). Used by the per-posting GET so the
+# UI can render the JD body in the detail panel; analysis/tailor flows
+# already read ``description_html`` directly off ``jobs``.
+_JP_DETAIL_SELECT_COLS = _JP_SELECT_COLS + ", description_html"
+
 
 def _list_jobs_for_target_rpc(
     supabase: Client,
@@ -719,15 +725,27 @@ async def backfill_salary(
 
 
 def _assert_user_owns_posting(
-    supabase: Client, posting_id: str, user_id: str
+    supabase: Client,
+    posting_id: str,
+    user_id: str,
+    *,
+    include_description: bool = False,
 ) -> dict[str, Any]:
     """Look up a posting and verify the caller is linked to its target.
     Returns the selected columns. 404 on either missing or unowned (don't
     leak existence of postings outside the user's targets).
+
+    ``include_description=True`` adds ``description_html`` to the
+    projection — needed by the per-posting detail GET, omitted from the
+    other callers (delete, ownership-only checks) so we don't move the
+    full JD body across the wire on every status mutation.
     """
+    select_cols = (
+        _JP_DETAIL_SELECT_COLS if include_description else _JP_SELECT_COLS
+    )
     posting_resp = (
         supabase.table("jobs")
-        .select(_JP_SELECT_COLS + ", target_id")
+        .select(select_cols + ", target_id")
         .eq("id", posting_id)
         .limit(1)
         .execute()
@@ -758,7 +776,12 @@ async def get_job(
     user_id: str = Depends(get_current_user_id),
     supabase: Client = Depends(get_supabase),
 ) -> dict[str, Any]:
-    row = _assert_user_owns_posting(supabase, posting_id, user_id)
+    # Detail GET pulls ``description_html`` so the UI can render the JD
+    # body. The list endpoint deliberately omits it for payload size, but
+    # there's no rendering of a single posting without the JD text.
+    row = _assert_user_owns_posting(
+        supabase, posting_id, user_id, include_description=True
+    )
     # Drop the helper target_id column we only fetched for ownership.
     row.pop("target_id", None)
     return row

--- a/apps/wyrdfold/src/app/(app)/jobs/JobDetailPanel.tsx
+++ b/apps/wyrdfold/src/app/(app)/jobs/JobDetailPanel.tsx
@@ -162,7 +162,30 @@ export default function JobDetailPanel({
         const data = (await res.json()) as JobAnalysis;
         setAnalysis(data);
       } else {
-        setAnalysisError('Analysis failed. The job may lack a description.');
+        // Distinguish the specific "no description in DB" 422 case (which
+        // the route surfaces with ``Job posting has no description to
+        // analyze.``) from every other failure mode (404, 503, LLM
+        // error, network reset). The previous blanket "lack a
+        // description" message was actively misleading — most analysis
+        // failures aren't about the description.
+        const body = (await res.json().catch(() => null)) as {
+          detail?: string;
+          error?: string;
+        } | null;
+        const detail = body?.detail ?? body?.error;
+        if (
+          res.status === 422 &&
+          typeof detail === 'string' &&
+          /no description/i.test(detail)
+        ) {
+          setAnalysisError(
+            'Analysis skipped — this job posting has no description text.'
+          );
+        } else if (typeof detail === 'string' && detail.trim()) {
+          setAnalysisError(`Analysis failed: ${detail}`);
+        } else {
+          setAnalysisError(`Analysis failed (${res.status}).`);
+        }
       }
     } catch {
       setAnalysisError('Network error running analysis.');


### PR DESCRIPTION
## Summary

Two related fixes around the job detail panel, surfaced while smoke-testing the analysis flow with real polled data on Railway dev.

### 1. wyrdfold-api: \`GET /jobs/{id}\` now includes \`description_html\`

The shared \`_JP_SELECT_COLS\` constant intentionally omits \`description_html\` because the list endpoint shouldn't drag the full JD body across the wire for every row. But the single-job **detail** GET uses the same projection — so the UI's detail panel never received the JD text, even though the row IS in the DB (every analysis call reads it directly off \`jobs\` and works).

Empirical: hit \`/api/jobs/{id}\` for all 122 polled postings → 122/122 returned \`description_html: ""\`. Same jobs analyzed successfully with full scorecards citing specific JD text. So the column is populated; only the projection was dropping it.

Fix: added \`_JP_DETAIL_SELECT_COLS\` (cols + description_html) and gated the projection behind a new \`include_description=False\` default on \`_assert_user_owns_posting\`. The detail GET passes \`True\`; status mutations and delete keep the lean projection.

### 2. wyrdfold: analysis error message reflects the actual failure

\`JobDetailPanel.runAnalysis\` previously surfaced **any** non-OK response as **"Analysis failed. The job may lack a description."** That message was correct exactly when the API returned 422 with that specific detail, and **actively misleading** for 404 / 503 / LLM error / network reset / Anthropic cap.

The originally-reported "Analysis failed" turned out to be a transient ECONNRESET, not a description problem — and the misleading copy sent us looking in the wrong place.

Now: extracts \`detail\` from the response (same pattern as PR #673's \`extractErrorDetail\`), shows the no-description copy only when status is 422 AND the detail names that branch, and falls back to the actual detail text — or \`Analysis failed (<status>)\` if no detail — for everything else.

## Test plan

- [x] \`pnpm tsc --noEmit\` clean
- [x] \`pnpm nx test wyrdfold\` — 382/382
- [x] \`uv run --package wyrdfold-api pytest\` — 844/844
- [x] \`ruff check\` + \`mypy --strict\` clean
- [ ] After Railway redeploy: open a job in /jobs detail panel → JD body renders → analysis surfaces real detail messages on any future failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)