### PR TITLE
chore(pr-review): audit log of runs + dispositions

### DIFF
--- a/.claude/docs/pr-review-log.md
+++ b/.claude/docs/pr-review-log.md
@@ -1,0 +1,17 @@
+# PR Review Audit Log
+
+Append-only log of `/pr-review` runs and their dispositions. Used to spot recurring false positives and tune reviewer prompts over time.
+
+## Entry shape
+
+```markdown
+- `YYYY-MM-DD` PR#<number> · <branch> · <verdict> · C:<n> W:<n> S:<n> · <reviewers run> · <one-sentence summary>
+  → Disposition: <action>
+```
+
+`<verdict>` is one of `BLOCK`, `NEEDS-ACK`, `READY` (see `.claude/skills/pr-review/SKILL.md`).
+`<action>` is added on the turn after the PR is dispositioned: `merged-as-is`, `merged-with-followup`, `closed-without-merge`, or `findings-overruled: <reason>`.
+
+## Log
+
+<!-- Newest entries at the bottom. Do not rewrite past entries except to add the disposition suffix. -->

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -194,6 +194,27 @@ The verdict is informational — the skill does not block any git operation. It'
 
 **Downgrading a Critical to a Warning** is allowed when the user provides a written rationale (e.g. "false positive — this path is api-key only, not user-reachable"). Note the downgrade inline next to the finding.
 
+### Step 10: Append to the audit log
+
+After printing the report, append a one-line summary to `.claude/docs/pr-review-log.md` so trends in findings (recurring categories, agent miss patterns) stay visible across runs. The log is the dataset that lets us tune reviewer prompts over time — what got flagged, what got accepted, what got ignored.
+
+Use the `Edit` tool to append (the file is checked in; do not `echo >>` it).
+
+Entry shape (one line per run, newest at the bottom):
+
+```markdown
+- `YYYY-MM-DD` PR#<number> · <branch> · <verdict> · C:<n> W:<n> S:<n> · <reviewers run, comma-separated> · <one-sentence summary>
+```
+
+Then, **on the next conversation turn after the user has dispositioned the findings** (merged the PR with or without fixes, or explicitly closed it), update the log entry inline with a `→ Disposition: <action>` suffix. Acceptable dispositions:
+
+- `merged-as-is` — all findings either fixed or downgraded
+- `merged-with-followup` — non-blocking findings deferred to a tracked TODO
+- `closed-without-merge` — PR abandoned
+- `findings-overruled: <reason>` — user shipped despite blocking findings
+
+The log is append-only — don't rewrite old entries except to add the disposition suffix. If a finding category recurs as a false positive (3+ identical flags across runs), open a follow-up to tune the relevant reviewer's prompt.
+
 ## Rules
 
 - Read-only analysis — no code changes.
@@ -202,3 +223,4 @@ The verdict is informational — the skill does not block any git operation. It'
 - Binary and snapshot files are always skipped.
 - Test files route to e2e-reviewer only.
 - Skill/meta files (`.claude/`) are always skipped.
+- The audit log is the only file the skill writes to. Do not delete or rewrite past entries.


### PR DESCRIPTION
## Summary

\`/pr-review\` produces findings, but each run is in isolation — there's no record of what was flagged, what was fixed, what was overruled. So there's no evidence base for tuning reviewer prompts: a recurring false positive looks the same as a one-off catch.

This PR adds an **append-only audit log** at \`.claude/docs/pr-review-log.md\`. The skill writes one line per run after printing the report, and updates that line with a disposition (\`merged-as-is\` / \`merged-with-followup\` / \`closed-without-merge\` / \`findings-overruled\`) on the turn after you act on the PR.

## Why

The log is the dataset that makes reviewer-prompt tuning evidence-based:

- 3+ identical findings dismissed across runs → tune the reviewer's prompt
- A category that consistently blocks but always gets overruled → severity miscalibration
- A reviewer that never flags anything → either the prompt is too narrow, or its category genuinely doesn't apply to this repo

Without the log, those signals get lost between runs.

## Changes

- **\`SKILL.md\`**: new Step 10 (\"Append to the audit log\") + a new rule that the audit log is the only file the skill writes to
- **\`.claude/docs/pr-review-log.md\`**: skeleton with entry shape + first-entry placeholder

## Entry shape

\`\`\`markdown
- \`YYYY-MM-DD\` PR#<number> · <branch> · <verdict> · C:<n> W:<n> S:<n> · <reviewers> · <one-sentence summary>
  → Disposition: <action>
\`\`\`

## Test plan

- [x] Skill + log files render clean as markdown
- [ ] Next \`/pr-review\` run appends an entry; the turn after merge/close adds the disposition suffix

🤖 Generated with [Claude Code](https://claude.com/claude-code)