### PR TITLE
fix(wyrdfold): inline-prompt for missing contact name on Generate

### DIFF
--- a/apps/wyrdfold/src/app/(app)/jobs/CoverLetterSection.tsx
+++ b/apps/wyrdfold/src/app/(app)/jobs/CoverLetterSection.tsx
@@ -6,6 +6,7 @@ import { Spinner } from '@danieljoffe.com/shared-ui/Spinner';
 import { Text } from '@danieljoffe.com/shared-ui/Text';
 import Button from '@/components/Button';
 import { useToast } from '@/state/Toast/ToastProvider';
+import { promptForMissingContactName } from './promptForMissingContactName';
 import type { TailoredResumeRecord, TailorResponse } from './types';
 
 interface CoverLetterSectionProps {
@@ -68,16 +69,36 @@ export default function CoverLetterSection({
         return;
       }
 
-      const res = await fetch('/api/jobs/tailor/cover-letter', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          job_description: jd,
-          job_posting_id: jobPostingId,
-          company_name: companyName,
-          role_title: roleTitle,
-        }),
-      });
+      const postTailor = () =>
+        fetch('/api/jobs/tailor/cover-letter', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            job_description: jd,
+            job_posting_id: jobPostingId,
+            company_name: companyName,
+            role_title: roleTitle,
+          }),
+        });
+
+      let res = await postTailor();
+
+      // Mirrors the contact-name capture in ResumeSection — same gate
+      // on the tailor pipeline, first-time users hit it without ever
+      // visiting Settings.
+      if (!res.ok) {
+        const peek = (await res
+          .clone()
+          .json()
+          .catch(() => null)) as {
+          detail?: { code?: string; message?: string } | string;
+        } | null;
+        const peekDetail =
+          typeof peek?.detail === 'string' ? peek.detail : undefined;
+        if (await promptForMissingContactName(peekDetail)) {
+          res = await postTailor();
+        }
+      }
 
       if (!res.ok) {
         const body = (await res.json().catch(() => null)) as {

--- a/apps/wyrdfold/src/app/(app)/jobs/ResumeSection.tsx
+++ b/apps/wyrdfold/src/app/(app)/jobs/ResumeSection.tsx
@@ -6,6 +6,7 @@ import { Spinner } from '@danieljoffe.com/shared-ui/Spinner';
 import { Text } from '@danieljoffe.com/shared-ui/Text';
 import Button from '@/components/Button';
 import { useToast } from '@/state/Toast/ToastProvider';
+import { promptForMissingContactName } from './promptForMissingContactName';
 import type { TailoredResumeRecord, TailorResponse } from './types';
 
 interface ResumeSectionProps {
@@ -74,14 +75,35 @@ export default function ResumeSection({ jobPostingId }: ResumeSectionProps) {
         return;
       }
 
-      const res = await fetch('/api/jobs/tailor/resume', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          job_description: jd,
-          job_posting_id: jobPostingId,
-        }),
-      });
+      const postTailor = () =>
+        fetch('/api/jobs/tailor/resume', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            job_description: jd,
+            job_posting_id: jobPostingId,
+          }),
+        });
+
+      let res = await postTailor();
+
+      // The onboarding wizard doesn't capture a contact name (Supabase
+      // magic-link auth has none), so first-time users hit the 400
+      // "No contact name on file" gate. Prompt for it inline + retry
+      // rather than dead-ending in Settings.
+      if (!res.ok) {
+        const peek = (await res
+          .clone()
+          .json()
+          .catch(() => null)) as {
+          detail?: { code?: string; message?: string } | string;
+        } | null;
+        const peekDetail =
+          typeof peek?.detail === 'string' ? peek.detail : undefined;
+        if (await promptForMissingContactName(peekDetail)) {
+          res = await postTailor();
+        }
+      }
 
       if (!res.ok) {
         // The 422 case carries a structured ``detail`` object for the

--- a/apps/wyrdfold/src/app/(app)/jobs/__tests__/promptForMissingContactName.spec.ts
+++ b/apps/wyrdfold/src/app/(app)/jobs/__tests__/promptForMissingContactName.spec.ts
@@ -1,0 +1,89 @@
+import { promptForMissingContactName } from '../promptForMissingContactName';
+
+describe('promptForMissingContactName', () => {
+  const originalPrompt = window.prompt;
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    window.prompt = originalPrompt;
+    global.fetch = originalFetch;
+    jest.clearAllMocks();
+  });
+
+  it('returns false without prompting when detail is undefined', async () => {
+    const promptSpy = jest.fn();
+    window.prompt = promptSpy;
+
+    const result = await promptForMissingContactName(undefined);
+
+    expect(result).toBe(false);
+    expect(promptSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns false without prompting when detail does not match the gate', async () => {
+    const promptSpy = jest.fn();
+    window.prompt = promptSpy;
+
+    const result = await promptForMissingContactName(
+      'Master doc has gaps — update it first'
+    );
+
+    expect(result).toBe(false);
+    expect(promptSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns false when the user cancels the prompt', async () => {
+    window.prompt = jest.fn(() => null);
+    const fetchSpy = jest.fn();
+    global.fetch = fetchSpy as unknown as typeof fetch;
+
+    const result = await promptForMissingContactName(
+      'No contact name on file. Set your name in Settings → Profile…'
+    );
+
+    expect(result).toBe(false);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns false when the user submits an empty / whitespace name', async () => {
+    window.prompt = jest.fn(() => '   ');
+    const fetchSpy = jest.fn();
+    global.fetch = fetchSpy as unknown as typeof fetch;
+
+    const result = await promptForMissingContactName(
+      'No contact name on file. Set your name in Settings → Profile…'
+    );
+
+    expect(result).toBe(false);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('PATCHes /api/profile/identity and returns true when PATCH succeeds', async () => {
+    window.prompt = jest.fn(() => '  Daniel Joffe  ');
+    const fetchSpy = jest.fn().mockResolvedValue({ ok: true });
+    global.fetch = fetchSpy as unknown as typeof fetch;
+
+    const result = await promptForMissingContactName(
+      'No contact name on file. Set your name in Settings → Profile…'
+    );
+
+    expect(result).toBe(true);
+    expect(fetchSpy).toHaveBeenCalledWith('/api/profile/identity', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'Daniel Joffe' }),
+    });
+  });
+
+  it('returns false when the PATCH fails', async () => {
+    window.prompt = jest.fn(() => 'Daniel Joffe');
+    const fetchSpy = jest.fn().mockResolvedValue({ ok: false });
+    global.fetch = fetchSpy as unknown as typeof fetch;
+
+    const result = await promptForMissingContactName(
+      'No contact name on file. Set your name in Settings → Profile…'
+    );
+
+    expect(result).toBe(false);
+  });
+});

