### PR TITLE
refactor(wyrdfold): compact single-row filter toolbar + active-filter chips

### DIFF
--- a/apps/wyrdfold/src/app/(app)/jobs/JobsActiveFilterChips.tsx
+++ b/apps/wyrdfold/src/app/(app)/jobs/JobsActiveFilterChips.tsx
@@ -1,0 +1,128 @@
+'use client';
+
+import { X } from 'lucide-react';
+import { cn } from '@/lib/cn';
+import {
+  formatStatus,
+  STATUS_DOT_CLASS,
+  type JobStatus,
+  type JobsFilterState,
+} from './types';
+
+const SCORE_LABEL: Record<string, string> = {
+  '40': 'Score 40+',
+  '70': 'Score 70+',
+  '85': 'Score 85+',
+};
+
+const CHIP_CLASS =
+  'inline-flex items-center gap-1 rounded-full border border-brand-500/40 bg-brand-500/10 py-0.5 pl-2.5 pr-1 text-xs text-text-primary';
+
+const REMOVE_BTN_CLASS =
+  'flex size-4 items-center justify-center rounded-full text-text-tertiary hover:bg-brand-500/20 hover:text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500';
+
+interface JobsActiveFilterChipsProps {
+  filters: JobsFilterState;
+  onChange: (next: JobsFilterState) => void;
+}
+
+export default function JobsActiveFilterChips({
+  filters,
+  onChange,
+}: JobsActiveFilterChipsProps) {
+  const chips: { key: string; label: React.ReactNode; onRemove: () => void }[] =
+    [];
+
+  if (filters.search) {
+    chips.push({
+      key: 'search',
+      label: `Search: "${filters.search}"`,
+      onRemove: () => onChange({ ...filters, search: '' }),
+    });
+  }
+
+  if (filters.minScore) {
+    chips.push({
+      key: 'minScore',
+      label: SCORE_LABEL[filters.minScore] ?? `Score ${filters.minScore}+`,
+      onRemove: () => onChange({ ...filters, minScore: '' }),
+    });
+  }
+
+  if (filters.status) {
+    chips.push({
+      key: 'status',
+      label: (
+        <span className='inline-flex items-center gap-1.5 capitalize'>
+          <span
+            className={cn(
+              'inline-block size-2 rounded-full',
+              STATUS_DOT_CLASS[filters.status as JobStatus]
+            )}
+            aria-hidden
+          />
+          {formatStatus(filters.status)}
+        </span>
+      ),
+      onRemove: () => onChange({ ...filters, status: '' }),
+    });
+  }
+
+  if (filters.onlyLocations) {
+    chips.push({
+      key: 'onlyLocations',
+      label: `Only: ${filters.onlyLocations}`,
+      onRemove: () => onChange({ ...filters, onlyLocations: '' }),
+    });
+  }
+
+  if (filters.excludeLocations) {
+    chips.push({
+      key: 'excludeLocations',
+      label: `Exclude: ${filters.excludeLocations}`,
+      onRemove: () => onChange({ ...filters, excludeLocations: '' }),
+    });
+  }
+
+  if (chips.length === 0) return null;
+
+  const clearAll = () =>
+    onChange({
+      search: '',
+      minScore: '',
+      status: '',
+      onlyLocations: '',
+      excludeLocations: '',
+    });
+
+  return (
+    <div
+      className='flex flex-wrap items-center gap-1.5'
+      role='region'
+      aria-label='Active filters'
+    >
+      {chips.map(chip => (
+        <span key={chip.key} className={CHIP_CLASS}>
+          {chip.label}
+          <button
+            type='button'
+            onClick={chip.onRemove}
+            aria-label={`Remove ${chip.key} filter`}
+            className={REMOVE_BTN_CLASS}
+          >
+            <X className='size-3' aria-hidden />
+          </button>
+        </span>
+      ))}
+      {chips.length > 1 && (
+        <button
+          type='button'
+          onClick={clearAll}
+          className='ml-1 text-xs text-text-secondary underline-offset-2 hover:text-text-primary hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 rounded'
+        >
+          Clear all
+        </button>
+      )}
+    </div>
+  );
+}

