### PR TITLE
fix(wyrdfold-api): require auth on five unguarded routes

### DIFF
--- a/apps/wyrdfold-api/app/routers/jobs.py
+++ b/apps/wyrdfold-api/app/routers/jobs.py
@@ -15,6 +15,7 @@ from app.dependencies import (
     get_current_user_id,
     get_current_user_id_optional,
     get_supabase,
+    verify_api_key,
     verify_api_key_or_jwt,
 )
 from app.http_client import (
@@ -677,12 +678,19 @@ async def add_manual_job(
     )
 
 
-@router.post("/rescore/{target_id}")
+@router.post("/rescore/{target_id}", dependencies=[Depends(verify_api_key)])
 async def rescore_for_target(
     target_id: str,
     supabase: Client = Depends(get_supabase),
 ) -> dict[str, Any]:
-    """Re-score all jobs against a target's scoring profile."""
+    """Re-score all jobs against a target's scoring profile.
+
+    Admin / operator-only: gated by ``verify_api_key`` so an
+    unauthenticated caller can't trigger an O(jobs × scoring_keywords)
+    DB-heavy re-score by hitting the API directly. Not reachable from
+    the wyrdfold FE — only invoked manually from the operator console
+    or from CLI scripts that supply the api key.
+    """
     target = get_target(supabase, target_id)
     if target is None:
         raise HTTPException(status_code=404, detail="Target not found")
@@ -692,7 +700,7 @@ async def rescore_for_target(
     return {"target_id": target_id, "jobs_scored": scored}
 
 
-@router.post("/backfill-salary")
+@router.post("/backfill-salary", dependencies=[Depends(verify_api_key)])
 async def backfill_salary(
     supabase: Client = Depends(get_supabase),
 ) -> dict[str, Any]:
@@ -701,6 +709,10 @@ async def backfill_salary(
     Per batch of 500, extract salaries in Python then write all rows in a
     single `bulk_update_salaries` RPC — turns ~N row-by-row UPDATEs
     into one statement per batch.
+
+    Admin-only: gated by ``verify_api_key`` so an unauthenticated
+    caller can't trigger a full-table scan + per-row salary extraction.
+    Not reachable from the wyrdfold FE.
     """
     batch_size = 500
     offset = 0

--- a/apps/wyrdfold-api/app/routers/targets.py
+++ b/apps/wyrdfold-api/app/routers/targets.py
@@ -149,7 +149,12 @@ async def _activate_pipeline(
 # ---- Target CRUD -----------------------------------------------------------
 
 
-@router.post("", response_model=JobTarget, status_code=201)
+@router.post(
+    "",
+    response_model=JobTarget,
+    status_code=201,
+    dependencies=[Depends(verify_api_key_or_jwt)],
+)
 async def create_target(
     body: TargetCreate,
     supabase: Client = Depends(get_supabase),
@@ -306,7 +311,11 @@ def get_my_targets(
     return MyTargetsListResponse(targets=items)
 
 
-@router.get("/{target_id}", response_model=JobTarget)
+@router.get(
+    "/{target_id}",
+    response_model=JobTarget,
+    dependencies=[Depends(verify_api_key_or_jwt)],
+)
 def get_target(
     target_id: str,
     supabase: Client = Depends(get_supabase),
@@ -317,7 +326,11 @@ def get_target(
     return target
 
 
-@router.patch("/{target_id}", response_model=JobTarget)
+@router.patch(
+    "/{target_id}",
+    response_model=JobTarget,
+    dependencies=[Depends(verify_api_key_or_jwt)],
+)
 def update_target(
     target_id: str,
     body: TargetUpdate,

--- a/apps/wyrdfold-api/tests/test_target_scoring.py
+++ b/apps/wyrdfold-api/tests/test_target_scoring.py
@@ -363,7 +363,7 @@ def test_rescore_endpoint_returns_count(
 ) -> None:
     from fastapi.testclient import TestClient
 
-    from app.dependencies import get_supabase, verify_api_key_or_jwt
+    from app.dependencies import get_supabase, verify_api_key, verify_api_key_or_jwt
     from app.main import app
     from app.routers import jobs as jobs_router
 
@@ -374,6 +374,9 @@ def test_rescore_endpoint_returns_count(
     supabase = MagicMock()
     app.dependency_overrides[get_supabase] = lambda: supabase
     app.dependency_overrides[verify_api_key_or_jwt] = lambda: "test"
+    # /rescore now requires the operator-only ``verify_api_key`` dep —
+    # not callable from the FE, so the route's auth model is api-key.
+    app.dependency_overrides[verify_api_key] = lambda: "test"
 
     try:
         tc = TestClient(app)
@@ -391,7 +394,7 @@ def test_rescore_endpoint_missing_target_returns_404(
 ) -> None:
     from fastapi.testclient import TestClient
 
-    from app.dependencies import get_supabase, verify_api_key_or_jwt
+    from app.dependencies import get_supabase, verify_api_key, verify_api_key_or_jwt
     from app.main import app
     from app.routers import jobs as jobs_router
 
@@ -400,6 +403,7 @@ def test_rescore_endpoint_missing_target_returns_404(
     supabase = MagicMock()
     app.dependency_overrides[get_supabase] = lambda: supabase
     app.dependency_overrides[verify_api_key_or_jwt] = lambda: "test"
+    app.dependency_overrides[verify_api_key] = lambda: "test"
 
     try:
         tc = TestClient(app)


### PR DESCRIPTION
## Summary

Five route handlers in \`jobs.py\` and \`targets.py\` had **no auth dependency at the route layer**. The Next.js proxy validated JWTs before forwarding, so the FE flows were protected in practice — but a direct request to the API host bypassed the proxy and got straight through to the handler. Defense-in-depth gap that becomes a real problem if the Railway URL leaks (and the URL has to be in the FE config, so it's not exactly secret).

## Admin-only — gated with \`verify_api_key\`

Not reachable from the FE:

| Route | Pre-fix exposure |
|---|---|
| \`POST /jobs/rescore/{target_id}\` | O(jobs × scoring_keywords) re-score across all jobs for a target. Free DB-heavy DoS for anyone hitting the URL. |
| \`POST /jobs/backfill-salary\` | Full-table scan + per-row salary extraction with batched RPC writes. Same shape. |

## FE + admin — gated with \`verify_api_key_or_jwt\`

Reachable from the wyrdfold UI:

| Route | Pre-fix exposure |
|---|---|
| \`POST /targets\` | Create target without auth. |
| \`GET /targets/{target_id}\` | Read shared target metadata. |
| \`PATCH /targets/{target_id}\` | **Mutate** shared target metadata (label, scoring_profile, search_keywords). Most concerning of the three — an unauthenticated direct request could rewrite anyone's scoring profile. |

Matches the existing pattern used by neighboring routes (\`POST /jobs/manual\` already had \`verify_api_key_or_jwt\`).

## Not in this PR

Targets are shared globally between users by design (the \`user_targets\` join table scopes ownership of activation / linking, but the target row itself is shared). So PATCH still lets any authed user edit shared metadata — that's an architectural property of the schema, not a bug. The auth check added here just ensures the caller is at least authenticated.

## Test plan

- [x] \`pnpm nx run wyrdfold-api:typecheck\` — clean
- [x] \`pnpm nx test wyrdfold-api\` — 849/849 pass
- [x] Updated 2 \`/rescore\` tests to override the new \`verify_api_key\` dep
- [ ] Smoke: \`curl -X POST $API_URL/jobs/rescore/foo\` without an api key — 401, not 200 / 404
- [ ] Smoke: FE flows still work (PATCH /targets/{id} from ScoringProfileEditor, GET /targets/{id} from TargetDetail)