### PR TITLE
fix(wyrdfold-api): pre-seed user_profiles.email from JWT on profile create

### DIFF
--- a/apps/wyrdfold-api/app/dependencies.py
+++ b/apps/wyrdfold-api/app/dependencies.py
@@ -226,6 +226,36 @@ def get_current_user_id(
     return sub
 
 
+def get_current_user_email(
+    request: Request,
+    s: Settings = Depends(get_settings),
+) -> str | None:
+    """Return the JWT `email` claim for the current request, if present.
+
+    Best-effort — Supabase issues JWTs with the verified email in the
+    ``email`` claim for password and magic-link sign-ins, but the claim
+    is optional in the spec and may be missing for some auth providers
+    (anonymous sign-ins, custom IdPs). Returns ``None`` when absent or
+    when the token can't be decoded; callers should treat this as "we
+    don't know the email" rather than an error.
+
+    Used by the user-profile routes to pre-seed the ``email`` column on
+    first-time profile creation, so onboarding's IdentityStep doesn't
+    ask the user to retype the email they just signed in with.
+    """
+    if not s.supabase_url:
+        return None
+    token = _extract_bearer_token(request)
+    if not token:
+        return None
+    try:
+        payload = _decode_supabase_jwt(token, s)
+    except HTTPException:
+        return None
+    email = payload.get("email")
+    return email if isinstance(email, str) and email else None
+
+
 def get_current_user_id_optional(
     request: Request,
     key: str | None = Security(api_key_header),

--- a/apps/wyrdfold-api/app/routers/user_profile.py
+++ b/apps/wyrdfold-api/app/routers/user_profile.py
@@ -12,7 +12,12 @@ from fastapi import APIRouter, Depends, HTTPException
 from supabase import Client
 
 from app.config import settings
-from app.dependencies import get_current_user_id, get_supabase, verify_supabase_jwt
+from app.dependencies import (
+    get_current_user_email,
+    get_current_user_id,
+    get_supabase,
+    verify_supabase_jwt,
+)
 from app.models.user_profile import (
     IdentityFields,
     IdentityFieldsUpdate,
@@ -58,13 +63,22 @@ _IDENTITY_COLUMNS = "name, email, phone_number, location, linkedin_url, website_
 
 
 async def _get_or_create_profile(
-    supabase: Client, user_id: str, columns: str
+    supabase: Client,
+    user_id: str,
+    columns: str,
+    seed_email: str | None = None,
 ) -> dict[str, Any]:
     """Return the user's profile row, creating one if none exists.
 
     Scoped by `user_id` (UNIQUE on user_profiles.user_id) so distinct
     callers never see each other's row even though service-role bypasses
     RLS.
+
+    ``seed_email`` pre-fills the ``email`` column on the create path so
+    onboarding's IdentityStep doesn't ask the user to retype the email
+    they just signed in with. Only applied at creation time — existing
+    rows aren't touched, since the user may have intentionally cleared
+    or changed the value in Settings.
     """
     resp = await asyncio.to_thread(
         lambda: supabase.table("user_profiles")
@@ -77,10 +91,11 @@ async def _get_or_create_profile(
     if rows:
         return cast(dict[str, Any], rows[0])
 
+    seed: dict[str, Any] = {"user_id": user_id}
+    if seed_email:
+        seed["email"] = seed_email
     insert = await asyncio.to_thread(
-        lambda: supabase.table("user_profiles")
-        .insert({"user_id": user_id})
-        .execute()
+        lambda: supabase.table("user_profiles").insert(seed).execute()
     )
     if not insert.data:
         raise HTTPException(status_code=500, detail="Failed to create profile")
@@ -97,9 +112,12 @@ async def _get_or_create_profile(
 @router.get("/notifications")
 async def get_notification_preferences(
     user_id: str = Depends(get_current_user_id),
+    user_email: str | None = Depends(get_current_user_email),
     supabase: Client = Depends(get_supabase),
 ) -> NotificationPreferences:
-    row = await _get_or_create_profile(supabase, user_id, _PREFS_COLUMNS)
+    row = await _get_or_create_profile(
+        supabase, user_id, _PREFS_COLUMNS, seed_email=user_email
+    )
     return NotificationPreferences(
         **row,
         email_available=_email_channel_available(),
@@ -111,6 +129,7 @@ async def get_notification_preferences(
 async def update_notification_preferences(
     body: NotificationPreferencesUpdate,
     user_id: str = Depends(get_current_user_id),
+    user_email: str | None = Depends(get_current_user_email),
     supabase: Client = Depends(get_supabase),
 ) -> NotificationPreferences:
     if body.job_notifications_enabled is True and not _email_channel_available():
@@ -126,7 +145,9 @@ async def update_notification_preferences(
             "configured Twilio credentials.",
         )
 
-    profile = await _get_or_create_profile(supabase, user_id, _PREFS_COLUMNS)
+    profile = await _get_or_create_profile(
+        supabase, user_id, _PREFS_COLUMNS, seed_email=user_email
+    )
 
     updates = body.model_dump(exclude_none=True)
     if not updates:
@@ -159,9 +180,12 @@ async def update_notification_preferences(
 @router.get("/identity")
 async def get_identity(
     user_id: str = Depends(get_current_user_id),
+    user_email: str | None = Depends(get_current_user_email),
     supabase: Client = Depends(get_supabase),
 ) -> IdentityFields:
-    row = await _get_or_create_profile(supabase, user_id, _IDENTITY_COLUMNS)
+    row = await _get_or_create_profile(
+        supabase, user_id, _IDENTITY_COLUMNS, seed_email=user_email
+    )
     return IdentityFields(**row)
 
 
@@ -169,9 +193,12 @@ async def get_identity(
 async def update_identity(
     body: IdentityFieldsUpdate,
     user_id: str = Depends(get_current_user_id),
+    user_email: str | None = Depends(get_current_user_email),
     supabase: Client = Depends(get_supabase),
 ) -> IdentityFields:
-    profile = await _get_or_create_profile(supabase, user_id, _IDENTITY_COLUMNS)
+    profile = await _get_or_create_profile(
+        supabase, user_id, _IDENTITY_COLUMNS, seed_email=user_email
+    )
 
     # Treat empty strings as explicit clears; None means "don't touch"
     updates = body.model_dump(exclude_none=True)


### PR DESCRIPTION
## Summary

\`IdentityStep\`'s email field has \`helperText='Pre-filled from your sign-in.'\` but the field was **empty on first load** for every brand-new account. The user had to manually retype the email they'd just signed in with.

Root cause: \`_get_or_create_profile\` inserted \`{"user_id": user_id}\` only — no email seeded. The subsequent SELECT returned \`email=NULL\`, IdentityStep's \`if (data.email) setEmail(data.email)\` guard skipped the setState, and the input stayed blank.

## Fix

- New \`get_current_user_email\` dependency in \`app/dependencies.py\` reads the JWT \`email\` claim. Returns \`None\` if the claim is absent (anonymous sign-ins, custom IdPs) — best-effort, not an error.
- \`_get_or_create_profile\` takes an optional \`seed_email\` kwarg, applied only on the **create** path so an existing row with intentionally-cleared email isn't touched.
- All four routes that call \`_get_or_create_profile\` (notifications GET/PATCH, identity GET/PATCH) thread the JWT email through. Any of them can be the one that creates the row for a new user — the typical dashboard-first path hits notifications before onboarding hits identity.

## What's unchanged

- Existing users with \`email = NULL\` in \`user_profiles\` keep that NULL. The seed only fires on row creation; an existing row is left alone (the user may have intentionally cleared it in Settings).
- The PATCH path's empty-string-clears-to-NULL behavior in \`update_identity\` is untouched.

## Test plan

- [x] \`pnpm tsc --noEmit\` clean
- [x] \`pnpm nx test wyrdfold-api\` — 849/849 pass
- [ ] Smoke: sign up a brand-new account, navigate through onboarding, confirm IdentityStep shows the auth email pre-filled (no manual retype).
- [ ] Smoke: existing test user (email already populated) — IdentityStep loads with the existing value, not overwritten.
- [ ] Smoke: existing user who cleared email in Settings — re-loading IdentityStep does NOT re-seed (because the row already exists, the seed_email branch is skipped).