--- a/apps/wyrdfold/src/app/(app)/jobs/promptForMissingContactName.ts
+++ b/apps/wyrdfold/src/app/(app)/jobs/promptForMissingContactName.ts
@@ -1,0 +1,41 @@
+/**
+ * Shared between ``ResumeSection`` and ``CoverLetterSection``: when the
+ * backend rejects a tailor request with the "No contact name on file"
+ * 400, prompt the user inline (native ``window.prompt`` for
+ * minimum-friction), PATCH ``/api/profile/identity``, and return whether
+ * the caller should retry. The onboarding wizard doesn't capture this
+ * field today (Supabase magic-link auth has no name), and the tailor
+ * pipeline requires it to render the resume header — so a fresh user
+ * always hits this gate on their first Generate click. Without the
+ * inline capture they have to context-switch to Settings, copy the
+ * Greenhouse JD URL, and start over.
+ *
+ * Caller pattern:
+ *
+ *     if (await promptForMissingContactName(detail)) {
+ *       // user filled in the name — try the same request again
+ *       return retry();
+ *     }
+ *
+ * Returns ``false`` if the detail doesn't match this specific failure
+ * (so the caller can fall through to its generic error toast), or if
+ * the user cancelled the prompt. ``true`` only when the PATCH
+ * succeeded and the caller should re-issue the original request.
+ */
+export async function promptForMissingContactName(
+  detail: string | undefined
+): Promise<boolean> {
+  if (!detail || !/no contact name on file/i.test(detail)) return false;
+  // eslint-disable-next-line no-alert -- personal tool, native prompt matches the codebase
+  const name = window.prompt(
+    'What name should appear on your resume / cover letter?'
+  );
+  const trimmed = name?.trim() ?? '';
+  if (!trimmed) return false;
+  const res = await fetch('/api/profile/identity', {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name: trimmed }),
+  });
+  return res.ok;
+}


### PR DESCRIPTION
## Summary
- Onboarding doesn't capture a contact name (Supabase magic-link auth has no ``name`` claim), so every new user's first Resume / Cover Letter Generate click hits the backend's ``contact`` gate with a 400 "No contact name on file…". The current UX dead-ends in Settings, forcing the user to dig up the JD URL and start over.
- Detect that specific detail string in both ``ResumeSection`` and ``CoverLetterSection``, fire a ``window.prompt`` (mirroring the codebase's existing native-confirm pattern for delete), PATCH ``/api/profile/identity`` with the entered name, and retry the original tailor request transparently.
- Shared helper ``promptForMissingContactName`` keeps both sections in sync, with a 6-case test suite covering the no-detail / non-matching / cancel / empty / success / PATCH-failure paths.

## Why this scope
A proper "Contact info" capture step in the onboarding wizard would solve the broader problem (email, phone, location, etc.) but it's a much bigger reshuffle. This PR unblocks the smoke walk by handling the only required field for the tailor pipeline. Email pre-seeding from the auth user is a related backend improvement to schedule next.

## Test plan
- [x] ``pnpm tsc --noEmit`` clean
- [x] ``pnpm nx test wyrdfold -- --testPathPatterns=promptForMissingContactName.spec.ts`` — 6/6 pass
- [ ] Live: log in as a fresh user with no profile row, click Generate Resume → prompt appears → submit name → resume drafts successfully
- [ ] Cancelling the prompt surfaces the original 400 detail as a toast (no silent failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)