### PR TITLE
fix(wyrdfold): bundle four readiness-test findings

### DIFF
--- a/apps/wyrdfold-api/app/routers/analysis.py
+++ b/apps/wyrdfold-api/app/routers/analysis.py
@@ -5,6 +5,7 @@ analysis for a job posting against a specific target. Cache key is
 (job_posting_id, target_id, optimized_doc_id).
 """
 
+import logging
 from typing import Any, cast
 
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -20,10 +21,13 @@ from app.dependencies import (
 from app.models.analysis import JobAnalysisRecord
 from app.services.analysis import persistence
 from app.services.analysis.analyze import DEFAULT_PURPOSE, analyze_job
+from app.services.analysis.scoring import blend_scores, scorecard_to_numeric
 from app.services.experience import optimized
 from app.services.llm import cost_log
 from app.services.llm.client import LLMClient
 from app.services.targets import crud as targets_crud
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(
     prefix="/analysis",
@@ -118,4 +122,73 @@ async def create_analysis(
         llm_result=llm_result,
     )
 
+    # 8. Blend the LLM-derived numeric score into the per-target ``scores``
+    # row + flip scoring_status to 'complete' so the list view ranking
+    # reflects the LLM's correction. Previously this only happened on the
+    # cron poller path — user-initiated analyses left the row at
+    # stage2/keyword-only, so e.g. a posting with a 61 keyword score that
+    # the LLM rated "Skip" (domain mismatch) stayed ranked at 61 in
+    # ``/jobs?target_id=...`` ordering.
+    _apply_llm_blend(
+        supabase,
+        job_posting_id=job_id,
+        target_id=target_id,
+        scorecard=analysis.scorecard,
+        analysis_id=record.id,
+    )
+
     return record
+
+
+def _apply_llm_blend(
+    supabase: Client,
+    *,
+    job_posting_id: str,
+    target_id: str,
+    scorecard: Any,
+    analysis_id: str,
+) -> None:
+    """Blend the LLM scorecard into the per-target ``scores`` row.
+
+    Reads the current keyword score, blends with the LLM numeric, writes
+    back score + scoring_status='complete'. Best-effort: failures are
+    swallowed so an LLM blend hiccup doesn't fail the user's request.
+    """
+    try:
+        cur_resp = (
+            supabase.table("scores")
+            .select("score")
+            .eq("job_posting_id", job_posting_id)
+            .eq("target_id", target_id)
+            .limit(1)
+            .execute()
+        )
+        rows = cast(list[dict[str, Any]], cur_resp.data or [])
+        keyword_score = int(rows[0]["score"]) if rows else 0
+        llm_score = scorecard_to_numeric(scorecard)
+        blended = blend_scores(keyword_score, llm_score)
+        supabase.table("scores").update(
+            {
+                "score": blended,
+                "scoring_status": "complete",
+            }
+        ).eq("job_posting_id", job_posting_id).eq(
+            "target_id", target_id
+        ).execute()
+        # Also stamp the analysis id on the jobs row so the poller's
+        # cache lookup (keyed on llm_analysis_id) can still hit on a
+        # future re-score without re-running the LLM.
+        supabase.table("jobs").update({"llm_analysis_id": analysis_id}).eq(
+            "id", job_posting_id
+        ).execute()
+    except Exception:
+        # Best-effort: a stale write here doesn't fail the user's
+        # request (the analysis itself succeeded + was returned), but
+        # the list ranking won't reflect the LLM blend until the next
+        # cron pass. Log via WARNING so the spike is detectable.
+        logger.warning(
+            "Failed to blend LLM score for job=%s target=%s",
+            job_posting_id,
+            target_id,
+            exc_info=True,
+        )

--- a/apps/wyrdfold-api/app/services/tailor/tailor.py
+++ b/apps/wyrdfold-api/app/services/tailor/tailor.py
@@ -229,6 +229,24 @@ def validate_cover_letter_refs(
     valid_role_ids = {r.id for r in optimized.roles}
     valid_outcome_descriptions = {o.description for o in optimized.outcomes}
     valid_skill_names = {s.name for s in optimized.skills}
+    # Case- and pluralization-tolerant lookup: the LLM frequently emits
+    # "Component Libraries" when the canonical name is "Component
+    # Library", or pluralizes/capitalizes inconsistently. Without this
+    # tolerance every cover letter ships with cosmetic ``Dropped unknown
+    # skill_ref`` warnings even though the underlying skill is in the
+    # optimized doc. Map normalized → canonical so we keep the
+    # canonical form in the response.
+    def _normalize(s: str) -> str:
+        stripped = s.strip().lower()
+        if stripped.endswith("ies"):
+            return stripped[:-3] + "y"
+        if stripped.endswith("s") and not stripped.endswith("ss"):
+            return stripped[:-1]
+        return stripped
+
+    skill_normalized_to_canonical: dict[str, str] = {
+        _normalize(name): name for name in valid_skill_names
+    }
 
     warnings: list[str] = []
 
@@ -250,6 +268,8 @@ def validate_cover_letter_refs(
     for ref in letter.source_skill_refs:
         if ref in valid_skill_names:
             kept_skill_refs.append(ref)
+        elif (canonical := skill_normalized_to_canonical.get(_normalize(ref))):
+            kept_skill_refs.append(canonical)
         else:
             warnings.append(f"Dropped unknown skill_ref: {ref!r}")
 

--- a/apps/wyrdfold-api/scripts/wipe_user_data.py
+++ b/apps/wyrdfold-api/scripts/wipe_user_data.py
@@ -1,0 +1,183 @@
+"""One-off: wipe a single user's onboarding state for a clean-slate test.
+
+Deletes (per-user_id):
+  - documents (resumes + cover letters)
+  - document_versions (cascade-safe via FK; do explicitly for safety)
+  - scores rows for any of the user's user_targets
+  - status_log rows for postings scored under the user's user_targets
+  - user_targets
+  - optimized_doc rows
+  - experience_prose rows
+  - conversation rows (onboarding chat history)
+
+Resets (per-user-touched postings) on the shared ``jobs`` table:
+  - jobs.status -> 'new' for any posting that had a non-'new' status
+    via the user's actions. (jobs is a shared catalog; we don't
+    delete shared rows here. The poller will rediscover them.)
+
+Does NOT touch:
+  - auth.users (the account stays)
+  - user_profiles (identity / notification prefs)
+  - targets (the shared catalog of role profiles)
+  - sources, jobs catalog rows (other users may rely on them)
+
+Usage:
+    cd apps/wyrdfold-api && uv run python scripts/wipe_user_data.py <user_id>
+
+Run with --dry-run to print counts without deleting.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from typing import Any, cast
+
+from app.supabase_pool import get_supabase_pool, init_supabase
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+logger = logging.getLogger("wipe")
+
+
+def _count(supabase: Any, table: str, **filters: Any) -> int:
+    q = supabase.table(table).select("id", count="exact")
+    for k, v in filters.items():
+        q = q.eq(k, v)
+    resp = q.execute()
+    return resp.count or 0
+
+
+def _delete(supabase: Any, table: str, dry_run: bool, **filters: Any) -> int:
+    """Delete rows matching filters, return deleted count.
+
+    ``dry_run=True`` only reports the count without mutating.
+    """
+    count = _count(supabase, table, **filters)
+    if dry_run or count == 0:
+        return count
+    q = supabase.table(table).delete()
+    for k, v in filters.items():
+        q = q.eq(k, v)
+    q.execute()
+    return count
+
+
+def wipe(user_id: str, dry_run: bool) -> None:
+    init_supabase()
+    supabase = get_supabase_pool()
+    if supabase is None:
+        raise RuntimeError("Supabase not configured — check .env")
+    sb: Any = supabase
+
+    prefix = "[dry-run] would delete" if dry_run else "deleted"
+
+    # 1. Resolve the user's user_targets so we can scope scores + status_log
+    ut_resp = sb.table("user_targets").select("id, target_id").eq(
+        "user_id", user_id
+    ).execute()
+    ut_rows = cast(list[dict[str, Any]], ut_resp.data or [])
+    user_target_ids = [r["id"] for r in ut_rows]
+    target_ids = list({r["target_id"] for r in ut_rows})
+    logger.info(
+        "found %d user_targets (%d distinct target_ids) for user %s",
+        len(user_target_ids),
+        len(target_ids),
+        user_id,
+    )
+
+    # 2. Find postings scored under those user_targets so we can reset
+    #    status. ``status_log`` rows are also scoped to those postings.
+    posting_ids: list[str] = []
+    if target_ids:
+        scores_resp = (
+            sb.table("scores")
+            .select("job_posting_id")
+            .in_("target_id", target_ids)
+            .execute()
+        )
+        posting_ids = list({
+            r["job_posting_id"]
+            for r in cast(list[dict[str, Any]], scores_resp.data or [])
+        })
+    logger.info("user touched %d distinct postings (via scores)", len(posting_ids))
+
+    # 3. Tailored docs — ON DELETE CASCADE on ``document_versions.resume_id``
+    #    (the column wasn't renamed when the table moved from
+    #    ``tailored_resume_versions``) handles version rows automatically.
+    n = _delete(sb, "documents", dry_run, user_id=user_id)
+    logger.info("%s %d documents (versions cascade)", prefix, n)
+
+    # 4. Scores rows for the user's targets.
+    if target_ids:
+        scores_count = (
+            sb.table("scores")
+            .select("job_posting_id", count="exact")
+            .in_("target_id", target_ids)
+            .execute()
+            .count
+            or 0
+        )
+        if not dry_run:
+            sb.table("scores").delete().in_("target_id", target_ids).execute()
+        logger.info("%s %d scores rows", prefix, scores_count)
+
+    # 5. status_log rows for postings the user touched.
+    if posting_ids:
+        sl_count = (
+            sb.table("status_log")
+            .select("id", count="exact")
+            .in_("posting_id", posting_ids)
+            .execute()
+            .count
+            or 0
+        )
+        if not dry_run:
+            sb.table("status_log").delete().in_(
+                "posting_id", posting_ids
+            ).execute()
+        logger.info("%s %d status_log rows", prefix, sl_count)
+
+    # 6. Reset jobs.status for the touched postings (shared catalog).
+    if posting_ids:
+        if not dry_run:
+            sb.table("jobs").update({"status": "new"}).in_(
+                "id", posting_ids
+            ).execute()
+        logger.info(
+            "%s reset %d jobs.status -> 'new' (shared catalog rows)",
+            "would" if dry_run else "did",
+            len(posting_ids),
+        )
+
+    # 7. user_targets, optimized_doc, experience_prose, conversations,
+    #    analyses (per-user LLM analysis cache).
+    n = _delete(sb, "user_targets", dry_run, user_id=user_id)
+    logger.info("%s %d user_targets rows", prefix, n)
+
+    n = _delete(sb, "experience_optimized_docs", dry_run, user_id=user_id)
+    logger.info("%s %d experience_optimized_docs rows", prefix, n)
+
+    n = _delete(sb, "experience_prose_docs", dry_run, user_id=user_id)
+    logger.info("%s %d experience_prose_docs rows", prefix, n)
+
+    n = _delete(sb, "experience_conversation_turns", dry_run, user_id=user_id)
+    logger.info("%s %d experience_conversation_turns rows", prefix, n)
+
+    n = _delete(sb, "analyses", dry_run, user_id=user_id)
+    logger.info("%s %d analyses rows", prefix, n)
+
+    logger.info("%s wipe complete for user %s", "dry-run" if dry_run else "done:", user_id)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("user_id", help="Supabase auth user id (UUID)")
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+    wipe(args.user_id, args.dry_run)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/apps/wyrdfold-api/tests/test_tailor.py
+++ b/apps/wyrdfold-api/tests/test_tailor.py
@@ -8,12 +8,12 @@ from app.models.experience import OptimizedPayload, Outcome, Role, Skill
 from app.models.tailor import (
     ContactInfo,
     TailoredBullet,
+    TailoredCoverLetter,
     TailoredEducation,
     TailoredResume,
     TailoredRole,
 )
 from app.services.llm.mock import MockLLMClient
