### PR TITLE
fix(wyrdfold-api): scope GET /tailor/batch/{id} to caller user_id

### DIFF
--- a/apps/wyrdfold-api/app/routers/tailor.py
+++ b/apps/wyrdfold-api/app/routers/tailor.py
@@ -699,9 +699,10 @@ async def create_batch_resumes(
 async def get_batch_status(
     batch_id: str,
     supabase: Client = Depends(get_supabase),
+    user_id: str | None = Depends(get_current_user_id_optional),
 ) -> BatchJob:
     """Poll batch processing progress."""
-    batch = get_batch(supabase, batch_id)
+    batch = get_batch(supabase, batch_id, user_id=user_id)
     if batch is None:
         raise HTTPException(status_code=404, detail="batch not found")
     return batch

--- a/apps/wyrdfold-api/app/services/batch.py
+++ b/apps/wyrdfold-api/app/services/batch.py
@@ -59,9 +59,25 @@ def create_batch(
     return BatchJob.model_validate(data)
 
 
-def get_batch(supabase: Client, batch_id: str) -> BatchJob | None:
-    """Fetch a batch by ID."""
-    resp = supabase.table(TABLE).select("*").eq("id", batch_id).execute()
+def get_batch(
+    supabase: Client, batch_id: str, *, user_id: str | None
+) -> BatchJob | None:
+    """Fetch a batch by ID, scoped to the caller.
+
+    Filters by both ``id`` AND ``user_id`` so a JWT caller can't poll
+    another user's batch by guessing the UUID — the service-role
+    client used by the route bypasses RLS. ``user_id=None`` matches
+    legacy single-tenant rows (api-key / background paths that
+    create batches without a user_id), mirroring the convention used
+    by ``persistence.get`` and ``list_recent``.
+
+    Returns ``None`` both when the row doesn't exist AND when it
+    belongs to another user — same response so existence isn't
+    leaked.
+    """
+    query = supabase.table(TABLE).select("*").eq("id", batch_id)
+    query = query.is_("user_id", "null") if user_id is None else query.eq("user_id", user_id)
+    resp = query.execute()
     if not resp.data:
         return None
     return BatchJob.model_validate(resp.data[0])
@@ -118,7 +134,7 @@ async def process_batch(
     checks for a reusable resume in the same target before running the
     full tailor pipeline (#504).
     """
-    batch = get_batch(supabase, batch_id)
+    batch = get_batch(supabase, batch_id, user_id=user_id)
     if batch is None:
         return
 

--- a/apps/wyrdfold-api/tests/test_batch.py
+++ b/apps/wyrdfold-api/tests/test_batch.py
@@ -107,6 +107,10 @@ def _set_mock_data(supabase: MagicMock, data: list[Any]) -> None:
     insert = supabase.table.return_value.insert.return_value
     insert.execute.return_value.data = data
     select = supabase.table.return_value.select.return_value
+    # ``get_batch`` (post user_id scoping): select → eq(id) → is_(user_id) → execute
+    select.eq.return_value.is_.return_value.execute.return_value.data = data
+    # Back-compat for the older single-``eq`` chain (kept for any callers
+    # that still go through it during refactoring).
     select.eq.return_value.execute.return_value.data = data
 
 
@@ -184,14 +188,14 @@ class TestBatchPersistence:
 
     def test_get_batch(self) -> None:
         supabase = _mock_supabase_for_batch()
-        batch = get_batch(supabase, "batch-1")
+        batch = get_batch(supabase, "batch-1", user_id=None)
         assert batch is not None
         assert batch.id == "batch-1"
 
     def test_get_batch_not_found(self) -> None:
         supabase = MagicMock()
         _set_mock_data(supabase, [])
-        batch = get_batch(supabase, "nonexistent")
+        batch = get_batch(supabase, "nonexistent", user_id=None)
         assert batch is None
 
     def test_update_batch(self) -> None:


### PR DESCRIPTION
## Summary

Follow-up to #714 — same cross-tenant access pattern in the batch polling endpoint. \`get_batch(supabase, batch_id)\` in \`services/batch.py\` looked up rows by id alone, and \`GET /tailor/batch/{id}\` took no user_id dependency. Any authed user could poll any other user's batch progress (status, completed counts, items array with resume IDs) by guessing the UUID.

## Impact vs. #714

Less direct than #714 — the batch row exposes processing metadata (status, counts, item-level error messages, the list of resume record IDs being processed), not the tailored documents themselves. But:

- The \`items\` array includes the per-job result with the freshly-created \`resume_record_id\` for each, which combined with the now-fixed #714 routes would have leaked metadata about another user's documents.
- Item error messages may leak prompt details or job-posting titles.
- Polling is the *intended* read pattern from the FE (\`handleBatchGenerate\` polls every 3s), so the leak is uniquely easy to exploit if you have the UUID.

## Fix

Same architectural shape as #714:

1. \`get_batch\` gains required keyword-only \`user_id: str | None\`. Filters by both \`id\` AND \`user_id\`. \`user_id=None\` matches legacy single-tenant rows.
2. \`GET /tailor/batch/{batch_id}\` adds \`Depends(get_current_user_id_optional)\` and threads it through.
3. Internal \`process_batch\` background task already had \`user_id\` in scope; updated its self-lookup at \`batch.py:137\` to pass it.

## Test plan

- [x] \`pnpm nx run wyrdfold-api:typecheck\` — clean
- [x] \`pnpm nx test wyrdfold-api\` — 849/849 pass
- [x] Updated \`test_get_batch\` + \`test_get_batch_not_found\` to pass \`user_id=None\` and added \`is_("user_id", "null")\` into the chain-mock setup
- [ ] Smoke: with two test users A and B, A polls \`GET /tailor/batch/{B's-batch-id}\` — should 404, not return B's batch