### PR TITLE
chore(wyrdfold): fix h1→h3 heading skip on /insights

### DIFF
--- a/apps/wyrdfold/src/app/(app)/insights/InsightsDashboard.tsx
+++ b/apps/wyrdfold/src/app/(app)/insights/InsightsDashboard.tsx
@@ -264,7 +264,7 @@ export default function InsightsDashboard() {
       <Card aria-busy={showVelocitySkeleton}>
         <CardHeader>
           <div className='flex items-baseline gap-x-4 gap-y-1 flex-wrap'>
-            <CardTitle>Weekly Activity</CardTitle>
+            <CardTitle as='h2'>Weekly Activity</CardTitle>
             <Text variant='meta'>
               Resumes drafted vs applications submitted, per week
             </Text>
@@ -283,7 +283,7 @@ export default function InsightsDashboard() {
       <div className='grid gap-6 grid-cols-1 lg:grid-cols-2'>
         <Card aria-busy={showFunnelSkeleton}>
           <CardHeader>
-            <CardTitle>Pipeline Funnel</CardTitle>
+            <CardTitle as='h2'>Pipeline Funnel</CardTitle>
           </CardHeader>
           <CardContent>
             {showFunnelSkeleton ? (
@@ -296,7 +296,7 @@ export default function InsightsDashboard() {
 
         <Card aria-busy={showScoreDistSkeleton}>
           <CardHeader>
-            <CardTitle>Score Distribution</CardTitle>
+            <CardTitle as='h2'>Score Distribution</CardTitle>
           </CardHeader>
           <CardContent>
             {showScoreDistSkeleton ? (
@@ -316,7 +316,7 @@ export default function InsightsDashboard() {
         <Card aria-busy={showTargetCmpSkeleton}>
           <CardHeader>
             <div className='flex items-baseline gap-x-4 gap-y-1 flex-wrap'>
-              <CardTitle>Target Comparison</CardTitle>
+              <CardTitle as='h2'>Target Comparison</CardTitle>
               <Text variant='meta'>
                 Avg score and interview conversion across your saved targets
               </Text>
@@ -334,7 +334,7 @@ export default function InsightsDashboard() {
         <Card aria-busy={showSkillFreqSkeleton}>
           <CardHeader>
             <div className='flex items-baseline gap-x-4 gap-y-1 flex-wrap'>
-              <CardTitle>Skill Mentions</CardTitle>
+              <CardTitle as='h2'>Skill Mentions</CardTitle>
               <Text variant='meta'>
                 How often each skill appears across your analyzed jobs
               </Text>
@@ -354,7 +354,7 @@ export default function InsightsDashboard() {
       <Card aria-busy={showSkillFreqSkeleton}>
         <CardHeader>
           <div className='flex items-baseline gap-x-4 gap-y-1 flex-wrap'>
-            <CardTitle>What to Learn Next</CardTitle>
+            <CardTitle as='h2'>What to Learn Next</CardTitle>
             <Text variant='meta'>
               Skills you&apos;re missing, ranked by impact on high-scoring jobs
             </Text>
@@ -373,7 +373,7 @@ export default function InsightsDashboard() {
       <Card aria-busy={showCostSkeleton}>
         <CardHeader>
           <div className='flex items-baseline gap-4'>
-            <CardTitle>LLM Cost</CardTitle>
+            <CardTitle as='h2'>LLM Cost</CardTitle>
             {skillsCost && (
               <Text variant='meta'>
                 Total: ${skillsCost.total_cost.toFixed(2)}

--- a/libs/shared/ui/src/lib/Card.tsx
+++ b/libs/shared/ui/src/lib/Card.tsx
@@ -28,6 +28,14 @@ export interface CardTitleProps extends Omit<
 > {
   ref?: Ref<HTMLHeadingElement> | undefined;
   children: ReactNode;
+  /**
+   * Override the rendered heading level. Defaults to ``h3`` (the
+   * underlying ``Heading variant='cardTitle'`` default). Pass ``h2``
+   * when a CardTitle is the first heading inside an ``h1``-titled
+   * page section — otherwise Lighthouse's ``heading-order`` audit
+   * flags the h1→h3 jump as a screen-reader hazard.
+   */
+  as?: 'h2' | 'h3' | 'h4';
 }
 
 export interface CardContentProps extends Omit<
@@ -96,10 +104,20 @@ export function CardTitle({
   children,
   className,
   ref,
+  as,
   ...props
 }: CardTitleProps) {
+  // ``exactOptionalPropertyTypes`` requires we omit ``as`` when undefined
+  // rather than passing ``as={undefined}`` (which doesn't satisfy
+  // ``HeadingLevel`` without ``undefined`` in its union).
   return (
-    <Heading ref={ref} variant='cardTitle' className={className} {...props}>
+    <Heading
+      ref={ref}
+      variant='cardTitle'
+      className={className}
+      {...(as ? { as } : {})}
+      {...props}
+    >
       {children}
     </Heading>
   );


### PR DESCRIPTION
## Summary
Lighthouse ``heading-order`` audit flagged ``/insights``: the page's h1 ("Insights") was followed directly by h3s (every chart's ``CardTitle``) with no h2 in between. Screen-reader users navigating by heading level can't tell the chart titles are sibling sections.

Extend ``CardTitle`` (shared-ui) with an optional ``as`` prop — default stays at h3 (no callsite churn elsewhere), callers nesting a CardTitle directly under an h1 pass ``as='h2'``. Bump all 7 ``CardTitle`` usages on ``InsightsDashboard``.

## Lighthouse pre/post
- Pre: ``/insights`` a11y **98**, heading-order ❌
- (post-deploy expected): a11y **100**, heading-order ✓

## Other lighthouse findings (flagged, not in scope)
- ``color-contrast`` on /dashboard + /jobs: ``text-text-tertiary`` on light backgrounds falls under WCAG AA. Token-level fix.
- ``label-content-name-mismatch``: sidebar logo link has aria-label "WyrdFold home" but visible content is doubled "WyrdFoldWyrdFold" (logo SVG + visually-hidden text both visible to ax tree).
- ``cumulative-layout-shift`` on /insights: charts pop in after data load. Skeleton with fixed chart height would fix.
- ``is-crawlable``: intentional ``noindex`` on the auth-gated app.

## Test plan
- [x] ``pnpm tsc --noEmit`` clean (6/6 projects)
- [x] ``pnpm nx test @danieljoffe.com/shared-ui -- Card.spec`` — 40/40 pass
- [x] ruff/eslint clean via pre-commit
- [ ] (preview) Re-run Lighthouse on /insights, confirm heading-order passes + a11y goes 98 → 100

🤖 Generated with [Claude Code](https://claude.com/claude-code)