### PR TITLE
fix(wyrdfold): tailor by-job returns 200 + null instead of 404 (silences console noise)

### DIFF
--- a/apps/wyrdfold-api/app/routers/tailor.py
+++ b/apps/wyrdfold-api/app/routers/tailor.py
@@ -305,12 +305,17 @@ async def get_resume_by_job(
     job_posting_id: str,
     supabase: Client = Depends(get_supabase),
     user_id: str | None = Depends(get_current_user_id_optional),
-) -> TailoredResumeRecord:
-    """Most recent resume for a given job posting."""
-    row = persistence.get_by_job(supabase, job_posting_id, user_id=user_id)
-    if row is None:
-        raise HTTPException(status_code=404, detail="no resume found for this job posting")
-    return row
+) -> TailoredResumeRecord | None:
+    """Most recent resume for a given job posting, or ``null`` if none exists.
+
+    Returns ``null`` with a 200 status (rather than 404) for the
+    "no record yet" case so the browser doesn't log a "Failed to
+    load resource: 404" console error on every job-detail visit
+    before generation. The FE consumer (``ResumeSection``) treats
+    ``null`` and 404 the same way — render a "Generate Resume"
+    CTA — so dropping the 404 is a no-op for the user.
+    """
+    return persistence.get_by_job(supabase, job_posting_id, user_id=user_id)
 
 
 @router.get("/cover-letters/by-job/{job_posting_id}")
@@ -318,14 +323,14 @@ async def get_cover_letter_by_job(
     job_posting_id: str,
     supabase: Client = Depends(get_supabase),
     user_id: str | None = Depends(get_current_user_id_optional),
-) -> TailoredResumeRecord:
-    """Most recent cover letter for a given job posting."""
-    row = persistence.get_by_job(
+) -> TailoredResumeRecord | None:
+    """Most recent cover letter for a given job posting, or ``null``
+    if none exists. See ``get_resume_by_job`` for the 200-with-null
+    rationale.
+    """
+    return persistence.get_by_job(
         supabase, job_posting_id, user_id=user_id, document_type="cover_letter"
     )
-    if row is None:
-        raise HTTPException(status_code=404, detail="no cover letter found for this job posting")
-    return row
 
 
 @router.post("/resumes/export-zip")

--- a/apps/wyrdfold-api/tests/test_resume_lifecycle.py
+++ b/apps/wyrdfold-api/tests/test_resume_lifecycle.py
@@ -680,25 +680,26 @@ class TestGetByJob:
         assert result.job_posting_id == "job-1"
 
     @pytest.mark.asyncio
-    async def test_get_by_job_not_found(self) -> None:
-        from fastapi import HTTPException
-
+    async def test_get_by_job_returns_none_when_missing(self) -> None:
+        """The route returns ``None`` (200 + null body) instead of raising
+        a 404 when no record exists — the FE consumer treats null as
+        "no record yet, render the Generate CTA", and dropping the 404
+        avoids polluting Sentry with a console error on every
+        job-detail visit before generation.
+        """
         from app.routers import tailor as tailor_router
 
         supabase = MagicMock()
 
