### PR TITLE
fix(wyrdfold): surface API error detail in 7 targets-page handlers

### DIFF
--- a/apps/wyrdfold/src/app/(app)/targets/TargetsList.tsx
+++ b/apps/wyrdfold/src/app/(app)/targets/TargetsList.tsx
@@ -55,14 +55,19 @@ export default function TargetsList({ initialTargets }: TargetsListProps) {
         const res = await fetch(`/api/targets/${id}/activate`, {
           method: 'POST',
         });
-        if (!res.ok) throw new Error('Activate failed');
+        if (!res.ok)
+          throw new Error(await extractApiError(res, 'Activate failed'));
         toast({ variant: 'success', title: 'Target activated' });
         // RSC re-render rather than a second client fetch — saves a
         // round-trip and keeps the targets page authoritative on the
         // server.
         router.refresh();
-      } catch {
-        toast({ variant: 'error', title: 'Failed to activate target' });
+      } catch (err) {
+        toast({
+          variant: 'error',
+          title:
+            err instanceof Error ? err.message : 'Failed to activate target',
+        });
       }
     },
     [toast, router]
@@ -74,11 +79,16 @@ export default function TargetsList({ initialTargets }: TargetsListProps) {
         const res = await fetch(`/api/targets/${id}/deactivate`, {
           method: 'POST',
         });
-        if (!res.ok) throw new Error('Deactivate failed');
+        if (!res.ok)
+          throw new Error(await extractApiError(res, 'Deactivate failed'));
         toast({ variant: 'success', title: 'Target deactivated' });
         router.refresh();
-      } catch {
-        toast({ variant: 'error', title: 'Failed to deactivate target' });
+      } catch (err) {
+        toast({
+          variant: 'error',
+          title:
+            err instanceof Error ? err.message : 'Failed to deactivate target',
+        });
       }
     },
     [toast, router]
@@ -92,14 +102,18 @@ export default function TargetsList({ initialTargets }: TargetsListProps) {
 
       try {
         const res = await fetch(`/api/targets/${id}`, { method: 'DELETE' });
-        if (!res.ok) throw new Error('Delete failed');
+        if (!res.ok)
+          throw new Error(await extractApiError(res, 'Delete failed'));
         toast({ variant: 'success', title: 'Target deleted' });
         // Optimistic removal so the card disappears instantly; refresh
         // brings authoritative state to backstop the optimistic delete.
         setTargets(prev => prev.filter(t => t.target.id !== id));
         router.refresh();
-      } catch {
-        toast({ variant: 'error', title: 'Failed to delete target' });
+      } catch (err) {
+        toast({
+          variant: 'error',
+          title: err instanceof Error ? err.message : 'Failed to delete target',
+        });
       }
     },
     [toast, router]
@@ -191,7 +205,8 @@ export default function TargetsList({ initialTargets }: TargetsListProps) {
     setSuggestions([]);
     try {
       const res = await fetch('/api/targets/suggest', { method: 'POST' });
-      if (!res.ok) throw new Error('Suggest failed');
+      if (!res.ok)
+        throw new Error(await extractApiError(res, 'Suggest failed'));
       const data = (await res.json()) as MatchedSuggestions;
       setSuggestions(data.matches);
       if (data.matches.length === 0) {
@@ -202,8 +217,12 @@ export default function TargetsList({ initialTargets }: TargetsListProps) {
             'Your existing targets already cover roles that fit your experience.',
         });
       }
-    } catch {
-      toast({ variant: 'error', title: 'Failed to generate suggestions' });
+    } catch (err) {
+      toast({
+        variant: 'error',
+        title:
+          err instanceof Error ? err.message : 'Failed to generate suggestions',
+      });
     } finally {
       setSuggesting(false);
     }

--- a/apps/wyrdfold/src/app/(app)/targets/[id]/ReferenceJDList.tsx
+++ b/apps/wyrdfold/src/app/(app)/targets/[id]/ReferenceJDList.tsx
@@ -10,6 +10,7 @@ import {
 } from '@danieljoffe.com/shared-ui/Card';
 import { Text } from '@danieljoffe.com/shared-ui/Text';
 import Button from '@/components/Button';
+import { extractApiError } from '@/lib/extractApiError';
 import { useToast } from '@/state/Toast/ToastProvider';
 import type { TargetReferenceJD } from '../types';
 import AddReferenceJDModal from './AddReferenceJDModal';
@@ -46,11 +47,18 @@ export default function ReferenceJDList({
           `/api/targets/${targetId}/reference-jds/${refId}`,
           { method: 'DELETE' }
         );
-        if (!res.ok) throw new Error('Delete failed');
+        if (!res.ok)
+          throw new Error(await extractApiError(res, 'Delete failed'));
         toast({ variant: 'success', title: 'Reference JD removed' });
         onChanged();
-      } catch {
-        toast({ variant: 'error', title: 'Failed to delete reference JD' });
+      } catch (err) {
+        toast({
+          variant: 'error',
+          title:
+            err instanceof Error
+              ? err.message
+              : 'Failed to delete reference JD',
+        });
       } finally {
         setDeletingId(null);
       }

