### PR TITLE
feat(wyrdfold): add Paste-URL CTA to /jobs empty state

### DIFF
--- a/apps/wyrdfold/src/app/(app)/jobs/JobsEmptyState.tsx
+++ b/apps/wyrdfold/src/app/(app)/jobs/JobsEmptyState.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import { useState } from 'react';
+import { Text } from '@danieljoffe.com/shared-ui/Text';
+import Button from '@/components/Button';
+import { useToast } from '@/state/Toast/ToastProvider';
+
+interface JobsEmptyStateProps {
+  /**
+   * Notify the parent table that a job was added so it can refresh. The
+   * parent owns the fetch hook + page state — this component shouldn't
+   * try to mutate it directly.
+   */
+  onJobAdded: () => void;
+}
+
+/**
+ * Shared empty state for the jobs list (desktop table + mobile cards).
+ *
+ * Was a static line of text saying "No jobs found. Try adjusting filters
+ * or adding jobs manually." — but ``/jobs`` had no actual UI affordance
+ * for adding a job manually; the API endpoint (POST /jobs/manual) was
+ * only reachable from the onboarding wizard. Users finishing onboarding
+ * with the suggest path landed on an empty Top Matches block and had
+ * no way to seed one.
+ *
+ * Surface a Paste URL CTA right where the user is already looking.
+ * Uses ``window.prompt`` to match the codebase's existing pattern
+ * (delete-job confirm, contact-name prompt) — a full modal isn't
+ * justified for what amounts to one input.
+ */
+export default function JobsEmptyState({ onJobAdded }: JobsEmptyStateProps) {
+  const [submitting, setSubmitting] = useState(false);
+  const { toast } = useToast();
+
+  async function handleAdd() {
+    // eslint-disable-next-line no-alert -- personal tool, native prompt matches the codebase
+    const url = window.prompt('Paste a job posting URL:');
+    const trimmed = url?.trim() ?? '';
+    if (!trimmed) return;
+    setSubmitting(true);
+    try {
+      const res = await fetch('/api/jobs/manual', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ url: trimmed }),
+      });
+      if (!res.ok) {
+        const body = (await res.json().catch(() => null)) as {
+          detail?: string;
+        } | null;
+        toast({
+          variant: 'error',
+          title: body?.detail || `Could not add job (${res.status})`,
+        });
+        return;
+      }
+      toast({ variant: 'success', title: 'Job added' });
+      onJobAdded();
+    } catch {
+      toast({ variant: 'error', title: 'Network error adding job' });
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className='flex flex-col items-center gap-3 py-12 text-center'>
+      <Text variant='body' className='text-text-tertiary'>
+        No jobs found. Try adjusting filters, or paste a posting URL to add one
+        manually.
+      </Text>
+      <Button
+        name='jobs-add-manual'
+        variant='outline'
+        size='sm'
+        onClick={handleAdd}
+        disabled={submitting}
+      >
+        {submitting ? 'Adding...' : 'Paste URL'}
+      </Button>
+    </div>
+  );
+}

--- a/apps/wyrdfold/src/app/(app)/jobs/JobsListMobile.tsx
+++ b/apps/wyrdfold/src/app/(app)/jobs/JobsListMobile.tsx
@@ -2,9 +2,9 @@
 
 import { Pagination } from '@danieljoffe.com/shared-ui/Pagination';
 import { Skeleton } from '@danieljoffe.com/shared-ui/Skeleton';
-import { Text } from '@danieljoffe.com/shared-ui/Text';
 import { useToast } from '@/state/Toast/ToastProvider';
 import JobCard from './JobCard';
+import JobsEmptyState from './JobsEmptyState';
 import type { JobPosting } from './types';
 
 interface JobsListMobileProps {
@@ -72,11 +72,7 @@ export default function JobsListMobile({
   }
 
   if (postings.length === 0) {
-    return (
-      <Text variant='body' className='py-12 text-center text-text-tertiary'>
-        No jobs found. Try adjusting filters or adding jobs manually.
-      </Text>
-    );
+    return <JobsEmptyState onJobAdded={onRefetch} />;
   }
 
   return (

--- a/apps/wyrdfold/src/app/(app)/jobs/JobsListTable.tsx
+++ b/apps/wyrdfold/src/app/(app)/jobs/JobsListTable.tsx
@@ -5,9 +5,9 @@ import { Badge } from '@danieljoffe.com/shared-ui/Badge';
 import { Pagination } from '@danieljoffe.com/shared-ui/Pagination';
 import { Skeleton } from '@danieljoffe.com/shared-ui/Skeleton';
 import { Spinner } from '@danieljoffe.com/shared-ui/Spinner';
-import { Text } from '@danieljoffe.com/shared-ui/Text';
 import { cn } from '@/lib/cn';
 import JobDetailPanel from './JobDetailPanel';
+import JobsEmptyState from './JobsEmptyState';
 import StatusIndicator from './StatusIndicator';
 import {
   MANUAL_SOURCE_ID,
@@ -126,11 +126,7 @@ export default function JobsListTable({
   }
 
   if (postings.length === 0) {
-    return (
-      <Text variant='body' className='text-center py-12 text-text-tertiary'>
-        No jobs found. Try adjusting filters or adding jobs manually.
-      </Text>
-    );
+    return <JobsEmptyState onJobAdded={onRefetch} />;
   }
 
   return (


### PR DESCRIPTION
## Summary
``/jobs`` had no manual-add affordance even though the existing copy ("No jobs found. Try adjusting filters or adding jobs manually.") pointed at a workflow that didn't exist anywhere in the app. ``POST /jobs/manual`` was only reachable from the onboarding wizard.

New ``JobsEmptyState`` component renders a Paste URL CTA — ``window.prompt`` for the URL (matches the existing codebase pattern for delete-confirm and contact-name capture), POST to ``/api/jobs/manual``, call the parent's ``onRefetch`` to repopulate. Used by both ``JobsListTable`` (desktop) and ``JobsListMobile``.

Toast surfaces upstream ``detail`` on failure (invalid URL, extraction failure, banned host) so users see the actual cause.

## Test plan
- [x] ``pnpm tsc --noEmit`` clean
- [ ] (live) Drain the LaunchDarkly seed target's list to empty (or apply a filter that returns 0), click Paste URL, enter a valid greenhouse URL, see the job appear in the list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)