### PR TITLE
fix(wyrdfold-api): Workday fetcher pulls JD body + correct URL from detail endpoint

### DIFF
--- a/apps/wyrdfold-api/app/services/workday.py
+++ b/apps/wyrdfold-api/app/services/workday.py
@@ -1,4 +1,6 @@
+import asyncio
 import logging
+from typing import Any
 
 from app.http_client import FetchExhaustedError, request_with_retry
 from app.services.standard_job import StandardJob
@@ -7,6 +9,49 @@ logger = logging.getLogger(__name__)
 
 MAX_JOBS = 200
 PAGE_SIZE = 20
+# Cap on per-posting detail fetches in flight so a 200-posting board doesn't
+# slam Workday's CXS endpoint. Five mirrors the SmartRecruiters fan-out.
+_DETAIL_CONCURRENCY = 5
+
+
+async def _fetch_one_posting_detail(
+    *, base_url: str, tenant: str, site: str, external_path: str
+) -> dict[str, Any] | None:
+    """GET the per-posting detail endpoint.
+
+    Workday's CXS detail URL is the same base + cxs prefix + site + the
+    externalPath returned by the list endpoint, e.g.
+    ``https://salesforce.wd12.myworkdayjobs.com/wday/cxs/salesforce/External_Career_Site/job/Japan---Tokyo/Senior-Manager--Sales_JR343895``.
+    The response carries ``jobPostingInfo.jobDescription`` (the JD body
+    we want) and ``jobPostingInfo.externalUrl`` (the human-facing apply
+    page).
+    """
+    url = f"{base_url}/wday/cxs/{tenant}/{site}{external_path}"
+    try:
+        resp = await request_with_retry("GET", url)
+    except FetchExhaustedError as exc:
+        logger.warning(
+            "workday detail fetch exhausted retries for %s%s: %s",
+            base_url,
+            external_path,
+            exc,
+        )
+        return None
+    if resp.status_code == 404:
+        return None
+    if resp.status_code >= 400:
+        logger.warning(
+            "workday detail %s returned %d for %s",
+            base_url,
+            resp.status_code,
+            external_path,
+        )
+        return None
+    body = resp.json()
+    if not isinstance(body, dict):
+        return None
+    info = body.get("jobPostingInfo")
+    return info if isinstance(info, dict) else None
 
 
 async def fetch_workday_jobs(board_token: str) -> list[StandardJob]:
@@ -14,22 +59,35 @@ async def fetch_workday_jobs(board_token: str) -> list[StandardJob]:
 
     board_token format: "{base_url}|{tenant}|{site}"
     e.g. "https://salesforce.wd12.myworkdayjobs.com|salesforce|External_Career_Site"
