### PR TITLE
fix(wyrdfold): send job_description on cover-letter tailor request

### DIFF
--- a/apps/wyrdfold/src/app/(app)/jobs/CoverLetterSection.tsx
+++ b/apps/wyrdfold/src/app/(app)/jobs/CoverLetterSection.tsx
@@ -51,34 +51,56 @@ export default function CoverLetterSection({
   async function handleGenerate() {
     setGenerating(true);
     try {
+      const detailRes = await fetch(`/api/jobs/${jobPostingId}`);
+      if (!detailRes.ok) {
+        toast({ variant: 'error', title: 'Could not load job description' });
+        return;
+      }
+      const detail = (await detailRes.json()) as {
+        description_html: string | null;
+      };
+      const jd = (detail.description_html ?? '').trim();
+      if (!jd) {
+        toast({
+          variant: 'error',
+          title: 'Job has no description — cannot tailor a cover letter.',
+        });
+        return;
+      }
+
       const res = await fetch('/api/jobs/tailor/cover-letter', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
+          job_description: jd,
           job_posting_id: jobPostingId,
           company_name: companyName,
           role_title: roleTitle,
         }),
       });
 
-      if (res.status === 422) {
-        const err = (await res.json()) as {
-          detail: { code: string | undefined; message: string | undefined };
-        };
-        if (err.detail?.code === 'gap_gate') {
+      if (!res.ok) {
+        const body = (await res.json().catch(() => null)) as {
+          detail?: { code?: string; message?: string } | string;
+        } | null;
+        const detail = body?.detail;
+        if (
+          typeof detail === 'object' &&
+          detail !== null &&
+          detail.code === 'gap_gate'
+        ) {
           toast({
             variant: 'error',
-            title:
-              err.detail.message ?? 'Master doc has gaps — update it first',
+            title: detail.message ?? 'Master doc has gaps — update it first',
           });
+        } else if (typeof detail === 'string' && detail.trim()) {
+          toast({ variant: 'error', title: detail });
         } else {
-          toast({ variant: 'error', title: 'Cover letter generation failed' });
+          toast({
+            variant: 'error',
+            title: `Cover letter generation failed (${res.status})`,
+          });
         }
-        return;
-      }
-
-      if (!res.ok) {
-        toast({ variant: 'error', title: 'Failed to generate cover letter' });
         return;
       }
 


### PR DESCRIPTION
## Summary
- Generate Cover Letter button was 422'ing silently — the section sent `{ job_posting_id, company_name, role_title }` but the backend `CoverLetterRequest` schema requires `job_description` (min_length=1). The lone structured error branch only matched `detail.code === 'gap_gate'`, so the 422 fell through without surfacing the real cause.
- Mirror the resume fix from #679: fetch `/api/jobs/{id}` first to pull `description_html`, bail with a clear toast if empty, and send it on the POST. Surface upstream `detail` strings for non-gap failures (e.g. missing contact name) the same way `ResumeSection` does.

## Why now
Found during the wyrdfold smoke walk continuing from #679 — clicking "Generate Cover Letter" on the LaunchDarkly test job (target: Senior Frontend Infrastructure Engineer) returned `[{"type":"missing","loc":["body","job_description"],"msg":"Field required"}]` from FastAPI's pydantic validator, and the UI showed nothing.

## Test plan
- [x] `pnpm tsc --noEmit` clean
- [ ] On a job whose description is present, "Generate Cover Letter" succeeds and flips to "Generated" + "Review Cover Letter"
- [ ] On a job whose description is missing, "Generate Cover Letter" shows the empty-JD toast (no POST fired)
- [ ] When the upstream returns `gap_gate` (no optimized doc), the structured `detail.message` is surfaced
- [ ] When the upstream returns a plain-string `detail` (e.g. "No contact name on file"), it is surfaced verbatim

🤖 Generated with [Claude Code](https://claude.com/claude-code)