### PR TITLE
fix(wyrdfold-api): invalidate job-list cache after on-demand LLM blend

### DIFF
--- a/apps/wyrdfold-api/app/routers/analysis.py
+++ b/apps/wyrdfold-api/app/routers/analysis.py
@@ -11,6 +11,7 @@ from typing import Any, cast
 from fastapi import APIRouter, Depends, HTTPException, Query
 from supabase import Client
 
+from app.cache import job_list_cache, jobs_cache_prefix
 from app.dependencies import (
     enforce_llm_budget,
     get_current_user_id_optional,
@@ -181,6 +182,19 @@ def _apply_llm_blend(
         supabase.table("jobs").update({"llm_analysis_id": analysis_id}).eq(
             "id", job_posting_id
         ).execute()
+        # Invalidate the in-memory list cache so the new blended score
+        # is reflected immediately. Without this the dashboard +
+        # /jobs ranking shows the old keyword-only score for up to 60s
+        # (the TTLCache default) after the user runs analysis — the
+        # detail endpoint refreshes correctly because it doesn't go
+        # through the list cache. Scope to the owning target + the
+        # untargeted global view; sibling targets aren't affected.
+        job_list_cache.invalidate(
+            prefix=f"{jobs_cache_prefix(target_id=target_id)}:"
+        )
+        job_list_cache.invalidate(
+            prefix=f"{jobs_cache_prefix(target_id=None)}:"
+        )
     except Exception:
         # Best-effort: a stale write here doesn't fail the user's
         # request (the analysis itself succeeded + was returned), but


### PR DESCRIPTION
## Summary
Follow-up to #689. The LLM blend writes the new per-target score to the ``scores`` row correctly, but the in-memory ``job_list_cache`` (60s TTL) keeps serving the old keyword-only score for up to a minute. The dashboard and ``/jobs`` ranking lag visibly until the cache expires.

Verified live right after the readiness-test bundle deployed: detail endpoint showed score **49 / scoring_status: complete** within seconds of running analysis on the Vercel Backend Engineer job, while the list endpoint still returned **52 / stage2** for 60s.

## Fix
Invalidate the owning-target + untargeted-global cache prefixes right after the blend writes succeed. Mirrors the scoped pattern in ``status.py``: sibling targets stay warm.

## Test plan
- [x] ``pnpm nx typecheck wyrdfold-api`` clean (mypy)
- [x] ``pnpm nx test wyrdfold-api -- tests/test_analysis.py`` — 15/15 pass
- [x] ``ruff check`` clean
- [ ] After Railway redeploy: confirm list score updates immediately (within one request) of running analysis, not after 60s

🤖 Generated with [Claude Code](https://claude.com/claude-code)