+
+    Two-phase fetch: paginated list endpoint surfaces titles + externalPaths,
+    then per-posting detail endpoint returns the JD body and the human-facing
+    apply URL. The list response's ``descriptionTeaser`` field is empty on
+    every Workday board I've probed; the body lives exclusively on the
+    detail endpoint. Without this we ship rows with ``description_html = ""``
+    and the LLM analyzer 422s with "no description to analyze".
+
+    Per-posting detail fetches fan out under ``_DETAIL_CONCURRENCY``. A
+    posting whose detail fetch fails is dropped from this run rather than
+    written with an empty body; the next poll cycle retries.
     """
     parts = board_token.split("|")
     if len(parts) != 3:
         return []
 
     base_url, tenant, site = parts
-    url = f"{base_url}/wday/cxs/{tenant}/{site}/jobs"
+    list_url = f"{base_url}/wday/cxs/{tenant}/{site}/jobs"
 
-    all_jobs: list[StandardJob] = []
+    # Phase 1: paginated list pull. Collect (externalPath, list_item) so we
+    # can pair list-time metadata (locationsText, postedOn) with detail-time
+    # body when we fan out.
+    shallow: list[dict[str, Any]] = []
     offset = 0
-
     while offset < MAX_JOBS:
         try:
             resp = await request_with_retry(
                 "POST",
-                url,
+                list_url,
                 json={
                     "appliedFacets": {},
                     "limit": PAGE_SIZE,
@@ -39,12 +97,12 @@ async def fetch_workday_jobs(board_token: str) -> list[StandardJob]:
             )
         except FetchExhaustedError as exc:
             logger.warning(
-                "workday fetch exhausted retries for %s (offset %d): %s",
+                "workday list fetch exhausted retries for %s (offset %d): %s",
                 board_token,
                 offset,
                 exc,
             )
-            return all_jobs
+            return []
 
         if resp.status_code != 200:
             logger.warning(
@@ -53,30 +111,76 @@ async def fetch_workday_jobs(board_token: str) -> list[StandardJob]:
                 resp.status_code,
                 offset,
             )
-            return all_jobs
+            return []
 
         data = resp.json()
         postings = data.get("jobPostings", [])
         if not postings:
             break
-
-        for item in postings:
-            external_path = item.get("externalPath", "")
-            all_jobs.append(
-                StandardJob(
-                    external_id=external_path or str(item.get("bulletFields", [""])[0]),
-                    title=item.get("title", ""),
-                    location_name=item.get("locationsText"),
-                    department=None,
-                    content=item.get("descriptionTeaser", ""),
-                    updated_at=item.get("postedOn", ""),
-                    absolute_url=f"{base_url}/job/{external_path}" if external_path else "",
-                )
-            )
+        shallow.extend(postings)
 
         total = data.get("total", 0)
         offset += PAGE_SIZE
         if offset >= total:
             break
 
-    return all_jobs
+    if not shallow:
+        return []
+
+    # Phase 2: fan out detail fetches under the concurrency cap.
+    semaphore = asyncio.Semaphore(_DETAIL_CONCURRENCY)
+
+    async def _bounded_detail(external_path: str) -> dict[str, Any] | None:
+        if not external_path:
+            return None
+        async with semaphore:
+            return await _fetch_one_posting_detail(
+                base_url=base_url,
+                tenant=tenant,
+                site=site,
+                external_path=external_path,
+            )
+
+    paths = [item.get("externalPath", "") for item in shallow]
+    detail_results = await asyncio.gather(
+        *(_bounded_detail(p) for p in paths),
+        return_exceptions=True,
+    )
+
+    jobs: list[StandardJob] = []
+    for list_item, detail_result in zip(shallow, detail_results, strict=True):
+        if isinstance(detail_result, BaseException):
+            logger.warning("workday detail raised: %s", detail_result)
+            continue
+        if detail_result is None:
+            # Detail fetch failed. Drop the posting — see module docstring
+            # for the trade-off rationale.
+            continue
+
+        external_path = list_item.get("externalPath", "")
+        # Prefer the detail endpoint's ``externalUrl`` (the apply page);
+        # fall back to constructing it from base + site + path. Note the
+        # previous code did ``f"{base_url}/job/{external_path}"`` which
+        # produced a broken URL with a doubled ``/job/`` segment whenever
+        # ``externalPath`` already started with ``/job/...`` (it always
+        # does). The correct construction is base + site + path.
+        absolute_url = (
+            detail_result.get("externalUrl")
+            or f"{base_url}/{site}{external_path}"
+            if external_path
+            else ""
+        )
+
+        jobs.append(
+            StandardJob(
+                external_id=external_path
+                or str(list_item.get("bulletFields", [""])[0]),
+                title=detail_result.get("title", list_item.get("title", "")),
+                location_name=list_item.get("locationsText"),
+                department=None,
+                content=detail_result.get("jobDescription", ""),
+                updated_at=detail_result.get("postedOn", list_item.get("postedOn", "")),
+                absolute_url=absolute_url,
+            )
+        )
+    return jobs

--- a/apps/wyrdfold-api/tests/test_workday.py
+++ b/apps/wyrdfold-api/tests/test_workday.py
@@ -1,3 +1,15 @@
+"""Tests for the Workday CXS fetcher.
+
+The fetcher does a two-phase pull:
+  1. ``POST .../wday/cxs/{tenant}/{site}/jobs`` — paginated list, surfaces
+     ``externalPath`` + shallow metadata.
+  2. ``GET .../wday/cxs/{tenant}/{site}{externalPath}`` — per-posting detail,
+     the only endpoint that returns ``jobPostingInfo.jobDescription`` (the
+     JD body) and ``jobPostingInfo.externalUrl`` (human-facing apply page).
+
+Tests mock both phases independently.
+"""
+
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
@@ -22,7 +34,16 @@ async def test_invalid_token_format() -> None:
 
 
 @pytest.mark.asyncio
-async def test_valid_response(mock_http_client: Any) -> None:
+async def test_fetch_pulls_jd_body_and_external_url_from_detail(
+    mock_http_client: Any,
+) -> None:
+    """Happy path: list returns posting paths, detail returns the full JD
+    body. We expect the JD body to land on ``content`` and the human-facing
+    ``externalUrl`` to land on ``absolute_url`` — not the broken
+    ``base_url/job/{path}`` construction the previous code produced.
+    """
+    # Phase 1: list endpoint returns two postings with empty descriptionTeaser
+    # (the bug from real Workday boards).
     mock_http_client.post = AsyncMock(
         return_value=_make_resp(
             200,
@@ -30,47 +51,203 @@ async def test_valid_response(mock_http_client: Any) -> None:
                 "total": 2,
                 "jobPostings": [
                     {
-                        "externalPath": "job/abc123",
-                        "title": "Software Engineer",
+                        "externalPath": "/job/SF/Senior-SWE_JR1",
+                        "title": "Senior SWE",
                         "locationsText": "San Francisco, CA",
-                        "descriptionTeaser": "Build things",
+                        "descriptionTeaser": "",  # always empty on the list
                         "postedOn": "2026-04-01",
-                        "bulletFields": ["abc123"],
                     },
                     {
-                        "externalPath": "job/def456",
+                        "externalPath": "/job/NYC/PM_JR2",
                         "title": "Product Manager",
-                        "locationsText": "Remote",
-                        "descriptionTeaser": "Manage things",
+                        "locationsText": "New York, NY",
+                        "descriptionTeaser": "",
                         "postedOn": "2026-04-02",
-                        "bulletFields": ["def456"],
                     },
                 ],
             },
         )
     )
 
-    token = "https://salesforce.wd12.myworkdayjobs.com|salesforce|External"
+    # Phase 2: detail endpoint returns the full body + externalUrl.
+    detail_responses = {
+        "/job/SF/Senior-SWE_JR1": _make_resp(
+            200,
+            {
+                "jobPostingInfo": {
+                    "title": "Senior SWE",
+                    "jobDescription": "<p>Build distributed systems</p>",
+                    "externalUrl": (
+                        "https://example.wd12.myworkdayjobs.com/External/job/SF/Senior-SWE_JR1"
+                    ),
+                    "postedOn": "2026-04-01",
+                }
+            },
+        ),
+        "/job/NYC/PM_JR2": _make_resp(
+            200,
+            {
+                "jobPostingInfo": {
+                    "title": "Product Manager",
+                    "jobDescription": "<p>Manage product</p>",
+                    "externalUrl": (
+                        "https://example.wd12.myworkdayjobs.com/External/job/NYC/PM_JR2"
+                    ),
+                    "postedOn": "2026-04-02",
+                }
+            },
+        ),
+    }
+
+    async def _detail_get(url: str, **_: Any) -> MagicMock:
+        # Detail URL is base + cxs prefix + site + externalPath
+        for path, resp in detail_responses.items():
+            if url.endswith(path):
+                return resp
+        return _make_resp(404)
+
+    mock_http_client.get = AsyncMock(side_effect=_detail_get)
+
+    token = "https://example.wd12.myworkdayjobs.com|example|External"
     jobs = await fetch_workday_jobs(token)
 
     assert len(jobs) == 2
-    assert jobs[0].title == "Software Engineer"
-    assert jobs[0].external_id == "job/abc123"
+    assert jobs[0].title == "Senior SWE"
+    assert jobs[0].external_id == "/job/SF/Senior-SWE_JR1"
     assert jobs[0].location_name == "San Francisco, CA"
+    assert jobs[0].content == "<p>Build distributed systems</p>"
+    # The detail's ``externalUrl`` wins — not the broken old base/job/path.
+    assert (
+        jobs[0].absolute_url
+        == "https://example.wd12.myworkdayjobs.com/External/job/SF/Senior-SWE_JR1"
+    )
     assert jobs[1].title == "Product Manager"
+    assert jobs[1].content == "<p>Manage product</p>"
 
 
 @pytest.mark.asyncio
-async def test_404_returns_empty(mock_http_client: Any) -> None:
+async def test_fetch_falls_back_to_constructed_url_when_external_url_missing(
+    mock_http_client: Any,
+) -> None:
+    """If the detail response omits ``externalUrl`` we construct the URL
+    from base + site + externalPath — the correct form, not the previous
+    code's broken ``base/job/{path}`` which double-prefixed ``/job/``.
+    """
+    mock_http_client.post = AsyncMock(
+        return_value=_make_resp(
+            200,
+            {
+                "total": 1,
+                "jobPostings": [
+                    {
+                        "externalPath": "/job/Remote/Designer_JR3",
+                        "title": "Designer",
+                        "locationsText": "Remote",
+                        "postedOn": "2026-04-03",
+                    },
+                ],
+            },
+        )
+    )
+
+    async def _detail_get(url: str, **_: Any) -> MagicMock:
+        return _make_resp(
+            200,
+            {
+                "jobPostingInfo": {
+                    "title": "Designer",
+                    "jobDescription": "<p>Design things</p>",
+                    # externalUrl deliberately omitted.
+                    "postedOn": "2026-04-03",
+                }
+            },
+        )
+
+    mock_http_client.get = AsyncMock(side_effect=_detail_get)
+
+    token = "https://example.wd12.myworkdayjobs.com|example|External"
+    jobs = await fetch_workday_jobs(token)
+
+    assert len(jobs) == 1
+    assert (
+        jobs[0].absolute_url
+        == "https://example.wd12.myworkdayjobs.com/External/job/Remote/Designer_JR3"
+    )
+
+
+@pytest.mark.asyncio
+async def test_fetch_drops_posting_when_detail_fetch_404s(
+    mock_http_client: Any,
+) -> None:
+    """A 404 from the detail endpoint should drop that posting, not write
+    an empty-body row that the LLM analyzer would 422 on every retry.
+    """
+    mock_http_client.post = AsyncMock(
+        return_value=_make_resp(
+            200,
+            {
+                "total": 2,
+                "jobPostings": [
+                    {
+                        "externalPath": "/job/Skipped_JR4",
+                        "title": "Skipped",
+                        "locationsText": "Remote",
+                        "postedOn": "2026-04-04",
+                    },
+                    {
+                        "externalPath": "/job/Kept_JR5",
+                        "title": "Kept",
+                        "locationsText": "Remote",
+                        "postedOn": "2026-04-05",
+                    },
+                ],
+            },
+        )
+    )
+
+    async def _detail_get(url: str, **_: Any) -> MagicMock:
+        if url.endswith("/job/Kept_JR5"):
+            return _make_resp(
+                200,
+                {
+                    "jobPostingInfo": {
+                        "title": "Kept",
+                        "jobDescription": "<p>Kept body</p>",
+                        "externalUrl": "https://example.wd12.myworkdayjobs.com/External/job/Kept_JR5",
+                        "postedOn": "2026-04-05",
+                    }
+                },
+            )
+        return _make_resp(404)
+
+    mock_http_client.get = AsyncMock(side_effect=_detail_get)
+
+    token = "https://example.wd12.myworkdayjobs.com|example|External"
+    jobs = await fetch_workday_jobs(token)
+
+    assert len(jobs) == 1
+    assert jobs[0].title == "Kept"
+    assert jobs[0].external_id == "/job/Kept_JR5"
+
+
+@pytest.mark.asyncio
+async def test_404_on_list_returns_empty(mock_http_client: Any) -> None:
+    """A 404 on the list endpoint short-circuits — no detail calls fire."""
     mock_http_client.post = AsyncMock(return_value=_make_resp(404))
+    mock_http_client.get = AsyncMock(
+        side_effect=AssertionError("detail must not be called")
+    )
     token = "https://example.wd5.myworkdayjobs.com|example|Site"
     jobs = await fetch_workday_jobs(token)
     assert jobs == []
 
 
 @pytest.mark.asyncio
-async def test_network_error(mock_http_client: Any) -> None:
+async def test_network_error_on_list_returns_empty(mock_http_client: Any) -> None:
     mock_http_client.post = AsyncMock(side_effect=httpx.HTTPError("timeout"))
+    mock_http_client.get = AsyncMock(
+        side_effect=AssertionError("detail must not be called")
+    )
     token = "https://example.wd5.myworkdayjobs.com|example|Site"
     jobs = await fetch_workday_jobs(token)
     assert jobs == []


### PR DESCRIPTION
## Summary

Audited the other ATS fetchers after #751 fixed SmartRecruiters. Live-probed each board for the same list-vs-detail gap:

| Provider | List endpoint has JD body? | List endpoint has human URL? | Verdict |
|---|---|---|---|
| **Lever** | ✅ \`description\` (1,137 chars) | ✅ \`hostedUrl\` | No fix needed |
| **Ashby** | ✅ \`descriptionHtml\` (9,493 chars) | ✅ \`jobUrl\` | No fix needed |
| **Workday** | ❌ \`descriptionTeaser\` empty | ❌ broken URL construction | **Fixed in this PR** |

## Workday bugs

### 1. JD body always empty on the list endpoint

Live verified against Salesforce (Workday): every list item's \`descriptionTeaser\` was an empty string. The actual body lives on the per-posting detail endpoint at \`jobPostingInfo.jobDescription\` (8,754 chars on the same posting). So every Workday row landed with \`description_html = ""\` and the LLM analyzer 422'd.

### 2. URL construction was broken

\`\`\`python
absolute_url = f"{base_url}/job/{external_path}" if external_path else ""
\`\`\`

The list endpoint's \`externalPath\` already starts with \`/job/...\`. So the f-string produced URLs like:

\`\`\`
https://salesforce.wd12.myworkdayjobs.com/job//job/Japan---Tokyo/...
\`\`\`

Doubled \`/job/\` prefix → 404. Also missing the \`{site}\` segment that Workday's actual apply pages use.

## Fix

Two-phase fetch, mirroring #751:

| Phase | Endpoint | Provides |
|---|---|---|
| 1 | \`POST .../wday/cxs/{tenant}/{site}/jobs\` (paginated) | externalPath + shallow metadata |
| 2 | \`GET .../wday/cxs/{tenant}/{site}{externalPath}\` | JD body + canonical externalUrl |

\`_DETAIL_CONCURRENCY = 5\` caps fan-out. Per-posting detail failures drop the row rather than writing an empty body.

**URL precedence**: detail's \`externalUrl\` → constructed fallback \`{base}/{site}{externalPath}\` (correct form, no doubled prefix).

## Tests

6 cases cover the happy path, externalUrl-missing fallback, detail-404 drops the posting, list-404 short-circuit, list transport error, and the invalid-token guard. **873 passing total**.

## Test plan
- [x] \`ruff\` + \`mypy\` clean
- [x] \`pytest\` — 873 pass
- [ ] After merge + Railway deploy: reactivate a target, wait for the Salesforce/Capital One sources to repoll, open one posting → "Open full view" should land on the real apply page (\`...myworkdayjobs.com/External_Career_Site/job/...\`) and the LLM analyzer should run cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)