### PR TITLE
fix(wyrdfold-api): apply LLM blend on cached analysis path too

### DIFF
--- a/apps/wyrdfold-api/app/routers/analysis.py
+++ b/apps/wyrdfold-api/app/routers/analysis.py
@@ -62,6 +62,22 @@ async def create_analysis(
         user_id=user_id,
     )
     if cached is not None:
+        # Re-apply the LLM blend even on a cache hit. The blend writes
+        # the per-target score + flips ``scoring_status`` to
+        # ``complete``, but analyses persisted *before* this code shipped
+        # never had that backfill done — so a returning user whose
+        # analysis was previously cached would still see the
+        # keyword-only score in the list view. ``_apply_llm_blend`` is
+        # idempotent (same blend math, same target, same scorecard),
+        # so re-running it on every cache hit is a cheap no-op once
+        # the row already has the blended score.
+        _apply_llm_blend(
+            supabase,
+            job_posting_id=job_id,
+            target_id=target_id,
+            scorecard=cached.scorecard,
+            analysis_id=cached.id,
+        )
         return cached
 
     # 3. Fetch target (existence check + context for the LLM)


### PR DESCRIPTION
## Summary
#689's ``_apply_llm_blend`` only ran on the fresh-LLM-call branch. The cache-hit early-return in ``create_analysis`` skipped the blend step entirely. So a user whose analysis was already cached (e.g. fired by the auto-fire useEffect on prior list-view exploration) still saw the keyword-only score, even after #689 + #690 deployed.

Caught while verifying #690 live: the Figma "Manager, Software Engineering" analysis returned in 943ms (cache hit) with the LLM ``Skip`` recommendation, but ``score`` stayed at **57** / ``scoring_status`` stayed at ``stage2``.

## Fix
Re-apply ``_apply_llm_blend`` on the cache-hit branch. The blend is idempotent — same scorecard → same numeric → same blended score, cache invalidation is a no-op once already invalidated. So re-running on every cache hit is a cheap correctness backfill for historical rows and trivially fast for new ones.

## Test plan
- [x] ``pnpm nx typecheck wyrdfold-api`` clean
- [x] ``pnpm nx test wyrdfold-api -- tests/test_analysis.py`` — 15/15 pass
- [x] ``ruff check`` clean
- [ ] After Railway redeploy: re-call analysis on the Figma job (cache hit), confirm list now shows blended score + ``scoring_status: complete``

🤖 Generated with [Claude Code](https://claude.com/claude-code)