### PR TITLE
chore(wyrdfold): route remaining string-detail callsites through extractApiError

### DIFF
--- a/apps/wyrdfold/src/app/(app)/jobs/JobsEmptyState.tsx
+++ b/apps/wyrdfold/src/app/(app)/jobs/JobsEmptyState.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { Text } from '@danieljoffe.com/shared-ui/Text';
 import Button from '@/components/Button';
+import { extractApiError } from '@/lib/extractApiError';
 import { useToast } from '@/state/Toast/ToastProvider';
 
 interface JobsEmptyStateProps {
@@ -46,12 +47,9 @@ export default function JobsEmptyState({ onJobAdded }: JobsEmptyStateProps) {
         body: JSON.stringify({ url: trimmed }),
       });
       if (!res.ok) {
-        const body = (await res.json().catch(() => null)) as {
-          detail?: string;
-        } | null;
         toast({
           variant: 'error',
-          title: body?.detail || `Could not add job (${res.status})`,
+          title: await extractApiError(res, 'Could not add job'),
         });
         return;
       }

--- a/apps/wyrdfold/src/app/(app)/settings/SettingsPage.tsx
+++ b/apps/wyrdfold/src/app/(app)/settings/SettingsPage.tsx
@@ -13,25 +13,10 @@ import { Skeleton } from '@danieljoffe.com/shared-ui/Skeleton';
 import { Spinner } from '@danieljoffe.com/shared-ui/Spinner';
 import { Switch } from '@danieljoffe.com/shared-ui/Switch';
 import { Text } from '@danieljoffe.com/shared-ui/Text';
+import { extractApiError } from '@/lib/extractApiError';
 import { useToast } from '@/state/Toast/ToastProvider';
 
 const AUTOSAVE_DEBOUNCE_MS = 800;
-
-async function extractFastApiError(res: Response): Promise<string | null> {
-  if (res.ok) return null;
-  try {
-    const body = (await res.clone().json()) as { detail?: unknown };
-    if (Array.isArray(body.detail)) {
-      const first = body.detail[0] as { msg?: string } | undefined;
-      if (first?.msg) return first.msg.replace(/^Value error,\s*/, '');
-    } else if (typeof body.detail === 'string') {
-      return body.detail;
-    }
-  } catch {
-    // not JSON / no body — fall through
-  }
-  return null;
-}
 
 interface NotificationPreferences {
   job_notifications_enabled: boolean;
@@ -211,8 +196,7 @@ export default function SettingsPage() {
         body: JSON.stringify(trimmed),
       });
       if (!res.ok) {
-        const message =
-          (await extractFastApiError(res)) ?? 'Failed to save profile';
+        const message = await extractApiError(res, 'Failed to save profile');
         toast({ variant: 'error', title: message });
         lastFailedProfileSigRef.current = sig;
         return;
@@ -266,8 +250,10 @@ export default function SettingsPage() {
         }),
       });
       if (!res.ok) {
-        const message =
-          (await extractFastApiError(res)) ?? 'Failed to save email settings';
+        const message = await extractApiError(
+          res,
+          'Failed to save email settings'
+        );
         toast({ variant: 'error', title: message });
         lastFailedEmailSigRef.current = sig;
         return;
@@ -311,8 +297,10 @@ export default function SettingsPage() {
         body: JSON.stringify(body),
       });
       if (!res.ok) {
-        const message =
-          (await extractFastApiError(res)) ?? 'Failed to save SMS settings';
+        const message = await extractApiError(
+          res,
+          'Failed to save SMS settings'
+        );
         toast({ variant: 'error', title: message });
         lastFailedSmsSigRef.current = sig;
         return;

--- a/apps/wyrdfold/src/lib/extractApiError.ts
+++ b/apps/wyrdfold/src/lib/extractApiError.ts
@@ -39,6 +39,21 @@ export async function extractApiError(
 
   if (typeof detail === 'string' && detail.trim()) return detail;
 
+  // FastAPI pydantic validation errors arrive as
+  // ``detail: [{ loc, msg, type, ... }, ...]``. Surface the first
+  // entry's ``msg`` (stripping the ``Value error,`` prefix pydantic
+  // adds when our validators raise ``ValueError``) so the user sees
+  // "Phone must be E.164" instead of a generic fallback. SettingsPage
+  // previously had a copy of this branch in its own
+  // ``extractFastApiError``; centralizing here so every PATCH/PUT
+  // gets the same treatment.
+  if (Array.isArray(detail) && detail.length > 0) {
+    const first = detail[0] as { msg?: unknown } | undefined;
+    if (first && typeof first.msg === 'string' && first.msg.trim()) {
+      return first.msg.replace(/^Value error,\s*/, '');
+    }
+  }
+
   if (
     detail &&
     typeof detail === 'object' &&


### PR DESCRIPTION
## Summary
Three follow-ups to #701 — ``SettingsPage`` and ``JobsEmptyState`` had their own string-only detail parsers + would have shown a generic fallback on an LLM-budget 429. Wire them through the shared helper.

While here, extend ``extractApiError`` to recognize the pydantic validation array shape (``detail: [{msg, loc, ...}]``), stripping the ``Value error,`` prefix pydantic prepends when a validator raises ``ValueError``. ``SettingsPage``'s local ``extractFastApiError`` had that branch; centralizing so every PATCH/PUT surface inherits it.

``ProfilePage``'s derive-stream error reader is left untouched — it reads ``detail`` from an SSE event payload (not a ``Response`` body) so the helper's signature doesn't fit. Different code path, different fix needed (if ever).

## Net effect
Any current or future LLM-cap 429, validation 422, or plain string detail flows through the same parser everywhere.

## Test plan
- [x] ``pnpm tsc --noEmit`` clean (6/6 projects)
- [ ] (preview) Trigger a Settings validation error (e.g. bad phone format) — toast surfaces the pydantic ``msg`` without the ``Value error,`` prefix.
- [ ] (preview) JobsEmptyState "Paste URL" with a banned host — toast surfaces the upstream ``detail`` instead of the generic "Could not add job (400)".

🤖 Generated with [Claude Code](https://claude.com/claude-code)