### PR TITLE
feat(wyrdfold): capture contact name in onboarding via Identity step

### DIFF
--- a/apps/wyrdfold/src/app/onboarding/IdentityStep.tsx
+++ b/apps/wyrdfold/src/app/onboarding/IdentityStep.tsx
@@ -1,0 +1,156 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Alert } from '@danieljoffe.com/shared-ui/Alert';
+import { Card } from '@danieljoffe.com/shared-ui/Card';
+import { Heading } from '@danieljoffe.com/shared-ui/Heading';
+import { Input } from '@danieljoffe.com/shared-ui/Input';
+import { Text } from '@danieljoffe.com/shared-ui/Text';
+import Button from '@/components/Button';
+import { extractApiError } from '@/lib/extractApiError';
+
+interface IdentityStepProps {
+  onComplete: () => void;
+  onSkip: () => void;
+}
+
+interface IdentityFields {
+  name?: string | null;
+  email?: string | null;
+}
+
+/**
+ * Capture the user's contact name (and confirm email) before any
+ * LLM-backed flow runs. Without this, first-time users hit the
+ * backend's "No contact name on file" 400 the moment they click
+ * Generate Resume / Cover Letter and have to deal with the
+ * mid-flow ``window.prompt`` from PR #683 — a usable fallback but
+ * a worse first impression.
+ *
+ * Pre-fills both fields from ``/api/profile/identity`` (the auth
+ * cookie pre-seeds email on the wyrdfold-api side for new accounts).
+ * Name is the only required field — everything else (phone,
+ * location, links) lives in Settings for users who want them on
+ * their resume header.
+ */
+export default function IdentityStep({
+  onComplete,
+  onSkip,
+}: IdentityStepProps) {
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      try {
+        const res = await fetch('/api/profile/identity');
+        if (!res.ok) return;
+        const data = (await res.json()) as IdentityFields;
+        if (cancelled) return;
+        if (data.name) setName(data.name);
+        if (data.email) setEmail(data.email);
+      } catch {
+        // Non-critical — the user will fill in fields manually
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  async function handleSave(e: React.FormEvent) {
+    e.preventDefault();
+    if (!name.trim() || saving) return;
+    setError(null);
+    setSaving(true);
+    try {
+      const res = await fetch('/api/profile/identity', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: name.trim(),
+          ...(email.trim() ? { email: email.trim() } : {}),
+        }),
+      });
+      if (!res.ok) {
+        setError(await extractApiError(res, 'Could not save your details'));
+        return;
+      }
+      onComplete();
+    } catch {
+      setError('Network error saving your details. Try again.');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <Card padding='lg' className='w-full'>
+      <form onSubmit={handleSave} className='flex flex-col gap-5'>
+        <div>
+          <Heading variant='component' as='h2'>
+            What goes on your resume?
+          </Heading>
+          <Text variant='caption' className='mt-1 text-text-secondary'>
+            We use these on the contact header of every tailored resume and
+            cover letter. You can update them later in Settings.
+          </Text>
+        </div>
+
+        <Input
+          label='Name'
+          required
+          value={name}
+          onChange={e => setName(e.target.value)}
+          placeholder='Daniel Joffe'
+          autoComplete='name'
+          autoFocus
+          disabled={loading || saving}
+          data-sentry-mask
+        />
+        <Input
+          label='Email'
+          type='email'
+          value={email}
+          onChange={e => setEmail(e.target.value)}
+          placeholder='you@example.com'
+          autoComplete='email'
+          helperText='Pre-filled from your sign-in.'
+          disabled={loading || saving}
+          data-sentry-mask
+        />
+
+        {error && <Alert variant='error'>{error}</Alert>}
+
+        <div className='flex items-center justify-between'>
+          <Button
+            name='onboarding-identity-skip'
+            variant='ghost'
+            size='sm'
+            type='button'
+            onClick={onSkip}
+            disabled={saving}
+          >
+            Skip for now
+          </Button>
+          <Button
+            name='onboarding-identity-save'
+            variant='primary'
+            size='sm'
+            type='submit'
+            disabled={!name.trim() || loading || saving}
+          >
+            {saving ? 'Saving...' : 'Continue'}
+          </Button>
+        </div>
+      </form>
+    </Card>
+  );
+}

