### PR TITLE
fix(wyrdfold): move re-adapt + lock behind ⋮ menu on review pages

### DIFF
--- a/apps/wyrdfold/src/app/(app)/jobs/[id]/cover-letter/CoverLetterReviewPage.tsx
+++ b/apps/wyrdfold/src/app/(app)/jobs/[id]/cover-letter/CoverLetterReviewPage.tsx
@@ -2,7 +2,16 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import Link from 'next/link';
-import { ArrowLeft, Download, Lock, RotateCcw, Unlock } from 'lucide-react';
+import {
+  ArrowLeft,
+  Download,
+  Lock,
+  MoreVertical,
+  RotateCcw,
+  Unlock,
+} from 'lucide-react';
+import { Dropdown } from '@danieljoffe.com/shared-ui/Dropdown';
+import type { DropdownItem } from '@danieljoffe.com/shared-ui/Dropdown';
 import { Badge } from '@danieljoffe.com/shared-ui/Badge';
 import { Heading } from '@danieljoffe.com/shared-ui/Heading';
 import { Skeleton } from '@danieljoffe.com/shared-ui/Skeleton';
@@ -584,6 +593,10 @@ export default function CoverLetterReviewPage({
           <Text variant='caption' as='span'>
             Cover letter markdown
           </Text>
+          {/* Same rationale as ResumeReviewPage: Download stays as
+              a standalone icon (frequent, free, non-destructive);
+              Re-generate (LLM-billed) and Lock/Unlock move behind a
+              ``⋮`` menu to prevent mis-tap of high-cost actions. */}
           <div className='flex items-center gap-1'>
             <Button
               name='download-cover-letter-docx'
@@ -597,55 +610,52 @@ export default function CoverLetterReviewPage({
             >
               <Download className='h-4 w-4' aria-hidden='true' />
             </Button>
-            <Button
-              name='regenerate-cover-letter'
-              variant='ghost'
-              size='sm'
-              iconOnly
-              aria-label='Re-generate cover letter with AI'
-              title='Re-generate with AI'
-              onClick={handleRegenerate}
-              disabled={
-                regenerating ||
-                approving ||
-                saveStatus === 'saving' ||
-                isApproved
+            <Dropdown
+              align='right'
+              trigger={
+                <span
+                  className='inline-flex h-8 w-8 items-center justify-center rounded text-text-secondary hover:bg-surface-tertiary hover:text-text-primary'
+                  aria-label='More actions'
+                  title='More actions'
+                >
+                  <MoreVertical className='h-4 w-4' aria-hidden='true' />
+                </span>
               }
-            >
-              <RotateCcw className='h-4 w-4' aria-hidden='true' />
-            </Button>
-            {isApproved ? (
-              <Button
-                name='unlock-cover-letter'
-                variant='ghost'
-                size='sm'
-                iconOnly
-                aria-label='Unlock cover letter for editing'
-                title='Unlock for editing'
-                onClick={handleUnapprove}
-                disabled={unapproving}
-              >
-                <Unlock className='h-4 w-4' aria-hidden='true' />
-              </Button>
-            ) : (
-              <Button
-                name='lock-cover-letter'
-                variant='ghost'
-                size='sm'
-                iconOnly
-                aria-label='Lock cover letter from editing'
-                title='Lock from editing'
-                onClick={handleApprove}
-                disabled={
-                  approving ||
-                  saveStatus === 'pending' ||
-                  saveStatus === 'saving' ||
-                  saveStatus === 'error'
-                }
-              >
-                <Lock className='h-4 w-4' aria-hidden='true' />
-              </Button>
-            )}
+              items={[
+                {
+                  label: 'Re-generate with AI',
+                  icon: <RotateCcw className='size-4' aria-hidden />,
+                  onClick: handleRegenerate,
+                  disabled:
+                    regenerating ||
+                    approving ||
+                    saveStatus === 'saving' ||
+                    isApproved,
+                },
+                ...(isApproved
+                  ? [
+                      {
+                        label: 'Unlock for editing',
+                        icon: <Unlock className='size-4' aria-hidden />,
+                        onClick: handleUnapprove,
+                        disabled: unapproving,
+                      } satisfies DropdownItem,
+                    ]
+                  : [
+                      {
+                        label: 'Lock from editing',
+                        icon: <Lock className='size-4' aria-hidden />,
+                        onClick: handleApprove,
+                        danger: true,
+                        disabled:
+                          approving ||
+                          saveStatus === 'pending' ||
+                          saveStatus === 'saving' ||
+                          saveStatus === 'error',
+                      } satisfies DropdownItem,
+                    ]),
+              ]}
+            />
           </div>
         </div>
         <textarea

--- a/apps/wyrdfold/src/app/(app)/jobs/[id]/resume/ResumeReviewPage.tsx
+++ b/apps/wyrdfold/src/app/(app)/jobs/[id]/resume/ResumeReviewPage.tsx
@@ -2,8 +2,17 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import Link from 'next/link';
-import { ArrowLeft, Download, Lock, RotateCcw, Unlock } from 'lucide-react';
+import {
+  ArrowLeft,
+  Download,
+  Lock,
+  MoreVertical,
+  RotateCcw,
+  Unlock,
+} from 'lucide-react';
 import { Badge } from '@danieljoffe.com/shared-ui/Badge';
+import { Dropdown } from '@danieljoffe.com/shared-ui/Dropdown';
+import type { DropdownItem } from '@danieljoffe.com/shared-ui/Dropdown';
 import { Heading } from '@danieljoffe.com/shared-ui/Heading';
 import { Skeleton } from '@danieljoffe.com/shared-ui/Skeleton';
 import { Text } from '@danieljoffe.com/shared-ui/Text';
@@ -605,6 +614,15 @@ export default function ResumeReviewPage({
           <Text variant='caption' as='span'>
             Resume markdown
           </Text>
+          {/* Download stays as a standalone icon — it's frequent,
+              non-destructive, and free. Re-adapt (LLM-billed) and
+              Lock/Unlock (irreversible from the lock side) move
+              behind a ``⋮`` menu so they can't be mis-tapped when
+              the user meant to download. Found via a real
+              chrome-devtools session: the previous icon row was
+              28×28 buttons in a tight cluster — adjacent 44×44
+              touch targets overlapped, so a sloppy tap on
+              Download could fire Re-adapt instead. */}
           <div className='flex items-center gap-1'>
             <Button
               name='download-docx'
@@ -618,52 +636,56 @@ export default function ResumeReviewPage({
             >
               <Download className='h-4 w-4' aria-hidden='true' />
             </Button>
-            <Button
-              name='readapt-resume'
-              variant='ghost'
-              size='sm'
-              iconOnly
-              aria-label='Re-adapt resume with AI'
-              title='Re-adapt with AI'
-              onClick={handleReadapt}
-              disabled={
-                readapting || approving || saveStatus === 'saving' || isApproved
+            <Dropdown
+              align='right'
+              trigger={
+                <span
+                  className='inline-flex h-8 w-8 items-center justify-center rounded text-text-secondary hover:bg-surface-tertiary hover:text-text-primary'
+                  aria-label='More actions'
+                  title='More actions'
+                >
+                  <MoreVertical className='h-4 w-4' aria-hidden='true' />
+                </span>
               }
-            >
-              <RotateCcw className='h-4 w-4' aria-hidden='true' />
-            </Button>
-            {isApproved ? (
-              <Button
-                name='unlock-resume'
-                variant='ghost'
-                size='sm'
-                iconOnly
-                aria-label='Unlock resume for editing'
-                title='Unlock for editing'
-                onClick={handleUnapprove}
-                disabled={unapproving}
-              >
-                <Unlock className='h-4 w-4' aria-hidden='true' />
-              </Button>
-            ) : (
-              <Button
-                name='lock-resume'
-                variant='ghost'
-                size='sm'
-                iconOnly
-                aria-label='Lock resume from editing'
-                title='Lock from editing'
-                onClick={handleApprove}
-                disabled={
-                  approving ||
-                  saveStatus === 'pending' ||
-                  saveStatus === 'saving' ||
-                  saveStatus === 'error'
-                }
-              >
-                <Lock className='h-4 w-4' aria-hidden='true' />
-              </Button>
-            )}
+              items={[
+                {
+                  label: 'Re-adapt with AI',
+                  icon: <RotateCcw className='size-4' aria-hidden />,
+                  onClick: handleReadapt,
+                  disabled:
+                    readapting ||
+                    approving ||
+                    saveStatus === 'saving' ||
+                    isApproved,
+                },
+                ...(isApproved
+                  ? [
+                      {
+                        label: 'Unlock for editing',
+                        icon: <Unlock className='size-4' aria-hidden />,
+                        onClick: handleUnapprove,
+                        disabled: unapproving,
+                      } satisfies DropdownItem,
+                    ]
+                  : [
+                      {
+                        label: 'Lock from editing',
+                        icon: <Lock className='size-4' aria-hidden />,
+                        onClick: handleApprove,
+                        // Lock is mostly-irreversible (Unlock is
+                        // available via the menu, but the doc
+                        // status flips downstream) — mark danger
+                        // so the menu styles it accordingly.
+                        danger: true,
+                        disabled:
+                          approving ||
+                          saveStatus === 'pending' ||
+                          saveStatus === 'saving' ||
+                          saveStatus === 'error',
+                      } satisfies DropdownItem,
+                    ]),
+              ]}
+            />
           </div>
         </div>
         <textarea


### PR DESCRIPTION
## Summary

Found via the chrome-devtools end-to-end session. The review-page toolbar (\`ResumeReviewPage\` + \`CoverLetterReviewPage\`) packed three 28×28 icon buttons — Download / Re-adapt / Lock — into a tight cluster. When you overlay the Apple HIG 44×44 minimum touch target on top, adjacent guides overlap each other horizontally:

![Before — 3 icons clustered, 28×28 actual vs 44×44 HIG guides overlapping](https://user-images.githubusercontent.com/placeholder/before.png)

A sloppy tap on Download could fire **Re-adapt** (LLM-billed real money) or **Lock** (mostly-irreversible) instead of just downloading the .docx. The asymmetry of consequences is the bug — Download is free and idempotent; Re-adapt and Lock aren't.

## Fix — restructure, don't just resize

The simpler fix (just bump button sizes) was rejected in favour of structural separation:

- **Download** stays as a standalone icon button — it's frequent, free, non-destructive, and benefits from quick access.
- **Re-adapt** and **Lock / Unlock** move behind a single \`⋮ More actions\` trigger that opens a \`role=\"menu\"\` dropdown with comfortably-sized rows.
- The two destructive paths now require **deliberate two-step interaction** (open menu → click item). A mis-tap on Download can't accidentally bill an LLM call or lock the doc.
- \`Lock from editing\` is styled with \`danger: true\` so the menu surfaces the irreversibility visually.
- \`align='right'\` on the dropdown so the menu doesn't overflow the page edge.

Same restructure applied to \`CoverLetterReviewPage\` for parity — the two files share the toolbar shape.

## Test plan

- [x] \`pnpm tsc --noEmit\` clean
- [x] \`pnpm nx test wyrdfold --skip-nx-cache -- --testPathPatterns='ResumeReviewPage|CoverLetterReviewPage'\` — 6/6 pass (existing tests don't exercise the toolbar interactions, so they pass without changes)
- [x] Live in browser: menu opens with \`aria-expanded=\"true\"\`, first actionable item auto-focused, Escape closes and returns focus to the trigger.
- [ ] Smoke: tap Download → only download fires. Open menu, tap Re-adapt → re-adapt confirmation flows. Open menu, tap Lock → lock confirmation flows. Approved doc opens menu and shows Unlock instead of Lock.

## Not in this PR

Download itself is still 28×28. Its mis-tap risk is bounded now (no destructive neighbour), but if you want WCAG 2.5.5 AAA compliance across the board it could be bumped to 36–44px in a follow-up. Same goes for the \`⋮\` trigger.