### PR TITLE
fix(wyrdfold): route remaining error-cast callsites through extractApiError

### DIFF
--- a/apps/wyrdfold/src/app/(app)/targets/TargetsList.tsx
+++ b/apps/wyrdfold/src/app/(app)/targets/TargetsList.tsx
@@ -9,6 +9,7 @@ import { Spinner } from '@danieljoffe.com/shared-ui/Spinner';
 import { Text } from '@danieljoffe.com/shared-ui/Text';
 import { Card, CardContent } from '@danieljoffe.com/shared-ui/Card';
 import Button from '@/components/Button';
+import { extractApiError } from '@/lib/extractApiError';
 import { useToast } from '@/state/Toast/ToastProvider';
 import TargetCard from './TargetCard';
 import CreateTargetModal, {
@@ -134,11 +135,7 @@ export default function TargetsList({ initialTargets }: TargetsListProps) {
           body: JSON.stringify(body),
         });
         if (!res.ok) {
-          const err = await res.json().catch(() => null);
-          throw new Error(
-            (err as Record<string, string> | null)?.detail ??
-              'Failed to add target'
-          );
+          throw new Error(await extractApiError(res, 'Failed to add target'));
         }
         const result = (await res.json()) as CreateOrLinkResult;
         const alreadyLinked = targets.some(
@@ -228,11 +225,7 @@ export default function TargetsList({ initialTargets }: TargetsListProps) {
             }),
           });
           if (!res.ok) {
-            const err = await res.json().catch(() => null);
-            throw new Error(
-              (err as Record<string, string> | null)?.detail ??
-                'Failed to add target'
-            );
+            throw new Error(await extractApiError(res, 'Failed to add target'));
           }
           const result = (await res.json()) as CreateOrLinkResult;
           entry = { user_target: result.user_target, target: result.target };

--- a/apps/wyrdfold/src/app/(app)/targets/[id]/AddReferenceJDModal.tsx
+++ b/apps/wyrdfold/src/app/(app)/targets/[id]/AddReferenceJDModal.tsx
@@ -7,6 +7,7 @@ import { Input } from '@danieljoffe.com/shared-ui/Input';
 import { Spinner } from '@danieljoffe.com/shared-ui/Spinner';
 import { Text } from '@danieljoffe.com/shared-ui/Text';
 import Button from '@/components/Button';