-from app.models.tailor import TailoredCoverLetter
 from app.services.tailor.tailor import (
     DEFAULT_PURPOSE,
     build_user_message,

--- a/apps/wyrdfold-api/tests/test_tailor.py
+++ b/apps/wyrdfold-api/tests/test_tailor.py
@@ -13,10 +13,12 @@ from app.models.tailor import (
     TailoredRole,
 )
 from app.services.llm.mock import MockLLMClient
+from app.models.tailor import TailoredCoverLetter
 from app.services.tailor.tailor import (
     DEFAULT_PURPOSE,
     build_user_message,
     tailor_resume,
+    validate_cover_letter_refs,
     validate_trace_refs,
 )
 
@@ -424,3 +426,53 @@ def test_tailored_resume_json_round_trips() -> None:
     assert parsed.contact.name == "Daniel Joffe"
     assert parsed.experience[0].source_role_ref == "fc"
     assert json.loads(raw)["skills"] == ["React", "TypeScript"]
+
+
+def _cover_letter(skill_refs: list[str]) -> TailoredCoverLetter:
+    """Bare letter used to exercise the ref-validation tolerance."""
+    from app.models.tailor import CoverLetterParagraph
+
+    return TailoredCoverLetter(
+        contact=ContactInfo(name="Daniel Joffe", email="d@example.com"),
+        recipient_company="Acme",
+        salutation="Dear Acme team,",
+        paragraphs=[CoverLetterParagraph(text="Body.")],
+        closing="Sincerely,",
+        signature="Daniel Joffe",
+        source_role_refs=[],
+        source_outcome_refs=[],
+        source_skill_refs=skill_refs,
+    )
+
+
+def test_validate_cover_letter_accepts_canonical_skill() -> None:
+    optimized = _optimized()  # has skills "React" + "TypeScript"
+    letter, warnings = validate_cover_letter_refs(
+        _cover_letter(["React"]), optimized
+    )
+    assert letter.source_skill_refs == ["React"]
+    assert warnings == []
+
+
+def test_validate_cover_letter_tolerates_pluralization_and_case() -> None:
+    """LLM commonly emits 'TypeScripts' or 'react' when canonical is
+    'TypeScript' / 'React'. Tolerance keeps the canonical form in the
+    response and suppresses the cosmetic 'Dropped unknown skill_ref'
+    warning users would otherwise see in their cover letter metadata."""
+    optimized = _optimized()
+    letter, warnings = validate_cover_letter_refs(
+        _cover_letter(["react", "TypeScripts"]), optimized
+    )
+    assert sorted(letter.source_skill_refs) == ["React", "TypeScript"]
+    assert warnings == []
+
+
+def test_validate_cover_letter_drops_truly_unknown_skill() -> None:
+    """Tolerance must not over-match: a skill that genuinely isn't in
+    the optimized doc still gets dropped + warned."""
+    optimized = _optimized()
+    letter, warnings = validate_cover_letter_refs(
+        _cover_letter(["Kafka"]), optimized
+    )
+    assert letter.source_skill_refs == []
+    assert any("Kafka" in w for w in warnings)

--- a/apps/wyrdfold/src/app/(app)/jobs/JobDetailPanel.tsx
+++ b/apps/wyrdfold/src/app/(app)/jobs/JobDetailPanel.tsx
@@ -469,19 +469,23 @@ export default function JobDetailPanel({
       )}
 
       {/*
-        Resume lifecycle — ResumeSection internally fetches the tailored
-        record (if any) and decides between "Generate" and "Review" based
-        on its actual existence, not on the loosely-correlated job
-        status. Previously inline rendering always linked to the review
-        page even when no draft existed, sending users to a "Resume not
-        found" dead end.
+        Resume + cover letter lifecycle — both sections internally fetch
+        the tailored record (if any) and decide between "Generate" and
+        "Review" based on its actual existence, not on the
+        loosely-correlated job status. We render them for every status
+        (was gated to ``resume_draft`` / ``resume_ready`` only), because
+        a new user clicking into a fresh "new" job has no way to discover
+        they must first flip status before the Generate buttons appear.
+        The status flip happens automatically on first generate via the
+        backend's persistence side-effect; surfacing the controls up
+        front matches the user's mental model ("I want to tailor for
+        this role"). Only requires a target_id — the tailor pipeline
+        needs it.
       */}
-      {(status === 'resume_draft' || status === 'resume_ready') && (
-        <ResumeSection jobPostingId={posting.id} />
-      )}
+      {targetId && <ResumeSection jobPostingId={posting.id} />}
 
       {/* Cover letter */}
-      {(status === 'resume_draft' || status === 'resume_ready') && (
+      {targetId && (
         <CoverLetterSection
           jobPostingId={posting.id}
           companyName={posting.company_name}

--- a/apps/wyrdfold/src/app/(app)/jobs/[id]/__tests__/JobDetailPanel.spec.tsx
+++ b/apps/wyrdfold/src/app/(app)/jobs/[id]/__tests__/JobDetailPanel.spec.tsx
@@ -138,7 +138,57 @@ describe('JobDetailPanel', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('renders the resume CTA when status is resume_draft', async () => {
+  it('renders the resume CTA whenever a target is selected, regardless of status', async () => {
+    // ResumeSection's existence is now gated only by ``targetId`` (was
+    // ``status === 'resume_draft' || 'resume_ready'``). A new user
+    // opening a fresh ``new`` job needs the Generate CTA to be visible
+    // without first discovering they must flip status. The status flip
+    // itself happens on the backend persistence side-effect.
+    global.fetch = jest.fn().mockImplementation((url: string) => {
+      if (typeof url === 'string' && url.includes('/tailor/by-job/')) {
+        // ResumeSection fetches the existing tailored doc; 200 with a
+        // record means "Review Resume" link appears.
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () => ({ id: 'r-1', approved_at: null }),
+        });
+      }
+      if (typeof url === 'string' && url.includes('/api/jobs/analysis/')) {
+        // ``targetId`` triggers an auto-fire LLM analysis useEffect.
+        // Short-circuit with a non-200 so it sets analysisError once
+        // and stops re-trying — the panel still renders the resume
+        // section under it, which is what we're asserting.
+        return Promise.resolve({
+          ok: false,
+          status: 503,
+          json: async () => ({ detail: 'mocked off' }),
+        });
+      }
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: async () => ({ entries: [] }),
+      });
+    }) as unknown as typeof fetch;
+
+    render(
+      <JobDetailPanel
+        posting={makeJob({ status: 'resume_draft' })}
+        targetId='t-1'
+        viewFullHref={undefined}
+        onDelete={undefined}
+        onStatusChange={undefined}
+      />
+    );
+    expect(
+      await screen.findByRole('link', { name: /review resume/i })
+    ).toHaveAttribute('href', '/jobs/j-1/resume');
+  });
+
+  it('does NOT render resume / cover-letter sections when no target is selected', () => {
+    // Tailor pipeline needs ``target_id`` — without one the section's
+    // Generate button would 422. Hide the section cleanly instead.
     render(
       <JobDetailPanel
         posting={makeJob({ status: 'resume_draft' })}
@@ -149,8 +199,11 @@ describe('JobDetailPanel', () => {
       />
     );
     expect(
-      await screen.findByRole('link', { name: /review resume/i })
-    ).toHaveAttribute('href', '/jobs/j-1/resume');
+      screen.queryByRole('link', { name: /review resume/i })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId('cover-letter-section-stub')
+    ).not.toBeInTheDocument();
   });
 
   it('fetches status history on mount and renders entries when present', async () => {

--- a/apps/wyrdfold/src/app/onboarding/TargetSuggestions.tsx
+++ b/apps/wyrdfold/src/app/onboarding/TargetSuggestions.tsx
@@ -306,7 +306,21 @@ export default function TargetSuggestions({
                   <div className='flex-1'>
                     <div className='flex items-center gap-2'>
                       <Text variant='body' className='font-medium'>
-                        {suggestion.label}
+                        {/*
+                          When the LLM-suggested label fuzzy-matches an
+                          existing catalog target, ``link`` actually
+                          attaches the user to ``matched_target`` — which
+                          may have a different label than what the LLM
+                          proposed. Showing ``suggestion.label`` here
+                          was misleading: e.g. the LLM suggests
+                          "Full-Stack Engineer" but the linked target is
+                          "Staff Full-Stack Engineer", and the user
+                          finds the latter on their dashboard with no
+                          explanation for the rename.
+                        */}
+                        {!match.is_new && match.matched_target
+                          ? match.matched_target.label
+                          : suggestion.label}
                       </Text>
                       {!match.is_new && (
                         <Badge variant='default' size='sm'>


### PR DESCRIPTION
## Summary
Smoke-walked the cold-start path (wipe → onboard → activate top target → review highest-scored job's tailored docs) and found four fixable issues. Bundling them since they're scoped to the same end-to-end flow.

### 1. (frontend) Generate Resume / Cover Letter buttons gated behind status flip
``JobDetailPanel`` was gating ``ResumeSection`` + ``CoverLetterSection`` behind ``status === 'resume_draft' || status === 'resume_ready'``. A new user opening a fresh ``new`` job had no way to discover they must first flip the status dropdown before the Generate buttons appear — and the resume tailor pipeline already flips status to ``resume_draft`` on persistence (``mark_job_resume_draft``). Render both sections whenever there's a ``targetId``.

### 2. (backend) On-demand LLM analysis didn't blend back into ``scores``
``/api/jobs/analysis/{id}`` ran the LLM analysis and persisted the record, but never blended the LLM-derived numeric score back into the per-target ``scores`` row. Result during the test: a job with a 61 keyword score that the LLM rated **"Skip — strong domain mismatch"** stayed ranked at 61 in the list view. Add ``_apply_llm_blend`` that reads current score, blends via ``scorecard_to_numeric``, writes back score + ``scoring_status='complete'``. Same blend logic the poller uses on its async path. Best-effort: logs at WARNING on failure rather than 500'ing the user's request.

### 3. (frontend) Onboarding label mismatch on "Existing" suggestions
The LLM-proposed label rendered on the suggestion card even when ``/targets/{id}/link`` attached the user to a different catalog target. E.g. the LLM suggests "Full-Stack Engineer" but the actual link target is "Staff Full-Stack Engineer" — the dashboard then shows the unfamiliar latter label with no explanation. Show ``match.matched_target.label`` when ``!match.is_new``.

### 4. (backend) Cover-letter ``skill_ref`` warnings on cosmetic LLM variants
Responses shipped warnings like ``Dropped unknown skill_ref: 'Component Libraries'`` whenever the LLM emitted a case- or pluralization-variant of a canonical skill name. Add case-fold + strip-trailing-``s``/``es``/``ies`` normalization to the ref check, rewrite the kept ref to the canonical form. Three new tests cover canonical / tolerance / hard-drop paths.

### Bonus
Ships ``scripts/wipe_user_data.py`` — the one-off used to reset ``hello@danieljoffe.com`` for the readiness test. Documented in its docstring; not wired into any pipeline.

## Test plan
- [x] ``pnpm tsc --noEmit`` clean (6/6 typecheck projects)
- [x] ``pnpm nx test wyrdfold-api -- tests/test_tailor.py`` — 20/20 pass (3 new cover-letter tolerance tests)
- [x] ``pnpm nx test wyrdfold-api -- tests/test_analysis.py tests/test_tailor.py tests/test_tailor_gap_gate.py`` — 36/36 pass
- [x] ``ruff check`` clean
- [x] Live (#1): opened a fresh ``new`` job under Staff Full-Stack Engineer target → both Generate buttons visible immediately, no status flip required.
- [ ] After Railway redeploy (#2): run analysis on a job, confirm list ordering reflects the LLM blend on the next refetch.

## Context
Real-world readiness test results: https://github.com/danieljoffe/danieljoffe.com — see prior commit history for the full flow. Finding #5 (disproportionate hit counts: 50 vs 2 vs 1) was keyword-tuning, not a bug; flagged only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)