### PR TITLE
fix(wyrdfold): static id for mobile More sheet to avoid hydration mismatch

### DIFF
--- a/apps/wyrdfold/src/app/(app)/WyrdfoldSidebar.tsx
+++ b/apps/wyrdfold/src/app/(app)/WyrdfoldSidebar.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useCallback, useRef, useId } from 'react';
+import { useState, useCallback, useRef } from 'react';
 import dynamic from 'next/dynamic';
 import Link from 'next/link';
 import { usePathname, useRouter } from 'next/navigation';
@@ -70,7 +70,16 @@ export default function WyrdfoldSidebar() {
   const moreButtonRef = useRef<HTMLButtonElement>(null);
   // Stable id linking the "More" trigger to the MoreSheet dialog so
   // assistive tech can announce the relationship (aria-controls).
-  const moreSheetId = useId();
+  // A static string instead of ``useId()`` because:
+  //
+  //   1. There's exactly one mobile sidebar per page, so id collisions
+  //      aren't possible.
+  //   2. ``useId()`` produced a SSR/CSR mismatch in Next 16 Turbopack
+  //      dev — Server emitted ``aria-controls="_R_xxx_"`` on the
+  //      button but the client hydration pass dropped it, triggering
+  //      a React hydration error overlay. Static id avoids the issue
+  //      entirely.
+  const moreSheetId = 'wyrdfold-mobile-more-sheet';
 
   const closeSheet = useCallback(() => {
     setSheetOpen(false);


### PR DESCRIPTION
## Summary

#728 wired \`aria-controls\` on the mobile bottom-nav "Open more menu" button using \`useId()\`. In Next 16 + Turbopack dev that produces a SSR/CSR hydration mismatch:

\`\`\`
+ (Client)
- (Server)
-   aria-controls="_R_qbmqlb_"
\`\`\`

Server emits the attribute, the client hydration pass doesn't, React logs a "tree hydrated but some attributes…didn't match" error and the dev overlay surfaces with the issues badge on every authed page load. The DOM eventually self-corrects (subsequent renders restore the attribute), but the initial-hydration warning is real and pollutes the dev console.

## Fix

There's exactly one mobile sidebar per page, so id collisions aren't possible — replace \`useId()\` with a static literal \`'wyrdfold-mobile-more-sheet'\`. Stable across SSR and CSR, identical behavior under assistive tech, no hydration error.

\`\`\`diff
-import { useState, useCallback, useRef, useId } from 'react';
+import { useState, useCallback, useRef } from 'react';

-const moreSheetId = useId();
+const moreSheetId = 'wyrdfold-mobile-more-sheet';
\`\`\`

## Found via

Driving session 6 — Next dev's "Open issues overlay" button surfaced on /jobs after #728 landed. Inspecting the More button's a11y tree showed \`aria-controls\` present in the live DOM but the React reconciler had logged a server/client mismatch on initial hydration.

## Test plan

- [x] \`pnpm tsc --noEmit\` clean
- [x] \`pnpm nx test wyrdfold --skip-nx-cache -- --testPathPatterns='WyrdfoldSidebar|MoreSheet'\` — 5/5 pass
- [x] Browser confirmed post-fix: no Next dev issues overlay, console clean, More button still has \`aria-controls='wyrdfold-mobile-more-sheet'\` matching the dialog id