### PR TITLE
fix(wyrdfold): mount sidebar shell on root not-found page

### DIFF
--- a/apps/wyrdfold/src/app/not-found.tsx
+++ b/apps/wyrdfold/src/app/not-found.tsx
@@ -2,6 +2,7 @@ import { Card, CardContent } from '@danieljoffe.com/shared-ui/Card';
 import { Heading } from '@danieljoffe.com/shared-ui/Heading';
 import { Text } from '@danieljoffe.com/shared-ui/Text';
 import Button from '@/components/Button';
+import WyrdfoldSidebar from './(app)/WyrdfoldSidebar';
 
 /**
  * Catches unmatched URLs that don't fall inside any route segment.
@@ -12,30 +13,43 @@ import Button from '@/components/Button';
  * `not-found.tsx` — this one. The middleware has already redirected
  * unauthenticated users to `/login`, so anyone landing here is signed
  * in and just typed a wrong URL.
+ *
+ * Wrap the content in the same sidebar shell ``(app)/layout.tsx``
+ * provides so the user keeps direct nav to every authed route from
+ * the not-found screen. Without this, the user has only "Back to
+ * dashboard" and has to navigate from there to anywhere else.
  */
 export default function NotFound() {
   return (
-    <main className='min-h-screen flex items-center justify-center p-6'>
-      <Card className='max-w-md w-full'>
-        <CardContent className='flex flex-col items-center gap-4 py-12 text-center'>
-          <Heading variant='hero' as='h1'>
-            Page not found
-          </Heading>
-          <Text variant='body' as='p' className='max-w-sm'>
-            We couldn&apos;t find that page. It may have moved, been removed, or
-            never existed.
-          </Text>
-          <Button
-            name='wyrdfold-root-not-found-home'
-            variant='primary'
-            size='sm'
-            as='link'
-            href='/dashboard'
-          >
-            Back to dashboard
-          </Button>
-        </CardContent>
-      </Card>
-    </main>
+    <div className='flex min-h-screen'>
+      <WyrdfoldSidebar />
+      <main
+        id='main-content'
+        className='flex-1 overflow-x-hidden p-4 pb-[calc(theme(spacing.16)+env(safe-area-inset-bottom)+1rem)] md:p-6'
+      >
+        <div className='flex min-h-full items-center justify-center'>
+          <Card className='max-w-md w-full'>
+            <CardContent className='flex flex-col items-center gap-4 py-12 text-center'>
+              <Heading variant='hero' as='h1'>
+                Page not found
+              </Heading>
+              <Text variant='body' as='p' className='max-w-sm'>
+                We couldn&apos;t find that page. It may have moved, been
+                removed, or never existed.
+              </Text>
+              <Button
+                name='wyrdfold-root-not-found-home'
+                variant='primary'
+                size='sm'
+                as='link'
+                href='/dashboard'
+              >
+                Back to dashboard
+              </Button>
+            </CardContent>
+          </Card>
+        </div>
+      </main>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary

Found in the session 3 chrome-devtools driving. The root \`not-found.tsx\` (which fires for any URL that doesn't match an \`(app)\` route segment — e.g., \`/this-does-not-exist\`) renders a barebones "Page not found" card with only a "Back to dashboard" button. The sidebar nav that wraps every other authed surface is missing, so a user who typed a wrong URL has to first land on /dashboard before they can navigate anywhere else.

The docstring already notes:

> The middleware has already redirected unauthenticated users to \`/login\`, so anyone landing here is signed in and just typed a wrong URL.

So showing them the same sidebar nav they're used to is the natural fix.

## Approach

Re-uses the same \`flex min-h-screen\` shell + \`<main id='main-content'>\` padding as \`(app)/layout.tsx\`, including the mobile-safe-area bottom padding. The "Page not found" Card sits centered inside the main column.

\`WyrdfoldSidebar\` is imported via a one-up relative path \`./(app)/WyrdfoldSidebar\` — slightly ugly, but the alternative (extracting the sidebar to its own non-(app) location) is more invasive than the value justifies.

## Test plan

- [x] \`pnpm tsc --noEmit\` clean
- [ ] Smoke: navigate to \`/this-does-not-exist\` (or any other unmatched URL) while signed in — sidebar renders alongside the "Page not found" card, every nav link clickable
- [ ] Smoke: nav still works on mobile (the bottom tab bar should appear; safe-area padding intact)