### PR TITLE
fix(wyrdfold-api): SmartRecruiters fetcher pulls JD body + human URL from detail endpoint

### DIFF
--- a/apps/wyrdfold-api/app/services/smartrecruiters.py
+++ b/apps/wyrdfold-api/app/services/smartrecruiters.py
@@ -1,4 +1,6 @@
+import asyncio
 import logging
+from typing import Any
 
 from app.http_client import FetchExhaustedError, request_with_retry
 from app.services.standard_job import StandardJob
@@ -7,20 +9,102 @@ logger = logging.getLogger(__name__)
 
 SMARTRECRUITERS_BASE = "https://api.smartrecruiters.com/v1/companies"
 
+# Cap on per-posting detail fetches per fan-out so we don't slam the
+# SmartRecruiters API. A board with 500 postings still completes — just in
+# batches.
+_DETAIL_CONCURRENCY = 5
 
-async def fetch_smartrecruiters_jobs(company_id: str) -> list[StandardJob]:
-    """Fetch jobs from SmartRecruiters' public Posting API."""
-    url = f"{SMARTRECRUITERS_BASE}/{company_id}/postings"
+
+def _build_content(posting_detail: dict[str, Any]) -> str:
+    """Assemble the full JD body from a posting-detail response.
+
+    SmartRecruiters partitions the JD body across four ``jobAd.sections``
+    keys: ``companyDescription``, ``jobDescription``, ``qualifications``,
+    ``additionalInformation``. Each value is HTML-ish (``<p>``, ``<ul>``,
+    ``<strong>`` etc.) but the API doesn't guarantee a full document, so
+    we concatenate the four section bodies with paragraph breaks. The
+    downstream sanitizer + parser are tolerant of fragment HTML.
+    """
+    sections = posting_detail.get("jobAd", {}).get("sections", {}) or {}
+    parts: list[str] = []
+    for key in (
+        "companyDescription",
+        "jobDescription",
+        "qualifications",
+        "additionalInformation",
+    ):
+        body = sections.get(key, {}).get("text")
+        if body:
+            parts.append(body)
+    return "\n\n".join(parts)
+
+
+async def _fetch_one_posting_detail(
+    company_id: str, posting_id: str
+) -> dict[str, Any] | None:
+    """GET ``/postings/{posting_id}`` — the detail endpoint, which is the
+    only one that actually returns ``jobAd.sections.*.text`` and the human
+    facing ``postingUrl``. The list endpoint returns shells with empty
+    sections even when called with ``?format=full``.
+    """
+    url = f"{SMARTRECRUITERS_BASE}/{company_id}/postings/{posting_id}"
     try:
         resp = await request_with_retry("GET", url)
     except FetchExhaustedError as exc:
-        logger.warning("smartrecruiters fetch exhausted retries for %s: %s", company_id, exc)
+        logger.warning(
+            "smartrecruiters detail fetch exhausted retries for %s/%s: %s",
+            company_id,
+            posting_id,
+            exc,
+        )
+        return None
+    if resp.status_code == 404:
+        return None
+    if resp.status_code >= 400:
+        logger.warning(
+            "smartrecruiters detail %s/%s returned %d",
+            company_id,
+            posting_id,
+            resp.status_code,
+        )
+        return None
+    body = resp.json()
+    return body if isinstance(body, dict) else None
+
+
+async def fetch_smartrecruiters_jobs(company_id: str) -> list[StandardJob]:
+    """Fetch jobs from SmartRecruiters' public Posting API.
+
+    Two-phase fetch: list endpoint surfaces the posting IDs + shallow
+    metadata, then the per-posting detail endpoint provides the JD body
+    and the apply-page URL. The list endpoint's ``?format=full`` flag
+    does NOT include the JD body — only the detail endpoint does.
+
+    Per-posting fans out under ``_DETAIL_CONCURRENCY`` so a 500-posting
+    board doesn't hammer the API on a single poll cycle. Per-posting
+    failures degrade gracefully — the posting is dropped from this run
+    and the next poll cycle will retry.
+    """
+    list_url = f"{SMARTRECRUITERS_BASE}/{company_id}/postings"
+    try:
+        resp = await request_with_retry("GET", list_url)
+    except FetchExhaustedError as exc:
+        logger.warning(
+            "smartrecruiters list fetch exhausted retries for %s: %s",
+            company_id,
+            exc,
+        )
         return []
 
     if resp.status_code == 404:
         return []
     if resp.status_code >= 400:
