### PR TITLE
fix(wyrdfold): search-by-title resets pagination to page 1

### DIFF
--- a/apps/wyrdfold/src/hooks/useAdminTableFetch.ts
+++ b/apps/wyrdfold/src/hooks/useAdminTableFetch.ts
@@ -35,6 +35,20 @@ export function useAdminTableFetch<T, S extends string>({
     defaultOrder
   );
 
+  // Reset to page 1 whenever filters change. Without this, a user on page 2+
+  // who types in the search box (or flips a status / score filter) keeps
+  // ``offset = (page - 1) * pageSize`` from the prior view — most searches
+  // narrow results so the new page is empty and the UI looks like the
+  // search didn't fire. ``useTableSort`` already does this on sort change;
+  // the filter path was the missing half. Serialize for the dep check so
+  // we react to value changes, not just reference changes (useMemo in the
+  // caller already gives a fresh ref on each filter change, but the
+  // serialized check is robust either way).
+  const extraParamsKey = JSON.stringify(extraParams ?? {});
+  useEffect(() => {
+    setPage(1);
+  }, [extraParamsKey]);
+
   const fetchData = useCallback(async () => {
     setLoading(true);
     try {


### PR DESCRIPTION
## Summary

User reported the "Search by title" input on /jobs wasn't working — typing didn't filter the visible results.

Full end-to-end trace via an investigation agent showed the wiring is correct: \`search\` makes it from the input through the debounce, into the filters state, into the URL search params, into the Next proxy, into the FastAPI handler, and into the SQL \`ilike\` filter on every code path (target view RPC, target view fallback, cross-target view, operator path).

The actual break is in \`useAdminTableFetch\`. \`useTableSort\` resets \`page\` to 1 on sort changes (existing behavior, intentional), but the equivalent reset for filter changes was missing. A user on page 2+ who types in the search box keeps \`offset = (page - 1) * pageSize\` from the prior view; most searches narrow results so the new page is empty and the UI looks like the search request never fired.

## Fix

Add a \`useEffect\` keyed on the serialized \`extraParams\` (\`JSON.stringify\` gives a stable primitive dep so we respond to value changes, not just reference changes) that calls \`setPage(1)\`. Same pattern \`useTableSort\` already uses for sort.

## Side effect

Resets page on delete / batch refresh too (anything that mutates \`extraParams._r\`). Net effect: any filter / tab / refresh action deterministically lands the user on page 1 of the new result set.

## Test plan
- [x] \`eslint\` + \`tsc --noEmit\` clean
- [x] \`pnpm nx test wyrdfold\` — 396 tests pass
- [ ] After merge + deploy: type in the search box on /jobs from page 2 — should reset to page 1 and show filtered results

🤖 Generated with [Claude Code](https://claude.com/claude-code)