### PR TITLE
fix(wyrdfold-api): require auth on 7 remaining unguarded targets routes

### DIFF
--- a/apps/wyrdfold-api/app/routers/targets.py
+++ b/apps/wyrdfold-api/app/routers/targets.py
@@ -19,6 +19,7 @@ from app.dependencies import (
     get_current_user_id_optional,
     get_llm_client,
     get_supabase,
+    verify_api_key,
     verify_api_key_or_jwt,
 )
 from app.http_client import ResponseTooLargeError, get_with_size_cap
@@ -252,7 +253,11 @@ async def create_target_from_url(
     )
 
 
-@router.get("", response_model=TargetsListResponse)
+@router.get(
+    "",
+    response_model=TargetsListResponse,
+    dependencies=[Depends(verify_api_key_or_jwt)],
+)
 def list_targets(
     supabase: Client = Depends(get_supabase),
 ) -> TargetsListResponse:
@@ -293,7 +298,11 @@ async def suggest(
     return matched
 
 
-@router.get("/active", response_model=TargetsListResponse)
+@router.get(
+    "/active",
+    response_model=TargetsListResponse,
+    dependencies=[Depends(verify_api_key_or_jwt)],
+)
 def get_active_targets(
     supabase: Client = Depends(get_supabase),
 ) -> TargetsListResponse:
@@ -475,12 +484,21 @@ async def derive_target_profile(
     return updated
 
 
-@router.post("/{target_id}/poll-jobs", response_model=PollResult)
+@router.post(
+    "/{target_id}/poll-jobs",
+    response_model=PollResult,
+    dependencies=[Depends(verify_api_key)],
+)
 async def poll_jobs_for_target(
     target_id: str,
     supabase: Client = Depends(get_supabase),
 ) -> PollResult:
-    """Poll all job sources, filtering for jobs matching this target's search keywords."""
+    """Poll all job sources, filtering for jobs matching this target's search keywords.
+
+    Admin / operator-only: gated by ``verify_api_key`` so an
+    unauthenticated caller can't trigger a fan-out poll across all
+    configured ATS sources. Not reachable from the wyrdfold FE.
+    """
     target = crud.get(supabase, target_id)
     if target is None:
         raise HTTPException(status_code=404, detail="Target not found")
@@ -492,7 +510,11 @@ async def poll_jobs_for_target(
     return await poll_sources_for_target(supabase, target)
 
 
-@router.get("/{target_id}/status", response_model=TargetStatusResponse)
+@router.get(
+    "/{target_id}/status",
+    response_model=TargetStatusResponse,
+    dependencies=[Depends(verify_api_key_or_jwt)],
+)
 async def get_target_status(
     target_id: str,
     supabase: Client = Depends(get_supabase),
@@ -524,7 +546,11 @@ async def get_target_status(
     )
 
 
-@router.delete("/{target_id}", response_model=DeleteResponse)
+@router.delete(
+    "/{target_id}",
+    response_model=DeleteResponse,
+    dependencies=[Depends(verify_api_key_or_jwt)],
+)
 async def delete_target(
     target_id: str,
     supabase: Client = Depends(get_supabase),
@@ -805,7 +831,11 @@ async def add_reference_jd(
     return updated
 
 
-@router.get("/{target_id}/reference-jds", response_model=ReferenceJDsListResponse)
+@router.get(
+    "/{target_id}/reference-jds",
+    response_model=ReferenceJDsListResponse,
+    dependencies=[Depends(verify_api_key_or_jwt)],
+)
 async def list_reference_jds(
     target_id: str,
     supabase: Client = Depends(get_supabase),
@@ -817,6 +847,7 @@ async def list_reference_jds(
 @router.delete(
     "/{target_id}/reference-jds/{ref_jd_id}",
     response_model=JobTarget,
+    dependencies=[Depends(verify_api_key_or_jwt)],
 )
 async def delete_reference_jd(
     target_id: str,


### PR DESCRIPTION
## Summary

Follow-up to #716. That PR caught 3 unguarded routes via targeted grep; a systematic per-route audit of \`targets.py\` turned up 7 more, including two destructive ones.

## FE + admin (\`verify_api_key_or_jwt\`)

Called from the wyrdfold UI:

| Route | Pre-fix exposure |
|---|---|
| \`GET /targets\` | List all targets unauthenticated |
| \`GET /targets/active\` | List globally active targets unauthenticated |
| \`GET /targets/{target_id}/status\` | Drives the JobsList polling effect (every 3s) + the thin-results CTA gate from #707. Status leak. |
| \`DELETE /targets/{target_id}\` | **Destructive.** Unauthenticated direct request could delete any target. |
| \`GET /targets/{target_id}/reference-jds\` | Read another user's reference JDs |
| \`DELETE /targets/{target_id}/reference-jds/{ref_jd_id}\` | **Destructive.** Same exposure for reference JDs. |

## Admin-only (\`verify_api_key\`)

Not called from the FE:

| Route | Pre-fix exposure |
|---|---|
| \`POST /targets/{target_id}/poll-jobs\` | Fans out to every configured ATS source. Free DoS / cost vector for any caller who knew the URL. |

## Verification

- [x] \`pnpm nx run wyrdfold-api:typecheck\` clean
- [x] \`pnpm nx test wyrdfold-api\` — 849/849 pass (no test setup currently exercises these routes via HTTP)
- [ ] Smoke: \`curl -X DELETE $API_URL/targets/foo\` without auth — 401, not 200/404
- [ ] Smoke: FE flows still work (TargetsList delete, ReferenceJDList delete, JobsList /status polling, GET /targets/active for the global view)

## Audit completeness

After #716 + this PR, \`targets.py\` has no remaining unguarded routes. Following the same pattern across other routers is the natural follow-up if you want to keep the sweep going.