### PR TITLE
test(wyrdfold-e2e): authed Settings identity round-trip + top-level routes smoke

### DIFF
--- a/apps/wyrdfold-e2e/playwright.config.ts
+++ b/apps/wyrdfold-e2e/playwright.config.ts
@@ -83,8 +83,12 @@ export default defineConfig({
           },
           {
             name: 'authed-chromium',
-            // Add new authed-spec filenames here as the suite grows.
-            testMatch: /onboarding\.spec\.ts/,
+            // ``onboarding`` is grandfathered in (predates the
+            // ``authed-`` prefix convention); new authed specs should
+            // be named ``authed-<feature>.spec.ts`` so the public
+            // projects' ``testIgnore`` glob picks them up
+            // automatically.
+            testMatch: /(onboarding|authed-.*)\.spec\.ts/,
             use: {
               ...devices['Desktop Chrome'],
               storageState: AUTH_STORAGE,

--- a/apps/wyrdfold-e2e/src/authed-routes-smoke.spec.ts
+++ b/apps/wyrdfold-e2e/src/authed-routes-smoke.spec.ts
@@ -1,0 +1,55 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Catch-all smoke for the top-level authenticated routes. Each route
+ * is hit fresh, asserted to stay off ``/login`` (middleware regression
+ * guard) and asserted to render an ``<h1>`` (renders-at-all guard).
+ *
+ * Doesn't assert specific heading copy — that's brittle to design
+ * tweaks and the existing onboarding.spec.ts already covers the
+ * Dashboard chrome with named assertions. This spec's job is the
+ * boring one: "every authed route returns 200 and hydrates."
+ *
+ * What this catches:
+ *   - ``fetchJsonFromWyrdfoldAPI`` SSR regression that bricks one
+ *     route while leaving the others intact (would not be caught
+ *     by /dashboard alone).
+ *   - Middleware accidentally redirecting an authed route to /login
+ *     for the signed-in user (cookie-shape drift, role-check bug).
+ *   - Build-output regression where a single route page chunk is
+ *     missing or fails to hydrate.
+ *
+ * Routes intentionally exclude resource-id-scoped paths
+ * (``/jobs/[id]``, ``/targets/[id]``) — those need seeded data and
+ * belong in feature-specific specs that own their setup.
+ */
+const TOP_LEVEL_AUTHED_ROUTES = [
+  '/dashboard',
+  '/jobs',
+  '/targets',
+  '/profile',
+  '/insights',
+  '/settings',
+] as const;
+
+test.describe('authenticated top-level routes smoke', () => {
+  for (const route of TOP_LEVEL_AUTHED_ROUTES) {
+    test(`${route} renders an h1 without redirecting to /login`, async ({
+      page,
+    }) => {
+      await page.goto(route);
+
+      // Middleware regression guard. If the cookie shape drifted or
+      // the SSR session decode broke, the route would redirect here
+      // and the page would silently "render" as the login form.
+      await expect(page).not.toHaveURL(/\/login/);
+
+      // Render guard. Each top-level page uses ``<Heading as='h1'>``
+      // from the kit; assert one exists rather than matching copy
+      // (resistant to design / wording tweaks).
+      await expect(
+        page.getByRole('heading', { level: 1 }).first()
+      ).toBeVisible();
+    });
+  }
+});

--- a/apps/wyrdfold-e2e/src/authed-settings-identity.spec.ts
+++ b/apps/wyrdfold-e2e/src/authed-settings-identity.spec.ts
@@ -1,0 +1,83 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Authenticated round-trip for the Settings → Profile identity card
+ * (added in #703 / extended in F3-A). Verifies the full FE → API →
+ * DB → API → FE loop without burning LLM credits:
+ *
+ *   1. ``GET /api/profile/identity`` populates the Name input on
+ *      mount.
+ *   2. Editing Name triggers the debounced autosave (800ms) which
+ *      ``PATCH``-es ``/api/profile/identity``.
+ *   3. Reloading the page re-runs the GET and the new value is
+ *      visible.
+ *
+ * Restores the original Name in a ``finally`` block so the shared
+ * test user identity stays clean. Other identity fields aren't
+ * touched — the autosave PATCHes all six on each diff, but the FE
+ * sends the same values it just read from the server for the
+ * untouched fields, so they round-trip without change.
+ *
+ * What this catches:
+ *   - GET /identity wiring regression (broken auth / RLS /
+ *     ``_get_or_create_profile``).
+ *   - PATCH /identity regression (Pydantic shape drift, empty-string
+ *     clear-to-NULL behavior, autosave debouncer never firing).
+ *   - The Settings page never re-syncing from the server response
+ *     (the page does a setState from the PATCH response in the
+ *     handleSaveProfile path — this catches a regression where it
+ *     drops that re-sync).
+ */
+test.describe('settings identity round-trip', () => {
+  test('Name edits persist across reload', async ({ page }) => {
+    const TEST_NAME = `E2E Test User ${Date.now()}`;
+
+    await page.goto('/settings');
+
+    // Wait for the Settings page to mount. The Name input lives in
+    // the Profile card; the Skeleton is replaced once GET /identity
+    // resolves.
+    const nameInput = page.getByLabel('Name', { exact: true });
+    await expect(nameInput).toBeVisible();
+
+    // The shared test user should have a name set (created via the
+    // beta-invite script or dashboard). If this assertion fires
+    // empty, the GET is broken or the user has never been seeded.
+    const original = await nameInput.inputValue();
+    expect(original.length).toBeGreaterThan(0);
+
+    try {
+      await nameInput.fill(TEST_NAME);
+
+      // Autosave is debounced ~800ms; the SavingIndicator pops on
+      // and off around the network call. Wait for the cycle to
+      // complete — once the indicator is gone, the PATCH has
+      // returned.
+      const savingIndicator = page.getByText('Saving…');
+      await expect(savingIndicator).toBeVisible({ timeout: 2_000 });
+      await expect(savingIndicator).toBeHidden({ timeout: 5_000 });
+
+      // Hard reload — re-runs SSR + client mount, so GET /identity
+      // fires fresh against the database.
+      await page.reload();
+
+      const reloadedNameInput = page.getByLabel('Name', { exact: true });
+      await expect(reloadedNameInput).toHaveValue(TEST_NAME);
+    } finally {
+      // Restore. If the previous step crashed mid-test we still
+      // want to leave the shared user's identity in its original
+      // state; otherwise subsequent runs would assert against
+      // ``E2E Test User <timestamp>`` and the manual UI would show
+      // a confusing stale name.
+      const restoreInput = page.getByLabel('Name', { exact: true });
+      if ((await restoreInput.inputValue()) !== original) {
+        await restoreInput.fill(original);
+        // Best-effort wait — don't fail the test on cleanup races.
+        await page
+          .getByText('Saving…')
+          .waitFor({ state: 'hidden', timeout: 5_000 })
+          .catch(() => {});
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Two authenticated specs landing under the new \`authed-<feature>.spec.ts\` naming convention:

### 1. \`authed-settings-identity.spec.ts\` — identity round-trip

Authenticated round-trip for the Settings → Profile identity card added in #703. Verifies the full FE → API → DB → API → FE loop without burning LLM credits:

\`\`\`
1. GET /api/profile/identity populates the Name input on mount.
2. Edit Name → 800ms debounce → autosave PATCH /api/profile/identity.
3. page.reload() → re-runs GET → assert new value persisted.
4. \`finally\`: restore original Name (the test user is shared).
\`\`\`

Catches: GET/PATCH wiring regressions, autosave debouncer never firing, Settings page dropping the server-response re-sync in \`handleSaveProfile\`.

### 2. \`authed-routes-smoke.spec.ts\` — top-level authed routes smoke

Loops through \`/dashboard\`, \`/jobs\`, \`/targets\`, \`/profile\`, \`/insights\`, \`/settings\` — each asserted to stay off \`/login\` and render an \`<h1>\`. No copy assertions (brittle to design tweaks); \`onboarding.spec.ts\` already covers Dashboard chrome by name.

Catches: a single authed route 500'ing during SSR while the others stay green, middleware redirecting an authed user to \`/login\` for one route only, build-chunk regressions where one route page fails to hydrate.

Resource-id-scoped routes (\`/jobs/[id]\`, \`/targets/[id]\`) deliberately excluded — they need seeded data and belong in feature-specific specs that own their setup.

## Naming convention going forward

The \`authed-chromium\` project's \`testMatch\` is now \`/(onboarding|authed-.*)/\`. Any spec named \`authed-<feature>.spec.ts\` is automatically picked up by the authed project AND excluded from the public projects' \`testIgnore\` glob — no further config edits as the suite grows. \`onboarding.spec.ts\` is grandfathered in (predates the convention); future specs should use the prefix.

## Test plan

- [x] \`pnpm tsc --noEmit\` clean
- [x] \`pnpm exec playwright test --list\` shows 45 public tests across 3 browsers (15 × Chromium/Firefox/WebKit) — same as before, new authed specs correctly excluded from public glob
- [ ] Local authed run once \`E2E_TEST_USER_EMAIL\` is in \`.env.local\`: \`pnpm nx e2e wyrdfold-e2e -- --project=authed-chromium\`
- [ ] CI authed run once \`SUPABASE_SERVICE_ROLE_KEY\` + \`E2E_TEST_USER_EMAIL\` are populated in repo secrets (see #702)