### PR TITLE
fix(wyrdfold): explicit min/max on ScoringProfileEditor weight inputs (a11y)

### DIFF
--- a/apps/wyrdfold/src/app/(app)/targets/[id]/ScoringProfileEditor.tsx
+++ b/apps/wyrdfold/src/app/(app)/targets/[id]/ScoringProfileEditor.tsx
@@ -297,6 +297,14 @@ export default function ScoringProfileEditor({
                         }
                         step={0.1}
                         min={0}
+                        // Chrome's a11y tree reports ``aria-valuemax="0"``
+                        // when ``max`` is omitted on ``<input type=number>``
+                        // — screen readers then announce "max reached" on
+                        // every value > 0 and keyboard arrow-step gets the
+                        // wrong upper limit. ``max=10`` keeps the editor's
+                        // useful range while making the SR announcement
+                        // honest. (WCAG 2.1 SC 4.1.2.)
+                        max={10}
                         className='w-16 rounded border border-border bg-surface px-2 py-1 text-xs text-text-primary'
                       />
                     </label>
@@ -464,6 +472,10 @@ export default function ScoringProfileEditor({
                 })
               }
               step={0.1}
+              // See category-weight block above — explicit bounds keep
+              // the a11y tree honest.
+              min={0}
+              max={10}
               className='w-16 rounded border border-border bg-surface px-2 py-1 text-xs text-text-primary'
             />
           </label>
@@ -505,6 +517,11 @@ export default function ScoringProfileEditor({
                 })
               }
               step={1}
+              // Penalty weights are always negative (drag the score
+              // down). See category-weight block for the broader a11y
+              // rationale on explicit bounds.
+              min={-100}
+              max={0}
               className='w-16 rounded border border-border bg-surface px-2 py-1 text-xs text-text-primary'
             />
           </label>


### PR DESCRIPTION
## Summary

Found via a real chrome-devtools end-to-end session on \`/targets/{id}\`. Five \`<input type='number'>\` weight inputs in \`ScoringProfileEditor\` were missing either \`min\`, \`max\`, or both. Chrome's a11y implementation reports \`aria-valuemax="0"\` for any number input without an explicit \`max\`, so:

- Screen readers announce **"max value reached"** on every value > 0 (including the live ones — category weight 2, domain weight 0.5).
- Keyboard arrow-step (↑/↓) gets the wrong upper bound.

WCAG 2.1 SC 4.1.2 — the role/value mismatch between a value of 2 and a reported max of 0 fails the criterion regardless of whether a real user runs into it today.

## Verification

Pre-fix, the live a11y tree showed:

\`\`\`
spinbutton "Weight for core_skills category"     value="2"   valuemax="0" valuemin="0"
spinbutton "Weight for nice_to_have category"    value="0.5" valuemax="0" valuemin="0"
spinbutton "Weight for secondary_skills category" value="1"  valuemax="0" valuemin="0"
spinbutton "Domain weight"                       value="0.5" valuemax="0" valuemin="0"
spinbutton "Negative keywords weight"            value="-10" valuemax="0" valuemin="0"
\`\`\`

Post-fix:

\`\`\`
spinbutton "Weight for core_skills category"     value="2"   valuemax="10"  valuemin="0"
spinbutton "Weight for nice_to_have category"    value="0.5" valuemax="10"  valuemin="0"
spinbutton "Weight for secondary_skills category" value="1"  valuemax="10"  valuemin="0"
spinbutton "Domain weight"                       value="0.5" valuemax="10"  valuemin="0"
spinbutton "Negative keywords weight"            value="-10" valuemax="0"   valuemin="-100"
\`\`\`

The penalty bounds are intentionally asymmetric — those weights must be ≤ 0 since they drag the score down; \`max=0\` matches the real product constraint.

## Test plan

- [x] \`pnpm tsc --noEmit\` clean
- [x] \`pnpm nx test wyrdfold --skip-nx-cache -- --testPathPatterns='ScoringProfileEditor'\` — 5/5 pass
- [x] Chrome a11y tree confirms honest \`valuemin\` / \`valuemax\` on the running dev server post-fix
- [ ] Smoke: edit a category weight via keyboard ↑/↓ in a screen-reader env — bounds announced correctly

## Other findings from the same session (NOT in this PR)

- 4× console errors per job-detail visit from expected \`/api/jobs/tailor/by-job/{id}\` 404s — browser auto-logs all 404s. Functionally correct, but pollutes Sentry. Could be fixed by switching the "no record" response to 200 + null body, but that's a wider API contract change.
- \`Settings > Email Notifications\` shows "Sending to: hello@danieljoffe.com" *under* the operator-disabled switch — UX implies sending will happen. Minor.
- Strict Mode dev double-fetches on every page — dev-only React behavior, not a prod bug.