### PR TITLE
chore(pr-review): add LOC guardrail alongside file-count guardrail

### DIFF
--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -71,13 +71,18 @@ Parse into a structured manifest. For each file determine:
 ### Step 3: Apply guardrails
 
 Count **reviewable files** = total minus `deleted`, `binary`, `skill-meta`, `docs`.
+Sum **reviewable lines** = `lines_changed` across the same set.
 
-| Reviewable files | Action                                                                        |
-| ---------------- | ----------------------------------------------------------------------------- |
-| 0                | Report clean — nothing to review. Stop.                                       |
-| 1–30             | Proceed normally.                                                             |
-| 31–80            | Warn the user. Suggest `--only` for focused review. Proceed.                  |
-| >80              | **Refuse** unless `--force`. Print the manifest summary and suggest `--only`. |
+| Reviewable files | Reviewable lines | Action                                                                        |
+| ---------------- | ---------------- | ----------------------------------------------------------------------------- |
+| 0                | any              | Report clean — nothing to review. Stop.                                       |
+| 1–30             | ≤ 400            | Proceed normally.                                                             |
+| 1–30             | 401–1500         | Warn the user about PR size. Suggest splitting. Proceed.                      |
+| 31–80            | ≤ 1500           | Warn the user. Suggest `--only` for focused review. Proceed.                  |
+| 31–80            | > 1500           | **Refuse** unless `--force`. Suggest splitting or `--only`.                   |
+| > 80             | any              | **Refuse** unless `--force`. Print the manifest summary and suggest `--only`. |
+
+The LOC threshold catches the 5-file / 2000-line refactor that slips past a pure file-count check. ~400 LOC is the reviewer-attention upper bound for a single PR — beyond it, real bugs hide in volume and findings get less specific.
 
 ### Step 4: Route files to reviewers
 


### PR DESCRIPTION
## Summary

The Step 3 guardrails counted *files only*. A 5-file / 2000-LOC refactor PR slipped past the 1-30 bucket and got reviewed end-to-end with no warning. ~400 LOC is the reviewer-attention upper bound for a single PR; beyond that, real bugs hide in the volume and findings get less specific.

## Changes

Cross-tab files × LOC so each tier picks the stricter signal:

| Files  | LOC       | Action                              |
| ------ | --------- | ----------------------------------- |
| 0      | any       | Clean, stop                         |
| ≤ 30   | ≤ 400     | Proceed normally                    |
| ≤ 30   | 401-1500  | Warn, suggest splitting             |
| 31-80  | ≤ 1500    | Warn, suggest \`--only\` (unchanged)  |
| 31-80  | > 1500    | Refuse without \`--force\`            |
| > 80   | any       | Refuse without \`--force\` (unchanged) |

LOC source: \`git diff --stat origin/<base>...HEAD\` (already collected in Step 2).

## Why ~400 LOC?

It's roughly where review attention falls off — the point at which "I read the whole diff" becomes "I skimmed and trusted the tests". Codebase-specific tuning may push this; bump it if real-world runs show false-positive warnings.

## Test plan

- [x] Skill file lints clean
- [ ] Next large refactor triggers the new warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)