### PR TITLE
test(wyrdfold-e2e): middleware-redirect coverage across all (app) routes

### DIFF
--- a/apps/wyrdfold-e2e/src/middleware.spec.ts
+++ b/apps/wyrdfold-e2e/src/middleware.spec.ts
@@ -1,0 +1,60 @@
+import { test, expect } from '@playwright/test';
+
+// Auth middleware regression coverage. Every (app) route should bounce
+// signed-out visitors to ``/login`` — when the middleware breaks (e.g.
+// matcher misconfigured, ``createServerClient`` import path drift, the
+// Supabase SSR cookie-write swallow regression from #681 hitting the
+// no-session path), these are the canonical surfaces that catch it
+// before users hit them.
+//
+// Each path here was a real fetch destination during the session-29
+// readiness walk; if the redirect breaks the user lands on an
+// auth-required page rendering "Loading..." or worse.
+const PROTECTED_ROUTES = [
+  '/dashboard',
+  '/jobs',
+  '/jobs/00000000-0000-0000-0000-000000000000', // detail route
+  '/jobs/00000000-0000-0000-0000-000000000000/resume',
+  '/jobs/00000000-0000-0000-0000-000000000000/cover-letter',
+  '/targets',
+  '/targets/00000000-0000-0000-0000-000000000000',
+  '/profile',
+  '/insights',
+  '/settings',
+  '/onboarding',
+];
+
+for (const path of PROTECTED_ROUTES) {
+  test(`signed-out visitor hitting ${path} is redirected to /login`, async ({
+    page,
+  }) => {
+    await page.goto(path);
+    await expect(page).toHaveURL(/\/login(\?.*)?$/);
+  });
+}
+
+test('login form Send button is disabled until an email is entered', async ({
+  page,
+}) => {
+  await page.goto('/login');
+  const button = page.getByRole('button', { name: 'Send magic link' });
+  await expect(button).toBeDisabled();
+  await page.getByLabel('Email', { exact: true }).fill('test@example.com');
+  await expect(button).toBeEnabled();
+});
+
+test('login form Send button stays disabled for empty email after blur', async ({
+  page,
+}) => {
+  // Regression for the early input-state bug noted in the user feedback:
+  // an empty-then-blurred input had triggered the button to enable
+  // briefly. Verify the form sticks to "non-empty required" cleanly.
+  await page.goto('/login');
+  const email = page.getByLabel('Email', { exact: true });
+  await email.fill('hello@example.com');
+  await email.fill('');
+  await email.blur();
+  await expect(
+    page.getByRole('button', { name: 'Send magic link' })
+  ).toBeDisabled();
+});


### PR DESCRIPTION
## Summary
The existing ``login.spec.ts`` only verifies ``/dashboard`` redirects unauthenticated visitors. Extend that to **every protected surface** exercised during this session's readiness walk — /jobs (list + detail + resume + cover-letter), /targets (list + detail), /profile, /insights, /settings, /onboarding — so a middleware matcher regression gets caught against every canonical landing page, not just the dashboard.

Also adds two login-form validation specs: button disabled until email is filled, button stays disabled after blur-on-empty (regression for the empty-input behavior noted earlier).

## Test plan
- [x] ``pnpm tsc --noEmit`` clean (6/6 typecheck projects)
- [x] All 13 specs pass locally against the running dev server in 4.6s
- [ ] CI: webServer config spawns a fresh dev on :3100 with placeholder Supabase creds; the no-cookie path triggers the redirect cleanly per the existing config comment

## Scope note
Real auth-gated specs (onboarding, tailoring, resume review) stay deferred — they need a test-user fixture which is out of scope for this batch. This PR covers the regression-prone middleware surface that runs cleanly in CI as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)