### PR TITLE
refactor(wyrdfold): job detail icon goes after the title

### DIFF
--- a/apps/wyrdfold/src/app/(app)/jobs/[id]/JobDetailPage.tsx
+++ b/apps/wyrdfold/src/app/(app)/jobs/[id]/JobDetailPage.tsx
@@ -230,10 +230,6 @@ export default function JobDetailPage({ id, targetId }: JobDetailPageProps) {
               className='group inline-flex items-center gap-2 min-w-0 max-w-full text-text-primary hover:text-brand-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 rounded-md'
               aria-label={`Open original posting for ${posting.title} in a new tab`}
             >
-              <ExternalLink
-                className='size-5 shrink-0 text-brand-500'
-                aria-hidden
-              />
               <Heading
                 variant='component'
                 as='h1'
@@ -242,6 +238,10 @@ export default function JobDetailPage({ id, targetId }: JobDetailPageProps) {
               >
                 {posting.title}
               </Heading>
+              <ExternalLink
+                className='size-5 shrink-0 text-brand-500'
+                aria-hidden
+              />
             </a>
           ) : (
             <Heading


### PR DESCRIPTION
## Summary

Per feedback, the external-link icon on the job detail header reads more naturally to the right of the title (\`Title [icon]\`) than to the left (\`[icon] Title\`). The icon stays inside the same external anchor, so the whole \`Title [icon]\` composite remains one click target opening the original posting.

## Changes

\`apps/wyrdfold/src/app/(app)/jobs/[id]/JobDetailPage.tsx\` — reorder \`Heading\` and \`ExternalLink\` inside the external \`<a>\`.

## Test plan

- [x] Unit: JobDetailPage spec passes (10/10)
- [ ] Visual: external title link reads \"Title [↗]\" on the job detail page

🤖 Generated with [Claude Code](https://claude.com/claude-code)