### PR TITLE
refactor(wyrdfold): move targets page CTAs below the grid

### DIFF
--- a/apps/wyrdfold/src/app/(app)/targets/TargetsList.tsx
+++ b/apps/wyrdfold/src/app/(app)/targets/TargetsList.tsx
@@ -283,22 +283,6 @@ export default function TargetsList({ initialTargets }: TargetsListProps) {
 
   return (
     <div className='flex flex-col gap-6'>
-      {hasContent && (
-        <div className='flex justify-end'>
-          <Button
-            name='target-create'
-            variant='primary'
-            size='sm'
-            iconOnly
-            aria-label='Create target'
-            className='rounded-full'
-            onClick={() => setModalOpen(true)}
-          >
-            <Plus className='size-4' aria-hidden />
-          </Button>
-        </div>
-      )}
-
       {!hasContent ? (
         <Card>
           <CardContent className='flex flex-col items-center gap-3 py-12'>
@@ -350,7 +334,16 @@ export default function TargetsList({ initialTargets }: TargetsListProps) {
             ))}
           </div>
 
-          <div className='flex items-center justify-center'>
+          <div className='flex flex-col items-stretch justify-center gap-3 sm:flex-row sm:items-center'>
+            <Button
+              name='target-create'
+              variant='primary'
+              size='sm'
+              onClick={() => setModalOpen(true)}
+            >
+              <Plus className='size-4' aria-hidden />
+              <span>Add Target</span>
+            </Button>
             <Button
               name='target-suggest'
               variant='outline'

--- a/apps/wyrdfold/src/app/(app)/targets/__tests__/TargetsList.spec.tsx
+++ b/apps/wyrdfold/src/app/(app)/targets/__tests__/TargetsList.spec.tsx
@@ -65,7 +65,7 @@ describe('TargetsList', () => {
     ).toBeInTheDocument();
   });
 
-  it('renders one card per target plus a top-right add button when populated', () => {
+  it('renders one card per target plus add/suggest buttons below the grid when populated', () => {
     render(
       <TargetsList
         initialTargets={[
@@ -77,7 +77,10 @@ describe('TargetsList', () => {
     expect(screen.getByText('Senior Frontend Engineer')).toBeInTheDocument();
     expect(screen.getByText('Full Stack Engineer')).toBeInTheDocument();
     expect(
-      screen.getByRole('button', { name: /^create target$/i })
+      screen.getByRole('button', { name: /^add target$/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /suggest from experience/i })
     ).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

The "+" icon button above the targets grid was an awkward affordance — small, separated from the suggest action, and visually competing with the page heading. Moves both primary CTAs ("Add Target" + "Suggest from Experience") to a single row beneath the targets grid so they sit where the user's eye lands after scanning the list.

Layout:

\`\`\`
Targets
[subtitle]
[targets grid]
[Add Target]  [Suggest from Experience]
\`\`\`

## Changes

- Remove the top-right circular "+" button on the populated state
- Add a full \`Add Target\` button (variant=primary) alongside the existing \`Suggest from Experience\` button below the grid
- Empty-state Card already hosts both CTAs inline — left unchanged
- Update \`TargetsList.spec.tsx\` to assert the new layout

## Test plan

- [x] Unit: \`pnpm nx test wyrdfold\` — 397/397 pass
- [x] Typecheck: \`pnpm tsc --noEmit\` clean
- [ ] UI smoke: load \`/targets\` with and without existing targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)