### PR TITLE
fix(wyrdfold): surface budget-exceeded detail in onboarding TargetSuggestions

### DIFF
--- a/apps/wyrdfold/src/app/onboarding/TargetSuggestions.tsx
+++ b/apps/wyrdfold/src/app/onboarding/TargetSuggestions.tsx
@@ -9,6 +9,7 @@ import { Heading } from '@danieljoffe.com/shared-ui/Heading';
 import { Spinner } from '@danieljoffe.com/shared-ui/Spinner';
 import { Alert } from '@danieljoffe.com/shared-ui/Alert';
 import Button from '@/components/Button';
+import { extractApiError } from '@/lib/extractApiError';
 import { cn } from '@/lib/cn';
 import type {
   JobTarget,
@@ -54,7 +55,17 @@ export default function TargetSuggestions({
         const res = await fetch(`/api/targets/from-posting/${postingId}`, {
           method: 'POST',
         });
-        if (!res.ok) throw new Error('Failed to create target');
+        if (!res.ok) {
+          // LLM-budgeted route — surface the structured
+          // ``llm_budget_exceeded`` 429 detail (PR #701) when present,
+          // but keep the friendly "you can create one manually"
+          // fallback for unknown errors. Pass empty fallback to
+          // ``extractApiError`` so we can distinguish "no useful
+          // detail" (only the status code came back) from "real
+          // server message".
+          const detail = await extractApiError(res, '');
+          throw new Error(detail);
+        }
         const data = (await res.json()) as { id: string; label: string };
         if (!cancelled) {
           setCreatedLabel(data.label);
@@ -68,10 +79,18 @@ export default function TargetSuggestions({
           );
           timerRef.current = setTimeout(onComplete, 2000);
         }
-      } catch {
+      } catch (err) {
         if (!cancelled) {
+          const message = err instanceof Error ? err.message.trim() : '';
+          // ``message`` shaped like " (500)" / "(429)" means
+          // ``extractApiError`` only had a status code to work with —
+          // prefer the friendly fallback in that case. A real detail
+          // string (e.g., "LLM hourly budget reached...") wins.
+          const onlyStatus = /^\(\d+\)$/.test(message);
           setError(
-            'Could not auto-create target. You can create one manually.'
+            message && !onlyStatus
+              ? message
+              : 'Could not auto-create target. You can create one manually.'
           );
         }
       } finally {
@@ -93,18 +112,30 @@ export default function TargetSuggestions({
     async function fetchSuggestions() {
       try {
         const res = await fetch('/api/targets/suggest', { method: 'POST' });
-        if (!res.ok) throw new Error('Failed to load suggestions');
+        if (!res.ok) {
+          const detail = await extractApiError(res, '');
+          throw new Error(detail);
+        }
         const data = (await res.json()) as MatchedSuggestions;
         if (!cancelled && data.matches?.length > 0) {
           setSuggestions(data.matches);
           // Pre-select all suggestions
           setSelected(new Set(data.matches.map(m => m.suggestion.label)));
         }
-      } catch {
-        if (!cancelled)
+      } catch (err) {
+        if (!cancelled) {
+          // Same friendly-fallback pattern as the from-posting branch:
+          // surface a real server detail (LLM budget exceeded etc.)
+          // when present, fall back to the manual-creation hint when
+          // we only got a bare status code.
+          const message = err instanceof Error ? err.message.trim() : '';
+          const onlyStatus = /^\(\d+\)$/.test(message);
           setError(
-            'Could not generate suggestions. You can create targets manually.'
+            message && !onlyStatus
+              ? message
+              : 'Could not generate suggestions. You can create targets manually.'
           );
+        }
       } finally {
         if (!cancelled) setLoading(false);
       }


### PR DESCRIPTION
## Summary

Both \`useEffect\`-driven fetches in onboarding's \`TargetSuggestions\` step — path A (\`/api/targets/from-posting/{id}\`) and path B/C (\`/api/targets/suggest\`) — hit \`enforce_llm_budget\` routes. Pre-fix, a user who blew through their LLM cap on an earlier action would land on the suggestions step and see a generic "Could not auto-create target. You can create one manually." with no hint about WHY auto-creation failed.

## Design choice: friendly fallback retained

Surface the structured \`llm_budget_exceeded\` 429 message (#701) when present, but **keep** the friendly manual-creation fallback for unknown errors (500s, network failures, body-less responses).

Mid-onboarding, "Failed to create target (500)" is hostile copy for a new user who hasn't seen the rest of the product yet. "Could not auto-create target. You can create one manually." gives them an actionable path forward. The friendly fallback was a real UX win, so worth preserving.

## How it works

\`extractApiError(res, '')\` returns just \`"(500)"\` when there's no usable detail in the body, vs. the full structured detail when there is one. The catch detects the bare-status shape:

\`\`\`ts
const onlyStatus = /^\(\d+\)$/.test(message);
setError(message && !onlyStatus ? message : friendlyFallback);
\`\`\`

…and routes to the friendly fallback in that case; otherwise it surfaces the server's message verbatim.

This pattern is intentionally different from #720 / #721 (which use \`extractApiError(res, 'fallback')\` and accept the technical-status format), because onboarding's UX bar for first-time users is higher than for established users mid-flow.

## Test plan

- [x] \`pnpm tsc --noEmit\` clean
- [x] \`pnpm nx test wyrdfold --skip-nx-cache -- --testPathPatterns='TargetSuggestions'\` — 11/11 pass (existing assertions on the friendly fallback continue to hold because the test mocks return no body)
- [ ] Smoke: trigger a 429 by being over LLM budget when entering onboarding — alert shows "LLM hourly budget reached..." instead of "Could not auto-create target"
- [ ] Smoke: 500 with no body — alert still shows "Could not auto-create target. You can create one manually." (friendly fallback retained)