### PR TITLE
fix(wyrdfold): a11y — drop nested <main> in resume + cover-letter review pages

### DIFF
--- a/apps/wyrdfold/src/app/(app)/jobs/[id]/cover-letter/CoverLetterReviewPage.tsx
+++ b/apps/wyrdfold/src/app/(app)/jobs/[id]/cover-letter/CoverLetterReviewPage.tsx
@@ -380,9 +380,12 @@ export default function CoverLetterReviewPage({
     setVersionsOpen(false);
   }
 
+  // ``(app)/layout.tsx`` already supplies the page's ``<main>``
+  // landmark — wrapping page content in a second ``<main>`` here
+  // gives SR users two main landmarks per page (WCAG 1.3.1).
   if (notFound) {
     return (
-      <main className='mx-auto max-w-4xl p-6'>
+      <div className='mx-auto max-w-4xl p-6'>
         <Heading variant='hero' as='h1'>
           Cover letter not found
         </Heading>
@@ -396,15 +399,16 @@ export default function CoverLetterReviewPage({
         >
           <ArrowLeft className='h-4 w-4' /> Back to job
         </Link>
-      </main>
+      </div>
     );
   }
 
   if (loading || !record || !posting) {
     return (
-      <main
+      <div
         className='mx-auto max-w-4xl space-y-4 p-6'
         aria-label='Loading cover letter'
+        role='status'
       >
         {/* Back link */}
         <Skeleton className='h-5 w-24' />
@@ -437,14 +441,14 @@ export default function CoverLetterReviewPage({
 
         {/* Markdown editor */}
         <Skeleton variant='rectangular' className='h-[60vh] w-full' />
-      </main>
+      </div>
     );
   }
 
   const isApproved = record.approved_at !== null;
 
   return (
-    <main className='mx-auto max-w-4xl space-y-4 p-6'>
+    <div className='mx-auto max-w-4xl space-y-4 p-6'>
       <div className='flex items-center justify-between'>
         <Link
           href={`/jobs/${jobPostingId}`}
@@ -670,7 +674,7 @@ export default function CoverLetterReviewPage({
           </Text>
         </div>
       </div>
-    </main>
+    </div>
   );
 }
 

--- a/apps/wyrdfold/src/app/(app)/jobs/[id]/resume/ResumeReviewPage.tsx
+++ b/apps/wyrdfold/src/app/(app)/jobs/[id]/resume/ResumeReviewPage.tsx
@@ -386,9 +386,13 @@ export default function ResumeReviewPage({
     setVersionsOpen(false);
   }
 
+  // The ``(app)/layout.tsx`` wrapper already supplies the page's
+  // ``<main id="main-content">`` landmark. Wrapping page-level content
+  // in a second ``<main>`` here gave SR users two main landmarks per
+  // page (WCAG 1.3.1 / ARIA spec). Use ``<div>`` instead.
   if (notFound) {
     return (
-      <main className='mx-auto max-w-4xl p-6'>
+      <div className='mx-auto max-w-4xl p-6'>
         <Heading variant='hero' as='h1'>
           Resume not found
         </Heading>
@@ -402,15 +406,16 @@ export default function ResumeReviewPage({
         >
           <ArrowLeft className='h-4 w-4' /> Back to job
         </Link>
-      </main>
+      </div>
     );
   }
 
   if (loading || !record || !posting) {
     return (
-      <main
+      <div
         className='mx-auto max-w-4xl space-y-4 p-6'
         aria-label='Loading resume'
+        role='status'
       >
         {/* Back link */}
         <Skeleton className='h-5 w-24' />
@@ -443,7 +448,7 @@ export default function ResumeReviewPage({
 
         {/* Markdown editor */}
         <Skeleton variant='rectangular' className='h-[60vh] w-full' />
-      </main>
+      </div>
     );
   }
 
@@ -452,7 +457,7 @@ export default function ResumeReviewPage({
     record.warnings?.includes('reused_from_similar_job') ?? false;
 
   return (
-    <main className='mx-auto max-w-4xl space-y-4 p-6'>
+    <div className='mx-auto max-w-4xl space-y-4 p-6'>
       <div className='flex items-center justify-between'>
         <Link
           href={`/jobs/${jobPostingId}`}
@@ -687,7 +692,7 @@ export default function ResumeReviewPage({
           </Text>
         </div>
       </div>
-    </main>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary

Found via the chrome-devtools end-to-end session. \`ResumeReviewPage\` and \`CoverLetterReviewPage\` each opened their page-level content with \`<main>\` — but \`(app)/layout.tsx\` already supplies a \`<main id="main-content">\` landmark for every authed route. SR users on the review pages saw two \`<main>\` landmarks, which breaks landmark-based navigation and fails WCAG 1.3.1.

## Verification

Pre-fix:

\`\`\`js
document.querySelectorAll('main') → [
  { id: 'main-content' },  // (app)/layout.tsx
  { id: '' }               // ResumeReviewPage
]
\`\`\`

Post-fix: 1 main per page (the layout's).

## Scope

Each file has three render branches that all opened \`<main>\`:
- loading skeleton
- not-found fallback
- normal review

→ 6 \`<main>\` → \`<div>\` swaps total. The loading branches keep their \`aria-label="Loading X"\` and gain \`role="status"\` so the skeleton still announces appropriately to SR users.

## Test plan

- [x] \`pnpm tsc --noEmit\` clean
- [x] \`pnpm nx test wyrdfold --skip-nx-cache -- --testPathPatterns='ResumeReviewPage|CoverLetterReviewPage'\` — 6/6 pass
- [x] Live browser confirmed: \`document.querySelectorAll('main')\` returns 1 element after the fix