--- a/apps/wyrdfold/src/app/onboarding/OnboardingWizard.tsx
+++ b/apps/wyrdfold/src/app/onboarding/OnboardingWizard.tsx
@@ -9,6 +9,7 @@ import WyrdfoldLogo from '@/components/WyrdfoldLogo';
 import ConversationChat from '../_components/ConversationChat';
 import PathChooser from './PathChooser';
 import ResumeUploader from './ResumeUploader';
+import IdentityStep from './IdentityStep';
 import JobUrlInput, { type JobData } from './JobUrlInput';
 import TargetSuggestions from './TargetSuggestions';
 import CompletionScreen from './CompletionScreen';
@@ -17,16 +18,35 @@ export type OnboardingPath = 'A' | 'B' | 'C';
 
 type Step =
   | 'path-chooser'
+  | 'identity'
   | 'upload-resume'
   | 'add-job'
   | 'pick-targets'
   | 'conversation'
   | 'completion';
 
+// ``identity`` runs first thing after path selection in every path.
+// Capturing contact name up front prevents the mid-flow window.prompt
+// from #683 (Generate Resume / Cover Letter would 400 with "No
+// contact name on file" otherwise). Email auto-fills from the
+// Supabase auth session; name is the only required field.
 const STEPS_BY_PATH: Record<OnboardingPath, Step[]> = {
-  A: ['path-chooser', 'upload-resume', 'add-job', 'pick-targets', 'completion'],
-  B: ['path-chooser', 'upload-resume', 'pick-targets', 'completion'],
-  C: ['path-chooser', 'conversation', 'pick-targets', 'completion'],
+  A: [
+    'path-chooser',
+    'identity',
+    'upload-resume',
+    'add-job',
+    'pick-targets',
+    'completion',
+  ],
+  B: [
+    'path-chooser',
+    'identity',
+    'upload-resume',
+    'pick-targets',
+    'completion',
+  ],
+  C: ['path-chooser', 'identity', 'conversation', 'pick-targets', 'completion'],
 };
 
 export default function OnboardingWizard() {
@@ -112,6 +132,9 @@ export default function OnboardingWizard() {
         >
           {currentStep === 'path-chooser' && (
             <PathChooser onSelect={handlePathSelect} onSkip={handleSkip} />
+          )}
+          {currentStep === 'identity' && (
+            <IdentityStep onComplete={goNext} onSkip={handleSkip} />
           )}
           {currentStep === 'upload-resume' && (
             <ResumeUploader onComplete={goNext} onSkip={handleSkip} />

--- a/apps/wyrdfold/src/app/onboarding/__tests__/OnboardingWizard.spec.tsx
+++ b/apps/wyrdfold/src/app/onboarding/__tests__/OnboardingWizard.spec.tsx
@@ -81,6 +81,26 @@ jest.mock('../TargetSuggestions', () => ({
   ),
 }));
 
+jest.mock('../IdentityStep', () => ({
+  __esModule: true,
+  default: ({
+    onComplete,
+    onSkip,
+  }: {
+    onComplete: () => void;
+    onSkip: () => void;
+  }) => (
+    <div data-testid='identity-step-stub'>
+      <button type='button' onClick={onComplete}>
+        identity-complete
+      </button>
+      <button type='button' onClick={onSkip}>
+        identity-skip
+      </button>
+    </div>
+  ),
+}));
+
 jest.mock('../CompletionScreen', () => ({
   __esModule: true,
   default: () => <div data-testid='completion-screen-stub'>completion</div>,
@@ -139,7 +159,7 @@ describe('OnboardingWizard — initial state', () => {
 });
 
 describe('OnboardingWizard — Path A (resume + role)', () => {
-  it('dispatches to ResumeUploader after selecting Path A', async () => {
+  it('dispatches to IdentityStep after selecting Path A', async () => {
     const user = userEvent.setup();
     render(<OnboardingWizard />);
 
@@ -149,10 +169,10 @@ describe('OnboardingWizard — Path A (resume + role)', () => {
       })
     );
 
-    expect(screen.getByTestId('resume-uploader-stub')).toBeInTheDocument();
+    expect(screen.getByTestId('identity-step-stub')).toBeInTheDocument();
   });
 
-  it('shows a progress bar on Path A non-completion steps (1 of 4)', async () => {
+  it('shows a progress bar on Path A non-completion steps', async () => {
     const user = userEvent.setup();
     render(<OnboardingWizard />);
 
@@ -162,14 +182,13 @@ describe('OnboardingWizard — Path A (resume + role)', () => {
       })
     );
 
-    // Path A renders 5 steps total (path-chooser + 4); upload-resume is index 1.
-    // ProgressBar uses percentage: (1+1)/5 = 40%.
+    // Path A has 6 steps; identity is index 1. ProgressBar: Math.round((2/6)*100) = 33.
     const progressBar = screen.getByRole('progressbar');
     expect(progressBar).toHaveAttribute('aria-valuemax', '100');
-    expect(progressBar).toHaveAttribute('aria-valuenow', '40');
+    expect(progressBar).toHaveAttribute('aria-valuenow', '33');
   });
 
-  it('advances through upload-resume -> add-job -> pick-targets -> completion', async () => {
+  it('advances through identity -> upload-resume -> add-job -> pick-targets -> completion', async () => {
     const user = userEvent.setup();
     render(<OnboardingWizard />);
 
@@ -179,15 +198,19 @@ describe('OnboardingWizard — Path A (resume + role)', () => {
       })
     );
 
-    // Step 1: upload-resume -> next
+    // Step 1: identity -> next
+    await user.click(screen.getByRole('button', { name: 'identity-complete' }));
+    expect(screen.getByTestId('resume-uploader-stub')).toBeInTheDocument();
+
+    // Step 2: upload-resume -> next
     await user.click(screen.getByRole('button', { name: 'resume-complete' }));
     expect(screen.getByTestId('job-url-input-stub')).toBeInTheDocument();
 
-    // Step 2: add-job -> next
+    // Step 3: add-job -> next
     await user.click(screen.getByRole('button', { name: 'job-complete' }));
     expect(screen.getByTestId('target-suggestions-stub')).toBeInTheDocument();
 
-    // Step 3: pick-targets -> next
+    // Step 4: pick-targets -> next
     await user.click(screen.getByRole('button', { name: 'targets-complete' }));
     expect(screen.getByTestId('completion-screen-stub')).toBeInTheDocument();
   });
@@ -201,6 +224,7 @@ describe('OnboardingWizard — Path A (resume + role)', () => {
         name: /i have a resume and a role in mind/i,
       })
     );
+    await user.click(screen.getByRole('button', { name: 'identity-complete' }));
     await user.click(screen.getByRole('button', { name: 'resume-complete' }));
     await user.click(screen.getByRole('button', { name: 'job-complete' }));
     await user.click(screen.getByRole('button', { name: 'targets-complete' }));
@@ -210,7 +234,7 @@ describe('OnboardingWizard — Path A (resume + role)', () => {
 });
 
 describe('OnboardingWizard — Path B (resume only)', () => {
-  it('dispatches to ResumeUploader and shows a 3-step progress bar', async () => {
+  it('dispatches to IdentityStep and shows a progress bar', async () => {
     const user = userEvent.setup();
     render(<OnboardingWizard />);
 
@@ -220,12 +244,11 @@ describe('OnboardingWizard — Path B (resume only)', () => {
       })
     );
 
-    expect(screen.getByTestId('resume-uploader-stub')).toBeInTheDocument();
-    // Path B renders 4 steps total (path-chooser + 3); upload-resume is index 1.
-    // ProgressBar uses percentage: (1+1)/4 = 50%.
+    expect(screen.getByTestId('identity-step-stub')).toBeInTheDocument();
+    // Path B has 5 steps; identity is index 1. ProgressBar: Math.round((2/5)*100) = 40.
     const progressBar = screen.getByRole('progressbar');
     expect(progressBar).toHaveAttribute('aria-valuemax', '100');
-    expect(progressBar).toHaveAttribute('aria-valuenow', '50');
+    expect(progressBar).toHaveAttribute('aria-valuenow', '40');
   });
 
   it('skips the add-job step and goes directly to pick-targets', async () => {
@@ -237,6 +260,7 @@ describe('OnboardingWizard — Path B (resume only)', () => {
         name: /i have a resume but i'm exploring roles/i,
       })
     );
+    await user.click(screen.getByRole('button', { name: 'identity-complete' }));
     await user.click(screen.getByRole('button', { name: 'resume-complete' }));
 
     expect(screen.getByTestId('target-suggestions-stub')).toBeInTheDocument();
@@ -245,7 +269,7 @@ describe('OnboardingWizard — Path B (resume only)', () => {
 });
 
 describe('OnboardingWizard — Path C (conversation)', () => {
-  it('dispatches to ConversationChat after selecting Path C', async () => {
+  it('dispatches to IdentityStep after selecting Path C', async () => {
     const user = userEvent.setup();
     render(<OnboardingWizard />);
 
@@ -253,16 +277,19 @@ describe('OnboardingWizard — Path C (conversation)', () => {
       screen.getByRole('button', { name: /i'm not sure where to start/i })
     );
 
-    expect(screen.getByTestId('conversation-chat-stub')).toBeInTheDocument();
+    expect(screen.getByTestId('identity-step-stub')).toBeInTheDocument();
   });
 
-  it('advances from conversation -> pick-targets -> completion', async () => {
+  it('advances from identity -> conversation -> pick-targets -> completion', async () => {
     const user = userEvent.setup();
     render(<OnboardingWizard />);
 
     await user.click(
       screen.getByRole('button', { name: /i'm not sure where to start/i })
     );
+
+    await user.click(screen.getByRole('button', { name: 'identity-complete' }));
+    expect(screen.getByTestId('conversation-chat-stub')).toBeInTheDocument();
 
     await user.click(screen.getByRole('button', { name: 'chat-complete' }));
     expect(screen.getByTestId('target-suggestions-stub')).toBeInTheDocument();


### PR DESCRIPTION
## Summary
The "No contact name on file" 400 from the tailor backend (the gate that triggers the ``window.prompt`` from #683) only fires the first time a user clicks Generate Resume / Cover Letter. The prompt-on-Generate is a workable fallback but a worse first impression — the user is mid-flow on an unrelated action and gets interrupted asking for identity under pressure.

Add an ``identity`` step right after path-chooser in all three onboarding paths. Pre-fills name + email from ``/api/profile/identity`` (email is seeded from the Supabase auth cookie on profile-row create, so the field usually shows their sign-in email already). PATCH on save; only ``name`` is required.

## Step counts
| Path | Before | After |
|---|---|---|
| A (resume + JD URL) | 5 | 6 |
| B (resume + suggest) | 4 | 5 |
| C (conversation) | 4 | 5 |

## Defense-in-depth
The ``window.prompt`` fallback in #683 stays. It covers users who skip the new step or were created before this PR landed.

## Test plan
- [x] ``pnpm tsc --noEmit`` clean (6/6 projects)
- [ ] (preview) Walk path A: identity → upload resume → JD URL → suggest → done. ``/api/profile/identity`` GET shows the saved name; tailor flows from a fresh account skip the prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)