### PR TITLE
chore(wyrdfold-api): remove 9 redundant per-route auth deps in targets

### DIFF
--- a/apps/wyrdfold-api/app/routers/targets.py
+++ b/apps/wyrdfold-api/app/routers/targets.py
@@ -150,12 +150,7 @@ async def _activate_pipeline(
 # ---- Target CRUD -----------------------------------------------------------
 
 
-@router.post(
-    "",
-    response_model=JobTarget,
-    status_code=201,
-    dependencies=[Depends(verify_api_key_or_jwt)],
-)
+@router.post("", response_model=JobTarget, status_code=201)
 async def create_target(
     body: TargetCreate,
     supabase: Client = Depends(get_supabase),
@@ -253,11 +248,7 @@ async def create_target_from_url(
     )
 
 
-@router.get(
-    "",
-    response_model=TargetsListResponse,
-    dependencies=[Depends(verify_api_key_or_jwt)],
-)
+@router.get("", response_model=TargetsListResponse)
 def list_targets(
     supabase: Client = Depends(get_supabase),
 ) -> TargetsListResponse:
@@ -298,11 +289,7 @@ async def suggest(
     return matched
 
 
-@router.get(
-    "/active",
-    response_model=TargetsListResponse,
-    dependencies=[Depends(verify_api_key_or_jwt)],
-)
+@router.get("/active", response_model=TargetsListResponse)
 def get_active_targets(
     supabase: Client = Depends(get_supabase),
 ) -> TargetsListResponse:
@@ -320,11 +307,7 @@ def get_my_targets(
     return MyTargetsListResponse(targets=items)
 
 
-@router.get(
-    "/{target_id}",
-    response_model=JobTarget,
-    dependencies=[Depends(verify_api_key_or_jwt)],
-)
+@router.get("/{target_id}", response_model=JobTarget)
 def get_target(
     target_id: str,
     supabase: Client = Depends(get_supabase),
@@ -335,11 +318,7 @@ def get_target(
     return target
 
 
-@router.patch(
-    "/{target_id}",
-    response_model=JobTarget,
-    dependencies=[Depends(verify_api_key_or_jwt)],
-)
+@router.patch("/{target_id}", response_model=JobTarget)
 def update_target(
     target_id: str,
     body: TargetUpdate,
@@ -510,11 +489,7 @@ async def poll_jobs_for_target(
     return await poll_sources_for_target(supabase, target)
 
 
-@router.get(
-    "/{target_id}/status",
-    response_model=TargetStatusResponse,
-    dependencies=[Depends(verify_api_key_or_jwt)],
-)
+@router.get("/{target_id}/status", response_model=TargetStatusResponse)
 async def get_target_status(
     target_id: str,
     supabase: Client = Depends(get_supabase),
@@ -546,11 +521,7 @@ async def get_target_status(
     )
 
 
-@router.delete(
-    "/{target_id}",
-    response_model=DeleteResponse,
-    dependencies=[Depends(verify_api_key_or_jwt)],
-)
+@router.delete("/{target_id}", response_model=DeleteResponse)
 async def delete_target(
     target_id: str,
     supabase: Client = Depends(get_supabase),
@@ -831,11 +802,7 @@ async def add_reference_jd(
     return updated
 
 
-@router.get(
-    "/{target_id}/reference-jds",
-    response_model=ReferenceJDsListResponse,
-    dependencies=[Depends(verify_api_key_or_jwt)],
-)
+@router.get("/{target_id}/reference-jds", response_model=ReferenceJDsListResponse)
 async def list_reference_jds(
     target_id: str,
     supabase: Client = Depends(get_supabase),
@@ -847,7 +814,6 @@ async def list_reference_jds(
 @router.delete(
     "/{target_id}/reference-jds/{ref_jd_id}",
     response_model=JobTarget,
-    dependencies=[Depends(verify_api_key_or_jwt)],
 )
 async def delete_reference_jd(
     target_id: str,


### PR DESCRIPTION
## Context

PRs #716 and #717 added \`dependencies=[Depends(verify_api_key_or_jwt)]\` to nine routes in \`targets.py\` based on a faulty audit — my \`awk\` script for the audit checked per-route decorators but missed that the router-level \`APIRouter(..., dependencies=[Depends(verify_api_key_or_jwt)])\` declaration at line 75 already gates *every* route on the router.

The added per-route deps were therefore duplicates: FastAPI runs the same auth check twice on each request, same outcome either way. No behavior change today, but the dead code overstates the auth model when read and would make later refactoring confusing ("why does this route need two auth checks?").

## Reverting

Nine redundant per-route deps:

- \`POST /targets\`
- \`GET /targets\`
- \`GET /targets/active\`
- \`GET /targets/{target_id}\`
- \`PATCH /targets/{target_id}\`
- \`GET /targets/{target_id}/status\`
- \`DELETE /targets/{target_id}\`
- \`GET /targets/{target_id}/reference-jds\`
- \`DELETE /targets/{target_id}/reference-jds/{ref_jd_id}\`

## Keeping

One *real* tightening from #717 stays:

- \`POST /targets/{target_id}/poll-jobs\` — now \`verify_api_key\`, where the router-level dep is \`verify_api_key_or_jwt\`. This is a meaningful restriction (operator-only fan-out poll) — the stricter per-route dep overrides the router-level allow-JWT default. ✅

Same shape as the two real tightenings from #716 in \`jobs.py\` (\`/rescore\`, \`/backfill-salary\`), which are unaffected by this PR.

## What about #714 and #715?

Those still stand. Router-level auth says "you're authenticated"; it does not say "you can access this row." The user_id scoping in \`persistence.get\` and \`get_batch\` was a real cross-tenant fix and isn't touched here.

## Test plan

- [x] \`pnpm nx run wyrdfold-api:typecheck\` — clean
- [x] \`pnpm nx test wyrdfold-api\` — 849/849 pass
- [ ] Smoke: every affected route still works behind the router-level auth (the duplicated dep was a no-op)