### PR TITLE
test(wyrdfold-e2e): switch auth fixture to OTP via service role + wire CI secrets

### DIFF
--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -99,10 +99,15 @@ jobs:
           # them through from the CI env so the authed smoke spec
           # runs against a real Supabase session. Absent secrets =
           # public tier only, exactly as before.
+          #
+          # SUPABASE_SERVICE_ROLE_KEY is required because the auth
+          # fixture mints an OTP via ``admin.generateLink`` (the
+          # wyrdfold login UI is magic-link only — there's no password
+          # path to verify against).
           NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
           NEXT_PUBLIC_SUPABASE_ANON_ID: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_ID }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
           E2E_TEST_USER_EMAIL: ${{ secrets.E2E_TEST_USER_EMAIL }}
-          E2E_TEST_USER_PASSWORD: ${{ secrets.E2E_TEST_USER_PASSWORD }}
 
       # --- lighthouse ---
       - name: Build app for Lighthouse

--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -93,6 +93,16 @@ jobs:
         env:
           NX_BASE: ${{ inputs.nx-base }}
           NX_HEAD: ${{ inputs.nx-head }}
+          # wyrdfold-e2e/playwright.config.ts only registers the
+          # ``setup`` + ``authed-chromium`` projects when all four of
+          # these are present (see apps/wyrdfold-e2e/README.md). Pass
+          # them through from the CI env so the authed smoke spec
+          # runs against a real Supabase session. Absent secrets =
+          # public tier only, exactly as before.
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+          NEXT_PUBLIC_SUPABASE_ANON_ID: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_ID }}
+          E2E_TEST_USER_EMAIL: ${{ secrets.E2E_TEST_USER_EMAIL }}
+          E2E_TEST_USER_PASSWORD: ${{ secrets.E2E_TEST_USER_PASSWORD }}
 
       # --- lighthouse ---
       - name: Build app for Lighthouse

--- a/apps/wyrdfold-e2e/README.md
+++ b/apps/wyrdfold-e2e/README.md
@@ -13,7 +13,9 @@ The authed tier depends on a one-shot `auth.setup.ts` that writes a signed-in st
 
 ### One-time: create the e2e test user
 
-This is a real Supabase user — create it once via the dashboard (Authentication → Users → Invite user with password) or via the CLI. Pick something memorable like `e2e@wyrdfold.test`. The user just needs to exist with a known password; no profile data required (specs that need data should seed it themselves).
+This is a real Supabase user — create it once via the dashboard (Authentication → Users → Invite user) or via the existing `pnpm --filter @danieljoffe.com/wyrdfold invite-beta <email>` script (which also seeds the `wyrdfold_beta_invites` allowlist row so the `before-user-created` auth hook lets the row through). Pick something memorable like `e2e@wyrdfold.test`. No profile data required — specs that need data should seed it themselves.
+
+The fixture authenticates by minting an OTP via `auth.admin.generateLink({type:'magiclink'})` and exchanging it via `verifyOtp` — same code path as a real user clicking the magic-link, but without the inbox round-trip.
 
 ### Per-machine: set the env
 
