### PR TITLE
fix(wyrdfold): add Generate Resume CTA — onboarded users couldn't tailor a resume

### DIFF
--- a/apps/wyrdfold/src/app/(app)/jobs/JobDetailPanel.tsx
+++ b/apps/wyrdfold/src/app/(app)/jobs/JobDetailPanel.tsx
@@ -11,6 +11,7 @@ import Button from '@/components/Button';
 import { cn } from '@/lib/cn';
 import { useToast } from '@/state/Toast/ToastProvider';
 import CoverLetterSection from './CoverLetterSection';
+import ResumeSection from './ResumeSection';
 import StatusIndicator from './StatusIndicator';
 import {
   formatStatus,
@@ -421,34 +422,16 @@ export default function JobDetailPanel({
         </div>
       )}
 
-      {/* Resume lifecycle */}
+      {/*
+        Resume lifecycle — ResumeSection internally fetches the tailored
+        record (if any) and decides between "Generate" and "Review" based
+        on its actual existence, not on the loosely-correlated job
+        status. Previously inline rendering always linked to the review
+        page even when no draft existed, sending users to a "Resume not
+        found" dead end.
+      */}
       {(status === 'resume_draft' || status === 'resume_ready') && (
-        <div className='flex flex-col gap-2'>
-          <div className='flex items-center gap-2'>
-            <Text variant='caption'>Resume</Text>
-            <Badge
-              variant={status === 'resume_ready' ? 'success' : 'info'}
-              size='sm'
-            >
-              {status === 'resume_ready' ? 'Approved' : 'Draft'}
-            </Badge>
-          </div>
-          <div>
-            <Button
-              as='link'
-              href={`/jobs/${posting.id}/resume`}
-              variant={status === 'resume_ready' ? 'secondary' : 'primary'}
-              size='sm'
-              name={
-                status === 'resume_ready'
-                  ? 'view-approved-resume'
-                  : 'review-resume'
-              }
-            >
-              {status === 'resume_ready' ? 'View / Download' : 'Review Resume'}
-            </Button>
-          </div>
-        </div>
+        <ResumeSection jobPostingId={posting.id} />
       )}
 
       {/* Cover letter */}

--- a/apps/wyrdfold/src/app/(app)/jobs/ResumeSection.tsx
+++ b/apps/wyrdfold/src/app/(app)/jobs/ResumeSection.tsx
@@ -1,0 +1,197 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { Badge } from '@danieljoffe.com/shared-ui/Badge';
+import { Spinner } from '@danieljoffe.com/shared-ui/Spinner';
+import { Text } from '@danieljoffe.com/shared-ui/Text';
+import Button from '@/components/Button';
+import { useToast } from '@/state/Toast/ToastProvider';
+import type { TailoredResumeRecord, TailorResponse } from './types';
+
+interface ResumeSectionProps {
+  jobPostingId: string;
+}
+
+/**
+ * Mirror of ``CoverLetterSection`` for the resume artifact. Distinguishes
+ * "no record yet" → renders a Generate button, from "record exists" →
+ * renders a Review (or View / Download for approved) button.
+ *
+ * The previous inline rendering inside ``JobDetailPanel`` always linked
+ * to ``/jobs/{id}/resume`` regardless of whether a tailored doc actually
+ * existed, leaving the user staring at a "Resume not found" dead-end
+ * page with nowhere to generate one.
+ */
+export default function ResumeSection({ jobPostingId }: ResumeSectionProps) {
+  const [record, setRecord] = useState<TailoredResumeRecord | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [generating, setGenerating] = useState(false);
+  const { toast } = useToast();
+
+  const fetchResume = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/jobs/tailor/by-job/${jobPostingId}`);
+      if (res.status === 404) {
+        setRecord(null);
+        return;
+      }
+      if (!res.ok) return;
+      const data = (await res.json()) as TailoredResumeRecord;
+      setRecord(data);
+    } catch {
+      // Non-critical — silently fail on initial load
+    } finally {
+      setLoading(false);
+    }
+  }, [jobPostingId]);
+
+  useEffect(() => {
+    fetchResume();
+  }, [fetchResume]);
+
+  async function handleGenerate() {
+    setGenerating(true);
+    try {
+      // The tailor route requires the JD text alongside ``job_posting_id``
+      // — fetch it from the posting detail (description_html lives there
+      // since PR #677). Cover letter doesn't need this because the
+      // backend resolves the JD itself for that pipeline.
+      const detailRes = await fetch(`/api/jobs/${jobPostingId}`);
+      if (!detailRes.ok) {
+        toast({ variant: 'error', title: 'Could not load job description' });
+        return;
+      }
+      const detail = (await detailRes.json()) as {
+        description_html: string | null;
+      };
+      const jd = (detail.description_html ?? '').trim();
+      if (!jd) {
+        toast({
+          variant: 'error',
+          title: 'Job has no description — cannot tailor a resume.',
+        });
+        return;
+      }
+
+      const res = await fetch('/api/jobs/tailor/resume', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          job_description: jd,
+          job_posting_id: jobPostingId,
+        }),
+      });
+
+      if (!res.ok) {
+        // The 422 case carries a structured ``detail`` object for the
+        // gap-gate failure mode (so it can show ``message`` + percent /
+        // tier in a future enhancement); other failures (400 ``no
+        // contact name on file``, 404 ``no optimized doc``, 503, etc.)
+        // carry a plain ``detail`` string. Surface the actual cause
+        // instead of a generic "failed" — chasing the wrong cause is
+        // exactly what the analysis-panel fix in #677 addressed.
+        const body = (await res.json().catch(() => null)) as {
+          detail?: { code?: string; message?: string } | string;
+        } | null;
+        const detail = body?.detail;
+        if (
+          typeof detail === 'object' &&
+          detail !== null &&
+          detail.code === 'gap_gate'
+        ) {
+          toast({
+            variant: 'error',
+            title: detail.message ?? 'Master doc has gaps — update it first',
+          });
+        } else if (typeof detail === 'string' && detail.trim()) {
+          toast({ variant: 'error', title: detail });
+        } else {
+          toast({
+            variant: 'error',
+            title: `Resume generation failed (${res.status})`,
+          });
+        }
+        return;
+      }
+
+      const data = (await res.json()) as TailorResponse;
+      setRecord(data.record);
+      toast({ variant: 'success', title: 'Resume drafted with AI' });
+    } catch {
+      toast({ variant: 'error', title: 'Network error generating resume' });
+    } finally {
+      setGenerating(false);
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className='flex flex-col gap-2'>
+        <div className='flex items-center gap-2'>
+          <Text variant='caption'>Resume</Text>
+          <Badge variant='default' size='sm'>
+            Loading...
+          </Badge>
+        </div>
+      </div>
+    );
+  }
+
+  const isApproved = record?.approved_at != null;
+  const statusLabel = generating
+    ? 'Generating...'
+    : !record
+      ? 'Not started'
+      : isApproved
+        ? 'Approved'
+        : 'Draft';
+  const statusVariant = generating
+    ? 'info'
+    : !record
+      ? 'default'
+      : isApproved
+        ? 'success'
+        : 'info';
+
+  return (
+    <div className='flex flex-col gap-2'>
+      <div className='flex items-center gap-2'>
+        <Text variant='caption'>Resume</Text>
+        <Badge variant={statusVariant} size='sm'>
+          {statusLabel}
+        </Badge>
+      </div>
+
+      {generating ? (
+        <div className='flex items-center gap-2'>
+          <Spinner size='sm' />
+          <Text variant='meta'>Generating resume...</Text>
+        </div>
+      ) : !record ? (
+        <div>
+          <Button
+            name='generate-resume'
+            variant='primary'
+            size='sm'
+            onClick={handleGenerate}
+          >
+            Generate Resume
+          </Button>
+        </div>
+      ) : (
+        <div>
+          <Button
+            as='link'
+            href={`/jobs/${jobPostingId}/resume`}
+            variant={isApproved ? 'secondary' : 'primary'}
+            size='sm'
+            name={isApproved ? 'view-approved-resume' : 'review-resume'}
+          >
+            {isApproved ? 'View / Download' : 'Review Resume'}
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

The Resume section inside \`JobDetailPanel\` was rendering a **"Review Resume"** link whenever the job status was \`resume_draft\` or \`resume_ready\` — regardless of whether a tailored record actually existed. Clicking it landed users on a **"Resume not found. Generate one from the job page first."** dead-end, with **no Generate button anywhere** to actually start from.

Cover Letter had the right pattern: a self-contained section that fetches \`/api/jobs/tailor/by-job/{id}/cover-letter\` and conditionally shows **Generate** vs **Review** based on actual record presence. Resume was the only artifact still wired to status-implies-existence.

## Fix

- New \`ResumeSection\` component mirroring \`CoverLetterSection\` — fetches \`/api/jobs/tailor/by-job/{id}\` on mount; distinguishes \`Not started → Generate Resume\`, \`Draft → Review Resume\`, \`Approved → View / Download\`.
- The Generate path fetches the posting detail (now exposing \`description_html\` after #677 + #678) to pass alongside \`job_posting_id\` to \`POST /api/jobs/tailor/resume\`.
- Surfaces upstream error \`detail\` strings (same pattern as #673's \`extractErrorDetail\`) instead of a generic "Resume generation failed". This is exactly how we found the actual blocker during smoke walk: a \`400 "No contact name on file. Set your name in Settings → Profile before generating resumes or cover letters."\` was getting swallowed by the previous catch-all toast.
- Wired into \`JobDetailPanel\` in place of the inline always-Review block.

## Verified end-to-end against Railway dev

Onboarding → targets ready → status flip to \`resume_draft\` → \`Generate Resume\` button → resume drafted in **25.8s** via Claude Sonnet 4.6 (\$0.0505, 8,675 tokens) → \`Review Resume\` opens the editable markdown view with a real tailored resume citing role-specific keywords (Feature Flags, strangler migration, Go workflow engine p95).

## Open finding (separate PR worth filing)

The onboarding wizard never captures the user's contact name. The resume/cover-letter tailoring pipeline both require it, so a freshly-onboarded user gets bounced with the \`400 "No contact name on file"\` error before they can generate anything. There's no in-flow prompt to fix this — only the Settings page. Two reasonable fixes:

1. Add a "Your name + contact info" step to the onboarding wizard
2. Make the resume/cover-letter routes auto-fill the contact name from the user's auth email/metadata if missing

Leaving that to a separate PR.

## Test plan

- [x] \`pnpm tsc --noEmit\` clean
- [x] \`pnpm nx test wyrdfold\` — 382/382
- [x] Full end-to-end smoke verified above

🤖 Generated with [Claude Code](https://claude.com/claude-code)