### PR TITLE
perf(wyrdfold): dynamic-import isomorphic-dompurify in JobDetailPanel

### DIFF
--- a/apps/wyrdfold/src/app/(app)/jobs/JobDetailPanel.tsx
+++ b/apps/wyrdfold/src/app/(app)/jobs/JobDetailPanel.tsx
@@ -1,7 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
-import DOMPurify from 'isomorphic-dompurify';
+import { useCallback, useEffect, useState } from 'react';
 import { ChevronDown, Maximize2 } from 'lucide-react';
 import { Badge } from '@danieljoffe.com/shared-ui/Badge';
 import { Dropdown } from '@danieljoffe.com/shared-ui/Dropdown';
@@ -250,18 +249,31 @@ export default function JobDetailPanel({
   // otherwise the panel just renders the encoded source as text.
   // DOMPurify itself scrubs against XSS — defence-in-depth even
   // though the source is first-party.
-  const sanitizedDescription = useMemo(() => {
+  //
+  // ``description_html`` is only populated on the /jobs/{id} detail
+  // response — the /jobs list omits it. Dynamic-import keeps the
+  // ~35 KB isomorphic-dompurify dep off the list-page bundle.
+  const [sanitizedDescription, setSanitizedDescription] = useState<
+    string | null
+  >(null);
+  useEffect(() => {
     const raw = posting.description_html ?? '';
-    if (!raw.trim()) return null;
-    const decoded =
-      typeof window === 'undefined'
-        ? raw
-        : (() => {
-            const ta = document.createElement('textarea');
-            ta.innerHTML = raw;
-            return ta.value;
-          })();
-    return DOMPurify.sanitize(decoded, { USE_PROFILES: { html: true } });
+    if (!raw.trim()) {
+      setSanitizedDescription(null);
+      return;
+    }
+    let cancelled = false;
+    void import('isomorphic-dompurify').then(mod => {
+      if (cancelled) return;
+      const ta = document.createElement('textarea');
+      ta.innerHTML = raw;
+      setSanitizedDescription(
+        mod.default.sanitize(ta.value, { USE_PROFILES: { html: true } })
+      );
+    });
+    return () => {
+      cancelled = true;
+    };
   }, [posting.description_html]);
 
   return (


### PR DESCRIPTION
## Summary

- `JobDetailPanel` lives in two places: the `/jobs` list (inline expand) and the `/jobs/{id}` detail page.
- The list response intentionally omits `description_html` (set in #682), so the eager `import DOMPurify from 'isomorphic-dompurify'` was loading a ~35 KB dep that the list never needs.
- Replace the `useMemo` with a `useEffect` that does `import('isomorphic-dompurify')` on demand. The bundle still ships the chunk, but it only downloads + parses on routes where `description_html` is non-empty.

## Bundle analysis context

Static analysis of `apps/wyrdfold` Next 16 Turbopack production output found:

| Chunk | Size | Notes |
|---|---|---|
| `@sentry/nextjs` (in rootMain) | 531 KB | already defers heavy integrations to `requestIdleCallback`; SDK core stays eager because `captureRouterTransitionStart` is exported synchronously |
| `recharts` (3 chunks) | 1069 KB total | already dynamic-imported per chart |
| `@supabase` (1 chunk) | 201 KB | always-needed |
| `isomorphic-dompurify` | 35 KB | **this PR** — was eager on list page |

The Sentry bundle is the largest single lever but the safe wins inside it have already shipped; further compression would mean giving up router-transition tracing. The dompurify move is a clean, scoped win.

## Test plan

- [x] `pnpm tsc --noEmit` clean
- [x] `pnpm nx test wyrdfold -- --testPathPatterns='JobDetailPanel'` — 8/8 pass
- [ ] Smoke: open a job detail page on the preview, confirm the JD body still renders sanitized HTML (network panel should show a deferred chunk request for dompurify)
- [ ] Smoke: open `/jobs` list, expand a row inline — sanitized body still renders if backend ever populates it; no DOMPurify chunk should load if `description_html` is empty/absent