### PR TITLE
feat(wyrdfold): make external posting URL the dominant header affordance

### DIFF
--- a/apps/wyrdfold/src/app/(app)/jobs/[id]/JobDetailPage.tsx
+++ b/apps/wyrdfold/src/app/(app)/jobs/[id]/JobDetailPage.tsx
@@ -222,27 +222,37 @@ export default function JobDetailPage({ id, targetId }: JobDetailPageProps) {
           <ArrowLeft className='size-5' aria-hidden />
         </Link>
         <div className='flex-1 min-w-0'>
-          <div className='flex items-center gap-2 min-w-0'>
+          {posting.absolute_url ? (
+            <a
+              href={posting.absolute_url}
+              target='_blank'
+              rel='noopener noreferrer'
+              className='group inline-flex items-center gap-2 min-w-0 max-w-full text-text-primary hover:text-brand-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 rounded-md'
+              aria-label={`Open original posting for ${posting.title} in a new tab`}
+            >
+              <ExternalLink
+                className='size-5 shrink-0 text-brand-500'
+                aria-hidden
+              />
+              <Heading
+                variant='component'
+                as='h1'
+                className='min-w-0 truncate underline decoration-dotted decoration-text-tertiary underline-offset-4 group-hover:decoration-brand-500'
+                title={posting.title}
+              >
+                {posting.title}
+              </Heading>
+            </a>
+          ) : (
             <Heading
               variant='component'
               as='h1'
-              className='flex-1 min-w-0 truncate'
+              className='min-w-0 truncate'
               title={posting.title}
             >
               {posting.title}
             </Heading>
-            {posting.absolute_url && (
-              <a
-                href={posting.absolute_url}
-                target='_blank'
-                rel='noopener noreferrer'
-                className='shrink-0 p-1.5 rounded-lg text-text-secondary hover:text-text-primary hover:bg-surface-tertiary transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500'
-                aria-label='View original posting'
-              >
-                <ExternalLink className='size-5' aria-hidden />
-              </a>
-            )}
-          </div>
+          )}
           <div className='mt-1 flex flex-col gap-0.5 text-text-secondary'>
             <div className='flex flex-wrap items-center gap-2'>
               <Text variant='caption' className='text-text-secondary'>
@@ -254,14 +264,14 @@ export default function JobDetailPage({ id, targetId }: JobDetailPageProps) {
                 </Badge>
               )}
             </div>
-            {posting.salary_text && (
-              <Text variant='caption' className='text-text-secondary'>
-                {posting.salary_text}
-              </Text>
-            )}
             {posting.location && (
               <Text variant='caption' className='text-text-secondary'>
                 {posting.location}
+              </Text>
+            )}
+            {posting.salary_text && (
+              <Text variant='caption' className='text-text-secondary'>
+                {posting.salary_text}
               </Text>
             )}
           </div>

--- a/apps/wyrdfold/src/app/(app)/jobs/[id]/__tests__/JobDetailPage.spec.tsx
+++ b/apps/wyrdfold/src/app/(app)/jobs/[id]/__tests__/JobDetailPage.spec.tsx
@@ -170,7 +170,7 @@ describe('JobDetailPage — happy path', () => {
       '/jobs'
     );
     const external = screen.getByRole('link', {
-      name: /view original posting/i,
+      name: /open original posting for senior frontend engineer/i,
     });
     expect(external).toHaveAttribute('href', 'https://example.com/job-42');
     expect(external).toHaveAttribute('target', '_blank');


### PR DESCRIPTION
## Summary

The job detail page's most important action is "view the original posting" — that's where the user actually applies. The previous design tucked a small ExternalLink icon next to the title and users overlooked it.

This PR promotes the external URL to be **the** primary affordance in the header:

- When \`absolute_url\` is set, the title heading itself is wrapped in the external \`<a>\`
- An \`ExternalLink\` icon (brand color) sits adjacent to the title
- The title has a dotted underline that brightens to brand color on hover
- The composite is one large click target that clearly telegraphs "this opens externally"

Layout:

\`\`\`
[back] | [external-icon] Title (one link, opens external)
         Company Name  [Manual badge?]
         Location
         Salary
\`\`\`

Manual postings (no \`absolute_url\`) still render the title as a plain Heading.

## Changes

- Wrap header in an external anchor when \`absolute_url\` is present
- Move \`ExternalLink\` icon inside the same anchor, ahead of the title
- Underline the title with a dotted decoration that becomes solid brand on hover
- Reorder metadata: company → location → salary (location is the more common decision factor; salary is often empty)
- Update \`aria-label\` from \`View original posting\` → \`Open original posting for <title> in a new tab\` (more descriptive context + new-tab signal)
- Update \`JobDetailPage.spec.tsx\` to assert the new accessible name

## Test plan

- [x] Unit: \`pnpm nx test wyrdfold\` — 397/397 pass (62 suites)
- [x] Typecheck: \`pnpm tsc --noEmit\` clean
- [ ] UI smoke: visit \`/jobs/<id>\` with an aggregator-sourced posting (icon + title → opens external)
- [ ] UI smoke: visit \`/jobs/<id>\` for a manual posting (no link, plain heading)

🤖 Generated with [Claude Code](https://claude.com/claude-code)