-        with (
-            patch(
-                "app.services.tailor.persistence.get_by_job",
-                return_value=None,
-            ),
-            pytest.raises(HTTPException) as exc_info,
+        with patch(
+            "app.services.tailor.persistence.get_by_job",
+            return_value=None,
         ):
-            await tailor_router.get_resume_by_job(
+            result = await tailor_router.get_resume_by_job(
                 job_posting_id="nonexistent",
                 supabase=supabase,
             )
-        assert exc_info.value.status_code == 404
+        assert result is None
 
 
 # ---------------------------------------------------------------------------

--- a/apps/wyrdfold/src/app/(app)/jobs/CoverLetterSection.tsx
+++ b/apps/wyrdfold/src/app/(app)/jobs/CoverLetterSection.tsx
@@ -32,12 +32,10 @@ export default function CoverLetterSection({
       const res = await fetch(
         `/api/jobs/tailor/by-job/${jobPostingId}/cover-letter`
       );
-      if (res.status === 404) {
-        setRecord(null);
-        return;
-      }
+      // The route returns 200 with a ``null`` body when no record
+      // exists yet — see ``ResumeSection`` for the rationale.
       if (!res.ok) return;
-      const data = (await res.json()) as TailoredResumeRecord;
+      const data = (await res.json()) as TailoredResumeRecord | null;
       setRecord(data);
     } catch {
       // Non-critical — silently fail on initial load

--- a/apps/wyrdfold/src/app/(app)/jobs/ResumeSection.tsx
+++ b/apps/wyrdfold/src/app/(app)/jobs/ResumeSection.tsx
@@ -34,12 +34,15 @@ export default function ResumeSection({ jobPostingId }: ResumeSectionProps) {
     setLoading(true);
     try {
       const res = await fetch(`/api/jobs/tailor/by-job/${jobPostingId}`);
-      if (res.status === 404) {
-        setRecord(null);
-        return;
-      }
+      // The route returns 200 with a ``null`` body when no record
+      // exists yet — see the route docstring in
+      // ``wyrdfold-api/app/routers/tailor.py``. Treating ``null``
+      // the same way the legacy 404 was treated (record = null →
+      // render the Generate CTA) means the only observable change
+      // is that the browser no longer logs a 404 to the console
+      // on every job-detail visit before generation.
       if (!res.ok) return;
-      const data = (await res.json()) as TailoredResumeRecord;
+      const data = (await res.json()) as TailoredResumeRecord | null;
       setRecord(data);
     } catch {
       // Non-critical — silently fail on initial load

--- a/apps/wyrdfold/src/app/(app)/jobs/__tests__/CoverLetterSection.spec.tsx
+++ b/apps/wyrdfold/src/app/(app)/jobs/__tests__/CoverLetterSection.spec.tsx
@@ -75,10 +75,15 @@ afterAll(() => {
 
 describe('CoverLetterSection', () => {
   it('renders the empty/not-started state with a Generate CTA when no record exists', async () => {
+    // ``/api/jobs/tailor/by-job/{id}/cover-letter`` now returns 200
+    // with a ``null`` body when no record exists (was 404). The
+    // section treats both null and the old 404 the same way —
+    // render the Generate CTA — see the route docstring for the
+    // browser-console-noise rationale.
     global.fetch = jest.fn().mockResolvedValue({
-      ok: false,
-      status: 404,
-      json: async () => ({}),
+      ok: true,
+      status: 200,
+      json: async () => null,
     }) as unknown as typeof fetch;
 
     render(
@@ -142,12 +147,15 @@ describe('CoverLetterSection', () => {
     const calls: string[] = [];
     global.fetch = jest.fn().mockImplementation((url: string) => {
       calls.push(url);
-      // Initial fetch — 404 (no existing record)
+      // Initial fetch — 200 with null body (no existing record).
+      // Switched from 404 in the by-job route to avoid the
+      // browser auto-logging a console error on every job-detail
+      // visit before generation.
       if (calls.length === 1) {
         return Promise.resolve({
-          ok: false,
-          status: 404,
-          json: async () => ({}),
+          ok: true,
+          status: 200,
+          json: async () => null,
         });
       }
       // Generate POST — 500


### PR DESCRIPTION
## Summary

Every visit to a job-detail page before resume / cover-letter generation fired \`GET /api/jobs/tailor/by-job/{id}\` and \`/cover-letter\` lookups that returned **404** for the "no record yet" case. Chrome auto-logs every 404 as a console error, so each visit emitted 2× \`Failed to load resource: 404\` errors and polluted Sentry / DevTools. Functionally correct (both FE consumers explicitly handled the 404 → \`record = null\`), but noisy.

Both \`ResumeSection\` and \`CoverLetterSection\` already treated a 404 the same way they'd treat a 200 + null body: render the "Generate" CTA. Switching the route:

- drops the browser console error (200 isn't flagged)
- simplifies the FE — single \`setRecord(data)\` where \`data\` may be null vs. the special-case 404 branch
- changes nothing observable to the user — record is null either way

## Backend

\`\`\`diff
-) -> TailoredResumeRecord:
-    row = persistence.get_by_job(...)
-    if row is None:
-        raise HTTPException(status_code=404, detail="no resume found for this job posting")
-    return row
+) -> TailoredResumeRecord | None:
+    return persistence.get_by_job(...)
\`\`\`

Applied to both \`/resumes/by-job/{id}\` and \`/cover-letters/by-job/{id}\`. FastAPI serialises \`None\` to \`null\` with a 200 status by default — no response-model gymnastics needed.

## Test plan

- [x] \`pnpm tsc --noEmit\` clean
- [x] \`pnpm nx test wyrdfold-api\` — 849/849 pass (renamed the existing 404 test to assert ``None`` is returned)
- [x] \`pnpm nx test wyrdfold --testPathPatterns='CoverLetterSection|ResumeSection|JobDetailPanel|ResumeReviewPage|CoverLetterReviewPage'\` — 18/18 pass (two mocks in \`CoverLetterSection.spec\` updated to \`200 + null\`)
- [ ] Smoke: open a job detail page that has no resume yet → no \`Failed to load resource: 404\` in the Console panel for the resume / cover-letter by-job calls