### PR TITLE
fix(wyrdfold-api): scope tailor /resumes routes to caller user_id (cross-tenant access bug)

### DIFF
--- a/apps/wyrdfold-api/app/routers/tailor.py
+++ b/apps/wyrdfold-api/app/routers/tailor.py
@@ -304,9 +304,10 @@ async def list_tailored_cover_letters(
 async def get_resume_by_job(
     job_posting_id: str,
     supabase: Client = Depends(get_supabase),
+    user_id: str | None = Depends(get_current_user_id_optional),
 ) -> TailoredResumeRecord:
     """Most recent resume for a given job posting."""
-    row = persistence.get_by_job(supabase, job_posting_id)
+    row = persistence.get_by_job(supabase, job_posting_id, user_id=user_id)
     if row is None:
         raise HTTPException(status_code=404, detail="no resume found for this job posting")
     return row
@@ -316,9 +317,12 @@ async def get_resume_by_job(
 async def get_cover_letter_by_job(
     job_posting_id: str,
     supabase: Client = Depends(get_supabase),
+    user_id: str | None = Depends(get_current_user_id_optional),
 ) -> TailoredResumeRecord:
     """Most recent cover letter for a given job posting."""
-    row = persistence.get_by_job(supabase, job_posting_id, document_type="cover_letter")
+    row = persistence.get_by_job(
+        supabase, job_posting_id, user_id=user_id, document_type="cover_letter"
+    )
     if row is None:
         raise HTTPException(status_code=404, detail="no cover letter found for this job posting")
     return row
@@ -328,12 +332,13 @@ async def get_cover_letter_by_job(
 async def export_resumes_zip(
     body: BulkExportRequest,
     supabase: Client = Depends(get_supabase),
+    user_id: str | None = Depends(get_current_user_id_optional),
 ) -> Response:
     """Download approved resumes as a single .zip archive."""
     records: list[TailoredResumeRecord] = []
     unapproved: list[str] = []
     for rid in body.resume_ids:
-        row = persistence.get(supabase, rid)
+        row = persistence.get(supabase, rid, user_id=user_id)
         if row is None:
             raise HTTPException(status_code=404, detail=f"resume not found: {rid}")
         if row.approved_at is None:
@@ -376,13 +381,14 @@ async def edit_tailored_resume(
     resume_id: str,
     body: ResumeEditRequest,
     supabase: Client = Depends(get_supabase),
+    user_id: str | None = Depends(get_current_user_id_optional),
 ) -> TailorResponse:
     """Edit a draft resume's markdown. Rejected if already approved.
 
     The .docx isn't re-rendered eagerly — saving is cheap and the
     download endpoint detects a stale hash to re-render lazily.
     """
-    row = persistence.get(supabase, resume_id)
+    row = persistence.get(supabase, resume_id, user_id=user_id)
     if row is None:
         raise HTTPException(status_code=404, detail="tailored document not found")
     if row.approved_at is not None:
@@ -407,6 +413,7 @@ async def checkpoint_tailored_resume(
     resume_id: str,
     body: ResumeCheckpointRequest | None = None,
     supabase: Client = Depends(get_supabase),
+    user_id: str | None = Depends(get_current_user_id_optional),
 ) -> dict[str, Any]:
     """Snapshot a draft resume's current markdown into version history.
 
@@ -419,7 +426,7 @@ async def checkpoint_tailored_resume(
     Idempotent via dedup: if the latest snapshot already matches, no
     new row is written.
     """
-    row = persistence.get(supabase, resume_id)
+    row = persistence.get(supabase, resume_id, user_id=user_id)
     if row is None:
         raise HTTPException(status_code=404, detail="tailored document not found")
     if row.approved_at is not None:
@@ -446,9 +453,10 @@ async def checkpoint_tailored_resume(
 async def approve_tailored_resume(
     resume_id: str,
     supabase: Client = Depends(get_supabase),
+    user_id: str | None = Depends(get_current_user_id_optional),
 ) -> TailoredResumeRecord:
     """Approve (lock) a tailored resume or cover letter. Idempotent if already approved."""
-    row = persistence.get(supabase, resume_id)
+    row = persistence.get(supabase, resume_id, user_id=user_id)
     if row is None:
         raise HTTPException(status_code=404, detail="tailored document not found")
 
@@ -472,9 +480,10 @@ async def approve_tailored_resume(
 async def unapprove_tailored_resume(
     resume_id: str,
     supabase: Client = Depends(get_supabase),
+    user_id: str | None = Depends(get_current_user_id_optional),
 ) -> TailoredResumeRecord:
     """Reopen an approved resume or cover letter for editing. Idempotent if already unlocked."""
-    row = persistence.get(supabase, resume_id)
+    row = persistence.get(supabase, resume_id, user_id=user_id)
     if row is None:
         raise HTTPException(status_code=404, detail="tailored document not found")
 
@@ -500,8 +509,9 @@ async def unapprove_tailored_resume(
 async def get_tailored_resume(
     resume_id: str,
     supabase: Client = Depends(get_supabase),
+    user_id: str | None = Depends(get_current_user_id_optional),
 ) -> TailoredResumeRecord:
-    row = persistence.get(supabase, resume_id)
+    row = persistence.get(supabase, resume_id, user_id=user_id)
     if row is None:
         raise HTTPException(status_code=404, detail="tailored resume not found")
     return row
@@ -511,9 +521,10 @@ async def get_tailored_resume(
 async def list_resume_versions(
     resume_id: str,
     supabase: Client = Depends(get_supabase),
+    user_id: str | None = Depends(get_current_user_id_optional),
 ) -> dict[str, Any]:
     """Return up to FREE_TIER_VERSION_CAP recent payload snapshots (F3-H)."""
-    row = persistence.get(supabase, resume_id)
+    row = persistence.get(supabase, resume_id, user_id=user_id)
     if row is None:
         raise HTTPException(status_code=404, detail="tailored resume not found")
     history = versions.list_for_resume(supabase, resume_id)
@@ -527,8 +538,9 @@ async def list_resume_versions(
 async def download_tailored_resume(
     resume_id: str,
     supabase: Client = Depends(get_supabase),
+    user_id: str | None = Depends(get_current_user_id_optional),
 ) -> Response:
-    row = persistence.get(supabase, resume_id)
+    row = persistence.get(supabase, resume_id, user_id=user_id)
     if row is None:
         raise HTTPException(status_code=404, detail="tailored resume not found")
 

--- a/apps/wyrdfold-api/app/services/tailor/persistence.py
+++ b/apps/wyrdfold-api/app/services/tailor/persistence.py
@@ -166,10 +166,32 @@ def persist_cover_letter(
     return insert_row(supabase, row, payload_md=payload_md)
 
 
-def get(supabase: Client, resume_id: str) -> TailoredResumeRecord | None:
-    resp = (
-        supabase.table(TABLE).select("*").eq("id", resume_id).single().execute()
-    )
+def get(
+    supabase: Client,
+    resume_id: str,
+    *,
+    user_id: str | None,
+) -> TailoredResumeRecord | None:
+    """Fetch a tailored document, scoped to the caller.
+
+    Filters by both ``id`` AND ``user_id`` so a JWT caller never reads
+    another user's document by guessing the UUID — the service-role
+    client used here bypasses RLS, so the scoping has to be enforced
+    at the query layer.
+
+    ``user_id=None`` matches the legacy single-tenant rows (api-key
+    cron/poller paths), mirroring the convention used by
+    ``list_recent`` and the upsert paths. Routes that accept JWT
+    callers thread ``get_current_user_id_optional`` through; pass that
+    same value here.
+
+    Returns ``None`` both when the row doesn't exist AND when it
+    exists but belongs to another user — same response so we don't
+    leak the existence of cross-tenant rows.
+    """
+    query = supabase.table(TABLE).select("*").eq("id", resume_id)
+    query = query.is_("user_id", "null") if user_id is None else query.eq("user_id", user_id)
+    resp = query.single().execute()
     if not resp.data:
         return None
     return TailoredResumeRecord.model_validate(cast(dict[str, Any], resp.data))
@@ -298,15 +320,24 @@ def get_by_job(
     supabase: Client,
     job_posting_id: str,
     *,
+    user_id: str | None,
     document_type: DocumentType = "resume",
 ) -> TailoredResumeRecord | None:
-    """Fetch the most recent tailored document of a given type for a job posting."""
-    resp = (
+    """Fetch the most recent tailored document of a given type for a job posting.
+
+    Scoped to the caller via ``user_id`` so the route never returns
+    another user's tailored doc for the same (globally-shared)
+    job posting. ``user_id=None`` matches legacy single-tenant rows.
+    """
+    query = (
         supabase.table(TABLE)
         .select("*")
         .eq("job_posting_id", job_posting_id)
         .eq("document_type", document_type)
-        .order("created_at", desc=True)
+    )
+    query = query.is_("user_id", "null") if user_id is None else query.eq("user_id", user_id)
+    resp = (
+        query.order("created_at", desc=True)
         .limit(1)
         .execute()
     )

--- a/apps/wyrdfold-api/tests/test_resume_lifecycle.py
+++ b/apps/wyrdfold-api/tests/test_resume_lifecycle.py
@@ -163,13 +163,15 @@ class TestPersistenceHelpers:
 
         supabase = MagicMock()
         record = _make_record()
+        # Chain: select → eq(job) → eq(doctype) → is_(user_id) → order → limit → execute
+        # (``user_id=None`` legacy path here)
         chain = supabase.table.return_value.select.return_value
-        chain = chain.eq.return_value.eq.return_value
+        chain = chain.eq.return_value.eq.return_value.is_.return_value
         chain.order.return_value.limit.return_value.execute.return_value.data = [
             record.model_dump(mode="json")
         ]
 
-        result = get_by_job(supabase, "job-1")
+        result = get_by_job(supabase, "job-1", user_id=None)
         assert result is not None
         assert result.id == "rec-1"
 
@@ -178,10 +180,10 @@ class TestPersistenceHelpers:
 
         supabase = MagicMock()
         chain = supabase.table.return_value.select.return_value
-        chain = chain.eq.return_value.eq.return_value
+        chain = chain.eq.return_value.eq.return_value.is_.return_value
         chain.order.return_value.limit.return_value.execute.return_value.data = []
 
-        result = get_by_job(supabase, "nonexistent")
+        result = get_by_job(supabase, "nonexistent", user_id=None)
         assert result is None
 
     def test_get_by_job_filters_by_document_type(self) -> None:
@@ -191,10 +193,10 @@ class TestPersistenceHelpers:
 
         supabase = MagicMock()
         chain = supabase.table.return_value.select.return_value
-        chain = chain.eq.return_value.eq.return_value
+        chain = chain.eq.return_value.eq.return_value.is_.return_value
         chain.order.return_value.limit.return_value.execute.return_value.data = []
 
-        get_by_job(supabase, "job-1", document_type="cover_letter")
+        get_by_job(supabase, "job-1", user_id=None, document_type="cover_letter")
 
         # Walk the .eq() calls and assert both the job + the document_type
         # filter were issued.


### PR DESCRIPTION
## Summary

**Cross-tenant data access bug** across 10 routes in the tailor router. \`persistence.get(supabase, resume_id)\` and \`persistence.get_by_job(supabase, job_posting_id)\` looked up rows by id alone, and the service-role client used by these handlers bypasses RLS. Combined with route handlers that took no \`user_id\` dependency at all, any authed caller could read or mutate any other user's tailored documents by guessing the UUID.

The beta-invite script (\`invite-beta-tester.ts\`) is already in use, so multiple users share the database today and the bug is actively exploitable: any beta tester learning another tester's UUID can act on their documents.

## Affected routes

| Route | Old behavior |
|---|---|
| PATCH /resumes/{id} | Edit anyone's draft |
| POST /resumes/{id}/checkpoint | Snapshot anyone's draft |
| POST /resumes/{id}/approve | Lock anyone's draft |
| POST /resumes/{id}/unapprove | Reopen anyone's draft |
| GET /resumes/{id} | Read anyone's resume |
| GET /resumes/{id}/versions | Read anyone's version history |
| GET /resumes/{id}/download | Download anyone's docx |
| POST /resumes/export-zip | Bulk-download anyone's |
| GET /resumes/by-job/{job} | Read anyone's resume for a globally-shared job posting |
| GET /cover-letters/by-job/{job} | Same for cover letters |

## Fix

1. \`persistence.get\` and \`persistence.get_by_job\` now take a required keyword-only \`user_id\` argument. They filter by both \`id\` AND \`user_id\` so a row owned by another user returns \`None\` — same response as "doesn't exist", so existence isn't leaked. \`user_id=None\` matches the legacy single-tenant rows, mirroring \`list_recent\`'s convention.

2. All 10 route handlers above gained \`user_id: str | None = Depends(get_current_user_id_optional)\` and thread it through to the persistence calls.

## What's *not* in this PR

Downstream mutating helpers (\`persistence.approve\`, \`unapprove\`, \`update_payload_md\`, \`download_docx\`) still operate by id alone. They're only called after the route has already ownership-checked via \`persistence.get\`, so the bug isn't exploitable through them today, but defense-in-depth there (scope every mutation by user_id) is a clear follow-up.

## Test plan

- [x] \`pnpm tsc --noEmit\` clean (no FE impact)
- [x] \`pnpm nx run wyrdfold-api:typecheck\` — clean
- [x] \`pnpm nx test wyrdfold-api\` — 849/849 pass
- [x] Updated 3 \`test_get_by_job_*\` unit tests for the new required \`user_id\` kwarg + chain mock for the new \`.is_("user_id", "null")\` call
- [ ] Smoke: with two test users A and B, A signs in and tries \`GET /resumes/{B's-resume-id}\` — should 404, not return B's resume
- [ ] Smoke: A approves their own resume — works as before