### PR TITLE
fix(wyrdfold-api): /targets/{id}/status excludes negative-filtered scores

### DIFF
--- a/apps/wyrdfold-api/app/routers/targets.py
+++ b/apps/wyrdfold-api/app/routers/targets.py
@@ -489,10 +489,18 @@ async def get_target_status(
     if target is None:
         raise HTTPException(status_code=404, detail="Target not found")
 
+    # Filter ``excluded=False`` so this count matches what the user
+    # actually sees in /jobs?target_id=... — the list endpoint hides
+    # rows the scorer flagged as excluded (negative-keyword matches),
+    # but this endpoint was previously counting all of them. Result:
+    # a "ready, 3 jobs scored" status that landed the user on a list
+    # showing 1, with the other 2 silently filtered out for being
+    # off-target.
     count_resp = (
         supabase.table("scores")
         .select("id", count=CountMethod.exact)
         .eq("target_id", target_id)
+        .eq("excluded", False)
         .execute()
     )
     jobs_count = count_resp.count or 0


### PR DESCRIPTION
## Summary
``GET /targets/{id}/status`` reported ``jobs_count`` counting every ``scores`` row, including the ones flagged ``excluded=true`` by negative-keyword matches during stage-1 scoring. ``GET /jobs?target_id=...`` filters those out correctly, so a user landed on UI showing "3 jobs scored" but a list with 1 — the other 2 silently dropped for matching negative keywords like ``junior``, ``backend engineer``, ``data engineer``.

Add ``.eq("excluded", False)`` to the count query so the status counter matches what the user can actually see.

## How found
Live observation: target ``aa27307e-...`` (Staff Frontend Engineer) reported ``jobs_count: 3`` from ``/status`` but ``total: 1`` from ``/jobs?target_id=...``. Same scores rows; the only difference was the missing ``excluded`` filter.

## Follow-up ideas (not in scope)
- Surface the excluded count separately in ``TargetStatusResponse`` so users can see "1 visible, 2 filtered by your negative keywords" and tune the negatives if they're too aggressive.
- When a target activates with very few visible jobs, suggest broader search keywords (or re-poll across more sources) so the user lands somewhere richer.

## Test plan
- [x] ``pnpm nx test wyrdfold-api`` — 849/849 pass
- [x] ``pnpm nx typecheck wyrdfold-api`` clean (mypy)
- [ ] After Railway redeploy: confirm ``/status`` and ``/jobs?target_id=...`` agree on count for the Staff Frontend Engineer target (expected: both report 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)