--- a/apps/wyrdfold/src/app/(app)/jobs/JobsFilter.tsx
+++ b/apps/wyrdfold/src/app/(app)/jobs/JobsFilter.tsx
@@ -6,6 +6,8 @@ import { Dropdown } from '@danieljoffe.com/shared-ui/Dropdown';
 import type { DropdownItem } from '@danieljoffe.com/shared-ui/Dropdown';
 import { Input } from '@danieljoffe.com/shared-ui/Input';
 import { cn } from '@/lib/cn';
+import JobsActiveFilterChips from './JobsActiveFilterChips';
+import JobsLocationFilter from './JobsLocationFilter';
 import {
   formatStatus,
   JOB_STATUSES,
@@ -16,7 +18,10 @@ import {
 } from './types';
 
 const PILL_CLASS =
-  'inline-flex items-center gap-1.5 rounded-full border border-border bg-surface-elevated px-3 py-1.5 text-xs text-text-primary hover:bg-surface-secondary';
+  'inline-flex items-center gap-1.5 rounded-full border border-border bg-surface-elevated px-3 py-1.5 text-xs text-text-primary hover:bg-surface-secondary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500';
+
+const PILL_ACTIVE_CLASS =
+  'border-brand-500/60 bg-brand-500/10 text-text-primary';
 
 const MIN_SCORE_OPTIONS: { value: string; label: string }[] = [
   { value: '', label: 'Any score' },
@@ -55,41 +60,23 @@ export default function JobsFilter({
   handleSort,
 }: JobsFilterProps) {
   const [searchDraft, setSearchDraft] = useState(filters.search);
-  const [excludeLocationsDraft, setExcludeLocationsDraft] = useState(
-    filters.excludeLocations
-  );
-  const [onlyLocationsDraft, setOnlyLocationsDraft] = useState(
-    filters.onlyLocations
-  );
   const timerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+  // Re-sync the search draft when the parent clears filters (e.g. via the
+  // chip row's X button or a tab switch). Without this the input would
+  // keep showing the stale value.
+  useEffect(() => {
+    setSearchDraft(filters.search);
+  }, [filters.search]);
 
   useEffect(() => {
     timerRef.current = setTimeout(() => {
-      const next = {
-        ...filters,
-        search: searchDraft,
-        excludeLocations: excludeLocationsDraft,
-        onlyLocations: onlyLocationsDraft,
-      };
-      // Skip the call when nothing changed — the debounce fires once per
-      // render of this effect so we'd otherwise trigger an extra refetch
-      // on every parent re-render.
-      if (
-        next.search !== filters.search ||
-        next.excludeLocations !== filters.excludeLocations ||
-        next.onlyLocations !== filters.onlyLocations
-      ) {
-        onChange(next);
+      if (searchDraft !== filters.search) {
+        onChange({ ...filters, search: searchDraft });
       }
     }, 300);
     return () => clearTimeout(timerRef.current);
-  }, [
-    searchDraft,
-    excludeLocationsDraft,
-    onlyLocationsDraft,
-    filters,
-    onChange,
-  ]);
+  }, [searchDraft, filters, onChange]);
 
   const minScoreLabel =
     MIN_SCORE_OPTIONS.find(o => o.value === filters.minScore)?.label ??
@@ -140,18 +127,24 @@ export default function JobsFilter({
   }));
 
   return (
-    <div className='flex flex-col gap-2.5'>
-      <Input
-        size='sm'
-        value={searchDraft}
-        onChange={e => setSearchDraft(e.target.value)}
-        placeholder='Search by title...'
-        aria-label='Search by title'
-      />
+    <div className='flex flex-col gap-2'>
+      {/* Single-row toolbar: search expands, pills cluster at the right.
+          On narrow viewports the pills wrap below the search. */}
       <div className='flex flex-wrap items-center gap-2'>
+        <div className='min-w-[12rem] flex-1'>
+          <Input
+            size='sm'
+            value={searchDraft}
+            onChange={e => setSearchDraft(e.target.value)}
+            placeholder='Search by title...'
+            aria-label='Search by title'
+          />
+        </div>
         <Dropdown
           trigger={
-            <span className={PILL_CLASS}>
+            <span
+              className={cn(PILL_CLASS, filters.minScore && PILL_ACTIVE_CLASS)}
+            >
               {minScoreLabel}
               <ChevronDown className='size-3 text-text-tertiary' aria-hidden />
             </span>
@@ -160,7 +153,13 @@ export default function JobsFilter({
         />
         <Dropdown
           trigger={
-            <span className={cn(PILL_CLASS, 'capitalize')}>
+            <span
+              className={cn(
+                PILL_CLASS,
+                'capitalize',
+                filters.status && PILL_ACTIVE_CLASS
+              )}
+            >
               {filters.status && (
                 <span
                   className={cn(
@@ -175,6 +174,17 @@ export default function JobsFilter({
             </span>
           }
           items={statusItems}
+        />
+        <JobsLocationFilter
+          only={filters.onlyLocations}
+          exclude={filters.excludeLocations}
+          onChange={({ only, exclude }) =>
+            onChange({
+              ...filters,
+              onlyLocations: only,
+              excludeLocations: exclude,
+            })
+          }
         />
         {/* Sort pill is mobile-only — desktop uses sortable column headers. */}
         <div className='md:hidden'>
@@ -193,26 +203,7 @@ export default function JobsFilter({
           />
         </div>
       </div>
-      {/* Location filters — comma-separated free-text. Substring match
-          against the job's location field on the API side. Two inputs so
-          a user can express "only US-or-Remote" and "never India" in the
-          same query. */}
-      <div className='grid gap-2 sm:grid-cols-2'>
-        <Input
-          size='sm'
-          value={onlyLocationsDraft}
-          onChange={e => setOnlyLocationsDraft(e.target.value)}
-          placeholder='Only locations (e.g. Remote, US)'
-          aria-label='Only show jobs in locations'
-        />
-        <Input
-          size='sm'
-          value={excludeLocationsDraft}
-          onChange={e => setExcludeLocationsDraft(e.target.value)}
-          placeholder='Exclude locations (e.g. India, Brazil)'
-          aria-label='Exclude jobs in locations'
-        />
-      </div>
+      <JobsActiveFilterChips filters={filters} onChange={onChange} />
     </div>
   );
 }

--- a/apps/wyrdfold/src/app/(app)/jobs/JobsFilter.tsx
+++ b/apps/wyrdfold/src/app/(app)/jobs/JobsFilter.tsx
@@ -131,7 +131,7 @@ export default function JobsFilter({
       {/* Single-row toolbar: search expands, pills cluster at the right.
           On narrow viewports the pills wrap below the search. */}
       <div className='flex flex-wrap items-center gap-2'>
-        <div className='min-w-[12rem] flex-1'>
+        <div className='min-w-[12rem] max-w-sm flex-1'>
           <Input
             size='sm'
             value={searchDraft}

--- a/apps/wyrdfold/src/app/(app)/jobs/JobsLocationFilter.tsx
+++ b/apps/wyrdfold/src/app/(app)/jobs/JobsLocationFilter.tsx
@@ -1,0 +1,144 @@
+'use client';
+
+import { useEffect, useId, useRef, useState } from 'react';
+import { ChevronDown, MapPin } from 'lucide-react';
+import { cn } from '@/lib/cn';
+
+const PILL_CLASS =
+  'inline-flex items-center gap-1.5 rounded-full border border-border bg-surface-elevated px-3 py-1.5 text-xs text-text-primary hover:bg-surface-secondary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500';
+
+const PILL_ACTIVE_CLASS =
+  'border-brand-500/60 bg-brand-500/10 text-text-primary';
+
+interface JobsLocationFilterProps {
+  only: string;
+  exclude: string;
+  onChange: (next: { only: string; exclude: string }) => void;
+}
+
+export default function JobsLocationFilter({
+  only,
+  exclude,
+  onChange,
+}: JobsLocationFilterProps) {
+  const [open, setOpen] = useState(false);
+  const [onlyDraft, setOnlyDraft] = useState(only);
+  const [excludeDraft, setExcludeDraft] = useState(exclude);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const onlyId = useId();
+  const excludeId = useId();
+
+  // Sync drafts when parent filters change (e.g. tab switch clears them).
+  useEffect(() => setOnlyDraft(only), [only]);
+  useEffect(() => setExcludeDraft(exclude), [exclude]);
+
+  function commit() {
+    if (onlyDraft !== only || excludeDraft !== exclude) {
+      onChange({ only: onlyDraft, exclude: excludeDraft });
+    }
+  }
+
+  // Hold a ref to the latest commit so the outside-click listener can fire
+  // without re-binding on every keystroke. Without this we'd either need
+  // ``commit`` in the effect's deps (forcing a re-bind per render) or an
+  // eslint-disable.
+  const commitRef = useRef(commit);
+  commitRef.current = commit;
+
+  // Close on outside click / Escape.
+  useEffect(() => {
+    if (!open) return;
+    function onDown(e: MouseEvent) {
+      if (!wrapperRef.current?.contains(e.target as Node)) {
+        commitRef.current();
+        setOpen(false);
+      }
+    }
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') {
+        setOpen(false);
+        triggerRef.current?.focus();
+      }
+    }
+    document.addEventListener('mousedown', onDown);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('mousedown', onDown);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [open]);
+
+  const activeCount = (only ? 1 : 0) + (exclude ? 1 : 0);
+  const label =
+    activeCount === 0
+      ? 'Locations'
+      : activeCount === 1
+        ? 'Locations · 1'
+        : 'Locations · 2';
+
+  return (
+    <div ref={wrapperRef} className='relative'>
+      <button
+        ref={triggerRef}
+        type='button'
+        aria-haspopup='dialog'
+        aria-expanded={open}
+        onClick={() => setOpen(o => !o)}
+        className={cn(PILL_CLASS, activeCount > 0 && PILL_ACTIVE_CLASS)}
+      >
+        <MapPin className='size-3.5 text-text-tertiary' aria-hidden />
+        {label}
+        <ChevronDown className='size-3 text-text-tertiary' aria-hidden />
+      </button>
+      {open && (
+        <div
+          role='dialog'
+          aria-label='Filter by location'
+          className='absolute right-0 z-20 mt-2 w-80 max-w-[calc(100vw-2rem)] rounded-lg border border-border bg-surface-elevated p-3 shadow-lg'
+        >
+          <div className='flex flex-col gap-3'>
+            <div className='flex flex-col gap-1'>
+              <label
+                htmlFor={onlyId}
+                className='text-xs font-medium text-text-secondary'
+              >
+                Only show jobs in
+              </label>
+              <input
+                id={onlyId}
+                type='text'
+                value={onlyDraft}
+                onChange={e => setOnlyDraft(e.target.value)}
+                onBlur={commit}
+                placeholder='Remote, US'
+                className='rounded-md border border-border bg-surface-base px-2.5 py-1.5 text-xs text-text-primary placeholder:text-text-tertiary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500'
+              />
+            </div>
+            <div className='flex flex-col gap-1'>
+              <label
+                htmlFor={excludeId}
+                className='text-xs font-medium text-text-secondary'
+              >
+                Hide jobs in
+              </label>
+              <input
+                id={excludeId}
+                type='text'
+                value={excludeDraft}
+                onChange={e => setExcludeDraft(e.target.value)}
+                onBlur={commit}
+                placeholder='India, Brazil'
+                className='rounded-md border border-border bg-surface-base px-2.5 py-1.5 text-xs text-text-primary placeholder:text-text-tertiary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500'
+              />
+            </div>
+            <p className='text-[11px] text-text-tertiary'>
+              Comma-separated. Case-insensitive substring match against the
+              job&apos;s location.
+            </p>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/wyrdfold/src/app/(app)/jobs/__tests__/JobsFilter.spec.tsx
+++ b/apps/wyrdfold/src/app/(app)/jobs/__tests__/JobsFilter.spec.tsx
@@ -64,7 +64,7 @@ describe('JobsFilter', () => {
     jest.useRealTimers();
   });
 
-  it('reflects the active min-score filter label', () => {
+  it('reflects the active min-score filter label on the pill', () => {
     render(
       <JobsFilter
         filters={{ ...baseFilters, minScore: '70' }}
@@ -74,10 +74,15 @@ describe('JobsFilter', () => {
         handleSort={() => undefined}
       />
     );
-    expect(screen.getByText(/score 70\+/i)).toBeInTheDocument();
+    // Matches both the pill (a Dropdown trigger button) and the chip row.
+    // Querying by button role pins us to the pill — the chip itself is a
+    // span; only its remove ``×`` is a button (and has a different name).
+    expect(
+      screen.getByRole('button', { name: /score 70\+/i })
+    ).toBeInTheDocument();
   });
 
-  it('shows the status label when a status filter is active', () => {
+  it('shows the status label on the pill when a status filter is active', () => {
     render(
       <JobsFilter
         filters={{ ...baseFilters, status: 'resume_draft' }}
@@ -87,7 +92,63 @@ describe('JobsFilter', () => {
         handleSort={() => undefined}
       />
     );
-    expect(screen.getByText(/resume draft/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /resume draft/i })
+    ).toBeInTheDocument();
+  });
+
+  it('renders active-filter chips with a Clear all link when 2+ filters are set', async () => {
+    const onChange = jest.fn();
+    render(
+      <JobsFilter
+        filters={{
+          ...baseFilters,
+          minScore: '70',
+          status: 'applied',
+          onlyLocations: 'Remote',
+        }}
+        onChange={onChange}
+        sort='score'
+        order='desc'
+        handleSort={() => undefined}
+      />
+    );
+
+    const region = screen.getByRole('region', { name: /active filters/i });
+    expect(region).toBeInTheDocument();
+    // Three chips → Clear all is visible.
+    const clearAll = screen.getByRole('button', { name: /clear all/i });
+    await userEvent.setup().click(clearAll);
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        search: '',
+        minScore: '',
+        status: '',
+        onlyLocations: '',
+        excludeLocations: '',
+      })
+    );
+  });
+
+  it('removes a single filter via its chip × button', async () => {
+    const onChange = jest.fn();
+    render(
+      <JobsFilter
+        filters={{ ...baseFilters, minScore: '70' }}
+        onChange={onChange}
+        sort='score'
+        order='desc'
+        handleSort={() => undefined}
+      />
+    );
+
+    const removeBtn = screen.getByRole('button', {
+      name: /remove minscore filter/i,
+    });
+    await userEvent.setup().click(removeBtn);
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ minScore: '' })
+    );
   });
 
   it('uses "All statuses" when no status filter is selected', () => {


### PR DESCRIPTION
## Summary

The /jobs filter area had grown to three rows (search input, pills, two location inputs) — a lot of vertical space for affordances that are mostly idle. This PR streamlines it to **one row when no filters are set, two rows when filters are active**.

### Before

\`\`\`
[ Search by title... (full row)              ]
[Score ▼] [Status ▼]                          <- pills
[Only locations input] [Exclude locations input]
\`\`\`

### After

\`\`\`
[ Search... (flex-1) ] [Score ▼] [Status ▼] [📍 Locations ▼] [Sort ▼ mobile]
[ Score 70+ ×  applied ×  Only: Remote ×   Clear all ]   ← only when active
\`\`\`

## Changes

- **Single-row toolbar** — search input takes \`flex-1\`, pills cluster at the right and wrap on narrow viewports
- **\`JobsLocationFilter\`** (new) — replaces the two free-text \`Input\`s with one \`Locations\` pill that opens a popover with Only/Exclude fields, an aria-described purpose, and click-outside / Esc-to-close handling
- **\`JobsActiveFilterChips\`** (new) — chip row beneath the toolbar lists each active filter with an inline × to remove it; renders a \`Clear all\` link when 2+ filters are set; hidden when no filters are active
- **Pill active state** — score/status/locations pills flip to a brand-tinted background when their filter is set, so the toolbar communicates state without the user having to crack open each dropdown
- **Search draft re-sync** — when filters are cleared externally (chip ×, tab switch), the search \`<Input>\`'s local draft re-syncs from props. Previously it kept the stale value.

## Test plan

- [x] Unit: \`pnpm nx test wyrdfold\` — 399/399 pass (added: chip render + remove + Clear-all; updated: pill label assertions to scope to the button)
- [x] Typecheck: \`pnpm tsc --noEmit\` clean
- [x] Lint: 0 errors
- [ ] UI smoke: set filters from each pill, verify chips appear; click chip × to remove; click \`Clear all\` to reset; back-button restores prior URL state (PR #753 contract)

🤖 Generated with [Claude Code](https://claude.com/claude-code)