### PR TITLE
feat(wyrdfold): persist /jobs filter+sort+page+target in URL for browser back/forward

### DIFF
--- a/apps/wyrdfold/src/app/(app)/jobs/JobsList.tsx
+++ b/apps/wyrdfold/src/app/(app)/jobs/JobsList.tsx
@@ -1,7 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useRef, useState } from 'react';
-import { useRouter } from 'next/navigation';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Heading } from '@danieljoffe.com/shared-ui/Heading';
 import { Spinner } from '@danieljoffe.com/shared-ui/Spinner';
 import { Text } from '@danieljoffe.com/shared-ui/Text';
@@ -14,31 +13,13 @@ import BatchActionBar from './BatchActionBar';
 import JobsListView from './JobsListView';
 import JobsThinResultsCallout from './JobsThinResultsCallout';
 import { promptForMissingContactName } from './promptForMissingContactName';
-import type { JobPosting, JobsFilterState } from './types';
+import type { JobPosting, JobsFilterState, JobsSortColumn } from './types';
+import { useJobsUrlState } from './useJobsUrlState';
 
 export interface TargetTab {
   id: string;
   label: string;
 }
-
-const INITIAL_FILTERS: JobsFilterState = {
-  minScore: '',
-  status: '',
-  search: '',
-};
-
-// ``minScore`` empty (= no implicit floor) so the "Any score" label
-// the dropdown shows actually means "any score". The previous default
-// of ``'45'`` silently filtered out matches in the 0–44 range while the
-// dropdown still rendered "Any score" — because ``'45'`` isn't one of
-// the ``MIN_SCORE_OPTIONS`` values (the gaps go 0 → 40 → 70 → 85), the
-// label-lookup fell through to "Any score" and target tabs hard-loaded
-// with an empty list whenever every match scored below 45.
-const TARGET_FILTERS: JobsFilterState = {
-  minScore: '',
-  status: '',
-  search: '',
-};
 
 const BATCH_POLL_INTERVAL = 3000;
 
