### PR TITLE
feat(wyrdfold): surface resume_ready on dashboard pipeline strip

### DIFF
--- a/apps/wyrdfold/src/app/(app)/DashboardPage.tsx
+++ b/apps/wyrdfold/src/app/(app)/DashboardPage.tsx
@@ -26,12 +26,19 @@ export interface DashboardInitial {
 }
 
 interface PipelineStat {
-  status: 'new' | 'saved' | 'resume_draft' | 'applied';
+  status: 'new' | 'saved' | 'resume_draft' | 'resume_ready' | 'applied';
   label: string;
   icon: React.ReactNode;
   href: string;
 }
 
+// ``resume_ready`` was missing from the dashboard until 2026-05 — users
+// who'd approved a resume saw "Drafts: 0 / Applied: 0" with no
+// acknowledgment that their work-in-progress existed. ``interviewing``
+// and ``offer`` are deliberately omitted for now: they're rare states
+// in personal-tool usage and adding more counters past 5 makes the
+// row noisy on mobile. Adding them is a one-line change if they
+// start mattering.
 const PIPELINE_STATS: PipelineStat[] = [
   {
     status: 'new',
@@ -50,6 +57,12 @@ const PIPELINE_STATS: PipelineStat[] = [
     label: 'Drafts',
     icon: <FileEdit className='size-4' aria-hidden />,
     href: '/jobs?status=resume_draft',
+  },
+  {
+    status: 'resume_ready',
+    label: 'Ready',
+    icon: <CheckCircle2 className='size-4' aria-hidden />,
+    href: '/jobs?status=resume_ready',
   },
   {
     status: 'applied',
@@ -170,8 +183,9 @@ export default function DashboardPage({ initial }: DashboardPageProps) {
         </Text>
       </div>
 
-      {/* Pipeline stats */}
-      <div className='grid grid-cols-2 gap-3 sm:grid-cols-4'>
+      {/* Pipeline stats — 5 statuses fit nicely on lg+, wrap as 3+2 on
+          smaller screens (mobile keeps 2-up to stay scannable). */}
+      <div className='grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5'>
         {PIPELINE_STATS.map(stat => (
           <Link
             key={stat.status}

--- a/apps/wyrdfold/src/app/(app)/dashboard/page.tsx
+++ b/apps/wyrdfold/src/app/(app)/dashboard/page.tsx
@@ -16,7 +16,15 @@ interface JobsListResponse {
   page_size: number;
 }
 
-const PIPELINE_STATUSES = ['new', 'saved', 'resume_draft', 'applied'] as const;
+// Mirrors ``PIPELINE_STATS`` in ``DashboardPage.tsx`` — keep in sync so
+// every counter shown on the dashboard has a backing fetch here.
+const PIPELINE_STATUSES = [
+  'new',
+  'saved',
+  'resume_draft',
+  'resume_ready',
+  'applied',
+] as const;
 
 export default async function WyrdfoldDashboard() {
   // ``hasProfile`` checks whether the user has authored prose at all —


### PR DESCRIPTION
## Summary
Approved-but-not-yet-applied resumes were invisible on the dashboard. ``PIPELINE_STATS`` jumped from ``resume_draft`` to ``applied``, so a user who'd just hit Approve saw "Drafts: 0 / Applied: 0" with no deep-link back to the ready-to-send queue.

Add a fifth counter — "Ready" (``CheckCircle2``) linking to ``/jobs?status=resume_ready``. Bump the grid to ``lg:grid-cols-5`` with a ``sm:grid-cols-3`` mid-breakpoint so 5 cells wrap cleanly on tablet without overflowing on mobile.

``interviewing`` and ``offer`` are deliberately omitted — they're rare states in personal-tool use; promoting them is a one-line addition if the user starts hitting them.

## Found
While walking the post-tailoring smoke flow: the LaunchDarkly job (approved resume, status=resume_ready) was uncounted on the dashboard even though it exists, has a docx ready, and is filterable in /jobs?status=resume_ready.

## Test plan
- [x] ``pnpm tsc --noEmit`` clean (6/6 typecheck projects)
- [x] Live: dashboard renders 5 counters with correct values (New 75 / Saved 1 / Drafts 0 / Ready 1 / Applied 0)
- [ ] Visual on tablet width (3-then-2 wrap) — quick eyeball in preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)