--- a/apps/wyrdfold/src/app/(app)/targets/[id]/ScoringProfileEditor.tsx
+++ b/apps/wyrdfold/src/app/(app)/targets/[id]/ScoringProfileEditor.tsx
@@ -13,6 +13,7 @@ import { Badge } from '@danieljoffe.com/shared-ui/Badge';
 import { Input } from '@danieljoffe.com/shared-ui/Input';
 import { Spinner } from '@danieljoffe.com/shared-ui/Spinner';
 import Button from '@/components/Button';
+import { extractApiError } from '@/lib/extractApiError';
 import { useToast } from '@/state/Toast/ToastProvider';
 import type {
   JobTarget,
@@ -65,11 +66,15 @@ export default function ScoringProfileEditor({
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ scoring_profile: profile }),
       });
-      if (!res.ok) throw new Error('Save failed');
+      if (!res.ok) throw new Error(await extractApiError(res, 'Save failed'));
       toast({ variant: 'success', title: 'Scoring profile saved' });
       onSaved();
-    } catch {
-      toast({ variant: 'error', title: 'Failed to save scoring profile' });
+    } catch (err) {
+      toast({
+        variant: 'error',
+        title:
+          err instanceof Error ? err.message : 'Failed to save scoring profile',
+      });
     } finally {
       setSaving(false);
     }

--- a/apps/wyrdfold/src/app/(app)/targets/[id]/TargetDetail.tsx
+++ b/apps/wyrdfold/src/app/(app)/targets/[id]/TargetDetail.tsx
@@ -6,6 +6,7 @@ import { ArrowLeft, Check, Pencil } from 'lucide-react';
 import { Heading } from '@danieljoffe.com/shared-ui/Heading';
 import { Badge } from '@danieljoffe.com/shared-ui/Badge';
 import Button from '@/components/Button';
+import { extractApiError } from '@/lib/extractApiError';
 import { useToast } from '@/state/Toast/ToastProvider';
 import type { JobTarget, TargetReferenceJD } from '../types';
 import ScoringProfileEditor from './ScoringProfileEditor';
@@ -76,12 +77,16 @@ export default function TargetDetail({ id }: TargetDetailProps) {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ label: trimmed }),
       });
-      if (!res.ok) throw new Error('Failed to update label');
+      if (!res.ok)
+        throw new Error(await extractApiError(res, 'Failed to update label'));
       setTarget(prev => (prev ? { ...prev, label: trimmed } : prev));
       setEditingLabel(false);
       toast({ variant: 'success', title: 'Label updated' });
-    } catch {
-      toast({ variant: 'error', title: 'Failed to update label' });
+    } catch (err) {
+      toast({
+        variant: 'error',
+        title: err instanceof Error ? err.message : 'Failed to update label',
+      });
     } finally {
       setSavingLabel(false);
     }


### PR DESCRIPTION
## Summary

Seven handlers across the targets pages had the same broken pattern:

\`\`\`ts
if (!res.ok) throw new Error('Activate failed');
...
} catch {
  toast({ variant: 'error', title: 'Failed to activate target' });
}
\`\`\`

The bare \`catch\` with no binding discards the thrown \`Error\`'s message, so a 422 with \`detail: "Target is already activated"\` or a structured \`llm_budget_exceeded\` 429 just renders as the generic "Failed to activate target" toast — same response the user gets on a network error, with no recovery hint.

## Pattern

Mirrors the ProfilePage fix in #711 and the per-callsite sweep across #710 / #711 / #712:

1. \`throw new Error(await extractApiError(res, 'Activate failed'))\`
2. \`} catch (err) {\`
3. \`title: err instanceof Error ? err.message : 'Failed to activate target'\`

## Sites fixed

| File | Handler |
|---|---|
| \`TargetsList\` | \`handleActivate\` |
| \`TargetsList\` | \`handleDeactivate\` |
| \`TargetsList\` | \`handleDelete\` |
| \`TargetsList\` | \`handleSuggest\` |
| \`TargetDetail\` | \`handleSaveLabel\` |
| \`ScoringProfileEditor\` | \`handleSave\` |
| \`ReferenceJDList\` | \`handleDelete\` |

Existing \`catch (err)\` sites in the same files (e.g., the \`runCreate\` / \`handleAddSuggestion\` paths already routed through \`extractApiError\` in #712) are unchanged.

## Not fixed in this PR

\`SettingsPage\` autosave catches at lines 165/223/271/322 *look* like the same pattern but already toast \`extractApiError\` from the \`!res.ok\` branch and use the bare catch only for network-level failures — generic toast is appropriate there.

## Test plan

- [x] \`pnpm tsc --noEmit\` clean
- [x] \`pnpm nx test wyrdfold --skip-nx-cache -- --testPathPatterns='TargetsList|TargetDetail|ScoringProfileEditor|ReferenceJDList'\` — 17/17 pass
- [ ] Smoke: trigger a 422 from any of these handlers (e.g., over LLM budget on \`handleSuggest\`) — toast shows the structured detail message, not the generic fallback