### PR TITLE
fix(wyrdfold): wire contact-name + extractApiError into batch generate

### DIFF
--- a/apps/wyrdfold/src/app/(app)/jobs/CoverLetterSection.tsx
+++ b/apps/wyrdfold/src/app/(app)/jobs/CoverLetterSection.tsx
@@ -84,9 +84,9 @@ export default function CoverLetterSection({
 
       let res = await postTailor();
 
-      // Mirrors the contact-name capture in ResumeSection — same gate
-      // on the tailor pipeline, first-time users hit it without ever
-      // visiting Settings.
+      // Defensive fallback for the contact-name gate. See
+      // ``promptForMissingContactName`` for which users still hit
+      // this post-#703.
       if (!res.ok) {
         const peek = (await res
           .clone()

--- a/apps/wyrdfold/src/app/(app)/jobs/JobsList.tsx
+++ b/apps/wyrdfold/src/app/(app)/jobs/JobsList.tsx
@@ -7,11 +7,13 @@ import { Spinner } from '@danieljoffe.com/shared-ui/Spinner';
 import { Text } from '@danieljoffe.com/shared-ui/Text';
 import { Card, CardContent } from '@danieljoffe.com/shared-ui/Card';
 import Button from '@/components/Button';
+import { extractApiError } from '@/lib/extractApiError';
 import { useToast } from '@/state/Toast/ToastProvider';
 import { cn } from '@/lib/cn';
 import BatchActionBar from './BatchActionBar';
 import JobsListView from './JobsListView';
 import JobsThinResultsCallout from './JobsThinResultsCallout';
+import { promptForMissingContactName } from './promptForMissingContactName';
 import type { JobPosting, JobsFilterState } from './types';
 
 export interface TargetTab {
@@ -198,21 +200,47 @@ export default function JobsList({
 
     setGenerating(true);
     try {
-      const res = await fetch('/api/jobs/tailor/batch', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          job_posting_ids: [...selectedIds],
-        }),
-      });
+      const postBatch = () =>
+        fetch('/api/jobs/tailor/batch', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            job_posting_ids: [...selectedIds],
+          }),
+        });
+
+      let res = await postBatch();
+
+      // The synchronous batch POST hits the same ``resolve_contact``
+      // gate as the single-job tailor routes — a user who skipped
+      // the onboarding identity step (#703) and clicks batch-generate
+      // would otherwise dead-end on "No contact name on file".
+      // Mirrors the inline-prompt + retry pattern from
+      // ResumeSection / CoverLetterSection.
+      if (!res.ok) {
+        const peek = (await res
+          .clone()
+          .json()
+          .catch(() => null)) as { detail?: unknown } | null;
+        const detailString =
+          typeof peek?.detail === 'string' ? peek.detail : undefined;
+        if (await promptForMissingContactName(detailString)) {
+          res = await postBatch();
+        }
+      }
 
       if (!res.ok) {
-        const err = await res.json().catch(() => null);
+        // ``extractApiError`` understands the structured
+        // ``llm_budget_exceeded`` 429 detail (PR #701) and plain-
+        // string details (404 missing optimized doc, missing job).
+        // The previous ad-hoc ``err.detail`` parser cast a possibly-
+        // object detail to ``Record<string, string>``, so budget-
+        // exceeded errors rendered as the generic fallback instead
+        // of the actionable "$X of $Y, try again in an hour"
+        // message.
         toast({
           variant: 'error',
-          title:
-            (err as Record<string, string> | null)?.detail ??
-            'Batch generation failed',
+          title: await extractApiError(res, 'Batch generation failed'),
         });
         setGenerating(false);
         return;

--- a/apps/wyrdfold/src/app/(app)/jobs/ResumeSection.tsx
+++ b/apps/wyrdfold/src/app/(app)/jobs/ResumeSection.tsx
@@ -88,10 +88,11 @@ export default function ResumeSection({ jobPostingId }: ResumeSectionProps) {
 
       let res = await postTailor();
 
-      // The onboarding wizard doesn't capture a contact name (Supabase
-      // magic-link auth has none), so first-time users hit the 400
-      // "No contact name on file" gate. Prompt for it inline + retry
-      // rather than dead-ending in Settings.
+      // Defensive fallback for the contact-name gate. Pre-#703 users,
+      // users who skipped the onboarding Identity step, or users who
+      // cleared their name in Settings still hit this. Prompt inline +
+      // retry rather than dead-ending in Settings. See
+      // ``promptForMissingContactName`` for the full rationale.
       if (!res.ok) {
         const peek = (await res
           .clone()

--- a/apps/wyrdfold/src/app/(app)/jobs/promptForMissingContactName.ts
+++ b/apps/wyrdfold/src/app/(app)/jobs/promptForMissingContactName.ts
@@ -1,14 +1,21 @@
 /**
- * Shared between ``ResumeSection`` and ``CoverLetterSection``: when the
- * backend rejects a tailor request with the "No contact name on file"
- * 400, prompt the user inline (native ``window.prompt`` for
- * minimum-friction), PATCH ``/api/profile/identity``, and return whether
- * the caller should retry. The onboarding wizard doesn't capture this
- * field today (Supabase magic-link auth has no name), and the tailor
- * pipeline requires it to render the resume header — so a fresh user
- * always hits this gate on their first Generate click. Without the
- * inline capture they have to context-switch to Settings, copy the
- * Greenhouse JD URL, and start over.
+ * Defensive fallback for the "No contact name on file" 400 from the
+ * tailor pipeline. PR #703 added an Identity step to onboarding that
+ * captures name up front, so the typical post-#703 user never hits
+ * this gate — but this still fires for:
+ *
+ *   - users who onboarded before #703 shipped
+ *   - users who clicked "Skip for now" on the onboarding Identity
+ *     step (skip = exit to /targets, not "save without name")
+ *   - users who cleared their name in Settings → Profile
+ *
+ * Wired into ``ResumeSection``, ``CoverLetterSection``, and
+ * ``JobsList`` batch generate. Prompts the user inline (native
+ * ``window.prompt`` for minimum-friction), PATCHes
+ * ``/api/profile/identity``, and returns whether the caller should
+ * retry. Without the inline capture the user would have to
+ * context-switch to Settings, copy the Greenhouse JD URL, and start
+ * over.
  *
  * Caller pattern:
  *


### PR DESCRIPTION
## Summary

\`handleBatchGenerate\` in \`JobsList.tsx\` was missing both error-recovery paths that the single-job \`ResumeSection\` / \`CoverLetterSection\` flows ship with:

### 1. No contact-name retry

The \`/tailor/batch\` route hits the same \`resolve_contact\` gate as the per-job tailor routes (confirmed at \`tailor.py:654\`). A user who skipped the onboarding Identity step (#703), or who cleared their name in Settings, would dead-end on \`"No contact name on file"\` with no inline recovery — the toast just shows the 400 detail and \`setGenerating(false)\`.

Wired \`promptForMissingContactName\` + retry, mirroring the \`ResumeSection\` / \`CoverLetterSection\` pattern.

### 2. Structured-error parser was broken

The handler did:

\`\`\`ts
const err = await res.json().catch(() => null);
toast({
  variant: 'error',
  title:
    (err as Record<string, string> | null)?.detail ??
    'Batch generation failed',
});
\`\`\`

The cast lied — \`detail\` is sometimes an object (\`llm_budget_exceeded\` structured 429 from PR #701, future structured errors). The expression then coerced to either \`undefined\` or \`[object Object]\` depending on the JS engine, falling through to the generic "Batch generation failed" — exactly the case where the user needed the actionable "$X of $Y, try again in an hour" message most.

Routed through \`extractApiError\` for parity with the single-job flows.

### 3. Stale comments refresh

Three comments in \`promptForMissingContactName.ts\`, \`ResumeSection.tsx\`, \`CoverLetterSection.tsx\` described a pre-#703 reality where onboarding didn't capture name. The inline-prompt path is now a defensive backstop for:

- Users who onboarded before #703
- Users who clicked "Skip for now" on the onboarding Identity step
- Users who cleared their name in Settings

Updated all three to reflect that.

## Test plan

- [x] \`pnpm tsc --noEmit\` clean
- [x] \`pnpm nx test wyrdfold --skip-nx-cache -- --testPathPatterns='Jobs|CoverLetter|Resume'\` — 89/89 pass
- [ ] Smoke: select 2+ jobs, click Generate from BatchActionBar with no contact name on file — inline prompt appears, name persists, retry succeeds
- [ ] Smoke: select 2+ jobs while LLM budget is exceeded — toast shows the structured 429 message, not the generic fallback