### PR TITLE
fix(wyrdfold): retry transient errors in SSR fetchJsonFromWyrdfoldAPI

### DIFF
--- a/apps/wyrdfold/src/lib/api/proxy.test.ts
+++ b/apps/wyrdfold/src/lib/api/proxy.test.ts
@@ -12,6 +12,7 @@ jest.mock('@/lib/supabase/auth-server', () => ({
 }));
 
 import {
+  fetchJsonFromWyrdfoldAPI,
   proxyMultipartToWyrdfoldAPI,
   proxyStreamingToWyrdfoldAPI,
   proxyToWyrdfoldAPI,
@@ -283,5 +284,74 @@ describe('proxyMultipartToWyrdfoldAPI', () => {
       error: 'Upstream returned non-JSON',
       upstreamStatus: 500,
     });
+  });
+});
+
+describe('fetchJsonFromWyrdfoldAPI retry behavior', () => {
+  it('returns parsed JSON on first success without retrying', async () => {
+    const fn = jest
+      .fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({ total: 76 })));
+    global.fetch = fn as unknown as typeof fetch;
+
+    const result = await fetchJsonFromWyrdfoldAPI<{ total: number }>('/jobs');
+    expect(result).toEqual({ total: 76 });
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries once on a thrown fetch error then succeeds', async () => {
+    const fn = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('ECONNRESET'))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ total: 76 })));
+    global.fetch = fn as unknown as typeof fetch;
+
+    const result = await fetchJsonFromWyrdfoldAPI<{ total: number }>('/jobs');
+    expect(result).toEqual({ total: 76 });
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it('retries once on a 5xx response then succeeds', async () => {
+    const fn = jest
+      .fn()
+      .mockResolvedValueOnce(new Response('boom', { status: 502 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true })));
+    global.fetch = fn as unknown as typeof fetch;
+
+    const result = await fetchJsonFromWyrdfoldAPI<{ ok: boolean }>('/jobs');
+    expect(result).toEqual({ ok: true });
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it('does NOT retry on 4xx (protocol-level rejection)', async () => {
+    const fn = jest
+      .fn()
+      .mockResolvedValueOnce(new Response('nope', { status: 404 }));
+    global.fetch = fn as unknown as typeof fetch;
+
+    const result = await fetchJsonFromWyrdfoldAPI<unknown>('/jobs');
+    expect(result).toBeNull();
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns null after exhausting retries on persistent errors', async () => {
+    const fn = jest.fn().mockRejectedValue(new Error('ECONNRESET'));
+    global.fetch = fn as unknown as typeof fetch;
+
+    const result = await fetchJsonFromWyrdfoldAPI<unknown>('/jobs', {
+      retries: 2,
+    });
+    expect(result).toBeNull();
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+
+  it('skips the upstream round-trip when there is no session', async () => {
+    mockGetSession.mockResolvedValueOnce({ data: { session: null } });
+    const fn = jest.fn();
+    global.fetch = fn as unknown as typeof fetch;
+
+    const result = await fetchJsonFromWyrdfoldAPI<unknown>('/jobs');
+    expect(result).toBeNull();
+    expect(fn).not.toHaveBeenCalled();
   });
 });

--- a/apps/wyrdfold/src/lib/api/proxy.ts
+++ b/apps/wyrdfold/src/lib/api/proxy.ts
@@ -36,12 +36,32 @@ export async function getAccessToken(): Promise<string | null> {
  *
  * Bypasses the /api/* route handler so the page doesn't pay an extra
  * client→Next round-trip; data streams inline with the RSC payload.
+ *
+ * Retries transient network errors and 5xx responses once with a short
+ * backoff. The dashboard and other RSC pages fan out 6–10 of these
+ * calls in parallel; a single Railway HTTP/2 stream drop used to
+ * collapse the whole counter strip to zeros (and Top Matches to "No
+ * new matches right now"). One retry absorbs the vast majority of
+ * those one-off failures without inflating worst-case latency
+ * meaningfully — the read is idempotent so a re-issue is safe.
  */
+const _DEFAULT_RETRIES = 1;
+const _RETRY_BACKOFF_MS = 150;
+
 export async function fetchJsonFromWyrdfoldAPI<T>(
   path: string,
-  options: { searchParams?: URLSearchParams; timeoutMs?: number } = {}
+  options: {
+    searchParams?: URLSearchParams;
+    timeoutMs?: number;
+    /** Override the default 1-retry pass. ``0`` disables retry entirely. */
+    retries?: number;
+  } = {}
 ): Promise<T | null> {
-  const { searchParams, timeoutMs = DEFAULT_TIMEOUT_MS } = options;
+  const {
+    searchParams,
+    timeoutMs = DEFAULT_TIMEOUT_MS,
+    retries = _DEFAULT_RETRIES,
+  } = options;
 
   const accessToken = await getAccessToken();
   if (accessToken === null) return null;
@@ -49,23 +69,35 @@ export async function fetchJsonFromWyrdfoldAPI<T>(
   const qs = searchParams ? `?${searchParams.toString()}` : '';
   const url = `${apiBaseUrl()}${path}${qs}`;
 
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), timeoutMs);
-
-  try {
-    const res = await fetch(url, {
-      method: 'GET',
-      headers: { Authorization: `Bearer ${accessToken}` },
-      signal: controller.signal,
-      cache: 'no-store',
-    });
-    if (!res.ok) return null;
-    return (await res.json()) as T;
-  } catch {
-    return null;
-  } finally {
-    clearTimeout(timer);
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+      const res = await fetch(url, {
+        method: 'GET',
+        headers: { Authorization: `Bearer ${accessToken}` },
+        signal: controller.signal,
+        cache: 'no-store',
+      });
+      // Don't retry 4xx — those are protocol-level rejections
+      // (auth, validation, not-found) where a re-issue won't help and
+      // would just amplify the load.
+      if (!res.ok) {
+        if (res.status < 500 || attempt === retries) return null;
+      } else {
+        return (await res.json()) as T;
+      }
+    } catch {
+      // Network / abort / timeout — retry once.
+      if (attempt === retries) return null;
+    } finally {
+      clearTimeout(timer);
+    }
+    if (attempt < retries) {
+      await new Promise(r => setTimeout(r, _RETRY_BACKOFF_MS));
+    }
   }
+  return null;
 }
 
 function unauthorized(): NextResponse {


### PR DESCRIPTION
## Summary
RSC pages (Dashboard, Targets, Profile, Insights) fan out 6–10 ``fetchJsonFromWyrdfoldAPI`` calls in parallel during a single render. The helper returns ``null`` on any network failure or non-OK status — and any one ``null`` collapses its section to the empty fallback.

Today a single transient hop — a Railway HTTP/2 stream drop, a 502 from a cold container, a timed-out keepalive — silently turns the dashboard counter strip into "0 / 0 / 0 / 0 / 0" and Top Matches into "No new matches right now" for users with real data.

## How found
Observed this session: dashboard rendered all-zeros + "No new matches" right after #687's API redeploy. The same SSR re-fetch on the very next reload showed the correct numbers (New 76 / Saved 1 / Ready 1 / Applied 0). Browser-side ``/api/*`` proxy calls were succeeding in parallel — only the Next.js → Railway SSR leg was flaky.

## Fix
Add a 1-retry pass (configurable via ``options.retries``, default ``1``) with a 150 ms backoff between attempts. Retry only on:
- Thrown fetch errors (network / abort / DNS)
- 5xx responses (server-side transient)

Do NOT retry 4xx — protocol-level rejections (auth, validation, 404) where a re-issue won't help. The read is idempotent.

Mirrors the ``supabase_retry`` helper #687 applied to the wyrdfold-api side — same architectural shape, different leg of the same request chain.

## Test plan
- [x] ``pnpm tsc --noEmit`` clean (6/6 typecheck projects)
- [x] ``pnpm nx test wyrdfold -- --testPathPatterns=proxy.test.ts`` — 21/21 pass (6 new cases: first-call success / retry on thrown / retry on 5xx / no-retry on 4xx / exhausted-returns-null / no-session short-circuit)
- [ ] (preview) Dashboard renders reliably under simulated single-stream-drop load

🤖 Generated with [Claude Code](https://claude.com/claude-code)