### PR TITLE
fix(wyrdfold): drop implicit minScore=45 default on /jobs target tab

### DIFF
--- a/apps/wyrdfold/src/app/(app)/jobs/JobsList.tsx
+++ b/apps/wyrdfold/src/app/(app)/jobs/JobsList.tsx
@@ -24,8 +24,15 @@ const INITIAL_FILTERS: JobsFilterState = {
   search: '',
 };
 
+// ``minScore`` empty (= no implicit floor) so the "Any score" label
+// the dropdown shows actually means "any score". The previous default
+// of ``'45'`` silently filtered out matches in the 0–44 range while the
+// dropdown still rendered "Any score" — because ``'45'`` isn't one of
+// the ``MIN_SCORE_OPTIONS`` values (the gaps go 0 → 40 → 70 → 85), the
+// label-lookup fell through to "Any score" and target tabs hard-loaded
+// with an empty list whenever every match scored below 45.
 const TARGET_FILTERS: JobsFilterState = {
-  minScore: '45',
+  minScore: '',
   status: '',
   search: '',
 };


### PR DESCRIPTION
## Summary
``TARGET_FILTERS.minScore`` defaulted to ``'45'`` but the dropdown's options list is ``['', '40', '70', '85']`` — so ``MIN_SCORE_OPTIONS.find(o => o.value === '45')`` returned ``undefined`` and the label fell back to **"Any score"** while the fetch hook was still passing ``min_score=45``.

Effect: hard-loading any ``/jobs?target=...`` tab where every match scored below 45 showed an empty list, with the filter UI lying about why. Toggling the dropdown to literally "Any score" then revealed the row.

Observed live: Staff Frontend Engineer target's only visible match scored 38, was filtered at 45, page rendered "No jobs found" with "Any score" label, exactly the symptom reported.

## Fix
Reset ``TARGET_FILTERS.minScore`` to ``''`` so the dropdown label and the fetched URL agree. Users who want a high-signal floor still get 40/70/85 buckets via the dropdown. Sibling "All Jobs" tab used ``INITIAL_FILTERS`` which has always defaulted to ``''`` — only the target tab had the mismatch.

## Test plan
- [x] ``pnpm tsc --noEmit`` clean (6/6 projects)
- [ ] (preview) Hard-load ``/jobs?target=aa27307e-...`` — list should show the 1 score-38 match without toggling the filter.
- [ ] (preview) Dropdown still defaults to "Any score" + clicking 40+/70+/85+ filters correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)