### PR TITLE
fix(wyrdfold-api): preserve score-sorted order across in_() fetch

### DIFF
--- a/apps/wyrdfold-api/app/routers/jobs.py
+++ b/apps/wyrdfold-api/app/routers/jobs.py
@@ -203,6 +203,16 @@ def _list_jobs_for_target_two_query(
         if total is None:
             total = len(postings)
             postings = postings[offset : offset + page_size]
+    else:
+        # Restore page_ids order — Supabase's in_() filter doesn't preserve
+        # list order, so even though page_ids was already sorted by score at
+        # the scores layer, the postings query returns rows in storage order.
+        order_index = {jid: i for i, jid in enumerate(page_ids)}
+        postings.sort(
+            key=lambda p: order_index.get(
+                cast(dict[str, Any], p)["id"], len(page_ids)
+            )
+        )
 
     return {"postings": postings, "total": total, "page": page, "page_size": page_size}
 
@@ -345,6 +355,16 @@ def _list_jobs_across_user_targets(
         if total is None:
             total = len(postings)
             postings = postings[offset : offset + page_size]
+    else:
+        # Restore page_ids order — Supabase's in_() filter doesn't preserve
+        # list order, so even though page_ids was already sorted by score at
+        # the scores layer, the postings query returns rows in storage order.
+        order_index = {jid: i for i, jid in enumerate(page_ids)}
+        postings.sort(
+            key=lambda p: order_index.get(
+                cast(dict[str, Any], p)["id"], len(page_ids)
+            )
+        )
 
     return {"postings": postings, "total": total, "page": page, "page_size": page_size}
 

--- a/apps/wyrdfold-api/tests/test_list_jobs_order.py
+++ b/apps/wyrdfold-api/tests/test_list_jobs_order.py
@@ -1,0 +1,132 @@
+"""Regression tests for /jobs response ordering.
+
+The score-sorted fast path computes ``page_ids`` in the correct order at
+the scores layer, then re-fetches postings via ``.in_("id", page_ids)``.
+Supabase's ``in_()`` does not preserve list order — without an explicit
+re-sort, the postings come back in storage order and the API returns the
+right rows in the wrong order.
+"""
+
+from typing import Any
+from unittest.mock import MagicMock
+
+from app.routers.jobs import (
+    _list_jobs_across_user_targets,
+    _list_jobs_for_target_two_query,
+)
+
+
+class _Resp:
+    def __init__(self, data: list[dict[str, Any]], count: int | None = None) -> None:
+        self.data = data
+        self.count = count
+
+
+class _Chain:
+    """Fluent stub — every builder method returns self; execute() returns the preloaded response."""
+
+    def __init__(self, resp: _Resp) -> None:
+        self._resp = resp
+
+    def select(self, *_a: Any, **_kw: Any) -> "_Chain":
+        return self
+
+    def eq(self, *_a: Any, **_kw: Any) -> "_Chain":
+        return self
+
+    def in_(self, *_a: Any, **_kw: Any) -> "_Chain":
+        return self
+
+    def gte(self, *_a: Any, **_kw: Any) -> "_Chain":
+        return self
+
+    def ilike(self, *_a: Any, **_kw: Any) -> "_Chain":
+        return self
+
+    def order(self, *_a: Any, **_kw: Any) -> "_Chain":
+        return self
+
+    def range(self, *_a: Any, **_kw: Any) -> "_Chain":
+        return self
+
+    def execute(self) -> _Resp:
+        return self._resp
+
+
+def _supabase_with(table_resps: dict[str, _Resp]) -> MagicMock:
+    sb = MagicMock()
+    sb.table.side_effect = lambda name: _Chain(table_resps[name])
+    return sb
+
+
+def test_target_two_query_restores_score_desc_order() -> None:
+    # Scores returned in score-desc order (highest first) — this is what
+    # Supabase produces because the query chains .order("score", desc=True).
+    ts_rows = [
+        {"job_posting_id": "j-high", "score": 90, "score_breakdown": {}, "scoring_status": "complete"},
+        {"job_posting_id": "j-mid", "score": 60, "score_breakdown": {}, "scoring_status": "complete"},
+        {"job_posting_id": "j-low", "score": 30, "score_breakdown": {}, "scoring_status": "complete"},
+    ]
+    # Postings returned by .in_("id", page_ids) in DIFFERENT (storage) order.
+    # The bug: without an explicit re-sort, the API returned this order.
+    postings_in_storage_order = [
+        {"id": "j-low", "title": "low"},
+        {"id": "j-high", "title": "high"},
+        {"id": "j-mid", "title": "mid"},
+    ]
+    sb = _supabase_with(
+        {"scores": _Resp(ts_rows, count=3), "jobs": _Resp(postings_in_storage_order)}
+    )
+
+    result = _list_jobs_for_target_two_query(
+        sb,
+        target_id="t-1",
+        offset=0,
+        page=1,
+        page_size=10,
+        sort="score",
+        ascending=False,
+        min_score=None,
+        status=None,
+        company=None,
+        search=None,
+    )
+
+    assert [p["id"] for p in result["postings"]] == ["j-high", "j-mid", "j-low"]
+    assert [p["score"] for p in result["postings"]] == [90, 60, 30]
+    assert result["total"] == 3
+
+
+def test_across_user_targets_restores_score_desc_order() -> None:
+    # Same shape, different aggregator (max score across the user's targets).
+    score_rows = [
+        {"job_posting_id": "j-high", "target_id": "t-1", "score": 80, "score_breakdown": {}, "scoring_status": "complete"},
+        {"job_posting_id": "j-mid", "target_id": "t-1", "score": 50, "score_breakdown": {}, "scoring_status": "complete"},
+        {"job_posting_id": "j-low", "target_id": "t-2", "score": 20, "score_breakdown": {}, "scoring_status": "complete"},
+    ]
+    postings_in_storage_order = [
+        {"id": "j-mid", "title": "mid"},
+        {"id": "j-low", "title": "low"},
+        {"id": "j-high", "title": "high"},
+    ]
+    sb = _supabase_with(
+        {"scores": _Resp(score_rows), "jobs": _Resp(postings_in_storage_order)}
+    )
+
+    result = _list_jobs_across_user_targets(
+        sb,
+        user_target_ids={"t-1", "t-2"},
+        offset=0,
+        page=1,
+        page_size=10,
+        sort="score",
+        ascending=False,
+        min_score=None,
+        status=None,
+        company=None,
+        search=None,
+    )
+
+    assert [p["id"] for p in result["postings"]] == ["j-high", "j-mid", "j-low"]
+    assert [p["score"] for p in result["postings"]] == [80, 50, 20]
+    assert result["total"] == 3


### PR DESCRIPTION
## Summary
- /jobs score-sorted responses were unordered: rows came back in storage order from the postings re-fetch instead of score-desc.
- Both two-query helpers (`_list_jobs_for_target_two_query`, `_list_jobs_across_user_targets`) restore `page_ids` order after the `.in_("id", page_ids)` query.
- Added regression tests that mock Supabase returning postings in shuffled order and assert the score-desc order is restored.

## Why
The fast path sorts + paginates at the scores layer (correct), then does `.in_("id", page_ids)` to fetch posting bodies. Supabase's `.in_()` doesn't preserve the input list's order, and the existing Python re-sort was gated on `total is None or sort_col != "score"` — so the score-sorted path skipped it entirely and returned whatever order Supabase happened to produce.

Observed score sequence (one page, sort=score, order=desc): `46, 72, 46, 48, 48, 48, 45, 46, 59, 61, 46, 52, 46, 54, 43, 45, 60, 60, 49, 53` — clearly not sorted. Fix produces monotonic desc within each page.

The RPC path (`_list_jobs_for_target_rpc`) and the operator/api-key single-query path were unaffected — they apply ORDER BY at the DB layer.

## Test plan
- [x] New `tests/test_list_jobs_order.py` fails on the previous code and passes after the fix
- [x] `ruff check` clean, `mypy` clean
- [ ] After merge + Railway deploy: re-hit `/api/jobs?page=1` from the dashboard and confirm scores are monotonic desc within each page (and across boundaries)

🤖 Generated with [Claude Code](https://claude.com/claude-code)