### PR TITLE
fix(wyrdfold-api): defense-in-depth user_id scoping on 5 persistence mutators

### DIFF
--- a/apps/wyrdfold-api/app/routers/tailor.py
+++ b/apps/wyrdfold-api/app/routers/tailor.py
@@ -404,7 +404,9 @@ async def edit_tailored_resume(
             },
         )
 
-    record = persistence.update_payload_md(supabase, resume_id, body.markdown)
+    record = persistence.update_payload_md(
+        supabase, resume_id, body.markdown, user_id=user_id
+    )
     return TailorResponse(record=record, lint_warnings=lint_result.warnings)
 
 
@@ -443,7 +445,9 @@ async def checkpoint_tailored_resume(
                     "violations": [v.model_dump() for v in lint_result.violations],
                 },
             )
-        persistence.update_payload_md(supabase, resume_id, body.markdown)
+        persistence.update_payload_md(
+            supabase, resume_id, body.markdown, user_id=user_id
+        )
 
     recorded = versions.checkpoint(supabase, resume_id)
     return {"recorded": recorded}
@@ -464,7 +468,7 @@ async def approve_tailored_resume(
     if row.approved_at is not None:
         return row
 
-    record = persistence.approve(supabase, resume_id)
+    record = persistence.approve(supabase, resume_id, user_id=user_id)
 
     # Resume approval also advances the linked job posting to resume_ready;
     # cover letters don't drive job status.
@@ -490,7 +494,7 @@ async def unapprove_tailored_resume(
     if row.approved_at is None:
         return row
 
-    record = persistence.unapprove(supabase, resume_id)
+    record = persistence.unapprove(supabase, resume_id, user_id=user_id)
 
     # Mirror the approve side: resume unlock walks the linked job back to
     # resume_draft so the lifecycle stays in sync.
@@ -592,6 +596,7 @@ async def download_tailored_resume(
                 resume_id,
                 storage_path=storage_path,
                 payload_md_hash=expected_hash or md_payload_hash(row.payload_md),
+                user_id=user_id,
             )
         except Exception:
             # Fall through and serve the freshly-rendered bytes regardless;

--- a/apps/wyrdfold-api/app/services/tailor/persistence.py
+++ b/apps/wyrdfold-api/app/services/tailor/persistence.py
@@ -197,17 +197,36 @@ def get(
     return TailoredResumeRecord.model_validate(cast(dict[str, Any], resp.data))
 
 
+def _scope_to_user(query: Any, user_id: str | None) -> Any:
+    """Apply the standard ``(id-only) → (id + user_id)`` scoping the
+    persistence helpers all share. Centralising the conditional keeps
+    the five mutation functions below identical in shape, so a future
+    change (e.g., a third tenant mode) only happens in one place.
+    """
+    if user_id is None:
+        return query.is_("user_id", "null")
+    return query.eq("user_id", user_id)
+
+
 def update_payload(
     supabase: Client,
     resume_id: str,
     payload_dict: dict[str, Any],
     storage_path: str | None = None,
     version_source: versions.VersionSource = "user_edit",
+    *,
+    user_id: str | None,
 ) -> TailoredResumeRecord:
     """Update the payload JSONB and set updated_at. Optionally update storage_path.
 
     Records a version snapshot before the update lands so history is captured
     even if the live update fails between snapshot and commit (F3-H).
+
+    Defense-in-depth (post-#714): scopes the update by ``user_id`` in
+    addition to ``id`` so a future caller that bypasses the route's
+    ``persistence.get`` ownership check still can't cross-tenant.
+    Same convention as ``persistence.get`` — ``user_id=None`` matches
+    the legacy single-tenant rows.
     """
     versions.record(
         supabase,
@@ -221,7 +240,8 @@ def update_payload(
     }
     if storage_path is not None:
         updates["storage_path"] = storage_path
-    resp = supabase.table(TABLE).update(updates).eq("id", resume_id).execute()
+    query = supabase.table(TABLE).update(updates).eq("id", resume_id)
+    resp = _scope_to_user(query, user_id).execute()
     rows = cast(list[dict[str, Any]], resp.data or [])
     if not rows:
         raise RuntimeError(f"Failed to update documents row {resume_id}")
@@ -232,6 +252,8 @@ def update_payload_md(
     supabase: Client,
     resume_id: str,
     payload_md: str,
+    *,
+    user_id: str | None,
 ) -> TailoredResumeRecord:
     """Update the markdown payload and invalidate the cached docx hash.
 
@@ -244,6 +266,8 @@ def update_payload_md(
     that need a snapshot (session-end flush, before approve, before
     re-adapt) call `versions.checkpoint` separately. That keeps the
     free-tier version cap from being flooded by routine keystrokes.
+
+    Defense-in-depth (post-#714): see ``update_payload``.
     """
     updates: dict[str, Any] = {
         "payload_md": payload_md,
@@ -254,7 +278,8 @@ def update_payload_md(
         "docx_payload_md_hash": None,
         "updated_at": "now()",
     }
-    resp = supabase.table(TABLE).update(updates).eq("id", resume_id).execute()
+    query = supabase.table(TABLE).update(updates).eq("id", resume_id)
+    resp = _scope_to_user(query, user_id).execute()
     rows = cast(list[dict[str, Any]], resp.data or [])
     if not rows:
         raise RuntimeError(f"Failed to update documents row {resume_id}")
@@ -267,19 +292,23 @@ def mark_docx_rendered(
     *,
     storage_path: str,
     payload_md_hash: str,
+    user_id: str | None,
 ) -> None:
     """Record that the docx for `payload_md_hash` is uploaded to storage_path.
 
     Called after a successful pandoc render + storage upload so future
     downloads can serve the cached bytes when the markdown hasn't
     changed.
+
+    Defense-in-depth (post-#714): see ``update_payload``.
     """
-    supabase.table(TABLE).update(
+    query = supabase.table(TABLE).update(
         {
             "storage_path": storage_path,
             "docx_payload_md_hash": payload_md_hash,
         }
-    ).eq("id", resume_id).execute()
+    ).eq("id", resume_id)
+    _scope_to_user(query, user_id).execute()
 
 
 def mark_job_resume_draft(supabase: Client, job_posting_id: str) -> None:
@@ -298,18 +327,30 @@ def mark_job_resume_draft(supabase: Client, job_posting_id: str) -> None:
     ).eq("id", job_posting_id).execute()
 
 
-def approve(supabase: Client, resume_id: str) -> TailoredResumeRecord:
-    """Set approved_at on a tailored resume."""
-    resp = supabase.table(TABLE).update({"approved_at": "now()"}).eq("id", resume_id).execute()
+def approve(
+    supabase: Client, resume_id: str, *, user_id: str | None
+) -> TailoredResumeRecord:
+    """Set approved_at on a tailored resume.
+
+    Defense-in-depth (post-#714): see ``update_payload``.
+    """
+    query = supabase.table(TABLE).update({"approved_at": "now()"}).eq("id", resume_id)
+    resp = _scope_to_user(query, user_id).execute()
     rows = cast(list[dict[str, Any]], resp.data or [])
     if not rows:
         raise RuntimeError(f"Failed to approve documents row {resume_id}")
     return TailoredResumeRecord.model_validate(rows[0])
 
 
-def unapprove(supabase: Client, resume_id: str) -> TailoredResumeRecord:
-    """Clear approved_at on a tailored resume — reopens it for editing."""
-    resp = supabase.table(TABLE).update({"approved_at": None}).eq("id", resume_id).execute()
+def unapprove(
+    supabase: Client, resume_id: str, *, user_id: str | None
+) -> TailoredResumeRecord:
+    """Clear approved_at on a tailored resume — reopens it for editing.
+
+    Defense-in-depth (post-#714): see ``update_payload``.
+    """
+    query = supabase.table(TABLE).update({"approved_at": None}).eq("id", resume_id)
+    resp = _scope_to_user(query, user_id).execute()
     rows = cast(list[dict[str, Any]], resp.data or [])
     if not rows:
         raise RuntimeError(f"Failed to unapprove documents row {resume_id}")

--- a/apps/wyrdfold-api/tests/test_resume_lifecycle.py
+++ b/apps/wyrdfold-api/tests/test_resume_lifecycle.py
@@ -120,11 +120,12 @@ class TestPersistenceHelpers:
 
         supabase = MagicMock()
         updated_record = _make_record()
-        supabase.table.return_value.update.return_value.eq.return_value.execute.return_value.data = [
+        # Chain: update → eq(id) → is_(user_id) → execute (user_id=None path)
+        supabase.table.return_value.update.return_value.eq.return_value.is_.return_value.execute.return_value.data = [
             updated_record.model_dump(mode="json")
         ]
 
-        result = update_payload(supabase, "rec-1", {"summary": "Updated"})
+        result = update_payload(supabase, "rec-1", {"summary": "Updated"}, user_id=None)
         assert result.id == "rec-1"
         supabase.table.assert_called_with("documents")
 
@@ -133,12 +134,16 @@ class TestPersistenceHelpers:
 
         supabase = MagicMock()
         updated_record = _make_record()
-        supabase.table.return_value.update.return_value.eq.return_value.execute.return_value.data = [
+        supabase.table.return_value.update.return_value.eq.return_value.is_.return_value.execute.return_value.data = [
             updated_record.model_dump(mode="json")
         ]
 
         result = update_payload(
-            supabase, "rec-1", {"summary": "Updated"}, storage_path="anon/rec-1.docx"
+            supabase,
+            "rec-1",
+            {"summary": "Updated"},
+            storage_path="anon/rec-1.docx",
+            user_id=None,
         )
         assert result.id == "rec-1"
         # Verify the update call included storage_path
@@ -150,11 +155,11 @@ class TestPersistenceHelpers:
 
         supabase = MagicMock()
         approved_record = _make_record(approved_at=_NOW)
-        supabase.table.return_value.update.return_value.eq.return_value.execute.return_value.data = [
+        supabase.table.return_value.update.return_value.eq.return_value.is_.return_value.execute.return_value.data = [
             approved_record.model_dump(mode="json")
         ]
 
-        result = approve(supabase, "rec-1")
+        result = approve(supabase, "rec-1", user_id=None)
         assert result.id == "rec-1"
         assert result.approved_at is not None
 
@@ -718,12 +723,12 @@ class TestUpdatePayloadMd:
 
         supabase = MagicMock()
         updated = _make_record(payload_md=_GOOD_MD, docx_payload_md_hash=None)
-        supabase.table.return_value.update.return_value.eq.return_value.execute.return_value.data = [
+        supabase.table.return_value.update.return_value.eq.return_value.is_.return_value.execute.return_value.data = [
             updated.model_dump(mode="json")
         ]
 
         with patch("app.services.tailor.versions.record") as mock_record:
-            update_payload_md(supabase, "rec-1", _GOOD_MD)
+            update_payload_md(supabase, "rec-1", _GOOD_MD, user_id=None)
 
         # Update payload includes the markdown and explicitly NULLs the cache hash.
         update_call = supabase.table.return_value.update.call_args[0][0]
@@ -800,7 +805,13 @@ class TestCheckpointEndpoint:
             )
 
         # Save lands first so checkpoint reads the fresh markdown.
-        mock_update.assert_called_once_with(supabase, "rec-1", new_md)
+        # ``user_id`` kwarg comes from the route's ``Depends`` default
+        # when called directly without a real request — the test
+        # exercises the call shape, not the resolved value.
+        mock_update.assert_called_once()
+        args, kwargs = mock_update.call_args
+        assert args[:3] == (supabase, "rec-1", new_md)
+        assert "user_id" in kwargs
         mock_checkpoint.assert_called_once_with(supabase, "rec-1")
 
     @pytest.mark.asyncio
@@ -890,6 +901,7 @@ class TestMarkDocxRendered:
             "rec-1",
             storage_path="anon/rec-1.docx",
             payload_md_hash="hash-xyz",
+            user_id=None,
         )
 
         update_call = supabase.table.return_value.update.call_args[0][0]
@@ -979,12 +991,12 @@ class TestDownloadCache:
         # mark_docx_rendered receives the freshly computed hash, not the stale one.
         from app.services.docx.pandoc_render import md_payload_hash
 
-        mock_mark.assert_called_once_with(
-            supabase,
-            "rec-1",
-            storage_path="anon/rec-1.docx",
-            payload_md_hash=md_payload_hash(_GOOD_MD),
-        )
+        mock_mark.assert_called_once()
+        args, kwargs = mock_mark.call_args
+        assert args == (supabase, "rec-1")
+        assert kwargs["storage_path"] == "anon/rec-1.docx"
+        assert kwargs["payload_md_hash"] == md_payload_hash(_GOOD_MD)
+        assert "user_id" in kwargs
 
     @pytest.mark.asyncio
     async def test_cache_stale_render_succeeds_even_if_upload_fails(self) -> None:


### PR DESCRIPTION
## Summary

Follow-up to #714. That PR scoped the read-side helpers (\`persistence.get\`, \`get_by_job\`) by \`user_id\`; the **mutating** helpers — \`update_payload\`, \`update_payload_md\`, \`mark_docx_rendered\`, \`approve\`, \`unapprove\` — still filtered by \`id\` alone.

They're safe today because the routes that call them always run \`persistence.get(supabase, resume_id, user_id=user_id)\` first and 404 on a cross-tenant id. But the unscoped mutators are a footgun: any future route or background task that bypasses the upstream ownership check (or calls these helpers in a different order) silently cross-tenants.

## Fix

Push the scoping down so it's enforced at the query layer:

- All five mutators take a required keyword-only \`user_id\`.
- New tiny helper \`_scope_to_user\` applies the standard \`is_("user_id", "null") if user_id is None else eq("user_id", user_id)\` conditional. Centralising it keeps the five functions identical in shape so a future change (e.g., a third tenant mode) only happens in one place.
- All five callsites in \`routers/tailor.py\` thread the route's \`user_id\` dependency through. (The routes already had it from #714.)

## Not in this PR

\`versions.checkpoint\` / \`versions.list_for_resume\` / \`versions.record\` left as-is — the versions table doesn't carry a \`user_id\` column today, so adding scoping there would need a schema migration. The version routes still ownership-check the parent resume via \`persistence.get\` before calling versions helpers, so the surface is closed at the route boundary.

## Test plan

- [x] \`pnpm nx run wyrdfold-api:typecheck\` — clean
- [x] \`pnpm nx test wyrdfold-api\` — 849/849 pass
- [x] Updated 7 affected tests: 4 \`TestPersistenceHelpers\` direct-call tests for the new required kwarg + chain-mock updates for the \`is_("user_id", "null")\` insertion; 2 route-handler tests (\`test_body_with_markdown_saves_then_checkpoints\`, \`test_cache_stale_rerenders_and_marks\`) to assert the call shape without binding to the resolved \`Depends\` sentinel; 1 \`TestMarkDocxRendered\` direct-call test for the new kwarg.