### PR TITLE
feat(wyrdfold-api): retro-score existing jobs on target activation

### DIFF
--- a/apps/wyrdfold-api/app/routers/targets.py
+++ b/apps/wyrdfold-api/app/routers/targets.py
@@ -5,6 +5,7 @@ triggers LLM-powered profile derivation and merges the result into the
 target's composite scoring profile.
 """
 
+import asyncio
 import logging
 from typing import Any, cast
 
@@ -51,6 +52,7 @@ from app.services.llm import cost_log
 from app.services.llm.client import LLMClient
 from app.services.poller import poll_sources_for_target
 from app.services.scoring import strip_html
+from app.services.target_scoring import score_title_and_upsert
 from app.services.targets import crud, from_input
 from app.services.targets.derive_profile import DEFAULT_PURPOSE, derive_profile_from_jd
 from app.services.targets.derive_profile_from_label import (
@@ -80,6 +82,47 @@ router = APIRouter(
 
 
 # ---- Background pipeline for activation ------------------------------------
+
+
+_RETRO_SCORE_BATCH = 500
+
+
+def _retro_score_existing_jobs(supabase: Client, target: JobTarget) -> int:
+    """Stage-1 score every posting in the ``jobs`` table against ``target``.
+
+    Used during target activation so jobs that pre-date the target still
+    appear under it in the UI. Iterates in batches of ``_RETRO_SCORE_BATCH``
+    so we never load the full job table into memory at once.
+    ``score_title_and_upsert`` returns ``None`` for jobs whose titles don't
+    match any keyword — those create no row. The return value is the
+    number of jobs we actually wrote a score row for, useful for log/UI
+    diagnostics on "ready but jobs_count=0".
+    """
+    written = 0
+    offset = 0
+    while True:
+        resp = (
+            supabase.table("jobs")
+            .select("id, title")
+            .range(offset, offset + _RETRO_SCORE_BATCH - 1)
+            .execute()
+        )
+        rows = cast(list[dict[str, Any]], resp.data or [])
+        if not rows:
+            break
+        for row in rows:
+            result = score_title_and_upsert(
+                supabase,
+                job_posting_id=row["id"],
+                title=row["title"],
+                target=target,
+            )
+            if result is not None:
+                written += 1
+        if len(rows) < _RETRO_SCORE_BATCH:
+            break
+        offset += _RETRO_SCORE_BATCH
+    return written
 
 
 async def _activate_pipeline(
@@ -137,6 +180,24 @@ async def _activate_pipeline(
             poll_result.sources_polled,
             poll_result.new_jobs,
         )
+
+        # Step 3: retro-score every existing posting against the new target.
+        # The poller stage-1-scores jobs at insert time, so anything that
+        # existed before this target activated had no scores row for it —
+        # the /jobs page filtered by this target would otherwise be empty
+        # even when there are plenty of matching titles already in the
+        # database. ``score_title_and_upsert`` returns ``None`` (no row
+        # written) when no keywords match, so this only creates rows where
+        # the title actually scores against the new profile.
+        retro_scored = await asyncio.to_thread(
+            _retro_score_existing_jobs, supabase, target
+        )
+        logger.info(
+            "Activation pipeline for target %s: retro-scored %d existing jobs",
+            target_id,
+            retro_scored,
+        )
+
         crud.update(
             supabase, target_id, TargetUpdate(activation_status="ready")
         )


### PR DESCRIPTION
## Summary

User report: activating a new target leaves \`/jobs\` (filtered by that target) empty, even when there are matching titles already in the database. Verified the bug by activating "Director of CX Operations & Transformation": pipeline ran to \`ready\`, \`jobs_count\` returned 0.

## Root cause

The poller calls \`score_title_and_upsert\` at insert time, so every freshly-polled posting picks up a stage-1 score against every currently-active target. That covers "new target + new postings" correctly, but leaves "new target + pre-existing postings" with no \`scores\` row at all — the \`/jobs\` page filters by \`scores.target_id\`, so those jobs are invisible under the new target.

## Fix

Add Step 3 inside \`_activate_pipeline\` that iterates the \`jobs\` table in 500-row batches and calls \`score_title_and_upsert\` for every existing posting against the newly-activated target.

- Function returns \`None\` when no keyword matches, so we only write rows where the title actually scores against the new profile.
- Runs inside \`asyncio.to_thread\` so the synchronous Supabase calls don't block the event loop while the background task is in flight.

## Verification

Pointed local wyrdfold dev at the local API with this fix, deactivated + reactivated the CX target through the browser session:

\`\`\`
jobs_count: 0 → 3
\`\`\`

The three rows are leadership-engineering titles that hit on the CX target's seniority signals ("Director, Software Engineering ...", "Head of AI Platform Engineering") — appropriate stage-1 matches.

## Out of scope

Source discovery — the other half of the user's "we had it working" report. No source-discovery service exists in the codebase; that's a separate effort.

## Test plan
- [x] \`ruff\` + \`mypy\` clean
- [x] \`pytest\` — 851 tests pass
- [x] Live verification: re-activating CX target now produces 3 matches (was 0)
- [ ] After merge + Railway deploy: deactivate / reactivate a target on prod; confirm jobs_count populates

🤖 Generated with [Claude Code](https://claude.com/claude-code)