### PR TITLE
chore(supabase): prefer localhost in local-Supabase auth config

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -150,10 +150,25 @@ max_indexes = 5
 [auth]
 enabled = true
 # The base URL of your website. Used as an allow-list for redirects and for constructing URLs used
-# in emails.
-site_url = "http://127.0.0.1:3000"
+# in emails. Use ``localhost`` rather than ``127.0.0.1`` so cookies set on the
+# auth callback are visible to the rest of the dev app (browsers treat the two
+# hosts as separate origins for session storage).
+site_url = "http://localhost:3000"
 # A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
-additional_redirect_urls = ["https://127.0.0.1:3000"]
+# Supabase substitutes ``site_url`` silently when ``emailRedirectTo`` does not
+# exactly match one of these entries — so we list every dev variant the app
+# might be served from (localhost vs. 127.0.0.1, port 3000 vs. 3100, with and
+# without ``/auth/callback``). HTTP only — local dev does not terminate TLS.
+additional_redirect_urls = [
+  "http://localhost:3000",
+  "http://localhost:3000/auth/callback",
+  "http://localhost:3100",
+  "http://localhost:3100/auth/callback",
+  "http://127.0.0.1:3000",
+  "http://127.0.0.1:3000/auth/callback",
+  "http://127.0.0.1:3100",
+  "http://127.0.0.1:3100/auth/callback",
+]
 # How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
 jwt_expiry = 3600
 # JWT issuer URL. If not set, defaults to the local API URL (http://127.0.0.1:<port>/auth/v1).


### PR DESCRIPTION
## Summary

Two long-standing bugs in \`supabase/config.toml\`:

1. \`site_url = "http://127.0.0.1:3000"\` — \`127.0.0.1\` and \`localhost\` are separate browser origins for cookies. A magic link redirected to \`127.0.0.1:3000/auth/callback\` sets its session cookie there, and the rest of the dev app served from \`localhost:3000\` can't see it.
2. \`additional_redirect_urls = ["https://127.0.0.1:3000"]\` — wrong protocol. Local dev is HTTP, so this entry never matched. Combined with Supabase's silent fallback to \`site_url\` when no allowlist entry matches, this is why every magic link came out pointing at \`127.0.0.1:3000\` instead of whatever URL the app actually requested.

## Fix

- \`site_url\` → \`http://localhost:3000\`
- \`additional_redirect_urls\` → expanded to cover \`localhost\` × \`127.0.0.1\` × ports \`3000\`/\`3100\` × with/without \`/auth/callback\`, all HTTP.

## Caveat

This is the **local Supabase** config (\`supabase start\`). The remote project (\`grwmzluuqyczatkxorfa.supabase.co\`) ignores this file — its Site URL and Redirect URL allowlist live in the dashboard at:

> Auth → URL Configuration

Those still need the same expansion applied there to fix magic-link redirects against the live setup. This PR keeps \`config.toml\` honest so future local-Supabase workflows don't reproduce the same break.

🤖 Generated with [Claude Code](https://claude.com/claude-code)