### PR TITLE
chore(wyrdfold): bundle open-gap fixes — a11y + dashboard counters + path 3 exit

### DIFF
--- a/apps/wyrdfold/src/app/(app)/DashboardPage.tsx
+++ b/apps/wyrdfold/src/app/(app)/DashboardPage.tsx
@@ -3,9 +3,11 @@
 import Link from 'next/link';
 import {
   ArrowRight,
+  Award,
   Briefcase,
   CheckCircle2,
   FileEdit,
+  MessageCircle,
   Send,
   Sparkles,
   Star,
@@ -26,19 +28,26 @@ export interface DashboardInitial {
 }
 
 interface PipelineStat {
-  status: 'new' | 'saved' | 'resume_draft' | 'resume_ready' | 'applied';
+  status:
+    | 'new'
+    | 'saved'
+    | 'resume_draft'
+    | 'resume_ready'
+    | 'applied'
+    | 'interviewing'
+    | 'offer';
   label: string;
   icon: React.ReactNode;
   href: string;
 }
 
-// ``resume_ready`` was missing from the dashboard until 2026-05 — users
-// who'd approved a resume saw "Drafts: 0 / Applied: 0" with no
-// acknowledgment that their work-in-progress existed. ``interviewing``
-// and ``offer`` are deliberately omitted for now: they're rare states
-// in personal-tool usage and adding more counters past 5 makes the
-// row noisy on mobile. Adding them is a one-line change if they
-// start mattering.
+// Full pipeline view. ``resume_ready`` was added in 2026-05 (#685);
+// ``interviewing`` and ``offer`` were initially deferred to keep the
+// row tight at 5 cells, then promoted here once it became clear the
+// late-stage statuses are exactly the ones a user wants visible (the
+// rare ones are also the ones with the highest emotional weight — a
+// dashboard that hides them is hiding the win). 7 cells now; grid
+// reflows from 2 → 3 → 4 (sm) → 7 (xl) so mobile stays scannable.
 const PIPELINE_STATS: PipelineStat[] = [
   {
     status: 'new',
@@ -69,6 +78,18 @@ const PIPELINE_STATS: PipelineStat[] = [
     label: 'Applied',
     icon: <Send className='size-4' aria-hidden />,
     href: '/jobs?status=applied',
+  },
+  {
+    status: 'interviewing',
+    label: 'Interviewing',
+    icon: <MessageCircle className='size-4' aria-hidden />,
+    href: '/jobs?status=interviewing',
+  },
+  {
+    status: 'offer',
+    label: 'Offer',
+    icon: <Award className='size-4' aria-hidden />,
+    href: '/jobs?status=offer',
   },
 ];
 
@@ -183,9 +204,11 @@ export default function DashboardPage({ initial }: DashboardPageProps) {
         </Text>
       </div>
 
-      {/* Pipeline stats — 5 statuses fit nicely on lg+, wrap as 3+2 on
-          smaller screens (mobile keeps 2-up to stay scannable). */}
-      <div className='grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5'>
+      {/* Pipeline stats — 7 statuses (new → saved → drafts → ready →
+          applied → interviewing → offer). Reflow: 2 cols on mobile,
+          3 on sm, 4 on md, 7 on xl so the row stays readable across
+          all widths without horizontal scroll. */}
+      <div className='grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4 xl:grid-cols-7'>
         {PIPELINE_STATS.map(stat => (
           <Link
             key={stat.status}

--- a/apps/wyrdfold/src/app/(app)/WyrdfoldSidebar.tsx
+++ b/apps/wyrdfold/src/app/(app)/WyrdfoldSidebar.tsx
@@ -100,7 +100,13 @@ export default function WyrdfoldSidebar() {
             aria-label='WyrdFold home'
             className='flex items-center gap-2 rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2'
           >
-            <WyrdfoldLogo aria-label='WyrdFold' className='h-4 w-5' />
+            {/* Decorative — the visible "WyrdFold" text and the link's
+                aria-label "WyrdFold home" already name this control.
+                The SVG having its own aria-label produced "WyrdFold
+                WyrdFold" in the accessible name, which Lighthouse's
+                ``label-content-name-mismatch`` flagged against the
+                outer "WyrdFold home" override. */}
+            <WyrdfoldLogo aria-hidden className='h-4 w-5' />
             <span className='text-sm font-semibold text-text-primary'>
               WyrdFold
             </span>

--- a/apps/wyrdfold/src/app/(app)/dashboard/page.tsx
+++ b/apps/wyrdfold/src/app/(app)/dashboard/page.tsx
@@ -24,6 +24,8 @@ const PIPELINE_STATUSES = [
   'resume_draft',
   'resume_ready',
   'applied',
+  'interviewing',
+  'offer',
 ] as const;
 
 export default async function WyrdfoldDashboard() {

--- a/apps/wyrdfold/src/app/(app)/insights/InsightsDashboard.tsx
+++ b/apps/wyrdfold/src/app/(app)/insights/InsightsDashboard.tsx
@@ -18,27 +18,41 @@ import { cn } from '@/lib/cn';
 import { downloadInsightsCsv } from './exportCsv';
 import type { Period } from './types';
 
-const CostChart = dynamic(() => import('./charts/CostChart'), { ssr: false });
+// Pass ``ChartSkeleton`` (declared below) as the dynamic-import
+// ``loading`` placeholder. Recharts containers render at
+// ``height={250}``; with no loading placeholder the chart slots were
+// 0-height until hydrate, then reflowed the page and Lighthouse
+// flagged CLS. ``next/dynamic`` enforces object-literal-at-callsite
+// (https://nextjs.org/docs/messages/invalid-dynamic-options-type)
+// so we can't extract a shared options const — repeat the literal
+// per chart.
+const CostChart = dynamic(() => import('./charts/CostChart'), {
+  ssr: false,
+  loading: () => <ChartSkeleton />,
+});
 const FunnelChart = dynamic(() => import('./charts/FunnelChart'), {
   ssr: false,
+  loading: () => <ChartSkeleton />,
 });
 const ScoreDistributionChart = dynamic(
   () => import('./charts/ScoreDistributionChart'),
-  { ssr: false }
+  { ssr: false, loading: () => <ChartSkeleton /> }
 );
 const SkillFrequencyChart = dynamic(
   () => import('./charts/SkillFrequencyChart'),
-  { ssr: false }
+  { ssr: false, loading: () => <ChartSkeleton /> }
 );
 const TopSkillGaps = dynamic(() => import('./charts/TopSkillGaps'), {
   ssr: false,
+  loading: () => <ChartSkeleton />,
 });
 const TargetComparisonChart = dynamic(
   () => import('./charts/TargetComparisonChart'),
-  { ssr: false }
+  { ssr: false, loading: () => <ChartSkeleton /> }
 );
 const VelocityChart = dynamic(() => import('./charts/VelocityChart'), {
   ssr: false,
+  loading: () => <ChartSkeleton />,
 });
 
 const PERIODS: { id: Period; label: string }[] = [

--- a/apps/wyrdfold/src/app/_components/ConversationChat.tsx
+++ b/apps/wyrdfold/src/app/_components/ConversationChat.tsx
@@ -100,6 +100,36 @@ export default function ConversationChat({
     };
   }, []);
 
+  /**
+   * Force the conversation to its derive step regardless of the
+   * orchestrator's done-signal. Use when the user has shared enough
+   * detail in their own judgment but the LLM is still probing.
+   * Same derive + onComplete path as the auto-done branch in
+   * ``handleSend``; failures surface the same error UI.
+   */
+  const handleFinishNow = useCallback(async () => {
+    if (sending || deriving) return;
+    setError(null);
+    setDeriving(true);
+    try {
+      const deriveRes = await fetch('/api/career/experience/derive', {
+        method: 'POST',
+      });
+      if (!deriveRes.ok) {
+        throw new Error(
+          await extractErrorDetail(deriveRes, 'Failed to build master document')
+        );
+      }
+      setTimeout(onComplete, 800);
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : 'Something went wrong. Try again.'
+      );
+    } finally {
+      setDeriving(false);
+    }
+  }, [sending, deriving, onComplete]);
+
   const handleSend = useCallback(async () => {
     const trimmed = input.trim();
     if (!trimmed || sending) return;
@@ -330,7 +360,7 @@ export default function ConversationChat({
 
       {error && <Alert variant='error'>{error}</Alert>}
 
-      <div className='flex items-center justify-between'>
+      <div className='flex flex-wrap items-center justify-between gap-2'>
         <Button
           name='onboarding-skip-question'
           variant='outline'
@@ -340,15 +370,39 @@ export default function ConversationChat({
         >
           Skip this question
         </Button>
-        <Button
-          name='onboarding-skip-conversation'
-          variant='ghost'
-          size='sm'
-          onClick={onSkip}
-          disabled={sending || deriving}
-        >
-          Skip for now
-        </Button>
+        <div className='flex items-center gap-2'>
+          {/*
+            "Build my profile" lets the user finish on their own terms.
+            The orchestrator only sets ``done=true`` after gathering
+            roles + outcomes for the last 3 positions — by-design to
+            produce a strong profile, but it left no exit for users who
+            ran out of time / patience after 17+ turns. ``Skip for now``
+            still exists for abandoning entirely; this CTA fires
+            ``/derive`` on whatever prose has accumulated and
+            advances the wizard to the completion step. The same
+            ``deriving`` state + handler is reused from the done-branch
+            of ``handleSend`` so the spinner + error toast paths stay
+            consistent.
+          */}
+          <Button
+            name='onboarding-finish-conversation'
+            variant='secondary'
+            size='sm'
+            onClick={handleFinishNow}
+            disabled={loading || sending || deriving || messages.length < 2}
+          >
+            {deriving ? 'Building...' : 'Build my profile'}
+          </Button>
+          <Button
+            name='onboarding-skip-conversation'
+            variant='ghost'
+            size='sm'
+            onClick={onSkip}
+            disabled={sending || deriving}
+          >
+            Skip for now
+          </Button>
+        </div>
       </div>
     </div>
   );

--- a/apps/wyrdfold/src/components/Button.tsx
+++ b/apps/wyrdfold/src/components/Button.tsx
@@ -64,7 +64,11 @@ const baseButtonStyles =
 
 const variantButtonStyles: Record<string, string> = {
   primary:
-    'hover:shadow-lg/12.5 bg-brand-500 text-white hover:bg-brand-600 active:bg-brand-700',
+    // ``text-text-on-brand`` (tokenized) instead of hardcoded
+    // ``text-white``. Pyre's chartreuse brand-500 with white text was
+    // 2.76:1 — below WCAG AA. The token resolves to a near-black on
+    // pyre and white on indigo so contrast clears AA on both themes.
+    'hover:shadow-lg/12.5 bg-brand-500 text-text-on-brand hover:bg-brand-600 active:bg-brand-700',
   secondary:
     'hover:shadow-lg/12.5 bg-surface-elevated text-text-primary hover:bg-surface border border-border',
   ghost:

--- a/libs/shared/ui/src/lib/Button.tsx
+++ b/libs/shared/ui/src/lib/Button.tsx
@@ -42,7 +42,10 @@ export const variantButtonStyles: Record<ButtonVariant, string> = {
   bare: '',
   primary: `${
     regularButton
-  } bg-brand-500 text-white hover:bg-brand-600 active:bg-brand-700`,
+    // ``text-text-on-brand`` (themed) instead of hardcoded ``text-white``.
+    // Pyre's chartreuse brand-500 with white text was 2.76:1 (below AA);
+    // the token resolves to near-black on pyre and white on indigo.
+  } bg-brand-500 text-text-on-brand hover:bg-brand-600 active:bg-brand-700`,
   secondary: `${
     regularButton
   } bg-surface-elevated text-text-primary hover:bg-surface border border-border`,

--- a/libs/shared/ui/src/styles/indigo-theme.css
+++ b/libs/shared/ui/src/styles/indigo-theme.css
@@ -59,6 +59,9 @@
   --color-text-tertiary: #6b6b6b;
   --color-text-inverse: #ffffff;
   --color-text-brand: oklch(0.5 0.19 250);
+  /* Tokenized text color paired with brand-500 bg. Indigo's brand-500
+     (oklch 0.54 0.19 250) is dark enough that white reads cleanly. */
+  --color-text-on-brand: #ffffff;
 
   /* Semantic Colors - Status */
   --color-success: #10b981;

--- a/libs/shared/ui/src/styles/pyre-theme.css
+++ b/libs/shared/ui/src/styles/pyre-theme.css
@@ -79,6 +79,10 @@
   --color-text-tertiary: oklch(0.6 0.02 90);
   --color-text-inverse: oklch(0.1 0.01 270);
   --color-text-brand: oklch(0.78 0.22 127);
+  /* Pyre's brand-500 chartreuse (oklch 0.67 0.28 127 ≈ #65ae00) is too
+     bright for white text — Lighthouse measured 2.76:1, below AA's
+     4.5:1. Pair it with a near-black to clear AA comfortably. */
+  --color-text-on-brand: oklch(0.15 0.02 127);
 
   /* Semantic Colors — Status (semantic hues, dimmed chroma for dark surface) */
   --color-success: oklch(0.72 0.2 145);


### PR DESCRIPTION
## Summary
Five frontend-only fixes bundled from the open-gaps audit:

### 1. Sidebar logo label-mismatch (a11y)
``aria-label="WyrdFold home"`` on the outer link + ``aria-label="WyrdFold"`` on the SVG produced an accessible name "WyrdFold WyrdFold" that mismatched the override. Make the SVG ``aria-hidden`` — visible text + link aria-label already name it.

### 2. Dashboard interviewing + offer counters
Promoted ``PIPELINE_STATS`` from 5 → 7 (full pipeline). Late-stage statuses are exactly the ones users want visible. Grid reflows 2 → 3 → 4 → 7 across mobile / sm / md / xl.

### 3. CLS on /insights
7 ``next/dynamic`` chart imports had no ``loading`` placeholder, so chart slots painted at 0 height until hydration, then reflowed. Pass existing ``ChartSkeleton`` (250px, matches recharts ``height={250}``) as ``loading``.

### 4. Path 3 conversation user-driven exit
The orchestrator only sets ``done=true`` after 3 roles + outcomes; users hit 17+ turns with no exit. Add a "Build my profile" CTA that fires ``/derive`` on accumulated prose and advances to completion. Disabled until ≥2 messages so it can't fire on empty state.

### 5. Color-contrast on Button primary
Pyre's chartreuse ``brand-500`` (#65ae00) with hardcoded ``text-white`` = **2.76:1** (below AA 4.5:1). Tokenized as ``--color-text-on-brand``: near-black on pyre, white on indigo. Updated both app + shared-ui Button.

## How found
Session-30 walkthrough: Lighthouse on /dashboard + /jobs + /insights, plus path 3 onboarding smoke that surfaced the no-exit dead end.

## Test plan
- [x] ``pnpm tsc --noEmit`` clean (6/6 projects)
- [x] ``pnpm nx test @danieljoffe.com/shared-ui`` — 754/754 pass
- [x] Sidebar verified live: visible text is now "WyrdFold" (was "WyrdFoldWyrdFold")
- [ ] (preview) Re-run Lighthouse: color-contrast + label-content-name-mismatch + cumulative-layout-shift should now pass
- [ ] (preview) Path 3 onboarding: "Build my profile" CTA appears after 2 messages, fires /derive, advances to completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)