@@ -55,14 +36,85 @@ export default function JobsList({
   initialMinScore,
   initialTargets,
 }: JobsListProps) {
-  const [filters, setFilters] = useState<JobsFilterState>(() => {
-    const base = targetId ? TARGET_FILTERS : INITIAL_FILTERS;
-    return {
-      ...base,
-      ...(initialStatus ? { status: initialStatus } : {}),
-      ...(initialMinScore ? { minScore: initialMinScore } : {}),
-    };
+  // Single source of truth for filters / sort / page / target — backed by
+  // URL query params so browser back/forward restores every dimension of
+  // the page state. The ``initialStatus`` and ``initialMinScore`` props
+  // were the previous server-side prelude to this state; they're now
+  // strictly fallbacks for the (rare) case where the URL has no params
+  // (e.g. server-side prerender before client hydration).
+  const defaultTargetId = targetId ?? initialTargets[0]?.id;
+  const { state: urlState, setState: setUrlState } = useJobsUrlState({
+    defaultSort: 'score',
+    defaultOrder: 'desc',
+    defaultTargetId,
   });
+
+  // Derived filter view for the existing JobsFilter component — keeps that
+  // component oblivious to the URL plumbing. Falls back to the server-side
+  // ``initialStatus`` / ``initialMinScore`` props only when the URL has no
+  // value for that key, so a deep-linked ``/jobs?status=applied`` URL still
+  // pins the filter on the first client render.
+  const filters: JobsFilterState = useMemo(
+    () => ({
+      search: urlState.search,
+      status: urlState.status || initialStatus || '',
+      minScore: urlState.minScore || initialMinScore || '',
+    }),
+    [
+      urlState.search,
+      urlState.status,
+      urlState.minScore,
+      initialStatus,
+      initialMinScore,
+    ]
+  );
+
+  const setFilters = useCallback(
+    (next: JobsFilterState) => {
+      setUrlState({
+        search: next.search || null,
+        status: next.status || null,
+        minScore: next.minScore || null,
+        // Filter changes always reset to page 1 — match
+        // ``useAdminTableFetch``'s ``extraParams`` reset.
+        page: 1,
+      });
+    },
+    [setUrlState]
+  );
+
+  const activeTargetId = urlState.targetId;
+
+  // Sort/order/page wiring for ``useAdminTableFetch``. Defined here so we
+  // can hand them down to JobsListView as a controlled trio + change
+  // callbacks. Sort defaults are mirrored from ``useJobsUrlState`` so the
+  // values match.
+  const controlledTableState = useMemo(
+    () => ({
+      sort: urlState.sort as JobsSortColumn,
+      order: urlState.order,
+      page: urlState.page,
+    }),
+    [urlState.sort, urlState.order, urlState.page]
+  );
+
+  const onTableSortChange = useCallback(
+    (sort: JobsSortColumn, order: 'asc' | 'desc') => {
+      // Sort changes reset to page 1 and create a history entry so back
+      // restores the old sort.
+      setUrlState({ sort, order, page: 1 }, 'push');
+    },
+    [setUrlState]
+  );
+
+  const onTablePageChange = useCallback(
+    (page: number) => {
+      // Page changes create history entries so the back button works.
+      setUrlState({ page }, 'push');
+    },
+    [setUrlState]
+  );
+
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [refreshKey, setRefreshKey] = useState(0);
   const [generating, setGenerating] = useState(false);
@@ -71,14 +123,6 @@ export default function JobsList({
   >(undefined);
   const [exporting, setExporting] = useState(false);
   const [visiblePostings, setVisiblePostings] = useState<JobPosting[]>([]);
-  // When there's no ``?target=...`` in the URL, fall back to the first
-  // active target. The /jobs API's untargeted "global view" filters by
-  // ``jobs.target_id`` — a column the poller never populates — so without
-  // an explicit target_id every authenticated user gets an empty list.
-  // Auto-selecting the first tab keeps /jobs useful as a default landing.
-  const [activeTargetId, setActiveTargetId] = useState<string | undefined>(
-    targetId ?? initialTargets[0]?.id
-  );
   const [activationStatus, setActivationStatus] = useState<string>('idle');
   // Total job count for the active target, sourced from
   // ``/api/targets/{id}/status``. Drives the thin-results CTA. Reset
@@ -88,7 +132,6 @@ export default function JobsList({
   const activatingRef = useRef<Set<string>>(new Set());
   const pollRef = useRef<ReturnType<typeof setInterval> | undefined>(undefined);
   const { toast } = useToast();
-  const router = useRouter();
 
   const targets = initialTargets;
 
@@ -177,15 +220,24 @@ export default function JobsList({
 
   const handleTabChange = useCallback(
     (id: string | undefined) => {
-      setActiveTargetId(id);
       setActivationStatus('idle');
       setJobsCount(null);
       setSelectedIds(new Set());
-      setFilters(id ? TARGET_FILTERS : INITIAL_FILTERS);
-      const url = id ? `/jobs?target=${id}` : '/jobs';
-      router.replace(url, { scroll: false });
+      // Tab change resets all filters AND the page, then writes the new
+      // target to the URL with ``push`` so the back button restores the
+      // previous tab.
+      setUrlState(
+        {
+          targetId: id ?? null,
+          search: null,
+          status: null,
+          minScore: null,
+          page: 1,
+        },
+        'push'
+      );
     },
-    [router]
+    [setUrlState]
   );
 
   // Cleanup polling on unmount
@@ -500,6 +552,9 @@ export default function JobsList({
             targetId={activeTargetId}
             analysisTargetId={activeTargetId ?? targets[0]?.id}
             onPostingsLoaded={setVisiblePostings}
+            controlledTableState={controlledTableState}
+            onTableSortChange={onTableSortChange}
+            onTablePageChange={onTablePageChange}
           />
 
           {/* Thin-results CTA. Empty state (0 jobs) is owned by

--- a/apps/wyrdfold/src/app/(app)/jobs/JobsListView.tsx
+++ b/apps/wyrdfold/src/app/(app)/jobs/JobsListView.tsx
@@ -53,6 +53,21 @@ interface JobsListViewProps {
    *  the "All Jobs" tab. */
   analysisTargetId: string | undefined;
   onPostingsLoaded?: ((postings: JobPosting[]) => void) | undefined;
+  /** URL-backed sort/order/page state, when the parent owns it. The
+   *  parent (JobsList) plumbs this from ``useJobsUrlState`` so browser
+   *  back/forward restores the table state. Optional so other callers
+   *  of JobsListView don't need to know about the URL plumbing. */
+  controlledTableState?:
+    | {
+        sort: JobsSortColumn;
+        order: 'asc' | 'desc';
+        page: number;
+      }
+    | undefined;
+  onTableSortChange?:
+    | ((sort: JobsSortColumn, order: 'asc' | 'desc') => void)
+    | undefined;
+  onTablePageChange?: ((page: number) => void) | undefined;
 }
 
 export default function JobsListView({
@@ -64,6 +79,9 @@ export default function JobsListView({
   targetId,
   analysisTargetId,
   onPostingsLoaded,
+  controlledTableState,
+  onTableSortChange,
+  onTablePageChange,
 }: JobsListViewProps) {
   const [deleteKey, setDeleteKey] = useState(0);
   const isDesktop = useIsDesktop();
@@ -107,6 +125,9 @@ export default function JobsListView({
     pageSize: 20,
     dataKey: 'postings',
     extraParams,
+    controlled: controlledTableState,
+    onSortChange: onTableSortChange,
+    onPageChange: onTablePageChange,
   });
 
   useEffect(() => {

--- a/apps/wyrdfold/src/app/(app)/jobs/__tests__/JobsList.spec.tsx
+++ b/apps/wyrdfold/src/app/(app)/jobs/__tests__/JobsList.spec.tsx
@@ -7,15 +7,54 @@ import type { JobPosting, JobsFilterState } from '../types';
 const mockReplace = jest.fn();
 const mockToast = jest.fn();
 
-jest.mock('next/navigation', () => ({
-  useRouter: () => ({
-    push: jest.fn(),
-    replace: (...args: unknown[]) => mockReplace(...args),
-    refresh: jest.fn(),
-    prefetch: jest.fn(),
-    back: jest.fn(),
-  }),
-}));
+// Live URL-state mock that triggers re-renders on write — push/replace
+// re-parse the query string, bump a tick counter, and notify the
+// subscribed components. Real Next.js does this via the App Router's
+// navigation context; the mock has to recreate enough of that contract
+// for ``useSearchParams`` to fire updates.
+type Listener = () => void;
+const navState: { params: URLSearchParams; listeners: Set<Listener> } = {
+  params: new URLSearchParams(),
+  listeners: new Set(),
+};
+const writeUrl = (url: unknown) => {
+  if (typeof url !== 'string') return;
+  const qs = url.includes('?') ? url.split('?', 2)[1] : '';
+  navState.params = new URLSearchParams(qs);
+  navState.listeners.forEach(l => l());
+};
+
+jest.mock('next/navigation', () => {
+  const { useEffect, useState } =
+    jest.requireActual<typeof import('react')>('react');
+  return {
+    useRouter: () => ({
+      push: (...args: unknown[]) => {
+        writeUrl(args[0]);
+        mockReplace(...args);
+      },
+      replace: (...args: unknown[]) => {
+        writeUrl(args[0]);
+        mockReplace(...args);
+      },
+      refresh: jest.fn(),
+      prefetch: jest.fn(),
+      back: jest.fn(),
+    }),
+    useSearchParams: () => {
+      const [, setTick] = useState(0);
+      useEffect(() => {
+        const listener = () => setTick(t => t + 1);
+        navState.listeners.add(listener);
+        return () => {
+          navState.listeners.delete(listener);
+        };
+      }, []);
+      return navState.params;
+    },
+    usePathname: () => '/jobs',
+  };
+});
 
 jest.mock('@/state/Toast/ToastProvider', () => ({
   useToast: () => ({
@@ -157,6 +196,9 @@ beforeEach(() => {
   mockPostings = [];
   mockLoading = false;
   lastJobsListViewProps = null;
+  // Reset the URL-state mock between tests so test order doesn't matter.
+  navState.params = new URLSearchParams();
+  navState.listeners.clear();
   global.fetch = jest.fn().mockResolvedValue({
     ok: true,
     json: async () => ({ activation_status: 'ready', jobs_count: 0 }),

--- a/apps/wyrdfold/src/app/(app)/jobs/useJobsUrlState.ts
+++ b/apps/wyrdfold/src/app/(app)/jobs/useJobsUrlState.ts
@@ -29,9 +29,9 @@ const KEYS = {
   target: 'target',
 } as const;
 
-export type JobsUrlOrder = 'asc' | 'desc';
+type JobsUrlOrder = 'asc' | 'desc';
 
-export interface JobsUrlState {
+interface JobsUrlState {
   search: string;
   status: string;
   minScore: string;
@@ -43,7 +43,7 @@ export interface JobsUrlState {
 
 /** Patch shape: pass only the keys you want to change. ``null`` clears
  *  the key. Omitted keys are left untouched. */
-export type JobsUrlPatch = Partial<{
+type JobsUrlPatch = Partial<{
   [K in keyof JobsUrlState]: JobsUrlState[K] | null;
 }>;
 

--- a/apps/wyrdfold/src/app/(app)/jobs/useJobsUrlState.ts
+++ b/apps/wyrdfold/src/app/(app)/jobs/useJobsUrlState.ts
@@ -1,0 +1,139 @@
+'use client';
+
+import { useCallback, useMemo, useRef } from 'react';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+
+/**
+ * Single source of truth for which filters / sort / page / target the
+ * /jobs page is showing. Reads from ``useSearchParams`` so browser
+ * back/forward "just works" — pressing back re-runs the read-from-URL
+ * effects and every consumer rehydrates from the new URL automatically.
+ *
+ * The setters all use ``router.replace`` (not ``push``) so typing in
+ * the search box doesn't generate a history entry per keystroke. The
+ * tab/page setters opt into ``push`` via the ``mode`` arg so they DO
+ * create history entries — that's the affordance a user expects when
+ * they navigate to page 2 and then hit back.
+ *
+ * Keys are kept short for URL hygiene: ``q`` (search), ``s`` (status),
+ * ``score`` (minScore), ``sort``, ``order``, ``page``, ``target``.
+ */
+
+const KEYS = {
+  search: 'q',
+  status: 's',
+  minScore: 'score',
+  sort: 'sort',
+  order: 'order',
+  page: 'page',
+  target: 'target',
+} as const;
+
+export type JobsUrlOrder = 'asc' | 'desc';
+
+export interface JobsUrlState {
+  search: string;
+  status: string;
+  minScore: string;
+  sort: string;
+  order: JobsUrlOrder;
+  page: number;
+  targetId: string | undefined;
+}
+
+/** Patch shape: pass only the keys you want to change. ``null`` clears
+ *  the key. Omitted keys are left untouched. */
+export type JobsUrlPatch = Partial<{
+  [K in keyof JobsUrlState]: JobsUrlState[K] | null;
+}>;
+
+interface UseJobsUrlStateOptions {
+  /** What to set ``sort`` to when the URL doesn't specify one. */
+  defaultSort: string;
+  /** What to set ``order`` to when the URL doesn't specify one. */
+  defaultOrder: JobsUrlOrder;
+  /** Auto-pick a target tab when the URL has none. Used so a bare
+   *  ``/jobs`` lands on the user's first active target rather than the
+   *  empty "All Jobs" view (which the poller doesn't populate). */
+  defaultTargetId?: string | undefined | null;
+}
+
+function parsePage(raw: string | null): number {
+  const n = Number.parseInt(raw ?? '', 10);
+  return Number.isFinite(n) && n >= 1 ? n : 1;
+}
+
+function parseOrder(raw: string | null): JobsUrlOrder {
+  return raw === 'asc' ? 'asc' : 'desc';
+}
+
+export function useJobsUrlState({
+  defaultSort,
+  defaultOrder,
+  defaultTargetId,
+}: UseJobsUrlStateOptions): {
+  state: JobsUrlState;
+  setState: (patch: JobsUrlPatch, mode?: 'replace' | 'push') => void;
+} {
+  const searchParams = useSearchParams();
+  const pathname = usePathname();
+  const router = useRouter();
+
+  // Snapshot the latest searchParams so the setter callback (memoised on
+  // ``pathname`` / ``router``) sees up-to-date values without retriggering
+  // every component that consumes the hook on every keystroke.
+  const paramsRef = useRef(searchParams);
+  paramsRef.current = searchParams;
+
+  const state = useMemo<JobsUrlState>(() => {
+    const target = searchParams.get(KEYS.target);
+    return {
+      search: searchParams.get(KEYS.search) ?? '',
+      status: searchParams.get(KEYS.status) ?? '',
+      minScore: searchParams.get(KEYS.minScore) ?? '',
+      sort: searchParams.get(KEYS.sort) ?? defaultSort,
+      order: parseOrder(searchParams.get(KEYS.order)) ?? defaultOrder,
+      page: parsePage(searchParams.get(KEYS.page)),
+      targetId: target ?? defaultTargetId ?? undefined,
+    };
+  }, [searchParams, defaultSort, defaultOrder, defaultTargetId]);
+
+  const setState = useCallback(
+    (patch: JobsUrlPatch, mode: 'replace' | 'push' = 'replace') => {
+      const next = new URLSearchParams(paramsRef.current.toString());
+      const apply = (key: string, value: string | null | undefined) => {
+        if (value === null || value === undefined || value === '') {
+          next.delete(key);
+        } else {
+          next.set(key, value);
+        }
+      };
+      if ('search' in patch) apply(KEYS.search, patch.search);
+      if ('status' in patch) apply(KEYS.status, patch.status);
+      if ('minScore' in patch) apply(KEYS.minScore, patch.minScore);
+      if ('sort' in patch) apply(KEYS.sort, patch.sort);
+      if ('order' in patch) apply(KEYS.order, patch.order);
+      if ('page' in patch) {
+        // Page 1 is the implicit default — drop it from the URL so the
+        // canonical "no filters" URL is just ``/jobs``.
+        if (patch.page === 1 || patch.page === null) {
+          next.delete(KEYS.page);
+        } else if (typeof patch.page === 'number') {
+          next.set(KEYS.page, String(patch.page));
+        }
+      }
+      if ('targetId' in patch) apply(KEYS.target, patch.targetId);
+
+      const qs = next.toString();
+      const url = qs ? `${pathname}?${qs}` : pathname;
+      if (mode === 'push') {
+        router.push(url, { scroll: false });
+      } else {
+        router.replace(url, { scroll: false });
+      }
+    },
+    [pathname, router]
+  );
+
+  return { state, setState };
+}

--- a/apps/wyrdfold/src/hooks/useAdminTableFetch.ts
+++ b/apps/wyrdfold/src/hooks/useAdminTableFetch.ts
@@ -14,6 +14,23 @@ interface UseAdminTableFetchOptions<S extends string> {
   dataKey: string;
   /** Additional query params to include (e.g. filters) */
   extraParams?: Record<string, string>;
+  /** External source of truth for sort/order/page (e.g. URL query params).
+   *  When provided, the hook re-initialises its internal state any time
+   *  the controlled value changes. Used so browser back/forward restores
+   *  the table state without losing the filter bar. */
+  controlled?:
+    | {
+        sort: S;
+        order: 'asc' | 'desc';
+        page: number;
+      }
+    | undefined;
+  /** Fired whenever the user sorts. Lets the caller mirror the change
+   *  into URL state so the back button restores it. */
+  onSortChange?: ((sort: S, order: 'asc' | 'desc') => void) | undefined;
+  /** Fired whenever the page changes (user click, sort reset, filter
+   *  reset). Lets the caller mirror the change into URL state. */
+  onPageChange?: ((page: number) => void) | undefined;
 }
 
 export function useAdminTableFetch<T, S extends string>({
@@ -23,16 +40,40 @@ export function useAdminTableFetch<T, S extends string>({
   pageSize = 20,
   dataKey,
   extraParams,
+  controlled,
+  onSortChange,
+  onPageChange,
 }: UseAdminTableFetchOptions<S>) {
   const [data, setData] = useState<T[]>([]);
   const [total, setTotal] = useState(0);
-  const [page, setPage] = useState(1);
+  const [page, setPageState] = useState(controlled?.page ?? 1);
   const [loading, setLoading] = useState(true);
+
+  // Re-sync the page from the controlled value (e.g. user hit browser
+  // back from page 3 → page 1).
+  useEffect(() => {
+    if (controlled) setPageState(controlled.page);
+  }, [controlled?.page, controlled]);
+
+  // ``setPage`` flows through the URL callback (when provided) so the
+  // pagination bar's click → state update → URL update is one path.
+  const setPage = useCallback(
+    (next: number) => {
+      setPageState(next);
+      onPageChange?.(next);
+    },
+    [onPageChange]
+  );
 
   const { sort, order, handleSort, sortIndicator } = useTableSort<S>(
     defaultSort,
-    () => setPage(1),
-    defaultOrder
+    (nextSort, nextOrder) => {
+      setPageState(1);
+      onPageChange?.(1);
+      onSortChange?.(nextSort, nextOrder);
+    },
+    defaultOrder,
+    controlled ? { sort: controlled.sort, order: controlled.order } : undefined
   );
 
   // Reset to page 1 whenever filters change. Without this, a user on page 2+

--- a/apps/wyrdfold/src/hooks/useTableSort.ts
+++ b/apps/wyrdfold/src/hooks/useTableSort.ts
@@ -1,21 +1,41 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 export function useTableSort<T extends string>(
   defaultSort: T,
-  onSortChange?: () => void,
-  defaultOrder: 'asc' | 'desc' = 'desc'
+  onSortChange?: (sort: T, order: 'asc' | 'desc') => void,
+  defaultOrder: 'asc' | 'desc' = 'desc',
+  /** External source of truth (e.g. URL query params). When provided and
+   *  it changes, the hook re-initialises ``sort``/``order`` from it. Used
+   *  to wire browser back/forward to the table state. */
+  controlled?: { sort: T; order: 'asc' | 'desc' }
 ) {
-  const [sort, setSort] = useState<T>(defaultSort);
-  const [order, setOrder] = useState<'asc' | 'desc'>(defaultOrder);
+  const [sort, setSort] = useState<T>(controlled?.sort ?? defaultSort);
+  const [order, setOrder] = useState<'asc' | 'desc'>(
+    controlled?.order ?? defaultOrder
+  );
+
+  // Re-sync from the controlled value whenever it changes (e.g. user hit
+  // browser back, URL flipped from ``sort=score`` to ``sort=title``).
+  useEffect(() => {
+    if (controlled) {
+      setSort(controlled.sort);
+      setOrder(controlled.order);
+    }
+  }, [controlled?.sort, controlled?.order, controlled]);
 
   function handleSort(column: T) {
+    let nextSort: T;
+    let nextOrder: 'asc' | 'desc';
     if (sort === column) {
-      setOrder(prev => (prev === 'asc' ? 'desc' : 'asc'));
+      nextSort = sort;
+      nextOrder = order === 'asc' ? 'desc' : 'asc';
     } else {
-      setSort(column);
-      setOrder('desc');
+      nextSort = column;
+      nextOrder = 'desc';
     }
-    onSortChange?.();
+    setSort(nextSort);
+    setOrder(nextOrder);
+    onSortChange?.(nextSort, nextOrder);
   }
 
   function sortIndicator(col: T) {


### PR DESCRIPTION
## Summary

User report: typing a search, picking a status filter, paginating, or switching targets was lost the moment they navigated away and hit back. None of those dimensions were in the URL.

Move every dimension of the /jobs view into URL query params:

\`\`\`
?q=<search>
 &s=<status>
 &score=<minScore>
 &sort=<column>
 &order=<asc|desc>
 &page=<n>
 &target=<targetId>
\`\`\`

## Implementation

New \`useJobsUrlState\` hook owns the read+write contract:

- Reads via \`useSearchParams\` so any change to the URL (including browser back/forward) re-runs subscribers automatically.
- Writes via \`router.replace\` for filter/search keystrokes (no history pollution) and \`router.push\` for tab/page changes (so the back button does what the user expects).
- Drops \`page=1\` from the URL so the canonical no-filters URL is just \`/jobs\`.

Extends \`useTableSort\` and \`useAdminTableFetch\` to accept an optional \`controlled\` source-of-truth plus \`onSortChange\` / \`onPageChange\` callbacks. \`JobsList\` owns the URL state and plumbs the trio down through \`JobsListView\`, which keeps both hooks happy without a full rewrite.

## Side benefits

- Deep-linkable filter URLs work for sharing.
- Filter changes still reset to page 1 (the dedup logic in \`useAdminTableFetch\` is unchanged; URL writes flow through the same page-reset path).

## Tests

\`JobsList.spec.tsx\` gets a stateful \`next/navigation\` mock — push/replace re-parse the URL, bump a tick counter, and notify subscribed \`useSearchParams\` consumers so derived state actually re-renders. **397 passing total** (+ no regressions).

## Test plan
- [x] \`pnpm nx test wyrdfold\` — 397 pass
- [x] \`pnpm tsc --noEmit\` — clean
- [ ] After merge + deploy: type a search → URL updates → navigate to a job → click back → search persists in input + URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)