### PR TITLE
feat(wyrdfold): paste-URL callout when active target has 1-4 jobs

### DIFF
--- a/apps/wyrdfold/src/app/(app)/jobs/JobsList.tsx
+++ b/apps/wyrdfold/src/app/(app)/jobs/JobsList.tsx
@@ -11,6 +11,7 @@ import { useToast } from '@/state/Toast/ToastProvider';
 import { cn } from '@/lib/cn';
 import BatchActionBar from './BatchActionBar';
 import JobsListView from './JobsListView';
+import JobsThinResultsCallout from './JobsThinResultsCallout';
 import type { JobPosting, JobsFilterState } from './types';
 
 export interface TargetTab {
@@ -77,6 +78,11 @@ export default function JobsList({
     targetId ?? initialTargets[0]?.id
   );
   const [activationStatus, setActivationStatus] = useState<string>('idle');
+  // Total job count for the active target, sourced from
+  // ``/api/targets/{id}/status``. Drives the thin-results CTA. Reset
+  // on tab switch so a fresh target doesn't briefly show the previous
+  // target's count.
+  const [jobsCount, setJobsCount] = useState<number | null>(null);
   const activatingRef = useRef<Set<string>>(new Set());
   const pollRef = useRef<ReturnType<typeof setInterval> | undefined>(undefined);
   const { toast } = useToast();
@@ -104,6 +110,7 @@ export default function JobsList({
         if (cancelled) return;
 
         setActivationStatus(data.activation_status);
+        setJobsCount(data.jobs_count);
 
         if (data.activation_status === 'ready') {
           // Jobs are ready — refresh the table
@@ -148,6 +155,7 @@ export default function JobsList({
     (id: string | undefined) => {
       setActiveTargetId(id);
       setActivationStatus('idle');
+      setJobsCount(null);
       setSelectedIds(new Set());
       setFilters(id ? TARGET_FILTERS : INITIAL_FILTERS);
       const url = id ? `/jobs?target=${id}` : '/jobs';
@@ -436,6 +444,28 @@ export default function JobsList({
             analysisTargetId={activeTargetId ?? targets[0]?.id}
             onPostingsLoaded={setVisiblePostings}
           />
+
+          {/* Thin-results CTA. Empty state (0 jobs) is owned by
+              JobsEmptyState inside JobsListTable / JobsListMobile;
+              this one fires in the 1–4 range to keep the user from
+              staring at a sparse list with no path to add more.
+              Only shows once activation is in the ``ready`` state —
+              while deriving / polling, the count is still settling
+              and a "you have few jobs" affordance would be premature. */}
+          {activeTargetId &&
+            activationStatus === 'ready' &&
+            jobsCount !== null &&
+            jobsCount > 0 &&
+            jobsCount < 5 && (
+              <JobsThinResultsCallout
+                jobsCount={jobsCount}
+                targetLabel={
+                  targets.find(t => t.id === activeTargetId)?.label ??
+                  'this target'
+                }
+                onJobAdded={() => setRefreshKey(k => k + 1)}
+              />
+            )}
 
           <BatchActionBar
             selectedCount={selectedIds.size}

--- a/apps/wyrdfold/src/app/(app)/jobs/JobsThinResultsCallout.tsx
+++ b/apps/wyrdfold/src/app/(app)/jobs/JobsThinResultsCallout.tsx
@@ -1,0 +1,91 @@
+'use client';
+
+import { useState } from 'react';
+import { Card, CardContent } from '@danieljoffe.com/shared-ui/Card';
+import { Text } from '@danieljoffe.com/shared-ui/Text';
+import Button from '@/components/Button';
+import { useToast } from '@/state/Toast/ToastProvider';
+
+interface JobsThinResultsCalloutProps {
+  jobsCount: number;
+  targetLabel: string;
+  /** Same hook ``JobsEmptyState`` uses — refresh the list after a
+   *  manual add succeeds. */
+  onJobAdded: () => void;
+}
+
+/**
+ * Surfaced below the jobs table when an active target has a small
+ * but non-empty job set (1–4 postings). The poller will keep
+ * filling in matches over time, but a user staring at three jobs
+ * may want to pad it themselves — this gives them the same
+ * paste-URL affordance that ``JobsEmptyState`` offers, without
+ * making them navigate away.
+ *
+ * Empty state (0 jobs) is owned by ``JobsEmptyState``; this
+ * callout deliberately doesn't try to handle it.
+ *
+ * Uses ``window.prompt`` to match the codebase's existing add-job
+ * pattern. A full modal isn't justified for one input.
+ */
+export default function JobsThinResultsCallout({
+  jobsCount,
+  targetLabel,
+  onJobAdded,
+}: JobsThinResultsCalloutProps) {
+  const [submitting, setSubmitting] = useState(false);
+  const { toast } = useToast();
+
+  async function handleAdd() {
+    // eslint-disable-next-line no-alert -- personal tool, native prompt matches the codebase
+    const url = window.prompt('Paste a job posting URL:');
+    const trimmed = url?.trim() ?? '';
+    if (!trimmed) return;
+    setSubmitting(true);
+    try {
+      const res = await fetch('/api/jobs/manual', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ url: trimmed }),
+      });
+      if (!res.ok) {
+        const body = (await res.json().catch(() => null)) as {
+          detail?: string;
+        } | null;
+        toast({
+          variant: 'error',
+          title: body?.detail || `Could not add job (${res.status})`,
+        });
+        return;
+      }
+      toast({ variant: 'success', title: 'Job added' });
+      onJobAdded();
+    } catch {
+      toast({ variant: 'error', title: 'Network error adding job' });
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  const jobsLabel = jobsCount === 1 ? 'posting' : 'postings';
+  return (
+    <Card>
+      <CardContent className='flex flex-col items-center gap-3 py-8 text-center'>
+        <Text variant='body' className='text-text-secondary'>
+          {jobsCount} {jobsLabel} so far for{' '}
+          <span className='text-text-primary'>{targetLabel}</span>. More may
+          arrive as the poller runs — or paste a URL to add one yourself.
+        </Text>
+        <Button
+          name='jobs-thin-results-add'
+          variant='outline'
+          size='sm'
+          onClick={handleAdd}
+          disabled={submitting}
+        >
+          {submitting ? 'Adding...' : 'Paste URL'}
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}


### PR DESCRIPTION
## Summary

\`JobsEmptyState\` (#683) handles the zero-jobs case on \`/jobs?target=X\` with a Paste URL prompt. The 1–4 range had no equivalent — a user staring at three jobs for a target had no in-place affordance to seed more, despite the same manual-add endpoint being available.

This PR adds \`JobsThinResultsCallout\`, rendered below the table when:

- An active target is selected (not the "All Jobs" tab).
- Activation status has reached \`ready\` (not while \`deriving\` / \`polling\` — the count is still settling, and a "you have few jobs" prompt would be premature).
- \`jobs_count\` is in \`(0, 5)\` — \`>0\` so we don't double up with the empty state, \`<5\` so a target with plenty of matches doesn't carry the callout.

\`jobs_count\` is sourced from the existing \`/api/targets/{id}/status\` response — no new endpoint, no \`JobsListView\` prop changes.

## UX decision rationale

Mirrors the existing \`JobsEmptyState\` pattern exactly:

- Same \`window.prompt\` paste-URL affordance.
- Same \`POST /api/jobs/manual\` endpoint.
- Same toast outcomes.
- Same \`onJobAdded\` callback shape (parent refreshes via \`setRefreshKey(k => k + 1)\`).

I considered three alternatives and rejected them:

1. **Lower score threshold suggestion** — would help broaden results, but the scoring profile is the *user's* spec; suggesting they soften it is opinionated UX I shouldn't make autonomously.
2. **"Broaden keywords" CTA** — same issue. The scoring profile editor already exists at \`/targets/[id]\`; users who want to broaden have a path.
3. **Inline form vs. \`window.prompt\`** — JobsEmptyState set the codebase precedent; staying consistent is more important than UX polish for a personal tool.

## Test plan

- [x] \`pnpm tsc --noEmit\` clean
- [x] \`pnpm nx test wyrdfold -- --testPathPatterns='Jobs'\` — 82/82 pass (no regressions in JobsList / JobsListView / JobsListTable / JobsListMobile / JobsEmptyState tests)
- [ ] Smoke locally: open \`/jobs?target=X\` for a target with 1–4 jobs, confirm the callout renders below the table; click Paste URL, paste a real posting URL, confirm the job appears in the table (and the callout disappears once count ≥ 5).
- [ ] Smoke: target with ≥5 jobs — no callout.
- [ ] Smoke: target with 0 jobs — still shows JobsEmptyState (not the new callout).
- [ ] Smoke: while activation is deriving / polling — no callout (would be premature).