### PR TITLE
fix(wyrdfold-api): force-include manually-pasted jobs regardless of excluded flag

### DIFF
--- a/apps/wyrdfold-api/app/routers/jobs.py
+++ b/apps/wyrdfold-api/app/routers/jobs.py
@@ -697,6 +697,26 @@ async def add_manual_job(
         except Exception:
             logger.exception("Global score update failed for manual job %s", posting_id)
 
+        # Force-include this posting in the user's /jobs view regardless of
+        # what the negative-keyword pass decided. The scorer flags
+        # ``excluded=True`` whenever a negative keyword matches in the title
+        # or any "requirements"/"default" section of the JD — perfectly
+        # sensible for the poller (which fires for jobs nobody asked for),
+        # but wrong here: the user explicitly pasted this URL. Mentions of
+        # "mentor junior engineers" or "collaborate with the data analyst
+        # team" silently buried the job. Keep the score breakdown honest
+        # (the negative penalty stays in the breakdown so the badge color
+        # still tells the user this isn't a great fit) but make the row
+        # visible so the user can act on it.
+        try:
+            supabase.table("scores").update({"excluded": False}).eq(
+                "job_posting_id", posting_id
+            ).execute()
+        except Exception:
+            logger.exception(
+                "Force-include update failed for manual job %s", posting_id
+            )
+
     # Invalidate job list cache after adding a new posting
     job_list_cache.invalidate()
 


### PR DESCRIPTION
## Summary

User report: pasting a URL into the jobs list ("Paste URL" CTA on \`JobsEmptyState\` / \`JobsThinResultsCallout\`) — the job never appears under the active target.

## Root cause

\`POST /api/jobs/manual\` correctly upserts the posting and Stage-2 scores it against every active target. But \`score_and_upsert\` sets \`excluded = True\` on the scores row whenever a negative keyword from the target's profile matches the title or any requirements/default section of the JD. \`/api/jobs\` filters with \`.eq("excluded", False)\`, so excluded rows are invisible.

For the "Director of CX Operations" target, the negative list includes "analyst", "specialist", "coordinator", "junior", "individual contributor", etc. A pasted Senior Staff SWE JD typically contains at least one of those words in its responsibilities ("mentor junior engineers", "partner with the data analyst team"). Row ships with \`excluded=True\`, user never sees it.

That's the right behavior for the poller (which fires for jobs nobody asked for, so exclusion saves the user from noise), but the wrong behavior for the manual-add path (the user explicitly pasted this URL).

## Fix

After the scoring loop in \`/jobs/manual\`, run a single UPDATE setting \`excluded = False\` for every scores row tied to the new \`posting_id\`. Score breakdown stays honest (negative weight remains, badge color still tells the user this isn't a great fit). Only the visibility flag flips.

## Verification

Live against the CX target — re-pasted a Senior Staff SWE URL that was previously hidden:

\`\`\`
before:  total=0  ← row existed with excluded=True
after:   total=1  ← same row, excluded now False
breakdown.negative: -10  ← preserved
\`\`\`

## Test plan
- [x] \`ruff\` + \`mypy\` clean
- [x] Live re-paste confirms job now appears in target-filtered /jobs
- [ ] After merge + Railway deploy: paste any URL on the jobs page; confirm it lands under the active target

🤖 Generated with [Claude Code](https://claude.com/claude-code)