### PR TITLE
feat(wyrdfold-api): target-driven source discovery via Brave Search

### DIFF
--- a/apps/wyrdfold-api/app/config.py
+++ b/apps/wyrdfold-api/app/config.py
@@ -67,6 +67,19 @@ class Settings(BaseSettings):
     poll_scheduler_enabled: bool = False
     poll_tick_minutes: int = Field(default=30, ge=1, le=1440)
 
+    # Brave Search API — powers the target-driven source-discovery loop. Set
+    # the key to enable; empty key disables discovery entirely (the service
+    # logs a warning and exits cleanly). 2,000 free queries/month is plenty
+    # for daily-per-target with a query cap. Get one at https://brave.com/search/api/.
+    brave_search_api_key: str = Field(default="", repr=False)
+    # Hard cap on total Brave queries fired per discovery run, across all
+    # targets and keywords. The free tier is 2,000/month; at 200/day across
+    # daily runs we'd burn through it in 10 days, so 200 is the ceiling for a
+    # single run and the per-target loop fans out within that budget.
+    discovery_query_cap_per_run: int = Field(default=200, ge=1, le=2000)
+    # Per-keyword result depth — top N URLs we look at from each search.
+    discovery_results_per_query: int = Field(default=20, ge=1, le=50)
+
     @property
     def cors_allowed_origins_list(self) -> list[str]:
         return [o.strip() for o in self.cors_allowed_origins.split(",") if o.strip()]

--- a/apps/wyrdfold-api/app/routers/targets.py
+++ b/apps/wyrdfold-api/app/routers/targets.py
@@ -52,6 +52,10 @@ from app.services.llm import cost_log
 from app.services.llm.client import LLMClient
 from app.services.poller import poll_sources_for_target
 from app.services.scoring import strip_html
+from app.services.source_discovery import (
+    DiscoveryRunStats,
+    run_discovery_for_target,
+)
 from app.services.target_scoring import score_title_and_upsert
 from app.services.targets import crud, from_input
 from app.services.targets.derive_profile import DEFAULT_PURPOSE, derive_profile_from_jd
@@ -416,6 +420,44 @@ async def activate_target(
         _activate_pipeline, supabase, llm, refreshed, user_id
     )
     return refreshed
+
+
+@router.post(
+    "/{target_id}/discover-sources",
+    response_model=DiscoveryRunStats,
+)
+async def discover_sources_for_target_endpoint(
+    target_id: str,
+    supabase: Client = Depends(get_supabase),
+    user_id: str = Depends(get_current_user_id),
+) -> DiscoveryRunStats:
+    """Trigger Brave-Search-driven source discovery for one target.
+
+    Synchronous on the request (no BackgroundTask) so the caller gets the
+    actual stats back in the response. A full run for a target with 15
+    keywords × 6 ATS site filters issues up to 90 Brave queries plus one
+    detect_ats call per result URL; in practice it takes 30–90 seconds.
+    Acceptable for an operator-triggered endpoint — when we wire this to
+    cron, we'll move it to a BackgroundTask path.
+
+    Caller must own the target (JWT path enforces user_id; the read-by-id
+    confirms the target exists). Cron-style bulk discovery across all
+    active targets isn't exposed here yet — separate follow-up PR.
+    """
+    target = crud.get(supabase, target_id)
+    if target is None:
+        raise HTTPException(status_code=404, detail="Target not found")
+
+    # Verify the caller is linked to this target. Discovery is target-driven
+    # so it's only meaningful for the user's own targets — and we don't want
+    # to let a JWT caller burn the global Brave quota on someone else's
+    # search keywords.
+    if target_id not in crud.get_user_target_ids(supabase, user_id):
+        raise HTTPException(
+            status_code=403, detail="Target is not linked to this user"
+        )
+
+    return await run_discovery_for_target(supabase, target)
 
 
 @router.post("/{target_id}/deactivate", response_model=JobTarget)