@@ -21,7 +23,8 @@ In `apps/wyrdfold/.env.local` (the dev server picks it up; Playwright inherits v
 
 ```bash
 E2E_TEST_USER_EMAIL=e2e@wyrdfold.test
-E2E_TEST_USER_PASSWORD=<the-password-you-set>
+# Already in your .env.local for dev; the e2e fixture needs it too
+SUPABASE_SERVICE_ROLE_KEY=<service-role-key-from-supabase-dashboard>
 ```
 
 The existing `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_ID` are already required for the dev server — Playwright reuses them.
@@ -41,19 +44,18 @@ pnpm nx e2e wyrdfold-e2e
 
 ## Running in CI
 
-CI currently runs only the **public** tier — `auth.setup.ts` calls `setup.skip()` when the `E2E_TEST_USER_*` vars are missing, and the authed project's `dependencies: ['setup']` chain means no authed spec executes.
+`.github/workflows/ci-full.yml` pipes `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_ID`, `SUPABASE_SERVICE_ROLE_KEY`, and `E2E_TEST_USER_EMAIL` into the e2e step. When all four secrets are populated in the repo settings, the authed tier runs; when any are missing, `auth.setup.ts` calls `setup.skip()` and the authed project's `dependencies: ['setup']` chain means no authed spec executes — the public tier still passes cleanly.
 
 To enable the authed tier in CI:
 
-1. Add `E2E_TEST_USER_EMAIL` and `E2E_TEST_USER_PASSWORD` to the GitHub Actions secrets (e.g. via the `secrets.E2E_TEST_USER_EMAIL` mapping in `.github/workflows/ci.yml`).
-2. Make sure the CI job also has `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_ID` — without them the dev server proxy hard-401s on every API call.
-3. The test user account itself stays out of CI — same one, shared.
+1. Add `SUPABASE_SERVICE_ROLE_KEY` and `E2E_TEST_USER_EMAIL` to the GitHub Actions secrets (`NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_ID` are already there).
+2. The test user account itself stays out of CI — same Supabase identity used locally, shared.
 
-## Why password sign-in (and not magic-link)
+## Why OTP via service role (and not password sign-in)
 
-The wyrdfold app uses magic-link auth in production. The Playwright setup uses Supabase password sign-in because magic-link requires either an inbox (slow + flaky) or the `auth.admin.generateLink` endpoint (needs the service-role key, which is a much bigger secret-surface to ship to CI). Password sign-in stays scoped to the anon key.
+The wyrdfold app's login UI is magic-link only (`signInWithOtp`). A password-sign-in fixture would diverge from the production auth path and only work if the test user happened to have a password set in addition to OTP, which is fragile.
 
-The test user is a parallel Supabase identity — it doesn't change anything about how production users authenticate.
+`auth.admin.generateLink({type:'magiclink'})` returns the email OTP token without sending an email; `verifyOtp` then exchanges it for a real session. Same code path as a real user clicking the magic-link in their inbox. The trade-off is the service-role key in CI — broader scope than the anon key, but scoped to a parallel test identity that doesn't touch production users.
 
 ## Adding a new authed spec
 

--- a/apps/wyrdfold-e2e/playwright.config.ts
+++ b/apps/wyrdfold-e2e/playwright.config.ts
@@ -15,17 +15,18 @@ const baseURL = process.env['BASE_URL'] || `http://localhost:${PORT}`;
 // build the path as a string — same result, no import.
 const AUTH_STORAGE = `${__dirname}/src/.auth/user.json`;
 
-// Auth-fixture availability gate. If the four required env vars aren't
-// set the ``setup`` spec ``test.skip``s, which leaves the storageState
-// file uncreated — and downstream ``authed-chromium`` then crashes on
-// ENOENT trying to load it. Detect that here and just omit the authed
-// project entirely. Public specs still run; authed specs report as
-// "not run" rather than "failed."
+// Auth-fixture availability gate. The setup spec mints an OTP via
+// ``admin.generateLink`` (service-role) and exchanges it via
+// ``verifyOtp`` (anon). All four env vars must be present; otherwise
+// ``setup`` ``test.skip``s, the storageState file never gets written,
+// and downstream ``authed-chromium`` would crash on ENOENT. Detect
+// that here and just omit the authed project entirely. Public specs
+// still run; authed specs report as "not run" rather than "failed."
 const AUTH_ENABLED =
   !!process.env['NEXT_PUBLIC_SUPABASE_URL'] &&
   !!process.env['NEXT_PUBLIC_SUPABASE_ANON_ID'] &&
-  !!process.env['E2E_TEST_USER_EMAIL'] &&
-  !!process.env['E2E_TEST_USER_PASSWORD'];
+  !!process.env['SUPABASE_SERVICE_ROLE_KEY'] &&
+  !!process.env['E2E_TEST_USER_EMAIL'];
 
 export default defineConfig({
   ...nxE2EPreset(__filename, { testDir: './src' }),

--- a/apps/wyrdfold-e2e/src/auth.setup.ts
+++ b/apps/wyrdfold-e2e/src/auth.setup.ts
@@ -3,18 +3,22 @@ import { test as setup, expect } from '@playwright/test';
 import { createClient } from '@supabase/supabase-js';
 
 /**
- * One-shot Supabase password sign-in that produces a storageState
+ * One-shot Supabase magic-link OTP sign-in that produces a storageState
  * file the authenticated specs reuse. Skips entirely when the four
  * required env vars are absent — that's the CI default until the
  * secrets are wired up (see ``apps/wyrdfold-e2e/README.md`` for
  * setup steps), so the un-authed specs (login, middleware) still run
  * cleanly there.
  *
- * Why password sign-in + manual cookie write instead of magic-link
- * or admin generateLink:
- *   - Magic-link needs an inbox / Supabase generateLink admin call,
- *     which means surfacing the service-role key to CI. Password
- *     stays at anon-key scope.
+ * Why OTP via service role instead of password sign-in:
+ *   - The wyrdfold login UI is magic-link only (``signInWithOtp``).
+ *     A password-sign-in fixture diverges from the production auth
+ *     path and only works if the test user happens to have a
+ *     password set in addition to OTP.
+ *   - ``admin.generateLink({type:'magiclink'})`` returns the email
+ *     OTP without sending an email, which ``verifyOtp`` can then
+ *     exchange for a real session. No inbox round-trip, but does
+ *     need the service-role key.
  *   - The supabase-js client stores the session in localStorage by
  *     default; the wyrdfold app reads it from cookies via
  *     ``@supabase/ssr``. We construct the cookie blob manually in
@@ -27,72 +31,84 @@ export const AUTH_STORAGE_STATE = path.join(__dirname, '.auth', 'user.json');
 
 const url = process.env['NEXT_PUBLIC_SUPABASE_URL'];
 const anonKey = process.env['NEXT_PUBLIC_SUPABASE_ANON_ID'];
+const serviceRoleKey = process.env['SUPABASE_SERVICE_ROLE_KEY'];
 const email = process.env['E2E_TEST_USER_EMAIL'];
-const password = process.env['E2E_TEST_USER_PASSWORD'];
 
-setup(
-  'authenticate via Supabase password sign-in',
-  async ({ page, context }) => {
-    // Skip when any env var is missing — CI without the e2e secrets
-    // shouldn't fail this step, it just won't have any authed specs
-    // to run.
-    setup.skip(
-      !url || !anonKey || !email || !password,
-      'E2E auth env not set: NEXT_PUBLIC_SUPABASE_URL, NEXT_PUBLIC_SUPABASE_ANON_ID, E2E_TEST_USER_EMAIL, E2E_TEST_USER_PASSWORD. Run setup locally first; see apps/wyrdfold-e2e/README.md.'
+setup('authenticate via Supabase magic-link OTP', async ({ page, context }) => {
+  // Skip when any env var is missing — CI without the e2e secrets
+  // shouldn't fail this step, it just won't have any authed specs
+  // to run.
+  setup.skip(
+    !url || !anonKey || !serviceRoleKey || !email,
+    'E2E auth env not set: NEXT_PUBLIC_SUPABASE_URL, NEXT_PUBLIC_SUPABASE_ANON_ID, SUPABASE_SERVICE_ROLE_KEY, E2E_TEST_USER_EMAIL. Run setup locally first; see apps/wyrdfold-e2e/README.md.'
+  );
+
+  // TypeScript narrowing — setup.skip with truthy-test guarantees
+  // these are defined but TS can't infer that.
+  if (!url || !anonKey || !serviceRoleKey || !email) return;
+
+  // Mint an OTP without sending the email.
+  const admin = createClient(url, serviceRoleKey, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+  const { data: linkData, error: linkErr } =
+    await admin.auth.admin.generateLink({ type: 'magiclink', email });
+  if (linkErr || !linkData.properties?.email_otp) {
+    throw new Error(
+      `generateLink failed: ${linkErr?.message ?? 'no email_otp returned'}`
     );
-
-    // TypeScript narrowing — setup.skip with truthy-test guarantees
-    // these are defined but TS can't infer that.
-    if (!url || !anonKey || !email || !password) return;
-
-    const supabase = createClient(url, anonKey);
-    const { data, error } = await supabase.auth.signInWithPassword({
-      email,
-      password,
-    });
-    if (error || !data.session) {
-      throw new Error(`Sign-in failed: ${error?.message ?? 'no session'}`);
-    }
-
-    // Reconstruct the cookie shape ``@supabase/ssr`` writes on the
-    // browser side. Cookie name format is
-    // ``sb-<project-ref>-auth-token``; the project ref is the first
-    // subdomain segment of ``NEXT_PUBLIC_SUPABASE_URL``. Value is the
-    // base64-prefixed JSON-encoded session.
-    const projectRef = new URL(url).hostname.split('.')[0];
-    const sessionBlob = {
-      access_token: data.session.access_token,
-      token_type: 'bearer',
-      expires_in: data.session.expires_in,
-      expires_at: data.session.expires_at,
-      refresh_token: data.session.refresh_token,
-      user: data.user,
-    };
-    const cookieValue = `base64-${Buffer.from(
-      JSON.stringify(sessionBlob),
-      'utf-8'
-    ).toString('base64')}`;
-
-    await context.addCookies([
-      {
-        name: `sb-${projectRef}-auth-token`,
-        value: cookieValue,
-        domain: 'localhost',
-        path: '/',
-        // Match the middleware-set cookie's flags so the session sticks
-        // across navigations.
-        httpOnly: false,
-        sameSite: 'Lax',
-        expires: data.session.expires_at ?? -1,
-      },
-    ]);
-
-    // Smoke the session by hitting /dashboard. If the cookie wasn't
-    // accepted (wrong shape, expired, wrong domain), middleware
-    // redirects to /login and this assertion fails fast.
-    await page.goto('/dashboard');
-    await expect(page).not.toHaveURL(/\/login/);
-
-    await context.storageState({ path: AUTH_STORAGE_STATE });
   }
-);
+
+  // Exchange the OTP for a real session on the anon client — same
+  // code path as a real user clicking the magic-link.
+  const supabase = createClient(url, anonKey);
+  const { data, error } = await supabase.auth.verifyOtp({
+    email,
+    token: linkData.properties.email_otp,
+    type: 'magiclink',
+  });
+  if (error || !data.session) {
+    throw new Error(`verifyOtp failed: ${error?.message ?? 'no session'}`);
+  }
+
+  // Reconstruct the cookie shape ``@supabase/ssr`` writes on the
+  // browser side. Cookie name format is
+  // ``sb-<project-ref>-auth-token``; the project ref is the first
+  // subdomain segment of ``NEXT_PUBLIC_SUPABASE_URL``. Value is the
+  // base64-prefixed JSON-encoded session.
+  const projectRef = new URL(url).hostname.split('.')[0];
+  const sessionBlob = {
+    access_token: data.session.access_token,
+    token_type: 'bearer',
+    expires_in: data.session.expires_in,
+    expires_at: data.session.expires_at,
+    refresh_token: data.session.refresh_token,
+    user: data.user,
+  };
+  const cookieValue = `base64-${Buffer.from(
+    JSON.stringify(sessionBlob),
+    'utf-8'
+  ).toString('base64')}`;
+
+  await context.addCookies([
+    {
+      name: `sb-${projectRef}-auth-token`,
+      value: cookieValue,
+      domain: 'localhost',
+      path: '/',
+      // Match the middleware-set cookie's flags so the session sticks
+      // across navigations.
+      httpOnly: false,
+      sameSite: 'Lax',
+      expires: data.session.expires_at ?? -1,
+    },
+  ]);
+
+  // Smoke the session by hitting /dashboard. If the cookie wasn't
+  // accepted (wrong shape, expired, wrong domain), middleware
+  // redirects to /login and this assertion fails fast.
+  await page.goto('/dashboard');
+  await expect(page).not.toHaveURL(/\/login/);
+
+  await context.storageState({ path: AUTH_STORAGE_STATE });
+});


### PR DESCRIPTION
## Summary

The wyrdfold login UI is magic-link only (\`signInWithOtp\`). The previous \`auth.setup.ts\` used \`signInWithPassword\`, which only works if the test user happens to have a password set in addition to OTP — fragile, and divergent from the production auth path.

This PR:

- Rewrites \`auth.setup.ts\` to mint an OTP via \`admin.generateLink({type:'magiclink'})\` (service-role) and exchange it via \`verifyOtp\` (anon). Same code path as a real user clicking the magic-link, no inbox round-trip.
- Threads the four required secrets through \`.github/workflows/ci-full.yml\`:
  - \`NEXT_PUBLIC_SUPABASE_URL\`
  - \`NEXT_PUBLIC_SUPABASE_ANON_ID\`
  - \`SUPABASE_SERVICE_ROLE_KEY\` (replaces \`E2E_TEST_USER_PASSWORD\`)
  - \`E2E_TEST_USER_EMAIL\`
- Updates the \`AUTH_ENABLED\` gate in \`playwright.config.ts\` to match.
- Rewrites the setup + CI sections of \`apps/wyrdfold-e2e/README.md\`, including the why-not-password rationale.

## Required CI secrets

The \`SUPABASE_SERVICE_ROLE_KEY\` secret needs to be added in repo Settings → Secrets → Actions for the authed tier to run. Until it (and \`E2E_TEST_USER_EMAIL\`) are populated, \`auth.setup.ts\` calls \`setup.skip()\` and only the public tier runs — same fail-safe as before.

## Test plan

- [x] \`pnpm tsc --noEmit\` clean
- [ ] Smoke locally: set all four envs in \`apps/wyrdfold/.env.local\`, run \`pnpm nx e2e wyrdfold-e2e -- --project=authed-chromium\`, confirm \`onboarding.spec.ts\` reaches a signed-in state
- [ ] Add \`SUPABASE_SERVICE_ROLE_KEY\` + \`E2E_TEST_USER_EMAIL\` to GH Actions secrets, then re-run CI on this PR and confirm the \`setup\` + \`authed-chromium\` projects execute (vs. \`skipped\`)