-        logger.warning("smartrecruiters %s returned %d for %s", company_id, resp.status_code, url)
+        logger.warning(
+            "smartrecruiters %s returned %d for %s",
+            company_id,
+            resp.status_code,
+            list_url,
+        )
         return []
 
     data = resp.json()
@@ -28,30 +112,67 @@ async def fetch_smartrecruiters_jobs(company_id: str) -> list[StandardJob]:
     if not isinstance(items, list):
         return []
 
+    # Phase 2: fan out detail fetches under a concurrency cap.
+    semaphore = asyncio.Semaphore(_DETAIL_CONCURRENCY)
+
+    async def _bounded_detail(posting_id: str) -> dict[str, Any] | None:
+        async with semaphore:
+            return await _fetch_one_posting_detail(company_id, posting_id)
+
+    detail_results = await asyncio.gather(
+        *(_bounded_detail(str(item.get("id", ""))) for item in items if item.get("id")),
+        return_exceptions=True,
+    )
+
+    # Build a lookup so we can pair each list item with its detail body.
+    details_by_id: dict[str, dict[str, Any]] = {}
+    for result in detail_results:
+        if isinstance(result, BaseException):
+            logger.warning("smartrecruiters detail raised: %s", result)
+            continue
+        if result is None:
+            continue
+        pid = str(result.get("id", ""))
+        if pid:
+            details_by_id[pid] = result
+
     jobs: list[StandardJob] = []
     for item in items:
-        location = item.get("location", {})
+        list_id = str(item.get("id", ""))
+        detail = details_by_id.get(list_id)
+        if detail is None:
+            # Detail fetch failed for this posting. Skip it — we'd otherwise
+            # write a row with empty description_html, which the LLM analyzer
+            # would 422 on anyway. The next poll cycle will retry.
+            continue
+
+        location = detail.get("location", {}) or {}
         city = location.get("city", "")
         country = location.get("country", "")
         location_str = f"{city}, {country}".strip(", ") if city or country else None
 
-        department = item.get("department", {})
+        department = detail.get("department", {}) or {}
 
-        company = item.get("company", {})
-        job_url = item.get("ref", "")
+        # Prefer ``postingUrl`` — that's the human-facing apply page
+        # (``jobs.smartrecruiters.com/{company}/{id}-{slug}``). Fall back
+        # in order: applyUrl → ref (API URL — last resort, the previous
+        # code used this and that's why the LLM analyzer was handed a
+        # JSON endpoint to parse as HTML).
+        absolute_url = (
+            detail.get("postingUrl")
+            or detail.get("applyUrl")
+            or detail.get("ref", "")
+        )
 
         jobs.append(
             StandardJob(
-                external_id=str(item.get("id", "")),
-                title=item.get("name", ""),
+                external_id=str(detail.get("id", list_id)),
+                title=detail.get("name", item.get("name", "")),
                 location_name=location_str,
                 department=department.get("label") if department else None,
-                content=item.get("jobAd", {})
-                .get("sections", {})
-                .get("jobDescription", {})
-                .get("text", ""),
-                updated_at=item.get("releasedDate", ""),
-                absolute_url=company.get("website", job_url) if company else job_url,
+                content=_build_content(detail),
+                updated_at=detail.get("releasedDate", item.get("releasedDate", "")),
+                absolute_url=absolute_url,
             )
         )
     return jobs

