### PR TITLE
fix(wyrdfold): surface API detail in JobDetailPanel status + delete

### DIFF
--- a/apps/wyrdfold/src/app/(app)/jobs/JobDetailPanel.tsx
+++ b/apps/wyrdfold/src/app/(app)/jobs/JobDetailPanel.tsx
@@ -156,10 +156,13 @@ export default function JobDetailPanel({
         onStatusChange?.(newStatus);
         fetchHistory();
       } else {
-        toast({ variant: 'error', title: 'Failed to update status' });
+        toast({
+          variant: 'error',
+          title: await extractApiError(res, 'Failed to update status'),
+        });
       }
     } catch {
-      toast({ variant: 'error', title: 'Failed to update status' });
+      toast({ variant: 'error', title: 'Network error updating status' });
     } finally {
       setUpdating(false);
     }
@@ -231,10 +234,13 @@ export default function JobDetailPanel({
         toast({ variant: 'success', title: 'Job deleted' });
         onDelete?.();
       } else {
-        toast({ variant: 'error', title: 'Failed to delete job' });
+        toast({
+          variant: 'error',
+          title: await extractApiError(res, 'Failed to delete job'),
+        });
       }
     } catch {
-      toast({ variant: 'error', title: 'Failed to delete job' });
+      toast({ variant: 'error', title: 'Network error deleting job' });
     } finally {
       setDeleting(false);
     }


### PR DESCRIPTION
## Summary

The last two sites of the generic-toast-drops-API-detail pattern in JobDetailPanel:

- \`updateStatus\` — \`POST /api/jobs/{id}/status\`
- \`handleDelete\` — \`DELETE /api/jobs/{id}\`

Both dropped the API detail on \`!res.ok\` and used the same generic toast in the bare \`catch\`. A 404 from cross-tenant scoping (post-#714), a 422 with an actionable message, or any future structured error rendered as the same "Failed to X" toast.

## Fix

Route the \`!res.ok\` branch through \`extractApiError\` (same pattern as #720 / #721) and reword the network-only \`catch\` to "Network error X" — same shape I used in onboarding fixes, so the user can distinguish a server-side rejection (real detail surfaced) from a connectivity failure (generic message).

\`runAnalysis\` at line 195 already does this — closing the gap on the other two handlers in the same component.

The history-fetch \`catch\` at line 137 stays silent: it's an auxiliary refresh, not the user's primary action, so toasting on a transient failure would be noisier than useful.

## State of the sweep

After this PR, an audit grep across \`apps/wyrdfold/src\` for \`if (!res.ok) { toast({...title: 'Failed\` returns no remaining hits in primary user-action handlers. The remaining bare catches are either:

1. Initial-load fetches with intentional silent-fail comments,
2. Auxiliary background refreshes (like the history fetch above),
3. Already routed through \`extractApiError\` from earlier PRs.

## Test plan

- [x] \`pnpm tsc --noEmit\` clean
- [x] \`pnpm nx test wyrdfold --skip-nx-cache -- --testPathPatterns='JobDetailPanel'\` — 8/8 pass
- [ ] Smoke: delete an already-deleted job (race) — surfaces the API detail, not "Failed to delete job"