### PR TITLE
fix(wyrdfold): render JD body + overlay live target score on /jobs/{id}

### DIFF
--- a/apps/wyrdfold-api/app/routers/jobs.py
+++ b/apps/wyrdfold-api/app/routers/jobs.py
@@ -781,19 +781,30 @@ def _assert_user_owns_posting(
     # 3. Confirm at least one of the user's targets has a score row for
     # this posting. Exposing the matched target_id on the returned row
     # so callers can scope cache invalidation, mirroring the old
-    # ``jobs.target_id`` contract.
+    # ``jobs.target_id`` contract. Also pull ``score`` + ``score_breakdown``
+    # so detail callers can overlay them — ``jobs.score`` and
+    # ``jobs.score_breakdown`` are vestigial pre-shared-targets columns
+    # that the poller doesn't update (it writes ``scores``), so reading
+    # them directly off the posting row yields stale ``0`` / ``{}``.
     score_resp = (
         supabase.table("scores")
-        .select("target_id")
+        .select("target_id, score, score_breakdown")
         .eq("job_posting_id", posting_id)
         .in_("target_id", list(user_target_ids))
+        .order("score", desc=True)
         .limit(1)
         .execute()
     )
     score_rows = cast(list[dict[str, Any]], score_resp.data or [])
     if not score_rows:
         raise HTTPException(status_code=404, detail="Posting not found")
-    row["target_id"] = score_rows[0]["target_id"]
+    best = score_rows[0]
+    row["target_id"] = best["target_id"]
+    # Stash the live score onto the row under an alias so callers can opt
+    # in to the overlay without changing the existing ``score`` /
+    # ``score_breakdown`` semantics on routes that don't need it.
+    row["_target_score"] = best.get("score")
+    row["_target_score_breakdown"] = best.get("score_breakdown")
     return row
 
 
@@ -809,6 +820,19 @@ async def get_job(
     row = _assert_user_owns_posting(
         supabase, posting_id, user_id, include_description=True
     )
+    # Overlay the live per-target score + breakdown. The ``jobs.score`` /
+    # ``jobs.score_breakdown`` columns are vestigial and never updated
+    # by the poller — without this, the detail view reads stale ``0`` /
+    # ``{}`` and the "Score Breakdown" panel renders "No factors
+    # contributed to this score" for every posting. Use the best score
+    # across the user's targets (matches the untargeted list view's
+    # per-job aggregation).
+    target_score = row.pop("_target_score", None)
+    target_breakdown = row.pop("_target_score_breakdown", None)
+    if target_score is not None:
+        row["score"] = target_score
+    if target_breakdown is not None:
+        row["score_breakdown"] = target_breakdown
     # Drop the helper target_id column we only fetched for ownership.
     row.pop("target_id", None)
     return row

--- a/apps/wyrdfold/package.json
+++ b/apps/wyrdfold/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@danieljoffe.com/shared-ui": "workspace:*",
     "@supabase/ssr": "^0.10.2",
+    "isomorphic-dompurify": "2.26.0",
     "next": "16.2.3",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/apps/wyrdfold/src/app/(app)/jobs/JobDetailPanel.tsx
+++ b/apps/wyrdfold/src/app/(app)/jobs/JobDetailPanel.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import DOMPurify from 'isomorphic-dompurify';
 import { ChevronDown, Maximize2 } from 'lucide-react';
 import { Badge } from '@danieljoffe.com/shared-ui/Badge';
 import { Dropdown } from '@danieljoffe.com/shared-ui/Dropdown';
@@ -31,6 +32,10 @@ interface JobDetailPanelProps {
   onStatusChange: ((status: string) => void) | undefined;
   /** Suppress the panel's own Delete action (the page renders one at root). */
   hideDelete?: boolean;
+  /** Default-open the JD description block on the full-page detail
+   *  view (where the user clearly wants to see it). The inline panel
+   *  in the list keeps it collapsed to avoid blowing up rows. */
+  defaultDescriptionOpen?: boolean;
 }
 
 const SCORE_FACTOR_LABEL: Record<string, string> = {
@@ -102,6 +107,7 @@ export default function JobDetailPanel({
   onDelete,
   onStatusChange,
   hideDelete = false,
+  defaultDescriptionOpen = false,
 }: JobDetailPanelProps) {
   const [status, setStatus] = useState(posting.status);
   const [updating, setUpdating] = useState(false);
@@ -229,6 +235,27 @@ export default function JobDetailPanel({
 
   const breakdown = posting.score_breakdown;
 
+  // Sanitize the upstream JD HTML once per posting. Greenhouse returns
+  // (and the poller persists) the description body entity-encoded —
+  // ``&lt;h4&gt;…&lt;/h4&gt;`` rather than ``<h4>…</h4>`` — so we have
+  // to decode one level before DOMPurify will recognize the tags;
+  // otherwise the panel just renders the encoded source as text.
+  // DOMPurify itself scrubs against XSS — defence-in-depth even
+  // though the source is first-party.
+  const sanitizedDescription = useMemo(() => {
+    const raw = posting.description_html ?? '';
+    if (!raw.trim()) return null;
+    const decoded =
+      typeof window === 'undefined'
+        ? raw
+        : (() => {
+            const ta = document.createElement('textarea');
+            ta.innerHTML = raw;
+            return ta.value;
+          })();
+    return DOMPurify.sanitize(decoded, { USE_PROFILES: { html: true } });
+  }, [posting.description_html]);
+
   return (
     <div className='border-t border-border bg-surface-tertiary p-4 space-y-4'>
       {/* Status dropdown + score */}
@@ -312,6 +339,25 @@ export default function JobDetailPanel({
           <Skeleton variant='text' lines={3} />
         )}
       </div>
+
+      {/* Job description body — rendered from the upstream JD HTML.
+          Wrapped in ``<details>`` so the inline list panel stays compact;
+          the full detail page passes ``defaultDescriptionOpen`` to open
+          it by default since the user navigated there explicitly. */}
+      {sanitizedDescription && (
+        <details open={defaultDescriptionOpen}>
+          <summary className='cursor-pointer text-text-secondary hover:text-text-primary'>
+            <Text variant='caption' as='span'>
+              Job description
+            </Text>
+          </summary>
+          <div
+            className='mt-2 prose prose-sm dark:prose-invert max-w-none text-text-primary [&_a]:text-brand-500 [&_a]:underline [&_ul]:list-disc [&_ol]:list-decimal [&_ul]:pl-5 [&_ol]:pl-5'
+            // Sanitized via DOMPurify above — safe to inject.
+            dangerouslySetInnerHTML={{ __html: sanitizedDescription }}
+          />
+        </details>
+      )}
 
       {/* Status History */}
       {history.length > 0 && (

--- a/apps/wyrdfold/src/app/(app)/jobs/[id]/JobDetailPage.tsx
+++ b/apps/wyrdfold/src/app/(app)/jobs/[id]/JobDetailPage.tsx
@@ -243,6 +243,7 @@ export default function JobDetailPage({ id, targetId }: JobDetailPageProps) {
           onDelete={undefined}
           onStatusChange={handleStatusChange}
           hideDelete
+          defaultDescriptionOpen
         />
       </Card>
 

--- a/apps/wyrdfold/src/app/(app)/jobs/types.ts
+++ b/apps/wyrdfold/src/app/(app)/jobs/types.ts
@@ -50,6 +50,9 @@ export interface JobPosting {
   greenhouse_updated_at: string | null;
   first_seen_at: string;
   created_at: string;
+  /** Present only on the detail GET ``/jobs/{id}`` — list responses
+   *  deliberately omit it to keep the payload small. */
+  description_html?: string | null;
 }
 
 export interface JobsFilterState {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -398,6 +398,9 @@ importers:
       '@supabase/ssr':
         specifier: ^0.10.2
         version: 0.10.2(@supabase/supabase-js@2.103.0)
+      isomorphic-dompurify:
+        specifier: 2.26.0
+        version: 2.26.0
       next:
         specifier: 16.2.3
         version: 16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.89.2)
@@ -2998,6 +3001,7 @@ packages:
 
   '@nx/s3-cache@5.0.4':
     resolution: {integrity: sha512-BnX/MowhJpttmwPVDje3Hvli/8yUUgBrN+lpPlGdaQ1Ew2+13Y05TOn4awB1rs1cZF8YZHCoBuUHPzF13XBaYA==}
+    deprecated: This package has been deprecated. See https://nx.dev/docs/reference/deprecated/self-hosted-cache-packages for details
     peerDependencies:
       nx: '>= 18 < 23'
 
@@ -11819,8 +11823,8 @@ packages:
   third-party-web@0.26.7:
     resolution: {integrity: sha512-buUzX4sXC4efFX6xg2bw6/eZsCUh8qQwSavC4D9HpONMFlRbcHhD8Je5qwYdCpViR6q0qla2wPP+t91a2vgolg==}
 
-  third-party-web@0.29.0:
-    resolution: {integrity: sha512-nBDSJw5B7Sl1YfsATG2XkW5qgUPODbJhXw++BKygi9w6O/NKS98/uY/nR/DxDq2axEjL6halHW1v+jhm/j1DBQ==}
+  third-party-web@0.29.2:
+    resolution: {integrity: sha512-fegtha91tq2DHphyoiBXVHjVi2YG9zFaRnboT9C28tO1en9Y3wJsfspuy40F+u5wl3hHVbw7cnd1b67kEGHb8g==}
 
   through@2.3.8:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
@@ -16852,7 +16856,7 @@ snapshots:
   '@paulirish/trace_engine@0.0.53':
     dependencies:
       legacy-javascript: 0.0.1
-      third-party-web: 0.29.0
+      third-party-web: 0.29.2
 
   '@phenomnomnominal/tsquery@6.1.4(typescript@5.9.3)':
     dependencies:
@@ -26699,7 +26703,7 @@ snapshots:
 
   third-party-web@0.26.7: {}
 
-  third-party-web@0.29.0: {}
+  third-party-web@0.29.2: {}
 
   through@2.3.8: {}
 


### PR DESCRIPTION
## Summary
Two bugs found on the full-page job detail view (``/jobs/{id}``) that conspired to make it look broken even after #677/#678 unblocked the ``description_html`` projection:

### 1. "No factors contributed to this score" on every posting
``get_job`` projected ``jobs.score`` and ``jobs.score_breakdown`` straight off the postings row, but those columns are vestigial pre-shared-targets columns that the poller never updates — per-target scores live in the ``scores`` table (same root cause as the ownership-check bugs in #676 / #678). The list endpoints already overlay scores from ``scores``; the detail endpoint was the last reader of the stale columns. ``_assert_user_owns_posting`` now fetches the matched scores row (ordered by best score across the user's targets) and ``get_job`` overlays both fields onto the response. Mirrors the per-job aggregation the untargeted list view uses.

### 2. JD body never rendered
The 12.7 KB ``description_html`` was on the wire but no component displayed it. Added a sanitized JD section inside ``JobDetailPanel`` wrapped in ``<details>`` — the inline list-row panel stays compact (no ``description_html`` in the list payload, so the section is hidden), while the full detail page passes ``defaultDescriptionOpen`` so the body shows by default.

Greenhouse persists the JD entity-encoded (``&lt;h4&gt;…``) rather than raw HTML, so without a decode step DOMPurify sees plain text and the panel renders the encoded source as-is. Decode once via a throwaway ``<textarea>`` before handing to DOMPurify (defensive sanitization with ``USE_PROFILES.html``).

## Test plan
- [x] ``pnpm tsc --noEmit`` clean (6/6 typecheck targets pass)
- [x] Smoke: ``/jobs/{id}`` renders the description body with proper headings/lists/paragraphs (4× h4, 37× p, 4× ul, 33× li on the LaunchDarkly test posting)
- [x] Smoke: inline list-row panel still does not render the JD block (intentional — list payload omits ``description_html``)
- [ ] Railway deploy then verify Score Breakdown shows factors on the full detail view (mocked locally; backend not redeployed yet)
- [ ] (followup) Unit test for ``_assert_user_owns_posting`` returning the highest score across multiple matching targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)