### PR TITLE
fix(wyrdfold): link user + activate target on onboarding /from-posting path

### DIFF
--- a/apps/wyrdfold-api/app/routers/targets.py
+++ b/apps/wyrdfold-api/app/routers/targets.py
@@ -594,7 +594,25 @@ async def create_target_from_posting(
                 "Profile derivation failed for posting %s", posting_id
             )
 
-    # Activate the target
+    # Link the calling user to the new target (multi-user flow) so it
+    # actually shows up in ``/targets/mine``. Without this insert, the
+    # onboarding "I have a resume and a role in mind" path completes
+    # with "All set!" but the user lands on a dashboard with zero
+    # targets — the catalog row is created and globally active, but
+    # ``user_targets`` was never populated, so every per-user view is
+    # empty. ``set_active`` only updates the catalog flag; the DB
+    # trigger on ``user_targets`` is what keeps that in sync for
+    # real users. Fall back to the legacy ``set_active`` for api-key
+    # (cron) callers where ``user_id is None`` — they don't have a
+    # user identity to link.
+    if user_id is not None:
+        crud.link_user_to_target(
+            supabase, user_id=user_id, target_id=target.id, is_active=True
+        )
+        # Re-read the target row so the response carries the
+        # trigger-synced ``is_active``.
+        refreshed = crud.get(supabase, target.id)
+        return refreshed or target
     activated = crud.set_active(supabase, target_id=target.id)
     return activated or target
 

--- a/apps/wyrdfold/src/app/onboarding/TargetSuggestions.tsx
+++ b/apps/wyrdfold/src/app/onboarding/TargetSuggestions.tsx
@@ -55,9 +55,17 @@ export default function TargetSuggestions({
           method: 'POST',
         });
         if (!res.ok) throw new Error('Failed to create target');
-        const data = (await res.json()) as { label: string };
+        const data = (await res.json()) as { id: string; label: string };
         if (!cancelled) {
           setCreatedLabel(data.label);
+          // Kick off the derive → poll → score pipeline so the new
+          // target actually has matched jobs by the time the user
+          // lands on /dashboard. Path B (suggest) does this after
+          // ``/link``; path A (from-posting) was missing it, so the
+          // user landed on an empty Top Matches block.
+          fetch(`/api/targets/${data.id}/activate`, { method: 'POST' }).catch(
+            () => undefined
+          );
           timerRef.current = setTimeout(onComplete, 2000);
         }
       } catch {


### PR DESCRIPTION
## Summary
The "**I have a resume and a role in mind**" onboarding path completed with the wizard's "All set!" screen but landed the user on a dashboard with **zero** targets and **zero** scored jobs. Two stacked bugs:

### 1. Backend never linked the user (``user_targets`` row missing)
``POST /targets/from-posting/{id}`` created the catalog ``targets`` row + derived the scoring profile + called ``crud.set_active`` to flip the global ``is_active`` flag — but never inserted a ``user_targets`` row. The catalog row exists, but every per-user view filters through ``user_targets`` and saw nothing.

The crud module already documents this: ``set_active`` says *"Prefer ``link_user_to_target()`` for multi-user flows"* but this caller never made the swap. Replace with ``link_user_to_target`` when ``user_id`` is present; keep ``set_active`` for api-key (cron) callers without user identity.

### 2. Frontend never fired the activation pipeline
``TargetSuggestions.tsx`` path A showed the success card + advanced to completion — but never called ``/api/targets/{id}/activate``, the endpoint that kicks the derive → poll → score pipeline. Path B (suggest) does this after ``/link``; path A was missing it entirely. Add the same fire-and-forget activate call.

## How found
Smoke-walking onboarding path 1 from a wiped account during the session-29 walkthrough.

## Test plan
- [x] ``pnpm tsc --noEmit`` clean (6/6 typecheck projects)
- [x] ``pnpm nx test wyrdfold-api`` — 849/849 pass
- [x] ``ruff check`` clean
- [ ] After Railway redeploy: re-walk path 1, confirm ``/targets/mine`` returns the new target + ``/jobs`` shows scored matches within ~30s of "All set!"

🤖 Generated with [Claude Code](https://claude.com/claude-code)