### PR TITLE
fix(wyrdfold): swallow Supabase cookie writes in Server Component SSR

### DIFF
--- a/apps/wyrdfold/src/lib/supabase/auth-server.test.ts
+++ b/apps/wyrdfold/src/lib/supabase/auth-server.test.ts
@@ -102,6 +102,38 @@ describe('createAuthServerClient', () => {
     });
   });
 
+  it('cookie adapter setAll() swallows cookieStore.set throws (Server Component context)', async () => {
+    // Next.js throws "Cookies can only be modified in a Server Action or
+    // Route Handler" when ``cookieStore.set`` is called from a Server
+    // Component. If we let that bubble, ``getAccessToken``'s catch
+    // collapses the whole session to null and every SSR fetch falls
+    // back to the "no data" state — even though the access token is
+    // perfectly valid. Suppress the write here; middleware refreshes.
+    process.env['NEXT_PUBLIC_SUPABASE_URL'] = 'https://supabase.test';
+    process.env['NEXT_PUBLIC_SUPABASE_ANON_ID'] = 'anon-key';
+    mockCookieStore.set.mockImplementation(() => {
+      throw new Error('Cookies can only be modified in a Server Action');
+    });
+
+    const { createAuthServerClient } = await import('./auth-server');
+    await createAuthServerClient();
+
+    const [, , opts] = mockCreateServerClient.mock.calls[0] as [
+      string,
+      string,
+      {
+        cookies: {
+          setAll: (
+            c: { name: string; value: string; options: unknown }[]
+          ) => void;
+        };
+      },
+    ];
+    expect(() =>
+      opts.cookies.setAll([{ name: 'a', value: '1', options: { path: '/' } }])
+    ).not.toThrow();
+  });
+
   it('throws when env vars are missing', async () => {
     delete process.env['NEXT_PUBLIC_SUPABASE_URL'];
     delete process.env['NEXT_PUBLIC_SUPABASE_ANON_ID'];

--- a/apps/wyrdfold/src/lib/supabase/auth-server.ts
+++ b/apps/wyrdfold/src/lib/supabase/auth-server.ts
@@ -33,8 +33,23 @@ export async function createAuthServerClient() {
         return cookieStore.getAll();
       },
       setAll(cookiesToSet) {
-        for (const { name, value, options } of cookiesToSet) {
-          cookieStore.set(name, value, options);
+        // Server Components can't mutate cookies — only Route Handlers,
+        // Server Actions, and Middleware can. Supabase still tries to
+        // write refreshed cookies whenever ``getSession()`` rotates the
+        // token, and the throw used to escape into ``getAccessToken``'s
+        // catch — collapsing the whole session to ``null`` and making
+        // every SSR ``fetchJsonFromWyrdfoldAPI`` call return null. The
+        // browser-side ``/api/*`` proxy routes were unaffected (Route
+        // Handlers can write), which is why the Targets / Dashboard
+        // pages rendered the zero-state while client fetches succeeded.
+        // Suppress the write in the read-only context — middleware
+        // handles the actual token refresh.
+        try {
+          for (const { name, value, options } of cookiesToSet) {
+            cookieStore.set(name, value, options);
+          }
+        } catch {
+          // no-op — see comment above
         }
       },
     },


### PR DESCRIPTION
## Summary
- `/dashboard` and `/targets` were rendering the "Build your profile" zero-state for users with valid sessions, derived prose, active targets, and scored jobs. Root cause: the `createServerClient` adapter forwarded every Supabase cookie write to `cookieStore.set` without a guard, and Next.js throws "Cookies can only be modified in a Server Action or Route Handler" whenever a Server Component triggers a refresh write.
- The throw escaped into `getAccessToken`'s `try/catch`, collapsing the session to `null` and making every `fetchJsonFromWyrdfoldAPI` call return `null`. Browser-side `/api/*` Route Handlers were unaffected (they're allowed to write cookies), which is why client fetches worked but RSC pages did not.
- Wrap the write loop in a `try/catch` — the canonical `@supabase/ssr` Server-Component pattern. Middleware continues to perform the actual token refresh on subsequent requests.

## Why now
Found mid-smoke walking the "Suggest from Experience" path: `/targets` consistently showed the zero-state, but `/api/targets/mine` returned 2 targets and `/api/experience/prose` returned a populated prose doc when hit directly with the cookie's access token against Railway.

## Test plan
- [x] `pnpm tsc --noEmit` clean
- [x] `pnpm nx test wyrdfold -- --testPathPatterns=auth-server.test.ts` (5/5 pass — new test asserts `setAll` no longer rethrows when `cookieStore.set` throws)
- [x] `/targets` and `/dashboard` now hydrate with real data for an onboarded user
- [ ] (preview) Confirm signed-out users still see the public auth state (no regression in the `null` access-token path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)