### PR TITLE
fix(wyrdfold): three edge cases in JobsList target activation polling

### DIFF
--- a/apps/wyrdfold/src/app/(app)/jobs/JobsList.tsx
+++ b/apps/wyrdfold/src/app/(app)/jobs/JobsList.tsx
@@ -99,6 +99,24 @@ export default function JobsList({
       current: ReturnType<typeof setInterval> | undefined;
     } = { current: undefined };
 
+    function clearStatusPoll() {
+      if (statusPollRef.current) {
+        clearInterval(statusPollRef.current);
+        // Null out the ref so a later branch that gates on
+        // ``!statusPollRef.current`` can re-establish polling.
+        // Previously the cleared timer ID lingered, so going
+        // ready → deriving → ready never re-established polling
+        // on the second cycle.
+        statusPollRef.current = undefined;
+      }
+    }
+
+    function ensureStatusPoll() {
+      if (!statusPollRef.current) {
+        statusPollRef.current = setInterval(checkStatus, 3000);
+      }
+    }
+
     async function checkStatus() {
       try {
         const res = await fetch(`/api/targets/${activeTargetId}/status`);
@@ -114,29 +132,33 @@ export default function JobsList({
 
         if (data.activation_status === 'ready') {
           // Jobs are ready — refresh the table
-          if (statusPollRef.current) clearInterval(statusPollRef.current);
+          clearStatusPoll();
           setRefreshKey(k => k + 1);
-        } else if (
-          data.activation_status === 'idle' &&
-          !activatingRef.current.has(activeTargetId!)
-        ) {
-          // Target hasn't been activated yet — trigger activation
-          activatingRef.current.add(activeTargetId!);
-          await fetch(`/api/targets/${activeTargetId}/activate`, {
-            method: 'POST',
-          });
-          // Start polling for status updates
-          statusPollRef.current = setInterval(checkStatus, 3000);
+        } else if (data.activation_status === 'idle') {
+          // Only POST /activate once per session per target;
+          // activatingRef tracks which ones we've already kicked off.
+          // But always ensure polling is running — without this the
+          // user could land on a target whose ref says "already
+          // activated" but whose status hasn't progressed, and the
+          // UI would silently get stuck on 'idle' forever.
+          if (!activatingRef.current.has(activeTargetId!)) {
+            activatingRef.current.add(activeTargetId!);
+            await fetch(`/api/targets/${activeTargetId}/activate`, {
+              method: 'POST',
+            });
+            // Navigation away during the POST shouldn't leave a
+            // no-op poller attached to a cancelled effect.
+            if (cancelled) return;
+          }
+          ensureStatusPoll();
         } else if (
           data.activation_status === 'deriving' ||
           data.activation_status === 'polling'
         ) {
           // Pipeline in progress — keep polling
-          if (!statusPollRef.current) {
-            statusPollRef.current = setInterval(checkStatus, 3000);
-          }
+          ensureStatusPoll();
         } else if (data.activation_status === 'error') {
-          if (statusPollRef.current) clearInterval(statusPollRef.current);
+          clearStatusPoll();
         }
       } catch {
         // Non-critical — will retry on next interval or tab switch
@@ -147,7 +169,7 @@ export default function JobsList({
 
     return () => {
       cancelled = true;
-      if (statusPollRef.current) clearInterval(statusPollRef.current);
+      clearStatusPoll();
     };
   }, [activeTargetId]);
 


### PR DESCRIPTION
## Summary

Three pre-existing edge cases in the \`useEffect\` at \`JobsList.tsx:94-152\` that drives the \`/api/targets/{id}/status\` polling. Found while reviewing the activation flow as backdrop for #707's thin-results CTA.

### 1. Stuck-idle on revisit

If \`activatingRef\` already contained the target ID (set on a previous tab visit) **and** the server status hadn't progressed past \`idle\` (e.g., the prior \`/activate\` POST failed silently, or the worker hadn't picked it up), the \`idle\` branch fell through with **no polling started**. The UI would silently sit on \`idle\` forever; the only escape was a tab switch — which also kept the ref entry, so re-entering didn't help.

**Fix:** split the POST guard (still once-per-session-per-target) from the polling start (always run while \`idle\`).

### 2. Post-cancellation interval leak

The \`await fetch('/activate')\` blocked while the body resolved. If the user navigated away during that await, \`cancelled\` flipped to true on cleanup, but the \`setInterval\` afterwards still attached. The poller then ticked forever calling \`checkStatus\`, which returned early on the \`cancelled\` guard — so no real work, but the interval itself was never cleared.

**Fix:** re-check \`cancelled\` after the POST resolves, before attaching the interval.

### 3. Stale \`statusPollRef\` after \`clearInterval\`

\`clearInterval(statusPollRef.current)\` clears the timer but doesn't null the ref. Subsequent branches gated on \`!statusPollRef.current\` then read the (dead) ID as truthy and skipped re-arming. So going \`ready → deriving → ready\` (e.g., server re-activation, or a status flap) never re-started polling on the second cycle.

**Fix:** extract \`clearStatusPoll()\` that clears the interval AND nulls the ref. Extract \`ensureStatusPoll()\` for the "re-arm if not running" idiom. Cleanup return uses the same helper for consistency.

## Test plan

- [x] \`pnpm tsc --noEmit\` clean
- [x] \`pnpm nx test wyrdfold --skip-nx-cache -- --testPathPatterns='JobsList'\` — 26/26 pass
- [ ] Smoke: open \`/jobs?target=X\` for a target that's \`idle\` server-side, confirm polling kicks off and progresses to \`deriving\`
- [ ] Smoke: tab away during the \`/activate\` POST roundtrip, confirm no orphan interval ticks in DevTools Performance after navigation
- [ ] Smoke: target whose status flaps (you can simulate by deactivating + re-activating via the UI / API), confirm polling re-establishes on the second \`deriving\` cycle