### PR TITLE
refactor(wyrdfold): move identity to /profile, reorder gaps to top

### DIFF
--- a/apps/wyrdfold/src/app/(app)/profile/ProfileIdentityCard.tsx
+++ b/apps/wyrdfold/src/app/(app)/profile/ProfileIdentityCard.tsx
@@ -1,0 +1,265 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from '@danieljoffe.com/shared-ui/Card';
+import { Input } from '@danieljoffe.com/shared-ui/Input';
+import { Spinner } from '@danieljoffe.com/shared-ui/Spinner';
+import { Text } from '@danieljoffe.com/shared-ui/Text';
+import { extractApiError } from '@/lib/extractApiError';
+import { useToast } from '@/state/Toast/ToastProvider';
+
+/**
+ * Identity / contact fields that appear in the header of every generated
+ * resume and cover letter. Lives on the Profile page (was previously stacked
+ * inside Settings — moved here because the data is semantically part of the
+ * candidate's profile, not their notification preferences).
+ *
+ * Fully self-contained: fetches its own data, owns its own form state, and
+ * debounces saves back to `/api/profile/identity`. No props.
+ */
+
+const AUTOSAVE_DEBOUNCE_MS = 800;
+
+interface IdentityFields {
+  name: string | null;
+  email: string | null;
+  phone_number: string | null;
+  location: string | null;
+  linkedin_url: string | null;
+  website_url: string | null;
+}
+
+function identitySig(fields: {
+  name: string;
+  email: string;
+  phone_number: string;
+  location: string;
+  linkedin_url: string;
+  website_url: string;
+}): string {
+  return JSON.stringify(fields);
+}
+
+export default function ProfileIdentityCard() {
+  const { toast } = useToast();
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [phone, setPhone] = useState('');
+  const [location, setLocation] = useState('');
+  const [linkedin, setLinkedin] = useState('');
+  const [website, setWebsite] = useState('');
+
+  // Server-known signature — autosave fires only when local state diverges.
+  // Failed-sig prevents retry-loops when the server rejects a value.
+  const lastSigRef = useRef<string | null>(null);
+  const lastFailedSigRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch('/api/profile/identity')
+      .then(async res => {
+        if (cancelled || !res.ok) return;
+        const data = (await res.json()) as IdentityFields;
+        if (cancelled) return;
+        setName(data.name ?? '');
+        setEmail(data.email ?? '');
+        setPhone(data.phone_number ?? '');
+        setLocation(data.location ?? '');
+        setLinkedin(data.linkedin_url ?? '');
+        setWebsite(data.website_url ?? '');
+        lastSigRef.current = identitySig({
+          name: (data.name ?? '').trim(),
+          email: (data.email ?? '').trim(),
+          phone_number: (data.phone_number ?? '').trim(),
+          location: (data.location ?? '').trim(),
+          linkedin_url: (data.linkedin_url ?? '').trim(),
+          website_url: (data.website_url ?? '').trim(),
+        });
+      })
+      .catch(() => {
+        if (!cancelled) {
+          toast({ variant: 'error', title: 'Failed to load identity' });
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [toast]);
+
+  const handleSave = useCallback(async () => {
+    const trimmed = {
+      name: name.trim(),
+      email: email.trim(),
+      phone_number: phone.trim(),
+      location: location.trim(),
+      linkedin_url: linkedin.trim(),
+      website_url: website.trim(),
+    };
+    const sig = identitySig(trimmed);
+    setSaving(true);
+    try {
+      const res = await fetch('/api/profile/identity', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(trimmed),
+      });
+      if (!res.ok) {
+        const message = await extractApiError(res, 'Failed to save identity');
+        toast({ variant: 'error', title: message });
+        lastFailedSigRef.current = sig;
+        return;
+      }
+      const data = (await res.json()) as IdentityFields;
+      // Re-sync from server response so normalized values (e.g. E.164 phone)
+      // replace the typed input.
+      setName(data.name ?? '');
+      setEmail(data.email ?? '');
+      setPhone(data.phone_number ?? '');
+      setLocation(data.location ?? '');
+      setLinkedin(data.linkedin_url ?? '');
+      setWebsite(data.website_url ?? '');
+      lastSigRef.current = identitySig({
+        name: (data.name ?? '').trim(),
+        email: (data.email ?? '').trim(),
+        phone_number: (data.phone_number ?? '').trim(),
+        location: (data.location ?? '').trim(),
+        linkedin_url: (data.linkedin_url ?? '').trim(),
+        website_url: (data.website_url ?? '').trim(),
+      });
+      lastFailedSigRef.current = null;
+      toast({ variant: 'success', title: 'Identity saved' });
+    } catch {
+      lastFailedSigRef.current = sig;
+      toast({ variant: 'error', title: 'Network error saving identity' });
+    } finally {
+      setSaving(false);
+    }
+  }, [name, email, phone, location, linkedin, website, toast]);
+
+  // Debounced autosave. Skip while still loading initial data and while a save
+  // is in flight. Also skip a sig that already failed once — the user has to
+  // edit it again before we retry.
+  useEffect(() => {
+    if (loading || saving) return;
+    if (lastSigRef.current === null) return;
+    const sig = identitySig({
+      name: name.trim(),
+      email: email.trim(),
+      phone_number: phone.trim(),
+      location: location.trim(),
+      linkedin_url: linkedin.trim(),
+      website_url: website.trim(),
+    });
+    if (sig === lastSigRef.current) return;
+    if (sig === lastFailedSigRef.current) return;
+    const t = setTimeout(handleSave, AUTOSAVE_DEBOUNCE_MS);
+    return () => clearTimeout(t);
+  }, [
+    name,
+    email,
+    phone,
+    location,
+    linkedin,
+    website,
+    loading,
+    saving,
+    handleSave,
+  ]);
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className='flex items-center justify-between gap-3'>
+          <CardTitle>Identity</CardTitle>
+          {saving && (
+            <Text
+              as='span'
+              variant='meta'
+              className='inline-flex items-center gap-1'
+              aria-live='polite'
+            >
+              <Spinner size='sm' aria-label='Saving' />
+              <span>Saving…</span>
+            </Text>
+          )}
+        </div>
+      </CardHeader>
+      <CardContent className='flex flex-col gap-4'>
+        <Text variant='caption' className='text-text-secondary'>
+          Used as the contact header on every generated resume and cover letter.
+          Name is required before you can generate.
+        </Text>
+        <div className='grid gap-4 sm:grid-cols-2'>
+          <Input
+            label='Name'
+            value={name}
+            onChange={e => setName(e.target.value)}
+            placeholder='Full name'
+            autoComplete='name'
+            required
+            data-sentry-mask
+          />
+          <Input
+            label='Email'
+            type='email'
+            value={email}
+            onChange={e => setEmail(e.target.value)}
+            placeholder='name@example.com'
+            autoComplete='email'
+            inputMode='email'
+            data-sentry-mask
+          />
+          <Input
+            label='Phone'
+            type='tel'
+            value={phone}
+            onChange={e => setPhone(e.target.value)}
+            placeholder='+1 555 555 5555'
+            autoComplete='tel'
+            inputMode='tel'
+            data-sentry-mask
+          />
+          <Input
+            label='Location'
+            value={location}
+            onChange={e => setLocation(e.target.value)}
+            placeholder='City, State'
+            autoComplete='address-level2'
+            data-sentry-mask
+          />
+          <Input
+            label='LinkedIn URL'
+            type='url'
+            value={linkedin}
+            onChange={e => setLinkedin(e.target.value)}
+            placeholder='https://linkedin.com/in/username'
+            autoComplete='url'
+            inputMode='url'
+            data-sentry-mask
+          />
+          <Input
+            label='Website'
+            type='url'
+            value={website}
+            onChange={e => setWebsite(e.target.value)}
+            placeholder='https://example.com'
+            autoComplete='url'
+            inputMode='url'
+            data-sentry-mask
+          />
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/wyrdfold/src/app/(app)/profile/ProfilePage.tsx
+++ b/apps/wyrdfold/src/app/(app)/profile/ProfilePage.tsx
@@ -21,6 +21,7 @@ import { extractApiError } from '@/lib/extractApiError';
 import { parsePartialJson } from '@/lib/parsePartialJson';
 import { useToast } from '@/state/Toast/ToastProvider';
 import ConversationChatModal from '../../_components/ConversationChatModal';
+import ProfileIdentityCard from './ProfileIdentityCard';
 import type {
   Gap,
   GapHealthResult,
@@ -479,6 +480,23 @@ export default function ProfilePage() {
         </Card>
       )}
 
+      {/* Gaps to Fill — sits directly under Document Health so the "are
+          there gaps?" answer and the "what are they?" answer are adjacent.
+          Hidden entirely when no gaps; default-collapsed when present so
+          the card doesn't dominate the page above the master document. */}
+      {gapHealth && gapHealth.gaps.length > 0 && (
+        <GapsList
+          gaps={gapHealth.gaps}
+          tier={gapHealth.tier}
+          onOpenChat={() => setChatOpen(true)}
+        />
+      )}
+
+      {/* Identity (resume + cover-letter contact header). Moved here from
+          /settings since it's part of the candidate's profile, not their
+          notification preferences. */}
+      <ProfileIdentityCard />
+
       {/* Master Document */}
       <Card>
         <CardHeader>
@@ -682,15 +700,6 @@ export default function ProfilePage() {
         </Card>
       )}
 
-      {/* Gaps */}
-      {gapHealth && gapHealth.gaps.length > 0 && (
-        <GapsList
-          gaps={gapHealth.gaps}
-          tier={gapHealth.tier}
-          onOpenChat={() => setChatOpen(true)}
-        />
-      )}
-
       {fileInput}
 
       <ConversationChatModal
@@ -713,6 +722,10 @@ function GapsList({
   tier: GapTier;
   onOpenChat: () => void;
 }) {
+  // Default to collapsed because the card lives near the top of the page —
+  // the user usually wants the count + "answer questions" CTA at a glance,
+  // not a wall of every gap.
+  const [open, setOpen] = useState(false);
   const visible = gaps.slice(0, 10);
   const count = gaps.length;
   const cta = (
@@ -732,52 +745,66 @@ function GapsList({
   return (
     <Card>
       <CardHeader>
-        <div className='flex items-center justify-between'>
+        <button
+          type='button'
+          onClick={() => setOpen(o => !o)}
+          aria-expanded={open}
+          aria-controls='gaps-list-body'
+          className='flex w-full items-center justify-between gap-2 text-left'
+        >
           <CardTitle>Gaps to Fill</CardTitle>
-          <Badge variant='default' size='sm'>
-            {count} {count === 1 ? 'gap' : 'gaps'}
-          </Badge>
-        </div>
+          <div className='flex items-center gap-2'>
+            <Badge variant='default' size='sm'>
+              {count} {count === 1 ? 'gap' : 'gaps'}
+            </Badge>
+            <RefreshCw
+              className={`size-4 text-text-tertiary transition-transform ${open ? 'rotate-90' : ''}`}
+              aria-hidden
+            />
+          </div>
+        </button>
       </CardHeader>
-      <CardContent className='flex flex-col gap-4'>
-        <div className='flex flex-col divide-y divide-border'>
-          {visible.map((gap, i) => (
-            <div
-              key={`${gap.kind}-${gap.ref}-${i}`}
-              className='flex items-start gap-3 py-2.5 first:pt-0 last:pb-0'
-            >
-              <Badge
-                variant={gapBadgeVariant(gap.kind)}
-                size='sm'
-                className='shrink-0 mt-0.5'
+      {open && (
+        <CardContent className='flex flex-col gap-4' id='gaps-list-body'>
+          <div className='flex flex-col divide-y divide-border'>
+            {visible.map((gap, i) => (
+              <div
+                key={`${gap.kind}-${gap.ref}-${i}`}
+                className='flex items-start gap-3 py-2.5 first:pt-0 last:pb-0'
               >
-                {GAP_KIND_LABELS[gap.kind] ?? gap.kind}
-              </Badge>
-              <Text variant='caption' className='text-text-secondary'>
-                {gap.context}
+                <Badge
+                  variant={gapBadgeVariant(gap.kind)}
+                  size='sm'
+                  className='shrink-0 mt-0.5'
+                >
+                  {GAP_KIND_LABELS[gap.kind] ?? gap.kind}
+                </Badge>
+                <Text variant='caption' className='text-text-secondary'>
+                  {gap.context}
+                </Text>
+              </div>
+            ))}
+            {gaps.length > 10 && (
+              <Text variant='caption' className='pt-2 text-text-tertiary'>
+                +{gaps.length - 10} more gaps
               </Text>
-            </div>
-          ))}
-          {gaps.length > 10 && (
-            <Text variant='caption' className='pt-2 text-text-tertiary'>
-              +{gaps.length - 10} more gaps
-            </Text>
+            )}
+          </div>
+          {tier === 'red' ? (
+            <Alert variant='warning'>
+              <div className='flex flex-col items-start gap-2'>
+                <span>
+                  Critical gaps detected. Generated resumes will be missing
+                  outcomes and metrics until you fill them in.
+                </span>
+                {cta}
+              </div>
+            </Alert>
+          ) : (
+            cta
           )}
-        </div>
-        {tier === 'red' ? (
-          <Alert variant='warning'>
-            <div className='flex flex-col items-start gap-2'>
-              <span>
-                Critical gaps detected. Generated resumes will be missing
-                outcomes and metrics until you fill them in.
-              </span>
-              {cta}
-            </div>
-          </Alert>
-        ) : (
-          cta
-        )}
-      </CardContent>
+        </CardContent>
+      )}
     </Card>
   );
 }

--- a/apps/wyrdfold/src/app/(app)/profile/__tests__/ProfileIdentityCard.spec.tsx
+++ b/apps/wyrdfold/src/app/(app)/profile/__tests__/ProfileIdentityCard.spec.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import ProfileIdentityCard from '../ProfileIdentityCard';
+
+const mockToast = jest.fn();
+jest.mock('@/state/Toast/ToastProvider', () => ({
+  useToast: () => ({ toast: mockToast }),
+}));
+
+const IDENTITY = {
+  name: 'Daniel',
+  email: 'me@example.com',
+  phone_number: null,
+  location: null,
+  linkedin_url: null,
+  website_url: null,
+};
+
+const originalFetch = global.fetch;
+
+beforeEach(() => {
+  mockToast.mockReset();
+  global.fetch = jest.fn().mockImplementation((url: string) => {
+    if (url.includes('/identity'))
+      return Promise.resolve({
+        ok: true,
+        json: async () => IDENTITY,
+      } as Response);
+    return Promise.resolve({ ok: false, json: async () => ({}) } as Response);
+  }) as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+});
+
+describe('ProfileIdentityCard', () => {
+  it('pre-fills inputs from /api/profile/identity', async () => {
+    render(<ProfileIdentityCard />);
+    // ``findByDisplayValue`` waits for the input to actually carry the value
+    // (the component renders immediately with empty defaults, then setState
+    // fires after the fetch resolves — ``findByLabelText`` would race that).
+    expect(await screen.findByDisplayValue('Daniel')).toBeInTheDocument();
+    expect(
+      await screen.findByDisplayValue('me@example.com')
+    ).toBeInTheDocument();
+  });
+
+  it('marks PII inputs with data-sentry-mask', async () => {
+    render(<ProfileIdentityCard />);
+    const nameInput = await screen.findByLabelText(/^Name\b/i);
+    expect(nameInput).toHaveAttribute('data-sentry-mask');
+    const emailInput = await screen.findByLabelText(/^Email$/i);
+    expect(emailInput).toHaveAttribute('data-sentry-mask');
+    const phoneInput = await screen.findByLabelText(/^Phone$/i);
+    expect(phoneInput).toHaveAttribute('data-sentry-mask');
+    const locationInput = await screen.findByLabelText(/^Location$/i);
+    expect(locationInput).toHaveAttribute('data-sentry-mask');
+  });
+});

--- a/apps/wyrdfold/src/app/(app)/settings/SettingsPage.tsx
+++ b/apps/wyrdfold/src/app/(app)/settings/SettingsPage.tsx
@@ -30,27 +30,9 @@ interface NotificationPreferences {
   sms_available: boolean;
 }
 
-interface IdentityFields {
-  name: string | null;
-  email: string | null;
-  phone_number: string | null;
-  location: string | null;
-  linkedin_url: string | null;
-  website_url: string | null;
-}
+// Identity fields moved to apps/wyrdfold/src/app/(app)/profile/ProfileIdentityCard.tsx.
 
-type Section = 'profile' | 'email' | 'sms';
-
-function profileSig(fields: {
-  name: string;
-  email: string;
-  phone_number: string;
-  location: string;
-  linkedin_url: string;
-  website_url: string;
-}): string {
-  return JSON.stringify(fields);
-}
+type Section = 'email' | 'sms';
 
 function emailSig(enabled: boolean, threshold: number): string {
   return JSON.stringify({
@@ -102,29 +84,16 @@ export default function SettingsPage() {
   const [smsDailyLimit, setSmsDailyLimit] = useState('5');
   const [phoneNumber, setPhoneNumber] = useState('');
 
-  // Profile identity (F3-A): contact info used for resume + cover-letter headers.
-  const [identityName, setIdentityName] = useState('');
-  const [identityEmail, setIdentityEmail] = useState('');
-  const [identityPhone, setIdentityPhone] = useState('');
-  const [identityLocation, setIdentityLocation] = useState('');
-  const [identityLinkedin, setIdentityLinkedin] = useState('');
-  const [identityWebsite, setIdentityWebsite] = useState('');
-
   // Server-known signatures — autosave fires only when local state diverges.
   // Failed-sigs prevent retry-loops when the server rejects a value.
-  const lastProfileSigRef = useRef<string | null>(null);
   const lastEmailSigRef = useRef<string | null>(null);
   const lastSmsSigRef = useRef<string | null>(null);
-  const lastFailedProfileSigRef = useRef<string | null>(null);
   const lastFailedEmailSigRef = useRef<string | null>(null);
   const lastFailedSmsSigRef = useRef<string | null>(null);
 
   const fetchPrefs = useCallback(async () => {
     try {
-      const [prefsRes, identityRes] = await Promise.all([
-        fetch('/api/profile/notifications'),
-        fetch('/api/profile/identity'),
-      ]);
+      const prefsRes = await fetch('/api/profile/notifications');
       if (prefsRes.ok) {
         const data = (await prefsRes.json()) as NotificationPreferences;
         setPrefs(data);
@@ -145,23 +114,6 @@ export default function SettingsPage() {
           data.phone_number ?? null
         );
       }
-      if (identityRes.ok) {
-        const data = (await identityRes.json()) as IdentityFields;
-        setIdentityName(data.name ?? '');
-        setIdentityEmail(data.email ?? '');
-        setIdentityPhone(data.phone_number ?? '');
-        setIdentityLocation(data.location ?? '');
-        setIdentityLinkedin(data.linkedin_url ?? '');
-        setIdentityWebsite(data.website_url ?? '');
-        lastProfileSigRef.current = profileSig({
-          name: (data.name ?? '').trim(),
-          email: (data.email ?? '').trim(),
-          phone_number: (data.phone_number ?? '').trim(),
-          location: (data.location ?? '').trim(),
-          linkedin_url: (data.linkedin_url ?? '').trim(),
-          website_url: (data.website_url ?? '').trim(),
-        });
-      }
     } catch {
       toast({
         variant: 'error',
@@ -177,64 +129,6 @@ export default function SettingsPage() {
   }, [fetchPrefs]);
 
   // -- Save handlers ----------------------------------------------------------
-
-  const handleSaveProfile = useCallback(async () => {
-    const trimmed = {
-      name: identityName.trim(),
-      email: identityEmail.trim(),
-      phone_number: identityPhone.trim(),
-      location: identityLocation.trim(),
-      linkedin_url: identityLinkedin.trim(),
-      website_url: identityWebsite.trim(),
-    };
-    const sig = profileSig(trimmed);
-    setSavingSection('profile');
-    try {
-      const res = await fetch('/api/profile/identity', {
-        method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(trimmed),
-      });
-      if (!res.ok) {
-        const message = await extractApiError(res, 'Failed to save profile');
-        toast({ variant: 'error', title: message });
-        lastFailedProfileSigRef.current = sig;
-        return;
-      }
-      const data = (await res.json()) as IdentityFields;
-      // Re-sync from server response so normalized values (e.g. E.164 phone)
-      // replace the typed input.
-      setIdentityName(data.name ?? '');
-      setIdentityEmail(data.email ?? '');
-      setIdentityPhone(data.phone_number ?? '');
-      setIdentityLocation(data.location ?? '');
-      setIdentityLinkedin(data.linkedin_url ?? '');
-      setIdentityWebsite(data.website_url ?? '');
-      lastProfileSigRef.current = profileSig({
-        name: (data.name ?? '').trim(),
-        email: (data.email ?? '').trim(),
-        phone_number: (data.phone_number ?? '').trim(),
-        location: (data.location ?? '').trim(),
-        linkedin_url: (data.linkedin_url ?? '').trim(),
-        website_url: (data.website_url ?? '').trim(),
-      });
-      lastFailedProfileSigRef.current = null;
-      toast({ variant: 'success', title: 'Profile saved' });
-    } catch {
-      toast({ variant: 'error', title: 'Failed to save profile' });
-      lastFailedProfileSigRef.current = sig;
-    } finally {
-      setSavingSection(null);
-    }
-  }, [
-    identityName,
-    identityEmail,
-    identityPhone,
-    identityLocation,
-    identityLinkedin,
-    identityWebsite,
-    toast,
-  ]);
 
   const handleSaveEmail = useCallback(async () => {
     const threshold = parseInt(emailThreshold, 10) || 100;
@@ -330,34 +224,6 @@ export default function SettingsPage() {
   // -- Autosave effects -------------------------------------------------------
 
   useEffect(() => {
-    if (lastProfileSigRef.current === null) return;
-    if (savingSection === 'profile') return;
-    const sig = profileSig({
-      name: identityName.trim(),
-      email: identityEmail.trim(),
-      phone_number: identityPhone.trim(),
-      location: identityLocation.trim(),
-      linkedin_url: identityLinkedin.trim(),
-      website_url: identityWebsite.trim(),
-    });
-    if (sig === lastProfileSigRef.current) return;
-    if (sig === lastFailedProfileSigRef.current) return;
-    const handle = setTimeout(() => {
-      handleSaveProfile();
-    }, AUTOSAVE_DEBOUNCE_MS);
-    return () => clearTimeout(handle);
-  }, [
-    identityName,
-    identityEmail,
-    identityPhone,
-    identityLocation,
-    identityLinkedin,
-    identityWebsite,
-    savingSection,
-    handleSaveProfile,
-  ]);
-
-  useEffect(() => {
     if (lastEmailSigRef.current === null) return;
     if (savingSection === 'email') return;
     const sig = emailSig(emailEnabled, parseInt(emailThreshold, 10) || 100);
@@ -420,80 +286,8 @@ export default function SettingsPage() {
         </Text>
       </div>
 
-      {/* Profile (resume + cover-letter contact info) */}
-      <Card>
-        <CardHeader>
-          <div className='flex items-center justify-between gap-3'>
-            <CardTitle>Profile</CardTitle>
-            <SavingIndicator active={savingSection === 'profile'} />
-          </div>
-        </CardHeader>
-        <CardContent className='flex flex-col gap-4'>
-          <Text variant='caption' className='text-text-secondary'>
-            Used as the contact header on every generated resume and cover
-            letter. Name is required before you can generate.
-          </Text>
-          <div className='grid gap-4 sm:grid-cols-2'>
-            <Input
-              label='Name'
-              value={identityName}
-              onChange={e => setIdentityName(e.target.value)}
-              placeholder='Full name'
-              autoComplete='name'
-              required
-              data-sentry-mask
-            />
-            <Input
-              label='Email'
-              type='email'
-              value={identityEmail}
-              onChange={e => setIdentityEmail(e.target.value)}
-              placeholder='name@example.com'
-              autoComplete='email'
-              inputMode='email'
-              data-sentry-mask
-            />
-            <Input
-              label='Phone'
-              type='tel'
-              value={identityPhone}
-              onChange={e => setIdentityPhone(e.target.value)}
-              placeholder='+1 555 555 5555'
-              autoComplete='tel'
-              inputMode='tel'
-              data-sentry-mask
-            />
-            <Input
-              label='Location'
-              value={identityLocation}
-              onChange={e => setIdentityLocation(e.target.value)}
-              placeholder='City, State'
-              autoComplete='address-level2'
-              data-sentry-mask
-            />
-            <Input
-              label='LinkedIn URL'
-              type='url'
-              value={identityLinkedin}
-              onChange={e => setIdentityLinkedin(e.target.value)}
-              placeholder='https://linkedin.com/in/username'
-              autoComplete='url'
-              inputMode='url'
-              data-sentry-mask
-            />
-            <Input
-              label='Website'
-              type='url'
-              value={identityWebsite}
-              onChange={e => setIdentityWebsite(e.target.value)}
-              placeholder='https://example.com'
-              autoComplete='url'
-              inputMode='url'
-              data-sentry-mask
-            />
-          </div>
-        </CardContent>
-      </Card>
+      {/* Identity (contact header used on generated resumes + cover letters)
+          lives on /profile now — see ProfileIdentityCard. */}
 
       {/* Email Notifications */}
       <Card>

--- a/apps/wyrdfold/src/app/(app)/settings/__tests__/SettingsPage.spec.tsx
+++ b/apps/wyrdfold/src/app/(app)/settings/__tests__/SettingsPage.spec.tsx
@@ -57,22 +57,15 @@ afterEach(() => {
 });
 
 describe('SettingsPage', () => {
-  it('renders the Profile section once preferences load', async () => {
+  it('no longer renders the Identity card — moved to /profile', async () => {
     render(<SettingsPage />);
-    expect(await screen.findByText('Profile')).toBeInTheDocument();
-    // Identity name pre-filled from server.
-    const nameInput = (await screen.findByLabelText(
-      /Name/i
-    )) as HTMLInputElement;
-    expect(nameInput.value).toBe('Daniel');
-  });
-
-  it('marks PII inputs with data-sentry-mask', async () => {
-    render(<SettingsPage />);
-    const nameInput = await screen.findByLabelText(/Name/i);
-    expect(nameInput).toHaveAttribute('data-sentry-mask');
-    const emailInput = await screen.findByLabelText(/^Email$/i);
-    expect(emailInput).toHaveAttribute('data-sentry-mask');
+    // Wait for prefs to settle so the page has finished rendering its cards.
+    expect(await screen.findByText(/email notifications/i)).toBeInTheDocument();
+    // Pre-refactor "Profile" CardTitle is gone. Use a strict match so we don't
+    // false-positive on "Profile" appearing in other strings (Sentry mask
+    // attributes, etc.).
+    expect(screen.queryByRole('heading', { name: /^Profile$/i })).toBeNull();
+    expect(screen.queryByLabelText(/^Name$/i)).toBeNull();
   });
 
   it('renders the email + SMS notification sections when those channels are available', async () => {


### PR DESCRIPTION
## Summary

Two IA cleanups requested by the user:

1. **Move "Profile" section from /settings to /profile.** It's identity data (Name, Email, Phone, Location, LinkedIn, Website) that anchors every generated resume and cover letter — semantically belongs with the master document, not next to notification preferences. Extracts a self-contained \`ProfileIdentityCard\` that fetches its own \`/api/profile/identity\`, owns its own form state, and debounces autosaves. SettingsPage drops the now-unused identity state, signature helpers, \`handleSaveProfile\`, and the identity autosave effect.

2. **Reorder /profile: move "Gaps to Fill" to right under "Document Health"** and default-collapse it. The header still shows the gap count and toggles the body open on click. Zero-gap case is unchanged (entire card hidden by existing conditional).

## Verification

Loaded /profile against the local API. Render order is now:

\`\`\`
Document Health       (top)
Gaps to Fill          (collapsed, "18 gaps" badge in header)
Identity              (loaded with hello@melissajoffe.com)
Master Document
Experience
Skills
\`\`\`

## Test plan
- [x] \`eslint\` + \`tsc --noEmit\` clean
- [x] Visual: render order matches the spec; Gaps default-collapsed; Identity card loads + saves
- [ ] After merge + deploy: settings page should no longer show the Profile card; profile page should pick up the new order

🤖 Generated with [Claude Code](https://claude.com/claude-code)