### PR TITLE
fix(wyrdfold-api): cap response size on user-pasted URL fetches (DoS guard)

### DIFF
--- a/apps/wyrdfold-api/app/http_client.py
+++ b/apps/wyrdfold-api/app/http_client.py
@@ -44,6 +44,81 @@ async def close_http_client() -> None:
     _client = None
 
 
+# ---- User-URL fetch with size cap ------------------------------------------
+
+# Hard cap on the response-body size we'll accept from a URL the user
+# pasted in. Real Greenhouse / Lever / Workday job pages are tens of
+# KB; 5 MB leaves ample headroom for one-off oddities while still
+# refusing a multi-GB payload that would OOM the API. The 15s
+# ``timeout`` on the shared client doesn't help here — a fast CDN can
+# stream gigabytes within 15 seconds, and ``client.get()`` would
+# buffer the entire body into memory before returning.
+MAX_USER_FETCH_BYTES = 5 * 1024 * 1024
+
+
+class ResponseTooLargeError(Exception):
+    """Raised by ``get_with_size_cap`` when the body exceeds the cap.
+
+    Carries the size we observed (``Content-Length`` advertised, or
+    streamed bytes before we aborted) so callers can include it in
+    user-facing error messages.
+    """
+
+    def __init__(self, message: str, *, size: int, limit: int) -> None:
+        super().__init__(message)
+        self.size = size
+        self.limit = limit
+
+
+async def get_with_size_cap(
+    url: str, *, max_bytes: int = MAX_USER_FETCH_BYTES
+) -> tuple[httpx.Response, bytes]:
+    """GET ``url`` reading at most ``max_bytes`` of the body.
+
+    Streams the response so a user-pasted URL pointing to a huge
+    payload (GB-scale CDN downloads, infinite-stream endpoints) can't
+    OOM the API the way ``client.get()`` would — its default behavior
+    is to buffer the entire body before returning.
+
+    Pre-checks ``Content-Length`` when the server provides it (cheap
+    fail-fast), then enforces the cap against the actually-streamed
+    byte count (catches missing or lying ``Content-Length`` headers).
+
+    Raises ``ResponseTooLargeError`` if either check trips. Caller
+    should map to a 400 / 422. Network failures propagate as the
+    underlying ``httpx.HTTPError``.
+
+    Returns ``(response, body_bytes)``. The response object's
+    ``.text`` / ``.content`` will be empty because the stream was
+    consumed manually — use ``body_bytes`` (or decode it) for the
+    body. ``.status_code``, ``.url``, and ``.headers`` remain valid
+    after the stream context closes.
+    """
+    client = get_http_client()
+    async with client.stream("GET", url) as resp:
+        advertised = resp.headers.get("content-length")
+        if advertised is not None and advertised.isdigit():
+            n = int(advertised)
+            if n > max_bytes:
+                raise ResponseTooLargeError(
+                    f"Content-Length {n} exceeds cap {max_bytes}",
+                    size=n,
+                    limit=max_bytes,
+                )
+        chunks: list[bytes] = []
+        total = 0
+        async for chunk in resp.aiter_bytes():
+            total += len(chunk)
+            if total > max_bytes:
+                raise ResponseTooLargeError(
+                    f"Streamed {total} bytes exceeds cap {max_bytes}",
+                    size=total,
+                    limit=max_bytes,
+                )
+            chunks.append(chunk)
+        return resp, b"".join(chunks)
+
+
 # ---- Retry helper ----------------------------------------------------------
 
 # 429 + 5xx are treated as transient and retried with exponential backoff.

--- a/apps/wyrdfold-api/app/routers/jobs.py
+++ b/apps/wyrdfold-api/app/routers/jobs.py
@@ -17,7 +17,10 @@ from app.dependencies import (
     get_supabase,
     verify_api_key_or_jwt,
 )