--- a/apps/wyrdfold-api/tests/test_smartrecruiters.py
+++ b/apps/wyrdfold-api/tests/test_smartrecruiters.py
@@ -1,3 +1,14 @@
+"""Tests for the SmartRecruiters fetcher.
+
+The fetcher does a two-phase pull:
+  1. ``GET /v1/companies/{slug}/postings`` — surfaces posting IDs + shallow
+     metadata.
+  2. ``GET /v1/companies/{slug}/postings/{id}`` — per-posting detail, the
+     only endpoint that actually returns the JD body and ``postingUrl``.
+
+Tests mock both phases by switching on the request URL.
+"""
+
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
@@ -6,6 +17,11 @@ import pytest
 
 from app.services.smartrecruiters import fetch_smartrecruiters_jobs
 from app.services.standard_job import StandardJob
+
+_LIST_URL = "https://api.smartrecruiters.com/v1/companies/{slug}/postings"
+_DETAIL_URL = (
+    "https://api.smartrecruiters.com/v1/companies/{slug}/postings/{posting_id}"
+)
 
 
 def _mock_response(
@@ -23,43 +39,95 @@ def _mock_response(
     return resp
 
 
+def _two_phase_handler(
+    *,
+    list_response: MagicMock,
+    detail_responses: dict[str, MagicMock] | None = None,
+):
+    """Build an AsyncMock side_effect that returns the list response for the
+    list-endpoint URL, and the corresponding per-id detail response for any
+    detail-endpoint URL. Default detail responses are 404 so unmapped IDs
+    fall out of the result.
+    """
+    detail_responses = detail_responses or {}
+
+    async def _handler(url, **_):
+        # The first call is always the list endpoint.
+        if "/postings/" not in url and url.endswith("/postings"):
+            return list_response
+        # Detail endpoint — extract the posting id from the URL.
+        posting_id = url.rsplit("/", 1)[-1]
+        return detail_responses.get(posting_id, _mock_response(404))
+
+    return _handler
+
+
 @pytest.mark.asyncio
 async def test_fetch_404_returns_empty(mock_http_client):
-    resp = _mock_response(404)
-    mock_http_client.get = AsyncMock(return_value=resp)
+    """List endpoint 404 → no detail calls, empty result."""
+    list_resp = _mock_response(404)
+    mock_http_client.get = AsyncMock(
+        side_effect=_two_phase_handler(list_response=list_resp)
+    )
     result = await fetch_smartrecruiters_jobs("missing-co")
     assert result == []
 
 
 @pytest.mark.asyncio
 async def test_fetch_http_error_returns_empty(mock_http_client):
+    """A transport error on the list call short-circuits to []."""
     mock_http_client.get = AsyncMock(side_effect=httpx.HTTPError("boom"))
     result = await fetch_smartrecruiters_jobs("bad")
     assert result == []
 
 
 @pytest.mark.asyncio
-async def test_fetch_valid_json_maps_jobs(mock_http_client):
-    payload = {
+async def test_fetch_pulls_jd_body_and_posting_url_from_detail(mock_http_client):
+    """Happy path: list returns a posting id, detail returns the full JD body
+    across all four ``jobAd.sections`` keys plus a ``postingUrl``. We expect
+    the returned StandardJob to carry the concatenated body and the
+    human-facing posting URL — not the API endpoint URL.
+    """
+    list_payload = {
         "content": [
             {
                 "id": "sr-001",
                 "name": "Backend Engineer",
                 "location": {"city": "Berlin", "country": "DE"},
                 "department": {"label": "Engineering"},
-                "company": {"website": "https://example.com"},
-                "ref": "https://api.smartrecruiters.com/v1/companies/ex/postings/sr-001",
                 "releasedDate": "2026-04-01T00:00:00Z",
-                "jobAd": {
-                    "sections": {
-                        "jobDescription": {"text": "Build APIs"},
-                    }
-                },
             }
         ]
     }
-    resp = _mock_response(200, payload)
-    mock_http_client.get = AsyncMock(return_value=resp)
+    detail_payload = {
+        "id": "sr-001",
+        "name": "Backend Engineer",
+        "location": {"city": "Berlin", "country": "DE"},
+        "department": {"label": "Engineering"},
+        "releasedDate": "2026-04-01T00:00:00Z",
+        "postingUrl": (
+            "https://jobs.smartrecruiters.com/example/sr-001-backend-engineer"
+        ),
+        "applyUrl": (
+            "https://jobs.smartrecruiters.com/example/sr-001-backend-engineer?oga=true"
+        ),
+        "ref": "https://api.smartrecruiters.com/v1/companies/example/postings/sr-001",
+        "jobAd": {
+            "sections": {
+                "companyDescription": {"text": "<p>About Example</p>"},
+                "jobDescription": {"text": "<p>Build APIs</p>"},
+                "qualifications": {"text": "<p>5+ years Python</p>"},
+                "additionalInformation": {"text": "<p>Remote OK</p>"},
+            }
+        },
+    }
+    mock_http_client.get = AsyncMock(
+        side_effect=_two_phase_handler(
+            list_response=_mock_response(200, list_payload),
+            detail_responses={"sr-001": _mock_response(200, detail_payload)},
+        )
+    )
+
     result = await fetch_smartrecruiters_jobs("example")
 
     assert len(result) == 1
@@ -67,37 +135,92 @@ async def test_fetch_valid_json_maps_jobs(mock_http_client):
     assert isinstance(job, StandardJob)
     assert job.external_id == "sr-001"
     assert job.title == "Backend Engineer"
-    assert job.location_name == "Berlin, DE"
-    assert job.department == "Engineering"
-    assert job.content == "Build APIs"
-    assert job.absolute_url == "https://example.com"
+    # The four section bodies should appear in the assembled content, in
+    # order, separated by blank lines.
+    assert "<p>About Example</p>" in job.content
+    assert "<p>Build APIs</p>" in job.content
+    assert "<p>5+ years Python</p>" in job.content
+    assert "<p>Remote OK</p>" in job.content
+    # The posting URL — the human-facing apply page — wins over applyUrl
+    # and over the API ``ref``. Previously the fetcher used ``company.website``
+    # which fell through to ``ref`` (the API URL) and that's why the LLM
+    # analyzer was being handed JSON instead of HTML.
+    assert (
+        job.absolute_url
+        == "https://jobs.smartrecruiters.com/example/sr-001-backend-engineer"
+    )
 
 
 @pytest.mark.asyncio
-async def test_fetch_missing_optional_fields(mock_http_client):
-    payload = {
-        "content": [
-            {
-                "id": "sr-002",
-                "name": "Designer",
-                "location": {},
-                "jobAd": {"sections": {}},
-            }
-        ]
+async def test_fetch_falls_back_to_apply_url_when_posting_url_missing(
+    mock_http_client,
+):
+    """If ``postingUrl`` is absent we use ``applyUrl`` next."""
+    list_payload = {"content": [{"id": "sr-002", "name": "Designer"}]}
+    detail_payload = {
+        "id": "sr-002",
+        "name": "Designer",
+        "applyUrl": "https://jobs.smartrecruiters.com/example/sr-002-designer?oga=true",
+        "ref": "https://api.smartrecruiters.com/v1/companies/example/postings/sr-002",
+        "jobAd": {"sections": {"jobDescription": {"text": "<p>Design things</p>"}}},
     }
-    resp = _mock_response(200, payload)
-    mock_http_client.get = AsyncMock(return_value=resp)
-    result = await fetch_smartrecruiters_jobs("co")
+    mock_http_client.get = AsyncMock(
+        side_effect=_two_phase_handler(
+            list_response=_mock_response(200, list_payload),
+            detail_responses={"sr-002": _mock_response(200, detail_payload)},
+        )
+    )
+
+    result = await fetch_smartrecruiters_jobs("example")
 
     assert len(result) == 1
-    assert result[0].location_name is None
-    assert result[0].department is None
-    assert result[0].content == ""
+    assert (
+        result[0].absolute_url
+        == "https://jobs.smartrecruiters.com/example/sr-002-designer?oga=true"
+    )
+
+
+@pytest.mark.asyncio
+async def test_fetch_drops_posting_when_detail_fetch_404s(mock_http_client):
+    """A 404 on the detail endpoint should drop that posting from the
+    result — we don't want to write a row with an empty description_html
+    because the LLM analyzer would 422 on it on every retry.
+    """
+    list_payload = {
+        "content": [
+            {"id": "sr-003", "name": "Skipped"},
+            {"id": "sr-004", "name": "Kept"},
+        ]
+    }
+    detail_kept = {
+        "id": "sr-004",
+        "name": "Kept",
+        "postingUrl": "https://jobs.smartrecruiters.com/example/sr-004-kept",
+        "jobAd": {"sections": {"jobDescription": {"text": "<p>Kept body</p>"}}},
+    }
+    mock_http_client.get = AsyncMock(
+        side_effect=_two_phase_handler(
+            list_response=_mock_response(200, list_payload),
+            detail_responses={
+                # sr-003 missing → defaults to 404 → dropped
+                "sr-004": _mock_response(200, detail_kept),
+            },
+        )
+    )
+
+    result = await fetch_smartrecruiters_jobs("example")
+
+    assert len(result) == 1
+    assert result[0].external_id == "sr-004"
 
 
 @pytest.mark.asyncio
 async def test_fetch_empty_content_returns_empty(mock_http_client):
-    resp = _mock_response(200, {"content": []})
-    mock_http_client.get = AsyncMock(return_value=resp)
+    """An empty ``content`` array on the list response → no detail calls."""
+    mock_http_client.get = AsyncMock(
+        side_effect=_two_phase_handler(
+            list_response=_mock_response(200, {"content": []})
+        )
+    )
     result = await fetch_smartrecruiters_jobs("empty")
     assert result == []


### PR DESCRIPTION
## Summary

User reported a ServiceNow posting whose LLM analysis failed because \`absolute_url\` pointed at \`https://api.smartrecruiters.com/v1/companies/servicenow/postings/744000128529264\` — the API endpoint, not a human-facing page. Analyzer tried to parse JSON as HTML and 422'd.

Two compounding bugs in \`fetch_smartrecruiters_jobs\`:

1. **`absolute_url` fell back to the API URL.** The list-endpoint items don't include \`postingUrl\` or \`applyUrl\` — those live on the per-posting detail endpoint. The fetcher used \`company.website\` then \`ref\` (API URL) as fallbacks, so real-world boards routinely produced API-URL rows.

2. **JD body was empty.** \`content\` was sourced from \`item.jobAd.sections.jobDescription.text\` on the LIST response. That field is always empty on the list endpoint (verified live — even with \`?format=full\`). The body lives exclusively on the per-posting detail endpoint. So every SR row was upserted with \`description_html = ""\`, and the analyzer short-circuited with "Job posting has no description to analyze".

## Fix

Two-phase fetch:

| Phase | Endpoint | Provides |
|---|---|---|
| 1 | \`GET /v1/companies/{slug}/postings\` | posting IDs + shallow metadata |
| 2 | \`GET /v1/companies/{slug}/postings/{id}\` | JD body + \`postingUrl\` |

\`_DETAIL_CONCURRENCY = 5\` caps fan-out so a 500-posting board doesn't burst the API. \`_build_content\` concatenates all four \`jobAd.sections.*.text\` fields (companyDescription, jobDescription, qualifications, additionalInformation) so the analyzer gets full JD context.

**URL precedence**: \`postingUrl\` → \`applyUrl\` → \`ref\` (last-resort, the previous broken behaviour).

A per-posting detail-fetch failure drops that posting from the run rather than writing an empty-body row; the next poll cycle retries.

## Tests

Rewritten for the two-phase shape. 6 cases cover the happy path, URL fallback, detail-404 drops, list-404, transport error short-circuit, empty content. **872 passing** (was 871 + 1 net, 6 new replacing 4 old).

## Test plan
- [x] \`ruff\` + \`mypy\` clean
- [x] \`pytest\` — 872 pass
- [ ] After merge + Railway deploy: re-poll any SmartRecruiters source (ServiceNow, Bosch, Visa, …), open one of its postings, confirm: (a) the "Open full view" link goes to \`jobs.smartrecruiters.com/...\` not \`api.smartrecruiters.com/...\`, and (b) the LLM analysis runs without 422

🤖 Generated with [Claude Code](https://claude.com/claude-code)