### PR TITLE
fix(wyrdfold): route 14 review-page error sites through extractApiError

### DIFF
--- a/apps/wyrdfold/src/app/(app)/jobs/JobsList.tsx
+++ b/apps/wyrdfold/src/app/(app)/jobs/JobsList.tsx
@@ -339,7 +339,14 @@ export default function JobsList({
       });
 
       if (!res.ok) {
-        toast({ variant: 'error', title: 'Export failed' });
+        // ``/tailor/export-zip`` surfaces actionable detail (e.g.,
+        // ``"resumes not yet approved: id1, id2"``) — without
+        // ``extractApiError`` the user just saw "Export failed" and
+        // had to guess which selected resume was the holdup.
+        toast({
+          variant: 'error',
+          title: await extractApiError(res, 'Export failed'),
+        });
         return;
       }
 

--- a/apps/wyrdfold/src/app/(app)/jobs/[id]/JobDetailPage.tsx
+++ b/apps/wyrdfold/src/app/(app)/jobs/[id]/JobDetailPage.tsx
@@ -10,6 +10,7 @@ import { Heading } from '@danieljoffe.com/shared-ui/Heading';
 import { Skeleton } from '@danieljoffe.com/shared-ui/Skeleton';
 import { Text } from '@danieljoffe.com/shared-ui/Text';
 import Button from '@/components/Button';
+import { extractApiError } from '@/lib/extractApiError';
 import { useToast } from '@/state/Toast/ToastProvider';
 import type { UserTargetWithTarget } from '../../targets/types';
 import JobDetailPanel from '../JobDetailPanel';
@@ -40,12 +41,16 @@ export default function JobDetailPage({ id, targetId }: JobDetailPageProps) {
           if (!cancelled) setNotFound(true);
           return;
         }
-        if (!res.ok) throw new Error('Failed to load job');
+        if (!res.ok)
+          throw new Error(await extractApiError(res, 'Failed to load job'));
         const data = (await res.json()) as JobPosting;
         if (!cancelled) setPosting(data);
-      } catch {
+      } catch (err) {
         if (!cancelled)
-          toast({ variant: 'error', title: 'Failed to load job' });
+          toast({
+            variant: 'error',
+            title: err instanceof Error ? err.message : 'Failed to load job',
+          });
       } finally {
         if (!cancelled) setLoading(false);
       }

--- a/apps/wyrdfold/src/app/(app)/jobs/[id]/cover-letter/CoverLetterReviewPage.tsx
+++ b/apps/wyrdfold/src/app/(app)/jobs/[id]/cover-letter/CoverLetterReviewPage.tsx
@@ -8,6 +8,7 @@ import { Heading } from '@danieljoffe.com/shared-ui/Heading';
 import { Skeleton } from '@danieljoffe.com/shared-ui/Skeleton';
 import { Text } from '@danieljoffe.com/shared-ui/Text';
 import Button from '@/components/Button';