+import { extractApiError } from '@/lib/extractApiError';
 import { useToast } from '@/state/Toast/ToastProvider';
 
 interface AddReferenceJDModalProps {
@@ -57,12 +58,9 @@ export default function AddReferenceJDModal({
       });
 
       if (!res.ok) {
-        const err = await res.json().catch(() => null);
         toast({
           variant: 'error',
-          title:
-            (err as Record<string, string> | null)?.detail ??
-            'Failed to add reference JD',
+          title: await extractApiError(res, 'Failed to add reference JD'),
         });
         setSaving(false);
         return;

--- a/apps/wyrdfold/src/app/onboarding/JobUrlInput.tsx
+++ b/apps/wyrdfold/src/app/onboarding/JobUrlInput.tsx
@@ -9,6 +9,7 @@ import { Input } from '@danieljoffe.com/shared-ui/Input';
 import { Spinner } from '@danieljoffe.com/shared-ui/Spinner';
 import { Alert } from '@danieljoffe.com/shared-ui/Alert';
 import Button from '@/components/Button';
+import { extractApiError } from '@/lib/extractApiError';
 
 export interface JobData {
   postingId: string;
@@ -57,11 +58,7 @@ export default function JobUrlInput({ onComplete, onSkip }: JobUrlInputProps) {
         });
 
         if (!res.ok) {
-          const data = await res.json().catch(() => null);
-          throw new Error(
-            (data as Record<string, string> | null)?.detail ??
-              `Failed to add job (${res.status})`
-          );
+          throw new Error(await extractApiError(res, 'Failed to add job'));
         }
 
         const data = (await res.json()) as {

--- a/apps/wyrdfold/src/app/onboarding/ResumeUploader.tsx
+++ b/apps/wyrdfold/src/app/onboarding/ResumeUploader.tsx
@@ -9,6 +9,7 @@ import { Spinner } from '@danieljoffe.com/shared-ui/Spinner';
 import { Alert } from '@danieljoffe.com/shared-ui/Alert';
 import Button from '@/components/Button';
 import { cn } from '@/lib/cn';
+import { extractApiError } from '@/lib/extractApiError';
 
 const ACCEPTED_TYPES = [
   'application/pdf',
@@ -63,11 +64,7 @@ export default function ResumeUploader({
         );
 
         if (!res.ok) {
-          const data = await res.json().catch(() => null);
-          throw new Error(
-            (data as Record<string, string> | null)?.detail ??
-              `Upload failed (${res.status})`
-          );
+          throw new Error(await extractApiError(res, 'Upload failed'));
         }
 
         setUploaded(true);

--- a/apps/wyrdfold/src/app/onboarding/__tests__/JobUrlInput.spec.tsx
+++ b/apps/wyrdfold/src/app/onboarding/__tests__/JobUrlInput.spec.tsx
@@ -111,10 +111,16 @@ describe('JobUrlInput', () => {
   });
 
   it('renders an error alert when the API returns a non-OK response', async () => {
+    // ``extractApiError`` reads via ``res.clone().json()`` so the
+    // mock has to expose both. Returning ``this`` keeps the same
+    // mock object intact for the second read.
     fetchMock.mockResolvedValueOnce({
       ok: false,
       status: 422,
       json: async () => ({ detail: 'Could not parse posting' }),
+      clone() {
+        return this;
+      },
     });
     const user = userEvent.setup();
     render(<JobUrlInput onComplete={jest.fn()} onSkip={jest.fn()} />);

--- a/apps/wyrdfold/src/app/onboarding/__tests__/ResumeUploader.spec.tsx
+++ b/apps/wyrdfold/src/app/onboarding/__tests__/ResumeUploader.spec.tsx
@@ -119,10 +119,15 @@ describe('ResumeUploader', () => {
   });
 
   it('renders the API error message when the upload fails', async () => {
+    // ``extractApiError`` reads via ``res.clone().json()`` so the
+    // mock has to expose both.
     fetchMock.mockResolvedValueOnce({
       ok: false,
       status: 422,
       json: async () => ({ detail: 'Could not parse resume' }),
+      clone() {
+        return this;
+      },
     });
     const user = userEvent.setup();
     render(<ResumeUploader onComplete={jest.fn()} onSkip={jest.fn()} />);


### PR DESCRIPTION
## Summary

Sweep of the five remaining \`Record<string, string>\` cast sites — same root cause as #710 (batch generate) and #711 (ProfilePage). A \`grep -r "as Record<string, string>"\` across \`apps/wyrdfold/src\` now returns nothing application-side (only test-file header casts remain).

| Site | Endpoint | Budgeted? | Highest-impact failure mode pre-fix |
|---|---|---|---|
| \`TargetsList.runCreate\` | \`/api/targets/from-manual\` or \`from-url\` | No | Future structured details would fall to generic "Failed to add target" |
| \`TargetsList.handleAddSuggestion\` | \`/api/targets/from-manual\` | No | Same |
| \`AddReferenceJDModal\` | \`/api/targets/{id}/reference-jds\` | No | Same |
| \`JobUrlInput\` (onboarding) | \`/api/jobs/manual\` | No | Same |
| **\`ResumeUploader\` (onboarding)** | \`/api/career/experience/upload-resume\` | **Yes** | User uploading resume during onboarding while over LLM budget got generic "Upload failed (429)" with no recovery path — same critical bug ProfilePage's matching handler had in #711 |

## Test-mock update

Two failing test mocks (\`JobUrlInput.spec\` "renders an error alert", \`ResumeUploader.spec\` "renders the API error message") needed \`clone() { return this }\` added — \`extractApiError\` reads the body via \`res.clone().json()\` so the caller can read it again afterward (this matters when the calling code does its own \`gap_gate\` peek after extractApiError). Pre-fix, those tests' mocks only exposed \`json()\` and the extractApiError clone path returned the status-prefixed fallback instead of the test's expected detail string.

## Test plan

- [x] \`pnpm tsc --noEmit\` clean
- [x] \`pnpm nx test wyrdfold --skip-nx-cache -- --testPathPatterns='TargetsList|AddReferenceJDModal|JobUrlInput|ResumeUploader'\` — 23/23 pass
- [ ] Smoke onboarding: upload a resume while over LLM budget — toast shows the structured 429 spend / limit message instead of "Upload failed (429)"