### PR TITLE
fix(wyrdfold): checkpoint before restoring a version on the review pages

### DIFF
--- a/apps/wyrdfold/src/app/(app)/jobs/[id]/cover-letter/CoverLetterReviewPage.tsx
+++ b/apps/wyrdfold/src/app/(app)/jobs/[id]/cover-letter/CoverLetterReviewPage.tsx
@@ -374,7 +374,7 @@ export default function CoverLetterReviewPage({
     }
   }
 
-  function restoreVersion(version: ResumeVersion) {
+  async function restoreVersion(version: ResumeVersion) {
     const md = (version as ResumeVersion & { payload_md?: string | null })
       .payload_md;
     if (!md) {
@@ -384,6 +384,20 @@ export default function CoverLetterReviewPage({
       });
       return;
     }
+    /* eslint-disable no-alert -- personal tool, native confirm is fine */
+    if (
+      !window.confirm(
+        'Load this version? Your current draft is saved as a version first so you can roll back.'
+      )
+    )
+      /* eslint-enable no-alert */
+      return;
+    // Mirrors ResumeReviewPage — snapshot the live draft before
+    // ``setMarkdown(md)`` so the autosave that follows doesn't
+    // overwrite the live document without leaving a recoverable
+    // entry in version history.
+    await flushPendingSave();
+    await recordCheckpoint();
     setMarkdown(md);
     setSaveStatus('pending');
     setVersionsOpen(false);
@@ -575,6 +589,10 @@ export default function CoverLetterReviewPage({
                         name={`restore-version-${v.id}`}
                         variant='ghost'
                         size='sm'
+                        // Disambiguate "Load" for SR users when
+                        // multiple versions exist — see the same
+                        // pattern in ResumeReviewPage.
+                        aria-label={`Load ${v.source.replace('_', ' ')} version from ${new Date(v.created_at).toLocaleString()}`}
                         onClick={() => restoreVersion(v)}
                       >
                         Load

--- a/apps/wyrdfold/src/app/(app)/jobs/[id]/resume/ResumeReviewPage.tsx
+++ b/apps/wyrdfold/src/app/(app)/jobs/[id]/resume/ResumeReviewPage.tsx
@@ -377,7 +377,7 @@ export default function ResumeReviewPage({
     }
   }
 
-  function restoreVersion(version: ResumeVersion) {
+  async function restoreVersion(version: ResumeVersion) {
     // Versions before the markdown pivot stored only structured payload.
     // Newer versions include payload_md. We fall back to current markdown
     // if the snapshot has no markdown to restore.
@@ -390,6 +390,22 @@ export default function ResumeReviewPage({
       });
       return;
     }
+    /* eslint-disable no-alert -- personal tool, native confirm is fine */
+    if (
+      !window.confirm(
+        'Load this version? Your current draft is saved as a version first so you can roll back.'
+      )
+    )
+      /* eslint-enable no-alert */
+      return;
+    // Snapshot the current draft before swapping markdown so the
+    // pre-restore content is recoverable from the same version
+    // history dropdown. Mirrors handleReadapt's pre-mutate pattern.
+    // Without this, the autosave that fires after ``setMarkdown(md)``
+    // overwrites the live document with the loaded version and the
+    // unsnapshotted pre-restore content is lost.
+    await flushPendingSave();
+    await recordCheckpoint();
     setMarkdown(md);
     setSaveStatus('pending');
     setVersionsOpen(false);
@@ -596,6 +612,12 @@ export default function ResumeReviewPage({
                         name={`restore-version-${v.id}`}
                         variant='ghost'
                         size='sm'
+                        // "Load" by itself is ambiguous to SR users
+                        // when several versions are listed — they'd
+                        // hear "Load" repeated with no way to
+                        // distinguish. Disambiguate via the version
+                        // source + timestamp.
+                        aria-label={`Load ${v.source.replace('_', ' ')} version from ${new Date(v.created_at).toLocaleString()}`}
                         onClick={() => restoreVersion(v)}
                       >
                         Load


### PR DESCRIPTION
## Summary

Found via a chrome-devtools end-to-end session inspecting the version-history panel on \`/jobs/{id}/resume\`. Two real issues in \`restoreVersion\` shared by both \`ResumeReviewPage\` and \`CoverLetterReviewPage\`:

### 1. Restore overwrites the live document without a checkpoint

\`restoreVersion\` sets \`setMarkdown(versionContent)\` immediately and lets the debounced autosave fire \~1500ms later to write the loaded version to the server. The **pre-restore draft is not snapshotted into version history first** — so any unsaved edits in the editor (or the just-saved-but-not-yet-snapshotted live content) get silently overwritten by the autosave with no way to roll back.

Other destructive paths in the same component already call:

\`\`\`ts
await flushPendingSave();
await recordCheckpoint();
\`\`\`

before mutating (see \`handleReadapt\`, \`handleApprove\`). \`restoreVersion\` skipped both.

**Fix:**
- Make \`restoreVersion\` async.
- Add a \`window.confirm\` prompt that names the rollback affordance ("…your current draft is saved as a version first so you can roll back.").
- Call \`flushPendingSave()\` + \`recordCheckpoint()\` before \`setMarkdown(md)\` so the pre-restore content lives in version history.

### 2. "Load" button is unintelligible to SR users with multiple versions

Each per-version Load button rendered only the visible text "Load" with no \`aria-label\`. With multiple versions in the list, SR users heard "Load" "Load" "Load" with no way to distinguish them — the version's source badge and timestamp are right next to the button visually but aren't in the button's accessible name.

**Fix:** \`aria-label={\`Load \${source} version from \${timestamp}\`}\` on each Load button.

## Test plan

- [x] \`pnpm tsc --noEmit\` clean
- [x] \`pnpm nx test wyrdfold --skip-nx-cache -- --testPathPatterns='ResumeReviewPage|CoverLetterReviewPage'\` — 6/6 pass
- [ ] Smoke: open version history, click Load on the only version → confirm prompt appears; after confirm, the previous draft becomes the new entry above the loaded one.
- [ ] Smoke: cancel the confirm → no state change.