### PR TITLE
fix(wyrdfold): target-card user-active flag + auto-refresh score after analysis

### DIFF
--- a/apps/wyrdfold/src/app/(app)/jobs/JobDetailPanel.tsx
+++ b/apps/wyrdfold/src/app/(app)/jobs/JobDetailPanel.tsx
@@ -30,6 +30,14 @@ interface JobDetailPanelProps {
   viewFullHref: string | undefined;
   onDelete: (() => void) | undefined;
   onStatusChange: ((status: string) => void) | undefined;
+  /** Fired after the LLM analysis completes. The blend write-back
+   *  (PR #689 / #690 / #691) updates the per-target score + flips
+   *  ``scoring_status`` to ``complete``, but the panel's ``posting``
+   *  prop is still stale until the parent refetches. Pages that own
+   *  ``posting`` state should re-GET ``/api/jobs/{id}`` here so the
+   *  Score badge + breakdown reflect the new blended values without
+   *  the user having to manually refresh. */
+  onAnalysisComplete?: (() => void) | undefined;
   /** Suppress the panel's own Delete action (the page renders one at root). */
   hideDelete?: boolean;
   /** Default-open the JD description block on the full-page detail
@@ -106,6 +114,7 @@ export default function JobDetailPanel({
   viewFullHref,
   onDelete,
   onStatusChange,
+  onAnalysisComplete,
   hideDelete = false,
   defaultDescriptionOpen = false,
 }: JobDetailPanelProps) {
@@ -168,6 +177,12 @@ export default function JobDetailPanel({
       if (res.ok) {
         const data = (await res.json()) as JobAnalysis;
         setAnalysis(data);
+        // Backend blended the LLM score into the per-target ``scores``
+        // row + flipped ``scoring_status`` to ``complete``. The
+        // ``posting`` prop is now stale (still shows the keyword-only
+        // score). Notify the parent so it can refetch and re-render
+        // the Score badge + breakdown without a manual page refresh.
+        onAnalysisComplete?.();
       } else {
         // Distinguish the specific "no description in DB" 422 case (which
         // the route surfaces with ``Job posting has no description to
@@ -199,7 +214,7 @@ export default function JobDetailPanel({
     } finally {
       setAnalyzing(false);
     }
-  }, [posting.id, targetId]);
+  }, [posting.id, targetId, onAnalysisComplete]);
 
   // Auto-trigger analysis on first open when a target is selected.
   // Cache hit returns instantly; cache miss runs the LLM exactly once

--- a/apps/wyrdfold/src/app/(app)/jobs/JobsListTable.tsx
+++ b/apps/wyrdfold/src/app/(app)/jobs/JobsListTable.tsx
@@ -272,6 +272,7 @@ export default function JobsListTable({
                           onRefetch();
                         }}
                         onStatusChange={() => onRefetch()}
+                        onAnalysisComplete={onRefetch}
                       />
                     </td>
                   </tr>

--- a/apps/wyrdfold/src/app/(app)/jobs/[id]/JobDetailPage.tsx
+++ b/apps/wyrdfold/src/app/(app)/jobs/[id]/JobDetailPage.tsx
@@ -85,6 +85,23 @@ export default function JobDetailPage({ id, targetId }: JobDetailPageProps) {
     setPosting(prev => (prev ? { ...prev, status: newStatus } : prev));
   }, []);
 
+  // Re-fetch the posting after the LLM analysis blend writes the new
+  // per-target score + flips ``scoring_status`` to ``complete``. The
+  // panel's ``onAnalysisComplete`` calls this; without it the Score
+  // badge stays at the keyword-only number (e.g. 70+ → 20 blend stayed
+  // visually at 70+ until the user manually refreshed).
+  const refetchPosting = useCallback(async () => {
+    try {
+      const res = await fetch(`/api/jobs/${id}`);
+      if (!res.ok) return;
+      const data = (await res.json()) as JobPosting;
+      setPosting(data);
+    } catch {
+      // Best-effort — the analysis result is already shown; the stale
+      // score is the worst case, and refreshing the page recovers.
+    }
+  }, [id]);
+
   const handleDelete = useCallback(async () => {
     if (!posting) return;
     /* eslint-disable no-alert -- personal tool, native confirm is fine */
@@ -242,6 +259,7 @@ export default function JobDetailPage({ id, targetId }: JobDetailPageProps) {
           viewFullHref={undefined}
           onDelete={undefined}
           onStatusChange={handleStatusChange}
+          onAnalysisComplete={refetchPosting}
           hideDelete
           defaultDescriptionOpen
         />

--- a/apps/wyrdfold/src/app/(app)/targets/TargetCard.tsx
+++ b/apps/wyrdfold/src/app/(app)/targets/TargetCard.tsx
@@ -11,6 +11,20 @@ import type { JobTarget } from './types';
 
 interface TargetCardProps {
   target: JobTarget;
+  /**
+   * THIS user's active flag for the target — read from
+   * ``user_targets.is_active``. ``isActive`` is the shared
+   * catalog flag synced by a DB trigger from any user's active
+   * link, so it can read ``true`` even when this user has the
+   * target deactivated. Reading the catalog flag for per-user UX
+   * (View jobs disabled, Activate/Deactivate label, status badge)
+   * made the dropdown's "View jobs" click-through to
+   * ``/jobs?target=...``, which then server-side-redirected to
+   * the untargeted view because the page filters by
+   * ``user_isActive``. User clicked, ended up nowhere
+   * useful, with no explanation.
+   */
+  isActive: boolean;
   fitScore: number | null;
   fitScoreReasoning: string | null;
   onActivate: (id: string) => void;
@@ -37,6 +51,7 @@ function fitScoreVariant(
 
 export default function TargetCard({
   target,
+  isActive,
   fitScore,
   fitScoreReasoning,
   onActivate,
@@ -58,13 +73,13 @@ export default function TargetCard({
       label: 'View jobs',
       icon: <Briefcase className='size-4' aria-hidden />,
       onClick: () => onViewJobs(target.id),
-      disabled: !target.is_active,
+      disabled: !isActive,
     },
     {
-      label: target.is_active ? 'Deactivate' : 'Activate',
+      label: isActive ? 'Deactivate' : 'Activate',
       icon: <Power className='size-4' aria-hidden />,
       onClick: () =>
-        target.is_active ? onDeactivate(target.id) : onActivate(target.id),
+        isActive ? onDeactivate(target.id) : onActivate(target.id),
     },
     { label: '', divider: true },
     {
@@ -143,11 +158,11 @@ export default function TargetCard({
             <span
               className={cn(
                 'inline-block size-2 rounded-full',
-                target.is_active ? 'bg-success' : 'bg-text-tertiary'
+                isActive ? 'bg-success' : 'bg-text-tertiary'
               )}
               aria-hidden
             />
-            {target.is_active ? 'Active' : 'Inactive'}
+            {isActive ? 'Active' : 'Inactive'}
           </span>
         </div>
       </CardContent>

--- a/apps/wyrdfold/src/app/(app)/targets/TargetsList.tsx
+++ b/apps/wyrdfold/src/app/(app)/targets/TargetsList.tsx
@@ -327,6 +327,7 @@ export default function TargetsList({ initialTargets }: TargetsListProps) {
               <TargetCard
                 key={target.id}
                 target={target}
+                isActive={user_target.is_active}
                 fitScore={user_target.fit_score}
                 fitScoreReasoning={user_target.fit_score_reasoning}
                 onActivate={handleActivate}

--- a/apps/wyrdfold/src/app/(app)/targets/__tests__/TargetCard.spec.tsx
+++ b/apps/wyrdfold/src/app/(app)/targets/__tests__/TargetCard.spec.tsx
@@ -45,6 +45,7 @@ describe('TargetCard', () => {
         target={makeTarget()}
         fitScore={null}
         fitScoreReasoning={null}
+        isActive
         onActivate={noop}
         onDeactivate={noop}
         onDelete={noop}
@@ -60,6 +61,7 @@ describe('TargetCard', () => {
         target={makeTarget()}
         fitScore={92}
         fitScoreReasoning='Great match'
+        isActive
         onActivate={noop}
         onDeactivate={noop}
         onDelete={noop}
@@ -75,6 +77,7 @@ describe('TargetCard', () => {
         target={makeTarget()}
         fitScore={null}
         fitScoreReasoning={null}
+        isActive
         onActivate={noop}
         onDeactivate={noop}
         onDelete={noop}
@@ -92,6 +95,7 @@ describe('TargetCard', () => {
         target={makeTarget()}
         fitScore={null}
         fitScoreReasoning={null}
+        isActive
         onActivate={noop}
         onDeactivate={noop}
         onDelete={noop}
@@ -111,6 +115,7 @@ describe('TargetCard', () => {
         target={makeTarget({ is_active: true })}
         fitScore={null}
         fitScoreReasoning={null}
+        isActive
         onActivate={noop}
         onDeactivate={noop}
         onDelete={noop}
@@ -120,12 +125,13 @@ describe('TargetCard', () => {
     expect(screen.getByText('Active')).toBeInTheDocument();
   });
 
-  it('shows an "Inactive" status when target.is_active is false', () => {
+  it('shows an "Inactive" status when isActive is false', () => {
     render(
       <TargetCard
         target={makeTarget({ is_active: false })}
         fitScore={null}
         fitScoreReasoning={null}
+        isActive={false}
         onActivate={noop}
         onDeactivate={noop}
         onDelete={noop}


### PR DESCRIPTION
Two related state-staleness bugs, bundled because they surface on the same flow (open a target → view its jobs → run analysis).

## 1. TargetCard "View jobs" wasn't disabled on user-inactive targets
The card read ``target.is_active`` — the *shared* catalog flag the DB trigger keeps in sync from any user's active link. So if user A activated target X and user B hadn't, both saw ``target.is_active=true`` and "View jobs" was clickable for user B. Clicking it navigated to ``/jobs?target=X`` → server-side redirect to ``/jobs`` (page filters by ``user_target.is_active``) → user ended up on All Jobs with no explanation. Activate/Deactivate label and the status badge had the same bug.

Fix: add ``isActive`` prop sourced from ``user_target.is_active``; use it for all three per-user states. ``TargetsList`` now passes ``isActive={user_target.is_active}``.

Test suite updated (10/10 pass) — added/aligned all renders to pass the new prop.

## 2. Job-detail score didn't refresh after LLM analysis blend
#689 / #690 / #691 wrote the blended score to ``scores`` + flipped ``scoring_status`` to ``complete`` + invalidated the list cache — but the panel's ``posting`` prop was set once on mount and never re-read. A job with a keyword score of 70+ that the LLM rated 20 displayed at 70+ until the user manually refreshed.

Fix: add ``onAnalysisComplete`` callback on ``JobDetailPanel``. ``JobDetailPage`` refetches ``/api/jobs/{id}`` (which already overlays the live per-target score from ``scores`` thanks to #682); inline ``JobsListTable`` panel re-fires its list refetch. Same pattern as the existing ``onStatusChange`` callback.

## Test plan
- [x] ``pnpm tsc --noEmit`` clean (6/6 projects)
- [x] ``pnpm nx test wyrdfold -- --testPathPatterns=TargetCard.spec.tsx`` — 10/10 pass
- [ ] (preview) Deactivate a target on /targets, open its dropdown — "View jobs" is disabled.
- [ ] (preview) Open ``/jobs/{id}`` on a stage-2 posting under an active target — LLM analysis fires, Score badge + breakdown update to the blended values without a manual refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)