-from app.http_client import get_http_client
+from app.http_client import (
+    ResponseTooLargeError,
+    get_with_size_cap,
+)
 from app.models.schemas import (
     ManualJobRequest,
     ManualJobResponse,
@@ -506,11 +509,19 @@ async def add_manual_job(
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
-    # Fetch the page
-    client = get_http_client()
+    # Fetch the page with a hard size cap — without this, a user
+    # pasting a URL to a multi-GB payload (CDN downloads, infinite
+    # streams) would OOM the API, since ``client.get()`` buffers the
+    # whole body before returning. ``get_with_size_cap`` streams and
+    # aborts past ``MAX_USER_FETCH_BYTES``.
     try:
-        resp = await client.get(cleaned)
+        resp, body_bytes = await get_with_size_cap(cleaned)
         final_url = str(resp.url)
+    except ResponseTooLargeError as exc:
+        raise HTTPException(
+            status_code=413,
+            detail=f"Page too large to fetch ({exc.size} bytes > {exc.limit}).",
+        ) from exc
     except httpx.HTTPError:
         raise HTTPException(status_code=400, detail="Failed to fetch URL") from None
 
@@ -536,8 +547,14 @@ async def add_manual_job(
             f"{registrable_domain(final_hostname)}"
         )
 
-    # Extract metadata
-    html = resp.text if resp.status_code == 200 else ""
+    # Extract metadata. ``body_bytes`` came from the size-capped
+    # streaming read; ``resp.text`` is empty here because the stream
+    # was consumed manually, so decode the bytes ourselves.
+    html = (
+        body_bytes.decode("utf-8", errors="replace")
+        if resp.status_code == 200
+        else ""
+    )
     extraction: ExtractionResult
     if html:
         extraction = extract_job_from_html(html, final_url)

--- a/apps/wyrdfold-api/app/routers/targets.py
+++ b/apps/wyrdfold-api/app/routers/targets.py
@@ -21,7 +21,7 @@ from app.dependencies import (
     get_supabase,
     verify_api_key_or_jwt,
 )
-from app.http_client import get_http_client
+from app.http_client import ResponseTooLargeError, get_with_size_cap
 from app.models.schemas import PollResult
 from app.models.targets import (
     CreateOrLinkResult,
@@ -653,10 +653,17 @@ async def _fetch_jd_from_url(url: str) -> tuple[str | None, str]:
             status_code=422, detail=f"Refusing to fetch JD URL: {exc}"
         ) from exc
 
-    client = get_http_client()
+    # Size-capped streaming fetch — without this, a user-pasted URL
+    # pointing to a huge payload could OOM the API (the shared
+    # client's 15s timeout doesn't help against fast CDNs).
     try:
-        resp = await client.get(url)
+        resp, body_bytes = await get_with_size_cap(url)
         final_url = str(resp.url)
+    except ResponseTooLargeError as exc:
+        raise HTTPException(
+            status_code=413,
+            detail=f"JD page too large to fetch ({exc.size} bytes > {exc.limit}).",
+        ) from exc
     except httpx.HTTPError as exc:
         raise HTTPException(status_code=400, detail="Failed to fetch JD URL") from exc
 
@@ -670,7 +677,13 @@ async def _fetch_jd_from_url(url: str) -> tuple[str | None, str]:
                 detail=f"Refusing to fetch JD URL after redirect: {exc}",
             ) from exc
 
-    html = resp.text if resp.status_code == 200 else ""
+    # The stream was consumed by ``get_with_size_cap`` so ``resp.text``
+    # is empty here; decode the bytes the helper returned.
+    html = (
+        body_bytes.decode("utf-8", errors="replace")
+        if resp.status_code == 200
+        else ""
+    )
     extraction: ExtractionResult
     if html:
         extraction = extract_job_from_html(html, final_url)

--- a/apps/wyrdfold-api/tests/test_manual_job.py
+++ b/apps/wyrdfold-api/tests/test_manual_job.py
@@ -20,6 +20,34 @@ def _mock_response(
     return resp
 
 
+def _patch_size_cap_fetch(
+    monkeypatch,
+    *,
+    text: str = "",
+    status_code: int = 200,
+    url: str = "https://example.com/jobs/123",
+    side_effect: Exception | None = None,
+) -> AsyncMock:
+    """Stub ``get_with_size_cap`` for ``add_manual_job`` tests.
+
+    The endpoint used to call ``client.get`` directly; the fetch was
+    moved into ``get_with_size_cap`` to stream and enforce a body-size
+    cap (prevents OOM via user-pasted URLs to huge payloads). The
+    helper is the right seam to mock from — it returns the
+    ``(response, body_bytes)`` tuple the caller decodes.
+    """
+    from app.routers import jobs as jobs_router
+
+    if side_effect is not None:
+        mock = AsyncMock(side_effect=side_effect)
+    else:
+        body = text.encode("utf-8")
+        resp = _mock_response(status_code=status_code, text=text, url=url)
+        mock = AsyncMock(return_value=(resp, body))
+    monkeypatch.setattr(jobs_router, "get_with_size_cap", mock)
+    return mock
+
+
 JSONLD_HTML = """
 <html><head>
 <script type="application/ld+json">
@@ -55,10 +83,8 @@ class TestManualJobEndpoint:
         monkeypatch.setattr(jobs_router, "get_active_target", lambda *_a, **_kw: [])
 
     @pytest.mark.asyncio
-    async def test_happy_path_jsonld(self, mock_http_client):
-        mock_http_client.get = AsyncMock(
-            return_value=_mock_response(text=JSONLD_HTML)
-        )
+    async def test_happy_path_jsonld(self, monkeypatch):
+        _patch_size_cap_fetch(monkeypatch, text=JSONLD_HTML)
 
         mock_supabase = MagicMock()
         mock_upsert = MagicMock()
@@ -88,11 +114,9 @@ class TestManualJobEndpoint:
         assert row["score"] >= 0
 
     @pytest.mark.asyncio
-    async def test_user_overrides(self, mock_http_client):
+    async def test_user_overrides(self, monkeypatch):
         # Page with OG tags, but user provides their own title
-        mock_http_client.get = AsyncMock(
-            return_value=_mock_response(text=OG_HTML)
-        )
+        _patch_size_cap_fetch(monkeypatch, text=OG_HTML)
 
         mock_supabase = MagicMock()
         mock_supabase.table.return_value.upsert.return_value.execute.return_value = (
@@ -143,11 +167,9 @@ class TestManualJobEndpoint:
         assert "Banned" in exc_info.value.detail
 
     @pytest.mark.asyncio
-    async def test_extraction_fails_needs_manual_fields(self, mock_http_client):
+    async def test_extraction_fails_needs_manual_fields(self, monkeypatch):
         # Empty page with no extractable metadata
-        mock_http_client.get = AsyncMock(
-            return_value=_mock_response(text="<html><body>Nothing</body></html>")
-        )
+        _patch_size_cap_fetch(monkeypatch, text="<html><body>Nothing</body></html>")
 
         from app.models.schemas import ManualJobRequest
         from app.routers.jobs import add_manual_job
@@ -160,11 +182,9 @@ class TestManualJobEndpoint:
         assert result.posting_id is None
 
     @pytest.mark.asyncio
-    async def test_extraction_fails_with_user_title_succeeds(self, mock_http_client):
+    async def test_extraction_fails_with_user_title_succeeds(self, monkeypatch):
         # Empty page but user provides a title
-        mock_http_client.get = AsyncMock(
-            return_value=_mock_response(text="<html><body>Nothing</body></html>")
-        )
+        _patch_size_cap_fetch(monkeypatch, text="<html><body>Nothing</body></html>")
 
         mock_supabase = MagicMock()
         mock_supabase.table.return_value.upsert.return_value.execute.return_value = (
@@ -185,16 +205,14 @@ class TestManualJobEndpoint:
         assert result.posting_id == "posting-uuid-3"
 
     @pytest.mark.asyncio
-    async def test_dedup_same_url(self, mock_http_client):
+    async def test_dedup_same_url(self, monkeypatch):
         """Same URL should generate same external_id."""
         import hashlib
 
         url = "https://example.com/jobs/same"
         expected_id = str(int(hashlib.sha256(url.encode()).hexdigest()[:15], 16))
 
-        mock_http_client.get = AsyncMock(
-            return_value=_mock_response(text=JSONLD_HTML, url=url)
-        )
+        _patch_size_cap_fetch(monkeypatch, text=JSONLD_HTML, url=url)
 
         mock_supabase = MagicMock()
         mock_supabase.table.return_value.upsert.return_value.execute.return_value = (
@@ -212,9 +230,9 @@ class TestManualJobEndpoint:
         assert row["external_id"] == expected_id
 
     @pytest.mark.asyncio
-    async def test_fetch_error(self, mock_http_client):
-        mock_http_client.get = AsyncMock(
-            side_effect=httpx.ConnectError("Connection refused")
+    async def test_fetch_error(self, monkeypatch):
+        _patch_size_cap_fetch(
+            monkeypatch, side_effect=httpx.ConnectError("Connection refused")
         )
 
         from fastapi import HTTPException
@@ -229,11 +247,9 @@ class TestManualJobEndpoint:
         assert "fetch" in exc_info.value.detail.lower()
 
     @pytest.mark.asyncio
-    async def test_redirect_to_banned(self, mock_http_client):
-        mock_http_client.get = AsyncMock(
-            return_value=_mock_response(
-                text="", url="https://www.ziprecruiter.com/redirect"
-            )
+    async def test_redirect_to_banned(self, monkeypatch):
+        _patch_size_cap_fetch(
+            monkeypatch, text="", url="https://www.ziprecruiter.com/redirect"
         )
 
         from fastapi import HTTPException


### PR DESCRIPTION
## Summary

Two user-controlled URL fetch sites in the API both called \`client.get(url)\` and read \`resp.text\` directly:

- \`add_manual_job\` (jobs.py:515) — onboarding paste-URL + /jobs empty-state + thin-results CTA
- \`_fetch_jd_from_url\` (targets.py:656) — JD URL helper for \`create_target_from_posting\`

\`httpx.AsyncClient.get\` buffers the entire response body into memory before returning. The shared client's 15s \`timeout\` doesn't help — a fast CDN can stream gigabytes inside that window, and the user could OOM the API (intentionally or accidentally) by pasting a URL pointing to a multi-GB payload.

## Fix

New \`get_with_size_cap(url, max_bytes=5MB)\` in \`http_client.py\`:

- Streams via \`client.stream("GET", url)\`.
- Pre-checks \`Content-Length\` when the server provides it (cheap fail-fast).
- Enforces the cap against actually-streamed bytes (catches missing or lying \`Content-Length\` headers).
- Raises \`ResponseTooLargeError\` carrying the observed size + limit so callers can include them in the user-facing error.

Both call sites now use the helper and map the error to a 413 with the message \`"Page too large to fetch (<bytes> > <limit>)"\`. Real Greenhouse / Lever / Workday job pages are tens of KB, so 5 MB is generous headroom.

## Test plan

- [x] \`pnpm tsc --noEmit\` clean (no TS impact)
- [x] \`pnpm nx test wyrdfold-api\` — 849/849 pass
- [x] Updated 7 \`test_manual_job\` tests that previously mocked \`client.get\` to mock at the \`get_with_size_cap\` seam (cleaner than mocking the streaming context manager, and the right level to test the route handler at)
- [ ] Smoke: paste a URL pointing to a small page — works as before
- [ ] Smoke: paste a URL where the server advertises a large \`Content-Length\` (e.g., \`https://release.archlinux.org/iso/latest/archlinux-x86_64.iso\`) — 413 with the size in the message, no memory spike on the API