+import { extractApiError } from '@/lib/extractApiError';
 import { useToast } from '@/state/Toast/ToastProvider';
 import type {
   CoverLetterPayload,
@@ -98,7 +99,10 @@ export default function CoverLetterReviewPage({
     try {
       const res = await fetch(`/api/jobs/tailor/${record.id}/versions`);
       if (!res.ok) {
-        toast({ variant: 'error', title: 'Failed to load version history' });
+        toast({
+          variant: 'error',
+          title: await extractApiError(res, 'Failed to load version history'),
+        });
         return;
       }
       const data = (await res.json()) as ResumeVersionsResponse;
@@ -141,7 +145,10 @@ export default function CoverLetterReviewPage({
         return false;
       }
       if (!res.ok) {
-        toast({ variant: 'error', title: 'Failed to save changes' });
+        toast({
+          variant: 'error',
+          title: await extractApiError(res, 'Failed to save changes'),
+        });
         setSaveStatus('error');
         return false;
       }
@@ -234,7 +241,10 @@ export default function CoverLetterReviewPage({
         method: 'POST',
       });
       if (!res.ok) {
-        toast({ variant: 'error', title: 'Failed to lock cover letter' });
+        toast({
+          variant: 'error',
+          title: await extractApiError(res, 'Failed to lock cover letter'),
+        });
         return;
       }
       const approved = (await res.json()) as TailoredResumeRecord;
@@ -258,7 +268,10 @@ export default function CoverLetterReviewPage({
         method: 'POST',
       });
       if (!res.ok) {
-        toast({ variant: 'error', title: 'Failed to unlock cover letter' });
+        toast({
+          variant: 'error',
+          title: await extractApiError(res, 'Failed to unlock cover letter'),
+        });
         return;
       }
       const reopened = (await res.json()) as TailoredResumeRecord;
@@ -281,7 +294,10 @@ export default function CoverLetterReviewPage({
     try {
       const res = await fetch(`/api/jobs/tailor/${record.id}/download`);
       if (!res.ok) {
-        toast({ variant: 'error', title: 'Download failed' });
+        toast({
+          variant: 'error',
+          title: await extractApiError(res, 'Download failed'),
+        });
         return;
       }
       const blob = await res.blob();
@@ -326,7 +342,14 @@ export default function CoverLetterReviewPage({
         }),
       });
       if (!res.ok) {
-        toast({ variant: 'error', title: 'Re-generation failed' });
+        // LLM-budgeted route — without ``extractApiError`` here, hitting
+        // the daily/hourly cap would render as the generic
+        // "Re-generation failed" instead of the structured "$X of $Y
+        // budget reached" message (PR #701).
+        toast({
+          variant: 'error',
+          title: await extractApiError(res, 'Re-generation failed'),
+        });
         return;
       }
       toast({ variant: 'success', title: 'Cover letter re-generated with AI' });

--- a/apps/wyrdfold/src/app/(app)/jobs/[id]/resume/ResumeReviewPage.tsx
+++ b/apps/wyrdfold/src/app/(app)/jobs/[id]/resume/ResumeReviewPage.tsx
@@ -8,6 +8,7 @@ import { Heading } from '@danieljoffe.com/shared-ui/Heading';
 import { Skeleton } from '@danieljoffe.com/shared-ui/Skeleton';
 import { Text } from '@danieljoffe.com/shared-ui/Text';
 import Button from '@/components/Button';
+import { extractApiError } from '@/lib/extractApiError';
 import { useToast } from '@/state/Toast/ToastProvider';
 import type {
   JobPosting,
@@ -97,7 +98,10 @@ export default function ResumeReviewPage({
     try {
       const res = await fetch(`/api/jobs/tailor/${record.id}/versions`);
       if (!res.ok) {
-        toast({ variant: 'error', title: 'Failed to load version history' });
+        toast({
+          variant: 'error',
+          title: await extractApiError(res, 'Failed to load version history'),
+        });
         return;
       }
       const data = (await res.json()) as ResumeVersionsResponse;
@@ -143,7 +147,10 @@ export default function ResumeReviewPage({
         return false;
       }
       if (!res.ok) {
-        toast({ variant: 'error', title: 'Failed to save changes' });
+        toast({
+          variant: 'error',
+          title: await extractApiError(res, 'Failed to save changes'),
+        });
         setSaveStatus('error');
         return false;
       }
@@ -247,7 +254,10 @@ export default function ResumeReviewPage({
         method: 'POST',
       });
       if (!res.ok) {
-        toast({ variant: 'error', title: 'Failed to approve resume' });
+        toast({
+          variant: 'error',
+          title: await extractApiError(res, 'Failed to approve resume'),
+        });
         return;
       }
       const approved = (await res.json()) as TailoredResumeRecord;
@@ -268,7 +278,10 @@ export default function ResumeReviewPage({
         method: 'POST',
       });
       if (!res.ok) {
-        toast({ variant: 'error', title: 'Failed to unlock resume' });
+        toast({
+          variant: 'error',
+          title: await extractApiError(res, 'Failed to unlock resume'),
+        });
         return;
       }
       const reopened = (await res.json()) as TailoredResumeRecord;
@@ -288,7 +301,10 @@ export default function ResumeReviewPage({
     try {
       const res = await fetch(`/api/jobs/tailor/${record.id}/download`);
       if (!res.ok) {
-        toast({ variant: 'error', title: 'Download failed' });
+        toast({
+          variant: 'error',
+          title: await extractApiError(res, 'Download failed'),
+        });
         return;
       }
       const blob = await res.blob();
@@ -331,7 +347,15 @@ export default function ResumeReviewPage({
         }),
       });
       if (!res.ok) {
-        toast({ variant: 'error', title: 'Re-adapt failed' });
+        // LLM-budgeted route — without ``extractApiError`` here, hitting
+        // the daily/hourly LLM cap would render as the generic
+        // "Re-adapt failed" with no recovery hint instead of the
+        // structured "$X of $Y budget reached — try again in an hour"
+        // message (PR #701).
+        toast({
+          variant: 'error',
+          title: await extractApiError(res, 'Re-adapt failed'),
+        });
         return;
       }
       toast({ variant: 'success', title: 'Resume re-adapted with AI' });


### PR DESCRIPTION
## Summary

Sweep the resume + cover-letter review pages and the JobsList batch export for the generic-toast-drops-API-detail pattern that #710 / #711 / #712 / #720 fixed elsewhere.

Both \`/readapt\` and \`/regenerate\` hit LLM-budgeted routes, so the worst case before this PR was: user hits the daily / hourly LLM budget cap on the most expensive paths (re-generating a tailored doc from scratch), sees "Re-adapt failed" / "Re-generation failed" with no recovery hint, instead of the structured "$X of $Y budget reached — try again in an hour" message from #701.

## Sites fixed (14)

| File | Handlers |
|---|---|
| \`ResumeReviewPage\` | \`loadVersions\`, \`persistMarkdown\`, \`handleApprove\`, \`handleUnapprove\`, \`handleDownload\`, **\`handleReadapt\`** (LLM-budgeted) |
| \`CoverLetterReviewPage\` | \`loadVersions\`, \`persistMarkdown\`, \`handleApprove\`, \`handleUnapprove\`, \`handleDownload\`, **\`handleRegenerate\`** (LLM-budgeted) |
| \`JobsList\` | \`handleBatchExport\` — surfaces the actionable \`"resumes not yet approved: id1, id2"\` detail from \`/tailor/export-zip\` |
| \`JobDetailPage\` | initial load — also flips \`} catch {\` → \`} catch (err) {\` so the thrown message isn't swallowed |

## Not touched

- The **422 + lint-violation special cases** at \`persistMarkdown\` (line 136 / 134 in resume / cover letter) — those already parse the structured detail to populate \`setLintWarnings\`; routing through \`extractApiError\` would discard the \`violations\` array.
- **Network-only \`} catch {\` blocks** — no Response to extract from; the generic "Network error X" toasts are appropriate.

## Test plan

- [x] \`pnpm tsc --noEmit\` clean
- [x] \`pnpm nx test wyrdfold --skip-nx-cache -- --testPathPatterns='ResumeReviewPage|CoverLetterReviewPage|JobsList|JobDetailPage'\` — 42/42 pass
- [ ] Smoke: trigger a 429 by re-adapting a resume while over LLM budget — toast shows the structured spend/limit message, not "Re-adapt failed"
- [ ] Smoke: select an unapproved resume + batch-export — toast names the specific unapproved IDs, not generic "Export failed"