### PR TITLE
fix(wyrdfold-api): stable ORDER BY for /jobs pagination (no duplicate rows at page boundaries)

### DIFF
--- a/apps/wyrdfold-api/app/routers/jobs.py
+++ b/apps/wyrdfold-api/app/routers/jobs.py
@@ -140,9 +140,15 @@ def _list_jobs_for_target_two_query(
     if min_score is not None:
         ts_query = ts_query.gte("score", min_score)
 
-    # Push sort + pagination to the scores query when sorting by score
+    # Push sort + pagination to the scores query when sorting by score.
+    # Chain a deterministic ``job_posting_id`` tiebreaker so rows with
+    # identical scores (very common at the same-score buckets) keep a
+    # stable position — without this, the last row of page N could
+    # reappear as the first row of page N+1.
     if sort_col == "score":
-        ts_query = ts_query.order("score", desc=not ascending)
+        ts_query = ts_query.order("score", desc=not ascending).order(
+            "job_posting_id"
+        )
     # For non-score sorts we still need all qualifying IDs (sorted in Python after join)
     # but we can at least get the total count from Supabase
     ts_resp = ts_query.execute()
@@ -289,9 +295,15 @@ def _list_jobs_across_user_targets(
     if sort_col == "score" and not status and not company and not search:
         # Sort + paginate at the scores layer when no posting-level filters
         # require us to load every candidate posting first.
+        # ``(score, job_posting_id)`` tuple key gives a deterministic
+        # tiebreaker — without the id leg, rows with identical scores
+        # could reorder between paginated calls (Python's ``sorted`` is
+        # stable, but only with respect to the input order, and the
+        # input order is itself non-deterministic since ``best.keys()``
+        # iterates a dict).
         ranked_ids = sorted(
             best.keys(),
-            key=lambda jid: best[jid]["score"],
+            key=lambda jid: (best[jid]["score"], jid),
             reverse=not ascending,
         )
         page_ids = ranked_ids[offset : offset + page_size]

--- a/supabase/migrations/20260528160000_get_target_jobs_stable_order.sql
+++ b/supabase/migrations/20260528160000_get_target_jobs_stable_order.sql
@@ -1,0 +1,98 @@
+-- Stabilise `get_target_jobs` pagination by adding a deterministic
+-- tiebreaker to the ORDER BY.
+--
+-- Bug: prior to this migration the ORDER BY only used the user's
+-- chosen sort column (score / created_at / company_name / title).
+-- Whenever two or more rows shared the same value (very common at
+-- score buckets like 43, 46, 48), Postgres' ordering of ties is
+-- non-deterministic — so the same row could end up as the LAST
+-- entry on page 1 AND the FIRST entry on page 2, producing visible
+-- duplicates at every page boundary and silently dropping rows that
+-- should appear on later pages.
+--
+-- Fix: append `jp.id` as a final sort key. UUIDs sort stably; the
+-- specific order isn't human-meaningful, but each row has exactly
+-- one position in the result set, so paging with LIMIT/OFFSET is
+-- now guaranteed to be disjoint.
+--
+-- The two-query Python fallback in `app/routers/jobs.py` mirrors the
+-- same change for the rare case where this RPC isn't deployed.
+
+DROP FUNCTION IF EXISTS get_target_jobs(UUID, INT, TEXT, TEXT, TEXT, TEXT, BOOLEAN, INT, INT);
+
+CREATE FUNCTION get_target_jobs(
+  p_target_id UUID,
+  p_min_score INT DEFAULT 0,
+  p_status TEXT DEFAULT NULL,
+  p_company TEXT DEFAULT NULL,
+  p_search TEXT DEFAULT NULL,
+  p_sort TEXT DEFAULT 'score',
+  p_ascending BOOLEAN DEFAULT FALSE,
+  p_limit INT DEFAULT 20,
+  p_offset INT DEFAULT 0
+)
+RETURNS TABLE (
+  id UUID,
+  external_id BIGINT,
+  source_id UUID,
+  title TEXT,
+  company_name TEXT,
+  location TEXT,
+  department TEXT,
+  absolute_url TEXT,
+  score INT,
+  score_breakdown JSONB,
+  status TEXT,
+  salary_text TEXT,
+  greenhouse_updated_at TIMESTAMPTZ,
+  first_seen_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ,
+  total_count BIGINT
+)
+LANGUAGE plpgsql
+STABLE
+SET search_path = ''
+AS $$
+BEGIN
+  RETURN QUERY
+  SELECT
+    jp.id,
+    jp.external_id,
+    jp.source_id,
+    jp.title,
+    jp.company_name,
+    jp.location,
+    jp.department,
+    jp.absolute_url,
+    jts.score,
+    jts.score_breakdown,
+    jp.status,
+    jp.salary_text,
+    jp.greenhouse_updated_at,
+    jp.first_seen_at,
+    jp.created_at,
+    COUNT(*) OVER () AS total_count
+  FROM public.job_target_scores jts
+  INNER JOIN public.job_postings jp ON jp.id = jts.job_posting_id
+  WHERE jts.target_id = p_target_id
+    AND jts.excluded = FALSE
+    AND jts.score >= p_min_score
+    AND (p_status IS NULL OR jp.status = p_status)
+    AND (p_company IS NULL OR jp.company_name = p_company)
+    AND (p_search IS NULL OR jp.title ILIKE '%' || p_search || '%')
+  ORDER BY
+    CASE WHEN p_sort = 'score' AND NOT p_ascending THEN jts.score END DESC NULLS LAST,
+    CASE WHEN p_sort = 'score' AND p_ascending THEN jts.score END ASC NULLS LAST,
+    CASE WHEN p_sort = 'created_at' AND NOT p_ascending THEN jp.created_at END DESC NULLS LAST,
+    CASE WHEN p_sort = 'created_at' AND p_ascending THEN jp.created_at END ASC NULLS LAST,
+    CASE WHEN p_sort = 'company_name' AND NOT p_ascending THEN jp.company_name END DESC NULLS LAST,
+    CASE WHEN p_sort = 'company_name' AND p_ascending THEN jp.company_name END ASC NULLS LAST,
+    CASE WHEN p_sort = 'title' AND NOT p_ascending THEN jp.title END DESC NULLS LAST,
+    CASE WHEN p_sort = 'title' AND p_ascending THEN jp.title END ASC NULLS LAST,
+    -- Deterministic tiebreaker — every row has exactly one position
+    -- in the result set so LIMIT/OFFSET paging is disjoint.
+    jp.id ASC
+  LIMIT p_limit
+  OFFSET p_offset;
+END;
+$$;


### PR DESCRIPTION
## Summary

Pagination on the \`/jobs\` list was non-disjoint at every page boundary. The last row of page N and the first row of page N+1 were sometimes the same job posting, and conversely some rows silently dropped off the list entirely.

## Reproduction

Driven via chrome-devtools session 6:

\`\`\`js
const targetId = 'c84284f2-bd59-48d7-9cf1-fd9cae5786c9';
const p1 = await fetch(\`/api/jobs?page=1&pageSize=20&sort=score&order=desc&target_id=\${targetId}\`).then(r => r.json());
const p2 = await fetch(\`/api/jobs?page=2&pageSize=20&sort=score&order=desc&target_id=\${targetId}\`).then(r => r.json());

p1.postings.at(-1).id === p2.postings[0].id
// → true   ← Staff Software Engineer, Assets (Webflow, score 43)
\`\`\`

## Cause

The \`get_target_jobs\` RPC ordered only by the user's chosen sort column (score / created_at / company_name / title). When two rows shared the same value — extremely common at score buckets that often hold 5–10 jobs (e.g., score = 43, 46, 48) — Postgres' ordering of the tie was non-deterministic. Different LIMIT/OFFSET calls could split the tie group differently and the boundary row could appear on both sides.

Same shape in the Python fallback (\`_list_jobs_for_target_two_query\` and \`_list_jobs_across_user_targets\`) — \`.order('score')\` without a tiebreaker, and a Python \`sorted\` key that returned only the score.

## Fix

Append a deterministic tiebreaker:

- **RPC** (\`supabase/migrations/20260528160000_get_target_jobs_stable_order.sql\`): \`jp.id ASC\` as a final \`ORDER BY\` leg.
- **Python fallback (target view)**: chain \`.order('job_posting_id')\` after the \`.order('score', desc=…)\`.
- **Python fallback (cross-targets)**: use a \`(score, jid)\` tuple key so \`sorted\` gets a full tiebreaker.

UUIDs sort stably; the specific order isn't human-meaningful but each row now has exactly one position in the result set, so LIMIT/OFFSET paging is disjoint.

Also took the opportunity to set \`SEARCH_PATH = ''\` on the recreated function (matches the pattern from #715/#717 hardening).

## Forward-only

This is a forward-only migration — the function is dropped and recreated. The RPC's return shape and parameter list are unchanged, so no FE call sites need updates.

## Test plan

- [x] \`pnpm nx run wyrdfold-api:typecheck\` clean
- [x] \`pnpm nx test wyrdfold-api\` — 849/849 pass (existing mocks don't care about chained \`.order()\` calls)
- [ ] Apply the migration to the live Supabase project, then re-run the reproduction above — \`p1.postings.at(-1).id === p2.postings[0].id\` should be \`false\` for every page boundary
- [ ] Click through every page on \`/jobs\` — total visible posting count should equal \`total\` returned by the API