### PR TITLE
fix(wyrdfold-api): filter excluded=true scores from insights aggregates

### DIFF
--- a/apps/wyrdfold-api/app/services/insights.py
+++ b/apps/wyrdfold-api/app/services/insights.py
@@ -92,6 +92,7 @@ def _posting_target_map(
         supabase.table("scores")
         .select("job_posting_id, target_id")
         .in_("target_id", list(target_ids))
+        .eq("excluded", False)
         .execute()
     )
     out: dict[str, set[str]] = defaultdict(set)
@@ -345,8 +346,10 @@ def compute_targets(
     # targets without repeated table queries.
     score_lookup: dict[tuple[str, str], int] = {}
     if posting_ids:
-        sq = supabase.table("scores").select(
-            "job_posting_id, target_id, score"
+        sq = (
+            supabase.table("scores")
+            .select("job_posting_id, target_id, score")
+            .eq("excluded", False)
         )
         if target_ids is not None:
             sq = sq.in_("target_id", list(target_ids))

--- a/apps/wyrdfold-api/tests/test_insights.py
+++ b/apps/wyrdfold-api/tests/test_insights.py
@@ -248,6 +248,50 @@ class TestComputeTargets:
         # At least 1 week bucket
         assert len(result.score_trend) >= 1
 
+    def test_per_user_path_excludes_excluded_scores(self):
+        """Scores marked ``excluded=true`` (closed jobs, irrelevant matches)
+        must not inflate the funnel / distribution. The list endpoint
+        filters ``excluded = False`` and insights has to mirror that —
+        otherwise pipeline funnel counts balloon by ~4x (one excluded
+        scores row per posting per re-poll).
+
+        This test mocks the mock to track that ``.eq("excluded", False)``
+        is invoked on the ``scores`` table query — exact filter values
+        can't be asserted with the current _mock_supabase shape, so we
+        spy on the chain. A regression here would mean the production
+        funnel returns counts that don't match the list view.
+        """
+        # The MagicMock chain returns the same table mock for every call,
+        # so we record the .eq() arguments to assert excluded filter.
+        from unittest.mock import MagicMock as MM
+
+        eq_calls: list[tuple] = []
+
+        sb = MM()
+        tbl = MM()
+
+        def eq_recorder(*args, **kwargs):
+            eq_calls.append(args)
+            return tbl
+
+        tbl.select.return_value = tbl
+        tbl.eq.side_effect = eq_recorder
+        tbl.in_.return_value = tbl
+        tbl.gte.return_value = tbl
+        tbl.lt.return_value = tbl
+        tbl.order.return_value = tbl
+        tbl.limit.return_value = tbl
+        tbl.execute.return_value.data = []
+        sb.table.return_value = tbl
+
+        compute_targets(sb, since=None, target_ids={"t1"})
+
+        # At least one .eq("excluded", False) on the scores table path.
+        assert ("excluded", False) in eq_calls, (
+            f"expected scores query to filter excluded=False, "
+            f"got eq() calls: {eq_calls}"
+        )
+
     def test_per_user_path_pivots_through_scores_table(self):
         """When ``target_ids`` is passed, membership + score come from
         the ``scores`` table — ``jobs.target_id`` is vestigial and

--- a/apps/wyrdfold-api/tests/test_insights.py
+++ b/apps/wyrdfold-api/tests/test_insights.py
@@ -263,12 +263,10 @@ class TestComputeTargets:
         """
         # The MagicMock chain returns the same table mock for every call,
         # so we record the .eq() arguments to assert excluded filter.
-        from unittest.mock import MagicMock as MM
-
         eq_calls: list[tuple] = []
 
-        sb = MM()
-        tbl = MM()
+        sb = MagicMock()
+        tbl = MagicMock()
 
         def eq_recorder(*args, **kwargs):
             eq_calls.append(args)


### PR DESCRIPTION
## Summary
Followup to #684. The new ``_posting_target_map`` helper was reading every ``scores`` row matching the user's targets, without filtering ``excluded = False`` — but the poller writes a scores row per (posting, target) on every re-scoring pass and flags stale / irrelevant ones with ``excluded=true``. The list endpoint filters those out; insights did not.

Effect on the live dashboard right after #684 deployed:
- pipeline funnel "new" count: **283 vs the list endpoint's 76** (~3.7x inflated)
- skills-cost ran over ~4x the postings it should have
- compute_targets per-target rollups picked up zero-score excluded rows alongside live ones, biasing ``avg_score`` down

Fix: add ``.eq("excluded", False)`` to both ``scores`` queries in this file (``_posting_target_map`` and the per-target score lookup in ``compute_targets``). New unit test spies on ``.eq()`` calls to assert the filter is applied on the ``compute_targets`` per-user path — a regression would silently re-inflate the funnel again.

## Validation
Verified live before the fix: pipeline funnel total 285 across all periods (7d / 30d / 90d / all returned identical inflated numbers — confirming the issue isn't period-related, it's the dedup-by-excluded gap). List endpoint untargeted total: 78.

## Test plan
- [x] ``pnpm nx test wyrdfold-api -- tests/test_insights.py`` — 21/21 pass
- [x] ``pnpm nx typecheck wyrdfold-api`` clean (mypy)
- [ ] After Railway redeploy: confirm pipeline funnel total within ±2 of the list endpoint's untargeted total (78 today)

🤖 Generated with [Claude Code](https://claude.com/claude-code)