### PR TITLE
fix(shared-ui): Spinner accent variant uses defined brand token for visible spin

### DIFF
--- a/libs/shared/ui/src/lib/Spinner.spec.tsx
+++ b/libs/shared/ui/src/lib/Spinner.spec.tsx
@@ -27,7 +27,7 @@ describe('Spinner', () => {
 
   it('applies accent variant by default', () => {
     const { container } = render(<Spinner />);
-    expect(container.firstChild).toHaveClass('border-t-accent');
+    expect(container.firstChild).toHaveClass('border-t-brand-500');
   });
 
   it('renders as inline-block element', () => {

--- a/libs/shared/ui/src/lib/Spinner.tsx
+++ b/libs/shared/ui/src/lib/Spinner.tsx
@@ -24,8 +24,16 @@ const sizeStyles: Record<ComponentSize, string> = {
   lg: 'size-12 border-3',
 };
 
+// The base ring sits at 30% opacity so the solid top-border arc reads as
+// the rotating indicator. The previous version referenced ``border-t-accent``,
+// but no ``--color-accent`` token is registered in either pyre or indigo theme
+// (only ``--color-brand-*`` and the semantic colors are). That made the top
+// border resolve to a fallback, so the donut appeared as a uniform light ring
+// — visually indistinguishable from a static circle even while ``animate-spin``
+// was running. Use the same brand color at full vs 30% opacity, matching the
+// pattern used by ``SEMANTIC_SPINNER``.
 const variantStyles: Record<SpinnerVariant, string> = {
-  accent: 'border-brand-500/30 border-t-accent',
+  accent: 'border-brand-500/30 border-t-brand-500',
   ...SEMANTIC_SPINNER,
 };
 


### PR DESCRIPTION
## Summary
- Default Spinner variant referenced \`border-t-accent\`, but no \`--color-accent\` token exists in either theme — only the brand scale and semantic colors are registered.
- Result: the top border resolved to a fallback, making the donut a uniform light ring. \`animate-spin\` was running but visually indistinguishable from static.
- Fix: switch to \`border-brand-500/30 border-t-brand-500\` (same pattern as \`SEMANTIC_SPINNER\` — base at 30%, solid arc on top).

## Why
Reported by user: "spinners next to the job score… look like a solid light green donut circle." Confirmed by grepping \`accent\` across \`libs/shared/ui/src\` and \`apps/wyrdfold/src\` — 0 hits for a token definition.

## Blast radius
Every Spinner using the default variant — \`ScoreBadge\` "Scoring in progress" indicator, Generate Resume/Cover Letter buttons, settings/profile/targets loading spinners. All start spinning visibly.

## Test plan
- [x] \`pnpm nx test shared-ui\` — 754 tests pass (Spinner spec updated to assert new class)
- [x] \`pnpm exec eslint libs/shared/ui/src/lib/Spinner.tsx\` clean
- [ ] After merge: visually confirm \`ScoreBadge\` spinner rotates on \`/jobs\` (jobs with \`scoring_status: stage1/stage2\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)