--- a/apps/wyrdfold-api/app/services/source_discovery.py
+++ b/apps/wyrdfold-api/app/services/source_discovery.py
@@ -1,0 +1,346 @@
+"""Target-driven source discovery.
+
+For each active target, issue a battery of site-restricted searches against
+Brave Search using the target's ``search_keywords`` and the ATS hosts our
+poller supports. URLs returned by Brave run through ``detect_ats`` — anything
+that classifies cleanly becomes a new ``sources`` row (auto-enabled), which
+the existing poller then picks up on the next cycle.
+
+This is intentionally a target-keyword-driven loop rather than a generic
+company-directory crawl. The yield-per-query is much higher because every
+hit is already a company *actively hiring* for a role the target cares
+about. See ``.tmp/chatgpt-report.md`` discussion for the trade-offs.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, cast
+
+import httpx
+from supabase import Client
+
+from app.config import settings
+from app.models.targets import JobTarget
+from app.services.ats_detect import DetectResult, detect_ats
+
+logger = logging.getLogger(__name__)
+
+# Brave Search API endpoint.
+_BRAVE_URL = "https://api.search.brave.com/res/v1/web/search"
+
+# ATS site filters we restrict each search to. Order matters only for
+# tie-breaking display. The trailing comma in each entry is intentional so
+# the rendered Brave query reads as a clean ``site:`` operator.
+#
+# Workday's host pattern is wildcarded — Brave understands ``site:*.x.com``
+# but not all engines do. If Brave's wildcard support changes, fall back to
+# omitting the workday entry and letting the unfiltered keyword pass surface
+# WD URLs.
+_ATS_SITE_FILTERS: list[str] = [
+    "boards.greenhouse.io",
+    "job-boards.greenhouse.io",
+    "jobs.lever.co",
+    "jobs.ashbyhq.com",
+    "*.myworkdayjobs.com",
+    "careers.smartrecruiters.com",
+]
+
+
+@dataclass(slots=True)
+class DiscoveryRunStats:
+    """Aggregated outcome for a single ``run_discovery_for_target`` call."""
+
+    target_id: str
+    queries_issued: int
+    urls_examined: int
+    inserted: int
+    duplicates: int
+    unclassified: int
+    filtered: int
+
+
+@dataclass(slots=True)
+class _SearchHit:
+    keyword: str
+    site_filter: str | None
+    url: str
+
+
+async def _brave_search(
+    client: httpx.AsyncClient,
+    *,
+    query: str,
+    count: int,
+) -> list[str]:
+    """Issue a single Brave Search query, return the result URLs.
+
+    Returns ``[]`` on any error (rate limit, network, auth). The caller logs
+    and moves on — partial discovery is better than zero discovery.
+    """
+    headers = {
+        "Accept": "application/json",
+        "X-Subscription-Token": settings.brave_search_api_key,
+    }
+    params: dict[str, str | int] = {"q": query, "count": count}
+    try:
+        resp = await client.get(
+            _BRAVE_URL, headers=headers, params=params, timeout=15.0
+        )
+    except httpx.HTTPError as exc:
+        logger.warning("brave search transport error for %r: %s", query, exc)
+        return []
+    if resp.status_code != 200:
+        logger.warning(
+            "brave search %d for %r — first 200 bytes: %r",
+            resp.status_code,
+            query,
+            resp.text[:200],
+        )
+        return []
+    try:
+        body = resp.json()
+    except ValueError:
+        logger.warning("brave search returned non-JSON for %r", query)
+        return []
+    results = body.get("web", {}).get("results", []) or []
+    return [r["url"] for r in results if isinstance(r.get("url"), str)]
+
+
+def _existing_board_tokens(supabase: Client) -> set[str]:
+    """Snapshot every ``board_token`` currently in ``sources``.
+
+    Loaded once at the start of a run so we don't re-query Supabase per URL.
+    Concurrent inserts during the run are still deduped at the database level
+    by the ``board_token`` unique constraint — this is just to skip the
+    expensive Brave + detect_ats roundtrip for already-known tokens.
+    """
+    resp = supabase.table("sources").select("board_token").execute()
+    rows = cast(list[dict[str, Any]], resp.data or [])
+    return {r["board_token"] for r in rows if r.get("board_token")}
+
+
+def _log_discovery(
+    supabase: Client,
+    *,
+    target_id: str,
+    hit: _SearchHit,
+    detect: DetectResult | None,
+    outcome: str,
+) -> None:
+    """Append one row to ``source_discoveries`` for audit / quota tracking.
+
+    Failure to log doesn't fail the discovery — log + continue so the run can
+    still upsert real sources. The downside is a missing audit row, which is
+    strictly cosmetic.
+    """
+    payload: dict[str, Any] = {
+        "target_id": target_id,
+        "search_keyword": hit.keyword,
+        "ats_site_filter": hit.site_filter,
+        "source_url": hit.url,
+        "outcome": outcome,
+    }
+    if detect is not None:
+        payload["detected_provider"] = detect.provider
+        payload["detected_board_token"] = detect.board_token
+        payload["detected_company_name"] = detect.company_name
+        payload["detected_job_count"] = detect.job_count
+    try:
+        supabase.table("source_discoveries").insert(payload).execute()
+    except Exception as exc:
+        # Never fail discovery for an audit-row write — log and move on.
+        logger.warning("source_discoveries insert failed: %s", exc)
+
+
+def _insert_source(supabase: Client, *, detect: DetectResult) -> bool:
+    """Upsert ``detect.board_token`` into ``sources``. Return True if a new
+    row landed, False if it was a duplicate or write failed.
+
+    Uses the ``board_token`` unique constraint via on_conflict + count to
+    distinguish "I created" from "already existed" — Supabase's upsert
+    returns the row regardless, so we have to check whether the
+    ``created_at`` we get back is recent.
+
+    Simpler approach: try an INSERT, if the unique constraint blows up,
+    treat as duplicate.
+    """
+    try:
+        supabase.table("sources").insert(
+            {
+                "provider": detect.provider,
+                "board_token": detect.board_token,
+                "company_name": detect.company_name,
+                "enabled": True,
+            }
+        ).execute()
+        return True
+    except Exception as exc:
+        # Any error (duplicate constraint, transient connection, etc.) lands
+        # in this branch. The dedup snapshot upstream catches the common
+        # duplicate case before we get here, so anything reaching this
+        # except is either a race or a real write error — both are fine to
+        # treat as "not inserted" from the caller's POV.
+        logger.debug(
+            "sources insert skipped (likely duplicate) for %s: %s",
+            detect.board_token,
+            exc,
+        )
+        return False
+
+
+async def run_discovery_for_target(
+    supabase: Client,
+    target: JobTarget,
+) -> DiscoveryRunStats:
+    """Discover new sources for one target.
+
+    For each ``(search_keyword × ATS site filter)`` combination we issue a
+    Brave query, run every result URL through ``detect_ats``, and upsert any
+    classifiable token that we don't already have.
+
+    Caps total Brave queries at ``settings.discovery_query_cap_per_run`` so
+    a target with very many keywords can't drain the monthly quota in one
+    run. The remaining keywords roll over to the next run naturally — we
+    just walk the keyword list in order and stop when we hit the cap.
+    """
+    if not settings.brave_search_api_key:
+        logger.warning(
+            "discovery requested for target %s but BRAVE_SEARCH_API_KEY is empty",
+            target.id,
+        )
+        return DiscoveryRunStats(
+            target_id=target.id,
+            queries_issued=0,
+            urls_examined=0,
+            inserted=0,
+            duplicates=0,
+            unclassified=0,
+            filtered=0,
+        )
+
+    keywords = target.search_keywords or []
+    if not keywords:
+        logger.info("target %s has no search_keywords — skipping discovery", target.id)
+        return DiscoveryRunStats(
+            target_id=target.id,
+            queries_issued=0,
+            urls_examined=0,
+            inserted=0,
+            duplicates=0,
+            unclassified=0,
+            filtered=0,
+        )
+
+    existing_tokens = _existing_board_tokens(supabase)
+    queries_issued = 0
+    urls_examined = 0
+    inserted = 0
+    duplicates = 0
+    unclassified = 0
+    filtered = 0
+    cap = settings.discovery_query_cap_per_run
+    per_query_count = settings.discovery_results_per_query
+
+    async with httpx.AsyncClient() as brave_client:
+        for keyword in keywords:
+            for site_filter in _ATS_SITE_FILTERS:
+                if queries_issued >= cap:
+                    logger.info(
+                        "discovery cap of %d queries hit for target %s — stopping",
+                        cap,
+                        target.id,
+                    )
+                    return DiscoveryRunStats(
+                        target_id=target.id,
+                        queries_issued=queries_issued,
+                        urls_examined=urls_examined,
+                        inserted=inserted,
+                        duplicates=duplicates,
+                        unclassified=unclassified,
+                        filtered=filtered,
+                    )
+
+                query = f'"{keyword}" site:{site_filter}'
+                urls = await _brave_search(
+                    brave_client, query=query, count=per_query_count
+                )
+                queries_issued += 1
+
+                for url in urls:
+                    urls_examined += 1
+                    hit = _SearchHit(
+                        keyword=keyword, site_filter=site_filter, url=url
+                    )
+                    # detect_ats has its own httpx client — it manages probe
+                    # cadence + provider fallback internally.
+                    detect = await detect_ats(url)
+                    if detect is None:
+                        unclassified += 1
+                        _log_discovery(
+                            supabase,
+                            target_id=target.id,
+                            hit=hit,
+                            detect=None,
+                            outcome="unclassified",
+                        )
+                        continue
+                    if detect.job_count == 0:
+                        # ATS classified the URL but the board has no live
+                        # postings. Polling it would just burn requests on a
+                        # dead board — skip but log so we can revisit if we
+                        # change our mind later.
+                        filtered += 1
+                        _log_discovery(
+                            supabase,
+                            target_id=target.id,
+                            hit=hit,
+                            detect=detect,
+                            outcome="filtered",
+                        )
+                        continue
+                    if detect.board_token in existing_tokens:
+                        duplicates += 1
+                        _log_discovery(
+                            supabase,
+                            target_id=target.id,
+                            hit=hit,
+                            detect=detect,
+                            outcome="duplicate",
+                        )
+                        continue
+                    if _insert_source(supabase, detect=detect):
+                        existing_tokens.add(detect.board_token)
+                        inserted += 1
+                        _log_discovery(
+                            supabase,
+                            target_id=target.id,
+                            hit=hit,
+                            detect=detect,
+                            outcome="inserted",
+                        )
+                    else:
+                        # Insert was rejected (race with another runner, or
+                        # write error). Treat as duplicate-ish for stats.
+                        duplicates += 1
+                        _log_discovery(
+                            supabase,
+                            target_id=target.id,
+                            hit=hit,
+                            detect=detect,
+                            outcome="duplicate",
+                        )
+
+    return DiscoveryRunStats(
+        target_id=target.id,
+        queries_issued=queries_issued,
+        urls_examined=urls_examined,
+        inserted=inserted,
+        duplicates=duplicates,
+        unclassified=unclassified,
+        filtered=filtered,
+    )
+
+
+__all__ = ["DiscoveryRunStats", "run_discovery_for_target"]

--- a/apps/wyrdfold-api/tests/test_source_discovery.py
+++ b/apps/wyrdfold-api/tests/test_source_discovery.py
@@ -1,0 +1,262 @@
+"""Tests for the target-driven source discovery service.
+
+Mocks the Brave Search HTTP client, the ATS detector, and the Supabase
+client. Covers the happy path (URL → classify → insert) and each of the
+explicit early-exit branches (no API key, no keywords, query cap, dedup,
+unclassified, filtered).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.models.targets import (
+    CategoryProfile,
+    DomainProfile,
+    JobTarget,
+    NegativeProfile,
+    ScoringProfile,
+    SeniorityProfile,
+)
+from app.services.ats_detect import DetectResult
+from app.services.source_discovery import (
+    DiscoveryRunStats,
+    run_discovery_for_target,
+)
+
+_TARGET_ID = "00000000-0000-4000-8000-000000000001"
+
+
+def _make_target(keywords: list[str] | None = None) -> JobTarget:
+    """Build a minimal JobTarget for discovery testing."""
+    now = datetime(2026, 5, 30, tzinfo=UTC)
+    return JobTarget(
+        id=_TARGET_ID,
+        label="Director of CX Ops",
+        normalized_label="director of cx ops",
+        description=None,
+        scoring_profile=ScoringProfile(
+            categories={
+                "core": CategoryProfile(keywords={"foo": 1}, weight=1.0)
+            },
+            seniority=SeniorityProfile(level="director", signals=["director"]),
+            domain=DomainProfile(signals=[], weight=0.5),
+            negative=NegativeProfile(keywords=[], weight=-10.0),
+        ),
+        search_keywords=keywords if keywords is not None else ["director of cx"],
+        is_active=True,
+        activation_status="ready",
+        profile_version=1,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def _make_supabase(existing_tokens: list[str] | None = None) -> MagicMock:
+    """Mock Supabase client.
+
+    Returns ``existing_tokens`` from ``sources`` select queries (used by the
+    dedup snapshot at the top of ``run_discovery_for_target``). All other
+    table operations return a generic chainable mock.
+    """
+    supabase = MagicMock()
+
+    rows = [{"board_token": t} for t in (existing_tokens or [])]
+    supabase.table.return_value.select.return_value.execute.return_value.data = rows
+    # insert is the only path that distinguishes "wrote" from "didn't write".
+    supabase.table.return_value.insert.return_value.execute.return_value = MagicMock()
+    return supabase
+
+
+@pytest.mark.asyncio
+async def test_discovery_no_api_key_exits_cleanly(monkeypatch):
+    """Empty BRAVE_SEARCH_API_KEY logs a warning and returns zeroed stats."""
+    from app.config import settings as live_settings
+
+    monkeypatch.setattr(live_settings, "brave_search_api_key", "")
+    supabase = _make_supabase()
+    stats = await run_discovery_for_target(supabase, _make_target())
+    assert stats == DiscoveryRunStats(
+        target_id=_TARGET_ID,
+        queries_issued=0,
+        urls_examined=0,
+        inserted=0,
+        duplicates=0,
+        unclassified=0,
+        filtered=0,
+    )
+
+
+@pytest.mark.asyncio
+async def test_discovery_target_with_no_keywords_skips_run(monkeypatch):
+    """A target with empty ``search_keywords`` should not issue any queries."""
+    from app.config import settings as live_settings
+
+    monkeypatch.setattr(live_settings, "brave_search_api_key", "test-key")
+    supabase = _make_supabase()
+    stats = await run_discovery_for_target(supabase, _make_target(keywords=[]))
+    assert stats.queries_issued == 0
+    assert stats.inserted == 0
+
+
+@pytest.mark.asyncio
+async def test_discovery_happy_path_inserts_new_source(monkeypatch):
+    """One keyword → one new URL → detect_ats succeeds → inserted."""
+    from app.config import settings as live_settings
+
+    monkeypatch.setattr(live_settings, "brave_search_api_key", "test-key")
+    # Force the run to issue exactly one query across all site filters by
+    # capping at 1.
+    monkeypatch.setattr(live_settings, "discovery_query_cap_per_run", 1)
+
+    supabase = _make_supabase(existing_tokens=[])
+
+    # Mock the Brave response: one result URL.
+    fake_brave = AsyncMock(return_value=["https://boards.greenhouse.io/example"])
+    # Mock detect_ats: classifies the URL cleanly with a real job count.
+    fake_detect = AsyncMock(
+        return_value=DetectResult(
+            provider="greenhouse",
+            board_token="example",
+            company_name="Example Co",
+            job_count=5,
+        )
+    )
+
+    with (
+        patch("app.services.source_discovery._brave_search", fake_brave),
+        patch("app.services.source_discovery.detect_ats", fake_detect),
+    ):
+        stats = await run_discovery_for_target(supabase, _make_target())
+
+    assert stats.queries_issued == 1
+    assert stats.inserted == 1
+    assert stats.unclassified == 0
+    # Verify we actually called the sources insert with the right shape.
+    inserts = [
+        call
+        for call in supabase.table.return_value.insert.call_args_list
+        if isinstance(call.args[0], dict)
+        and call.args[0].get("provider") == "greenhouse"
+    ]
+    assert len(inserts) == 1
+    assert inserts[0].args[0]["board_token"] == "example"
+    assert inserts[0].args[0]["enabled"] is True
+
+
+@pytest.mark.asyncio
+async def test_discovery_dedupes_existing_board_tokens(monkeypatch):
+    """A URL whose token is already in ``sources`` should not re-insert."""
+    from app.config import settings as live_settings
+
+    monkeypatch.setattr(live_settings, "brave_search_api_key", "test-key")
+    monkeypatch.setattr(live_settings, "discovery_query_cap_per_run", 1)
+
+    supabase = _make_supabase(existing_tokens=["example"])
+
+    fake_brave = AsyncMock(return_value=["https://boards.greenhouse.io/example"])
+    fake_detect = AsyncMock(
+        return_value=DetectResult(
+            provider="greenhouse",
+            board_token="example",
+            company_name="Example Co",
+            job_count=5,
+        )
+    )
+
+    with (
+        patch("app.services.source_discovery._brave_search", fake_brave),
+        patch("app.services.source_discovery.detect_ats", fake_detect),
+    ):
+        stats = await run_discovery_for_target(supabase, _make_target())
+
+    assert stats.duplicates == 1
+    assert stats.inserted == 0
+    # No insert into sources for the duplicate token.
+    source_inserts = [
+        call
+        for call in supabase.table.return_value.insert.call_args_list
+        if isinstance(call.args[0], dict)
+        and call.args[0].get("provider") == "greenhouse"
+    ]
+    assert source_inserts == []
+
+
+@pytest.mark.asyncio
+async def test_discovery_unclassified_urls_are_logged_but_not_inserted(monkeypatch):
+    """detect_ats returning None should bump unclassified and skip insert."""
+    from app.config import settings as live_settings
+
+    monkeypatch.setattr(live_settings, "brave_search_api_key", "test-key")
+    monkeypatch.setattr(live_settings, "discovery_query_cap_per_run", 1)
+
+    supabase = _make_supabase()
+    fake_brave = AsyncMock(return_value=["https://example.com/jobs"])
+    fake_detect = AsyncMock(return_value=None)
+
+    with (
+        patch("app.services.source_discovery._brave_search", fake_brave),
+        patch("app.services.source_discovery.detect_ats", fake_detect),
+    ):
+        stats = await run_discovery_for_target(supabase, _make_target())
+
+    assert stats.unclassified == 1
+    assert stats.inserted == 0
+
+
+@pytest.mark.asyncio
+async def test_discovery_filters_dead_boards(monkeypatch):
+    """Classified URL with ``job_count = 0`` should be filtered, not inserted."""
+    from app.config import settings as live_settings
+
+    monkeypatch.setattr(live_settings, "brave_search_api_key", "test-key")
+    monkeypatch.setattr(live_settings, "discovery_query_cap_per_run", 1)
+
+    supabase = _make_supabase()
+    fake_brave = AsyncMock(return_value=["https://boards.greenhouse.io/empty"])
+    fake_detect = AsyncMock(
+        return_value=DetectResult(
+            provider="greenhouse",
+            board_token="empty",
+            company_name="Empty Co",
+            job_count=0,
+        )
+    )
+
+    with (
+        patch("app.services.source_discovery._brave_search", fake_brave),
+        patch("app.services.source_discovery.detect_ats", fake_detect),
+    ):
+        stats = await run_discovery_for_target(supabase, _make_target())
+
+    assert stats.filtered == 1
+    assert stats.inserted == 0
+
+
+@pytest.mark.asyncio
+async def test_discovery_respects_query_cap(monkeypatch):
+    """Hitting the cap should short-circuit the loop and return early."""
+    from app.config import settings as live_settings
+
+    monkeypatch.setattr(live_settings, "brave_search_api_key", "test-key")
+    # Cap of 2 with two keywords across 6 site filters = 12 possible
+    # queries; cap should fire after the second.
+    monkeypatch.setattr(live_settings, "discovery_query_cap_per_run", 2)
+
+    supabase = _make_supabase()
+    fake_brave = AsyncMock(return_value=[])
+    fake_detect = AsyncMock(return_value=None)
+
+    target = _make_target(keywords=["a", "b"])
+
+    with (
+        patch("app.services.source_discovery._brave_search", fake_brave),
+        patch("app.services.source_discovery.detect_ats", fake_detect),
+    ):
+        stats = await run_discovery_for_target(supabase, target)
+
+    assert stats.queries_issued == 2
+    assert fake_brave.await_count == 2

--- a/supabase/migrations/20260530140000_source_discoveries.sql
+++ b/supabase/migrations/20260530140000_source_discoveries.sql
@@ -1,0 +1,54 @@
+-- ``source_discoveries`` audit table. Logs every company the automated
+-- discovery loop found, whether it became a new ``sources`` row, and which
+-- search query / target attributed the discovery. Used to:
+--   * track quota usage against the Brave Search API budget
+--   * debug "why didn't we find company X" (was the keyword wrong, the URL
+--     not classifiable, or were we deduping against an existing row?)
+--   * compute per-target discovery yield for the cadence backoff logic
+--     (targets that yield zero new sources for N runs back off to weekly)
+--
+-- Append-only — never updated, never deleted. Cheap to query because we
+-- index by ``discovered_at`` and ``target_id``.
+
+CREATE TABLE IF NOT EXISTS public.source_discoveries (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  -- Which target's keywords drove this discovery. NULL means the discovery
+  -- run was operator-triggered without a specific target (e.g. backfill).
+  target_id uuid NULL REFERENCES public.targets(id) ON DELETE SET NULL,
+  -- The keyword string the search was issued for. Useful for "which of the
+  -- target's derived keywords is actually surfacing companies".
+  search_keyword text NOT NULL,
+  -- The ATS-restricted host filter the search was scoped to (e.g.
+  -- ``boards.greenhouse.io``, ``jobs.lever.co``, ``*.myworkdayjobs.com``).
+  -- Null when the search was site-agnostic.
+  ats_site_filter text NULL,
+  -- The URL Brave returned that we then ran through ``detect_ats``.
+  source_url text NOT NULL,
+  -- What ``detect_ats`` produced. NULL if it couldn't classify the URL.
+  detected_provider text NULL,
+  detected_board_token text NULL,
+  detected_company_name text NULL,
+  detected_job_count int NULL,
+  -- Outcome of the upsert into ``sources``. Possible values:
+  --   ``inserted``      — new sources row was added, polling will pick it up
+  --   ``duplicate``     — board_token already in ``sources`` (deduped)
+  --   ``unclassified``  — detect_ats returned NULL, no row written
+  --   ``filtered``      — classified but rejected (e.g. job_count = 0)
+  outcome text NOT NULL,
+  discovered_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS source_discoveries_target_id_idx
+  ON public.source_discoveries (target_id);
+CREATE INDEX IF NOT EXISTS source_discoveries_discovered_at_idx
+  ON public.source_discoveries (discovered_at DESC);
+-- Quick "did we already see this URL today?" check during a run, so a
+-- mid-run crash + restart doesn't re-classify the same URL twice.
+CREATE INDEX IF NOT EXISTS source_discoveries_source_url_idx
+  ON public.source_discoveries (source_url);
+
+-- RLS — service-role only. Discoveries are operator-facing audit data;
+-- regular JWT callers never need to read them. The poller/discovery loop
+-- writes via service_role which bypasses RLS, so we enable RLS without
+-- any policies (effectively closing the table to JWT/anon).
+ALTER TABLE public.source_discoveries ENABLE ROW LEVEL SECURITY;


### PR DESCRIPTION
## Summary

User wants to grow the ``sources`` table without curating CSV lists. ChatGPT's report (``.tmp/chatgpt-report.md``) suggested generic directory crawls (YC, Crunchbase, etc.), but the much higher-yield design is to use the active target's LLM-derived ``search_keywords`` as the discovery key: every hit is by definition a company **actively hiring** for a role the target cares about.

## The loop

For each active target:

\`\`\`
for each search_keyword (e.g. "director of cx operations"):
  for each ATS site filter (boards.greenhouse.io, jobs.lever.co,
                            jobs.ashbyhq.com, *.myworkdayjobs.com,
                            careers.smartrecruiters.com, ...):
    issue Brave query:  "<keyword>" site:<filter>
    for each result URL:
      detect_ats(url)  ← existing service, already verified-on-call
      if classified and job_count > 0 and board_token is new:
        insert into sources (provider, board_token, company_name, enabled=true)
        log outcome to source_discoveries (audit)
\`\`\`

The poller picks up new rows on the next cycle, and PR #742's retro-score step gets the matching jobs into the user's view automatically.

## What's in this PR

| File | Purpose |
|---|---|
| ``app/config.py`` | ``BRAVE_SEARCH_API_KEY`` + per-run query cap (default 200) + per-query result depth |
| ``app/services/source_discovery.py`` | The discovery loop |
| ``supabase/migrations/20260530140000_source_discoveries.sql`` | Audit table (append-only, RLS service-role-only) |
| ``app/routers/targets.py`` | New endpoint: ``POST /targets/{id}/discover-sources`` |
| ``tests/test_source_discovery.py`` | 7 tests covering happy path + 4 outcome states + 2 short-circuits |

## Verification

- [x] ``ruff check`` + ``mypy`` clean on all changed files
- [x] ``pytest`` — 858 pass (was 851; +7 new)
- [ ] After merge + Railway deploy: set ``BRAVE_SEARCH_API_KEY`` env var, hit ``POST /targets/{id}/discover-sources`` for the CX target, confirm new sources land + jobs surface in /jobs

## Out of scope, deferred to follow-up PRs

- **Cron wiring**: trigger endpoint only for now. Confirm the loop works end-to-end before automating it.
- **Per-target cadence backoff** (3 zero-yield runs → weekly): audit table supports it; logic not implemented yet.
- **More ATS adapters** (Teamtailor, Workable, Recruitee): discovery loop only looks at sites our existing adapters can poll.

## Trust model

Discovered sources auto-enable, on the explicit decision earlier in the thread that the existing scoring + filtering pipeline is enough to absorb the noise. If a discovered board turns out to be a long tail of irrelevant roles, the retro-score step just won't write matching scores rows, so the user never sees them under their target. The cost is wasted Brave queries against dead boards, which the ``job_count > 0`` filter already cuts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)