### PR TITLE
fix(wyrdfold): four quick UX/a11y wins from chrome-devtools sessions

### DIFF
--- a/apps/wyrdfold/src/app/(app)/MoreSheet.tsx
+++ b/apps/wyrdfold/src/app/(app)/MoreSheet.tsx
@@ -16,6 +16,11 @@ export interface MoreSheetItem {
 }
 
 interface MoreSheetProps {
+  /**
+   * Stable id used by the trigger button's `aria-controls` so assistive
+   * tech can link the "More" button to this dialog.
+   */
+  id: string;
   open: boolean;
   onClose: () => void;
   items: MoreSheetItem[];
@@ -30,6 +35,7 @@ interface MoreSheetProps {
  * sidebar bundle on every authed page.
  */
 export default function MoreSheet({
+  id,
   open,
   onClose,
   items,
@@ -76,6 +82,7 @@ export default function MoreSheet({
 
       <div
         ref={sheetRef}
+        id={id}
         role='dialog'
         aria-label='More navigation'
         aria-modal='true'

--- a/apps/wyrdfold/src/app/(app)/WyrdfoldSidebar.tsx
+++ b/apps/wyrdfold/src/app/(app)/WyrdfoldSidebar.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useCallback, useRef } from 'react';
+import { useState, useCallback, useRef, useId } from 'react';
 import dynamic from 'next/dynamic';
 import Link from 'next/link';
 import { usePathname, useRouter } from 'next/navigation';
@@ -68,6 +68,9 @@ export default function WyrdfoldSidebar() {
 
   const [sheetOpen, setSheetOpen] = useState(false);
   const moreButtonRef = useRef<HTMLButtonElement>(null);
+  // Stable id linking the "More" trigger to the MoreSheet dialog so
+  // assistive tech can announce the relationship (aria-controls).
+  const moreSheetId = useId();
 
   const closeSheet = useCallback(() => {
     setSheetOpen(false);
@@ -188,6 +191,7 @@ export default function WyrdfoldSidebar() {
             ref={moreButtonRef}
             onClick={sheetOpen ? closeSheet : () => setSheetOpen(true)}
             aria-expanded={sheetOpen}
+            aria-controls={moreSheetId}
             aria-label={sheetOpen ? 'Close more menu' : 'Open more menu'}
             className={cn(
               'flex flex-col items-center justify-center flex-1 gap-0.5 p-0 rounded-none hover:scale-100 text-[10px] font-medium transition-colors cursor-pointer',
@@ -207,6 +211,7 @@ export default function WyrdfoldSidebar() {
           the user taps "More". */}
       {sheetOpen && (
         <MoreSheet
+          id={moreSheetId}
           open={sheetOpen}
           onClose={closeSheet}
           items={MORE_ITEMS}

--- a/apps/wyrdfold/src/app/(app)/insights/InsightsDashboard.tsx
+++ b/apps/wyrdfold/src/app/(app)/insights/InsightsDashboard.tsx
@@ -392,7 +392,7 @@ export default function InsightsDashboard() {
               <Text variant='meta'>
                 Total: ${skillsCost.total_cost.toFixed(2)}
                 {skillsCost.avg_cost_per_resume !== null &&
-                  ` | Avg/resume: $${skillsCost.avg_cost_per_resume.toFixed(3)}`}
+                  ` | Avg/resume: $${skillsCost.avg_cost_per_resume.toFixed(2)}`}
               </Text>
             )}
           </div>

--- a/apps/wyrdfold/src/app/(app)/jobs/[id]/JobDetailPage.tsx
+++ b/apps/wyrdfold/src/app/(app)/jobs/[id]/JobDetailPage.tsx
@@ -32,6 +32,17 @@ export default function JobDetailPage({ id, targetId }: JobDetailPageProps) {
   const router = useRouter();
   const { toast } = useToast();
 
+  // Reflect the 404 state in the tab title so the browser tab/history
+  // doesn't read "Job Detail | WyrdFold" for a job that doesn't exist.
+  useEffect(() => {
+    if (!notFound) return;
+    const previousTitle = document.title;
+    document.title = 'Job not found | WyrdFold';
+    return () => {
+      document.title = previousTitle;
+    };
+  }, [notFound]);
+
   useEffect(() => {
     let cancelled = false;
     async function load() {

--- a/apps/wyrdfold/src/app/(app)/settings/SettingsPage.tsx
+++ b/apps/wyrdfold/src/app/(app)/settings/SettingsPage.tsx
@@ -522,7 +522,7 @@ export default function SettingsPage() {
               the email provider credentials.
             </Text>
           )}
-          {prefs?.email && (
+          {emailAvailable && prefs?.email && (
             <Text variant='meta' className='text-text-tertiary'>
               Sending to: {prefs.email}
             </Text>


### PR DESCRIPTION
## Summary

Four small, independent UX / a11y fixes uncovered during chrome-devtools walkthroughs, bundled into one PR.

### 1. Settings — hide "Sending to: <email>" when email channel is operator-disabled
`apps/wyrdfold/src/app/(app)/settings/SettingsPage.tsx` — the Email Notifications card already shows "Email notifications are unavailable until the operator configures the email provider credentials." when `prefs.email_available === false`. Gating the "Sending to:" line on `emailAvailable` removes the contradictory copy so users don't see "Sending to: foo@bar" right next to "email is unavailable".

### 2. Job detail — dynamic tab title on the not-found state
`apps/wyrdfold/src/app/(app)/jobs/[id]/JobDetailPage.tsx` — when the API returns 404 the body switches to "Job not found" but the tab stayed "Job Detail | WyrdFold". Added a `useEffect` that sets `document.title = 'Job not found | WyrdFold'` while `notFound` is true and restores the previous title on cleanup.

### 3. Mobile bottom nav — wire `aria-controls` on the "Open more menu" trigger
`apps/wyrdfold/src/app/(app)/WyrdfoldSidebar.tsx` + `apps/wyrdfold/src/app/(app)/MoreSheet.tsx` — the trigger had `aria-expanded` but no `aria-controls` linking it to the dialog. Added a stable `useId()` in the sidebar, set it as `aria-controls` on the trigger button, and threaded it through `MoreSheet` so the dialog `<div role='dialog' aria-label='More navigation'>` carries the same `id`.

### 4. Insights — consistent decimal format on LLM Cost summary
`apps/wyrdfold/src/app/(app)/insights/InsightsDashboard.tsx` — the summary read `Total: $3.52 | Avg/resume: $3.524` because Total used `.toFixed(2)` and Avg/resume used `.toFixed(3)`. Both now use `.toFixed(2)`.

## Test plan

- [x] `pnpm tsc --noEmit` clean
- [x] `pnpm nx test wyrdfold` covering SettingsPage / JobDetailPage / InsightsDashboard / WyrdfoldSidebar / MoreSheet — 23 passed
- [ ] Manual: Settings page with `email_available: false` no longer shows the "Sending to:" line
- [ ] Manual: navigate to a deleted job's URL — tab title flips to "Job not found | WyrdFold"
- [ ] Manual: inspect mobile "More" button — `aria-controls` matches the dialog's `id`
- [ ] Manual: Insights LLM Cost reads `Total: $X.XX | Avg/resume: $Y.YY` (two decimals on both)

Generated with [Claude Code](https://claude.com/claude-code)