### PR TITLE
fix(wyrdfold): route ProfilePage errors through extractApiError

### DIFF
--- a/apps/wyrdfold/src/app/(app)/profile/ProfilePage.tsx
+++ b/apps/wyrdfold/src/app/(app)/profile/ProfilePage.tsx
@@ -17,6 +17,7 @@ import { Spinner } from '@danieljoffe.com/shared-ui/Spinner';
 import { Text } from '@danieljoffe.com/shared-ui/Text';
 import Button from '@/components/Button';
 import { consumeSse } from '@/lib/consumeSse';
+import { extractApiError } from '@/lib/extractApiError';
 import { parsePartialJson } from '@/lib/parsePartialJson';
 import { useToast } from '@/state/Toast/ToastProvider';
 import ConversationChatModal from '../../_components/ConversationChatModal';
@@ -174,11 +175,7 @@ export default function ProfilePage() {
           body: JSON.stringify({ content: draft }),
         });
         if (!res.ok) {
-          const data = await res.json().catch(() => null);
-          throw new Error(
-            (data as Record<string, string> | null)?.detail ??
-              `Save failed (${res.status})`
-          );
+          throw new Error(await extractApiError(res, 'Save failed'));
         }
         lastSavedProseRef.current = draft;
         toast({ variant: 'success', title: 'Master document saved' });
@@ -215,11 +212,7 @@ export default function ProfilePage() {
           { method: 'POST', body: formData }
         );
         if (!res.ok) {
-          const data = await res.json().catch(() => null);
-          throw new Error(
-            (data as Record<string, string> | null)?.detail ??
-              `Upload failed (${res.status})`
-          );
+          throw new Error(await extractApiError(res, 'Upload failed'));
         }
         toast({ variant: 'success', title: 'Resume uploaded and processed' });
         await fetchData();
@@ -253,7 +246,13 @@ export default function ProfilePage() {
       const res = await fetch('/api/career/experience/derive/stream', {
         method: 'POST',
       });
-      if (!res.ok) throw new Error('Derive failed');
+      // The derive endpoint is LLM-budgeted; ``enforce_llm_budget``
+      // returns a structured ``llm_budget_exceeded`` 429 before the
+      // stream begins. Previously we threw away the response body
+      // here, so users saw the generic "Failed to re-derive
+      // profile" toast with no recovery hint. ``extractApiError``
+      // surfaces the actionable spend / limit message.
+      if (!res.ok) throw new Error(await extractApiError(res, 'Derive failed'));
 
       let streamError: string | null = null;
       await consumeSse(res, (event, data) => {
@@ -281,8 +280,12 @@ export default function ProfilePage() {
           : 'Profile re-derived from experience',
       });
       await fetchData();
-    } catch {
-      toast({ variant: 'error', title: 'Failed to re-derive profile' });
+    } catch (err) {
+      toast({
+        variant: 'error',
+        title:
+          err instanceof Error ? err.message : 'Failed to re-derive profile',
+      });
     } finally {
       setDeriving(false);
       setStreamingPayload(null);
@@ -296,11 +299,7 @@ export default function ProfilePage() {
         method: 'POST',
       });
       if (!res.ok) {
-        const data = await res.json().catch(() => null);
-        throw new Error(
-          (data as Record<string, string> | null)?.detail ??
-            `Consolidate failed (${res.status})`
-        );
+        throw new Error(await extractApiError(res, 'Consolidate failed'));
       }
       const body = (await res.json()) as {
         no_op: boolean;


### PR DESCRIPTION
## Summary

Five error-handling sites in \`ProfilePage.tsx\` all dropped the structured \`llm_budget_exceeded\` 429 detail (PR #701) — same pattern bug as the batch generate fix in #710. Three of the five hit LLM-budgeted endpoints, so a user over budget got generic fallback toasts with no actionable info.

### Sites fixed

| Site | Endpoint | Budgeted? | Old behavior | New behavior |
|---|---|---|---|---|
| prose autosave | \`POST /experience/prose\` | No | "Save failed (status)" on any structured detail | \`extractApiError\` |
| upload-resume | \`POST /experience/upload-resume\` | **Yes** | "Upload failed (429)" on budget hit | actionable \`extractApiError\` message |
| derive/stream | \`POST /experience/derive/stream\` | **Yes** | \`throw new Error('Derive failed')\` — body discarded | \`extractApiError\` |
| derive/stream catch | (same flow) | n/a | \`catch {}\` rewrote thrown error to "Failed to re-derive profile" | \`catch (err)\` surfaces \`err.message\` |
| prose/consolidate | \`POST /experience/prose/consolidate\` | **Yes** | "Consolidate failed (429)" on budget hit | actionable \`extractApiError\` message |

The derive/stream case was the worst — \`enforce_llm_budget\` runs as a route dependency *before* the SSE stream begins, so a 429 returned synchronously and the response body (the structured spend / limit detail) was thrown away.

## Test plan

- [x] \`pnpm tsc --noEmit\` clean
- [x] \`pnpm nx test wyrdfold --skip-nx-cache -- --testPathPatterns='ProfilePage'\` — 2/2 pass
- [ ] Smoke: trigger upload / derive / consolidate while LLM budget is exceeded — toasts show the structured 429 message, not the generic fallbacks