### PR TITLE
docs: 5 wyrdfold investigation reports

### DIFF
--- a/.claude/docs/research-wyrdfold-docx-styling.md
+++ b/.claude/docs/research-wyrdfold-docx-styling.md
@@ -1,0 +1,112 @@
+# Wyrdfold Resume DOCX Styling — Research Report
+
+_Scope: user-controllable typography, spacing, and color for the tailored-resume `.docx` export. Templates and the markdown editor are covered by separate reports._
+
+## 1. Current State
+
+There are **two** docx code paths in `apps/wyrdfold-api/app/services/docx/`:
+
+- **`pandoc_render.py`** — the **active** renderer. Spawns `pandoc -f markdown -t docx -o -` over the row's `payload_md` (see `apps/wyrdfold-api/app/routers/tailor.py:546` `download_tailored_resume`). All styling is whatever pandoc's built-in `reference.docx` defaults are. Output is cached in Supabase Storage and keyed by `md_payload_hash(payload_md)` (sha256) via `docx_payload_md_hash` on the `tailored_resumes` row.
+- **`renderer.py`** — legacy structured renderer using `python-docx>=1.1` (`pyproject.toml`). Builds the document run-by-run from `TailoredResume`/`TailoredCoverLetter` (`app/models/tailor.py`). Per its docstring it is "going away," but still imported from `app/services/docx/__init__.py` and exercised by `tests/test_docx_renderer.py`.
+
+Both paths are **single-style, hard-coded, single-column, Calibri-only**, no user input. The legacy renderer explicitly forces `run.font.name = "Calibri"` on the title heading and otherwise uses python-docx's built-in styles (`List Bullet`, heading levels). Pandoc inherits its internal reference-doc defaults. There is no `resume_style`/preferences field anywhere in `app/models/tailor.py`, `app/models/user_profile.py`, or `apps/wyrdfold/src/app/(app)/jobs/types.ts`.
+
+The frontend has no styling affordance — only `BatchActionBar.tsx` ("Export (.zip)") and per-resume download buttons in `ResumeSection.tsx`. The `/settings` route exists (`apps/wyrdfold/src/app/(app)/settings/SettingsPage.tsx`) and is the natural home for global defaults.
+
+## 2. Library Capabilities
+
+### `python-docx` (legacy renderer path)
+
+Direct, fine-grained control — what you'd want if styling becomes a product feature:
+
+- **Font family per run/paragraph**: `run.font.name = "Inter"` (also requires setting `w:eastAsia` via `rPr` XML for cross-platform reliability).
+- **Font size**: `run.font.size = Pt(11)`.
+- **Weight/italic**: `run.bold`, `run.italic`.
+- **Color**: `run.font.color.rgb = RGBColor(0x1F, 0x29, 0x37)`.
+- **Paragraph spacing**: `paragraph.paragraph_format.space_before = Pt(6)`, `.space_after`, `.line_spacing = 1.15`.
+- **Section margins**: `section.top_margin = Inches(0.5)` etc. on `doc.sections[0]`.
+- **Word "styles" inheritance**: Modify `doc.styles['Heading 1'].font` once; all `add_heading(level=1)` calls inherit. **Preferred** — single source of truth and matches how Word users edit theme fonts.
+
+**Cannot** reliably do: arbitrary CSS-style layout, web-font embedding (must rely on fonts the reader has installed — stick to Calibri / Arial / Georgia / Helvetica or embed via `w:embedRegular` XML hacking), guaranteed cross-Word-version pagination, kerning beyond what Word exposes.
+
+### `pandoc` (active path)
+
+Styling is via a `--reference-doc=reference.docx` flag — a Word template whose styles pandoc copies into the output. This means user choices must be **materialized into a reference docx** (either prebuilt per preset or generated on the fly with `python-docx`, then passed via temp file). Pandoc itself takes no per-run flags.
+
+**Trade-off**: keeping pandoc means we either ship a small set of reference docs (Compact/Comfortable × 3 fonts) or generate one per user. Switching back to the structured renderer gives direct control but loses pandoc's markdown niceties.
+
+## 3. Proposed Settings Shape
+
+Pydantic model in `app/models/user_profile.py` (new) + matching TS in `jobs/types.ts`:
+
+```json
+{
+  "font_family": "Calibri", // enum: Calibri | Arial | Georgia | Helvetica | Inter
+  "name_size_pt": 18, // 14–28
+  "section_heading_size_pt": 11, // 10–16
+  "body_size_pt": 10, // 9–12
+  "line_height": 1.15, // 1.0–1.5
+  "accent_color_hex": "#1F2937", // applies to name + section headings only
+  "spacing": "comfortable" // "compact" | "comfortable" — drives margins + paragraph spacing presets
+}
+```
+
+Constraints are enforceable via Pydantic `Field(ge=, le=, pattern=)`. Validating `font_family` against an allowlist avoids embedding-license footguns. `spacing` as a preset (not raw `space_after_pt`) keeps the UI surface small.
+
+## 4. Storage
+
+**Recommended: user default + per-resume override.**
+
+- New table column `user_profiles.resume_style_settings JSONB` (single row per user) — the default applied to every new tailoring.
+- New nullable column `tailored_resumes.style_settings JSONB` — populated at render time from the user's default and frozen with the record so re-rendering an old resume stays deterministic. Editing the style for a single approved/unapproved record is a discrete operation.
+- The docx cache key must include the style hash. Today `docx_payload_md_hash` keys on markdown only (`pandoc_render.md_payload_hash`); extend it to `sha256(payload_md + json.dumps(style, sort_keys=True))` so a style change re-renders. See `apps/wyrdfold-api/app/services/tailor/persistence.py:289 mark_docx_rendered`.
+
+## 5. UI Affordance
+
+Two surfaces, both already exist:
+
+- **`/settings`** — new "Resume style" card under `SettingsPage.tsx`. Edits user default. Saves via new `PUT /api/user/resume-style`.
+- **Resume review page** (`apps/wyrdfold/src/app/(app)/jobs/.../review/*`) — a collapsed "Style" disclosure above the download button that lets the user override for this resume only, with a "Save as my default" secondary action.
+
+## 6. Live Preview
+
+In-browser docx preview is fragile. Three viable options, in increasing fidelity / cost:
+
+1. **No preview** — show a sample paragraph rendered in HTML/CSS that mimics the chosen typography. Cheap, ~80% accurate, no backend round-trip. Recommended for v1.
+2. **Server-side PDF preview** — render docx → PDF via LibreOffice headless (`soffice --convert-to pdf`) and stream to an `<iframe>`. Reliable, ~1–2s latency, adds a system dependency.
+3. **In-browser docx render** — `docx-preview` (npm) or `mammoth.js`. Both approximate Word styles in HTML/CSS — line breaks and pagination diverge from real Word. Acceptable but never byte-perfect.
+
+Pure browser preview of pandoc-emitted docx is not worth the complexity. Start with option 1; add option 2 if users ask.
+
+## 7. API Surface
+
+```
+GET    /api/user/resume-style                     → ResumeStyleSettings (default if unset)
+PUT    /api/user/resume-style                     → updated settings
+GET    /tailor/resumes/{id}/style                 → effective style for this record
+PATCH  /tailor/resumes/{id}/style                 → per-record override; invalidates docx cache
+```
+
+Tailor request body (`POST /tailor/resume`) gains an optional `style_settings: ResumeStyleSettings | null` — `null` means "use my profile default at render time."
+
+## 8. Migration Cost
+
+Low. Existing rows have `style_settings IS NULL`; the renderer falls back to today's hard-coded Calibri defaults — pixel-identical output. New exports honor the user setting. The cache-key change is backwards-compatible (old hashes still match for null-style rows). One Supabase migration adds two JSONB columns, neither indexed.
+
+**Recommendation**: do this work on top of the **structured `python-docx` renderer** (revive `renderer.py`) rather than pandoc — direct styling control is exactly the use case `python-docx` is good at, and pandoc's reference-doc indirection adds complexity for no upside once the markdown editor lands.
+
+## Key paths
+
+- `apps/wyrdfold-api/app/services/docx/renderer.py` — legacy structured renderer (python-docx).
+- `apps/wyrdfold-api/app/services/docx/pandoc_render.py` — active pandoc renderer.
+- `apps/wyrdfold-api/app/services/docx/__init__.py` — public exports.
+- `apps/wyrdfold-api/app/routers/tailor.py:336` — `/resumes/export-zip`.
+- `apps/wyrdfold-api/app/routers/tailor.py:546` — `/resumes/{id}/download` (lazy re-render).
+- `apps/wyrdfold-api/app/services/tailor/persistence.py` — `upload_docx`, `mark_docx_rendered`, hash gate.
+- `apps/wyrdfold-api/app/models/tailor.py` — `TailoredResume`, `TailoredCoverLetter`, `TailoredResumeRecord`.
+- `apps/wyrdfold-api/app/models/user_profile.py` — where `ResumeStyleSettings` would live.
+- `apps/wyrdfold-api/pyproject.toml` — `python-docx>=1.1` already a dep.
+- `apps/wyrdfold/src/app/(app)/jobs/ResumeSection.tsx` — per-resume download UI.
+- `apps/wyrdfold/src/app/(app)/jobs/BatchActionBar.tsx` — bulk export UI.
+- `apps/wyrdfold/src/app/(app)/jobs/types.ts:135` — `TailoredResumePayload`.
+- `apps/wyrdfold/src/app/(app)/settings/SettingsPage.tsx` — settings page host.

--- a/.claude/docs/research-wyrdfold-markdown-editor.md
+++ b/.claude/docs/research-wyrdfold-markdown-editor.md
@@ -1,0 +1,85 @@
+# Research: Markdown Editor for Wyrdfold Resume & Cover Letter Review
+
+Date: 2026-05-31
+Status: Research / proposal only — not implemented.
+
+## 1. Current state
+
+Both review pages (`apps/wyrdfold/src/app/(app)/jobs/[id]/resume/ResumeReviewPage.tsx`, `apps/wyrdfold/src/app/(app)/jobs/[id]/cover-letter/CoverLetterReviewPage.tsx`) render the markdown directly into a plain `<textarea>` (resume line 713, cover-letter line 679) styled with `font-mono text-sm`. There is no rendered preview today — users see raw markdown source. A grep of `apps/wyrdfold/package.json` and the workspace root confirms **no markdown library is installed anywhere in wyrdfold** (no `react-markdown`, `remark`, `marked`, `markdown-it`, `tiptap`, `lexical`, `milkdown`, or `codemirror`). The only existing markdown tooling in the repo is MDX (`@mdx-js/react`, `@next/mdx`) which is used by the `root` site's blog and is unsuitable for runtime user input.
+
+Storage is already markdown-first: the API treats `payload_md` (string, max 50 000 chars) as the source of truth (`apps/wyrdfold-api/app/models/tailor.py` — `ResumeEditRequest.markdown`). The page autosaves with a 1500ms debounce by PATCHing `/api/jobs/tailor/{id}` with `{ markdown }`. A 422 response returns `{ detail: { violations: LintViolation[] } }` (`apps/wyrdfold-api/app/services/ats_lint/markdown_linter.py`) which the UI surfaces in a banner. `LintViolation` is `{ code, message, severity }` and lives in `apps/wyrdfold/src/app/(app)/jobs/types.ts`. Version snapshots, approve/unapprove, and `navigator.sendBeacon` flush on `pagehide` are already wired around the same `markdown` state variable. The docx renderer (pandoc) consumes `payload_md` directly — no structured payload is required for the edit/save loop.
+
+## 2. Editor library survey
+
+| Library                                    | Bundle (gz, core)\*                                       | React 19 / `forwardRef`                                                                                    | MD round-trip                                                                                                     | Customization cost                                                               |
+| ------------------------------------------ | --------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| **TipTap v3** (ProseMirror)                | ~80–120KB with starter-kit + `tiptap-markdown`            | Native React 19 hooks API; no `forwardRef` reliance in v3                                                  | Good via `tiptap-markdown` extension; some normalization (smart quotes, list markers)                             | Medium — node/mark schema must be curated to ATS-safe set (no images, no tables) |
+| **Lexical** (Meta)                         | ~50–70KB core + ~30KB markdown plugin                     | First-class React 19; uses modern hooks                                                                    | `@lexical/markdown` does round-trip but headings/lists only — code blocks and links require explicit transformers | High — Lexical is a framework; you ship nodes + commands + toolbar yourself      |
+| **Milkdown** (ProseMirror, markdown-first) | ~150–200KB with commonmark + gfm + listener               | React 19 compatible (v7+); uses `@milkdown/react`; some internal refs but no app-level `forwardRef` needed | Excellent — markdown is the canonical representation, not a serializer afterthought                               | Low–medium — opinionated theming, plugin ecosystem matches the use case          |
+| **CodeMirror 6** + preview pane            | ~60KB editor + ~30–50KB markdown renderer (e.g. `marked`) | Vanilla TS, framework-agnostic; wrap manually, no React-specific issues                                    | Trivial — user edits raw markdown, preview renders it. Zero round-trip risk                                       | Lowest — split-pane UI, no WYSIWYG, matches current mental model                 |
+| Monaco                                     | ~1MB+                                                     | —                                                                                                          | —                                                                                                                 | Overkill for prose. **Skip.**                                                    |
+
+\* Numbers are approximate gzipped sizes for the minimum useful feature set; real-world depends on plugins chosen.
+
+**React 19 forwardRef constraint** (per `CLAUDE.md` coding conventions): the `shared-ui` library must not use `forwardRef`; React 19 props-as-ref pattern is preferred. TipTap v3, Lexical, and Milkdown all expose ref-free React APIs that work without app-level forwardRef. CodeMirror 6 is framework-agnostic and sidesteps the question entirely.
+
+## 3. Recommended path
+
+**TipTap v3 with the `tiptap-markdown` extension and a curated schema** (no tables, no images, no inline HTML — mirroring the existing ATS lint rules in `markdown_linter.py`).
+
+Reasons:
+
+1. The "preview by default, click into edit mode" vision needs **true WYSIWYG**, not a split pane. CodeMirror would force a layout regression (two panes for non-technical users).
+2. Markdown is already the API contract; TipTap's `tiptap-markdown` extension serializes deterministically and we can pin a normalization function on save.
+3. The schema can be **locked to the exact set the ATS linter accepts** (headings, paragraphs, bullet lists, bold/italic, links). Any feature the linter rejects (tables, images) is simply not in the schema, so the user can't create lint-failing content via the UI.
+4. Active maintenance, large React 19-ready ecosystem, predictable bundle.
+
+Milkdown is a close second but its plugin churn is higher and theming over Tailwind 4 requires more wiring. Lexical is excellent but the markdown plugin's gaps (links, code) mean we'd write transformers ourselves — not worth it for a personal product. CodeMirror is the right pick **only if** the WYSIWYG vision is dropped.
+
+## 4. Architecture sketch
+
+Component shape:
+
+```ts
+interface MarkdownPreviewEditorProps {
+  value: string;
+  onChange: (next: string) => void;
+  onBlur?: () => void; // hook for the flush-on-blur flow
+  disabled?: boolean; // approved/locked
+  ariaLabel: string;
+  className?: string | undefined;
+}
+```
+
+Location: **`apps/wyrdfold/src/components/MarkdownPreviewEditor/`** (Next.js-adjacent kit, not shared-ui). Rationale: TipTap pulls ProseMirror which is heavy and wyrdfold-specific; `shared-ui` is meant for React + Tailwind only and is reused by the portfolio site, which shouldn't pay the bundle cost. Mark the component `'use client'`.
+
+State swap:
+
+- A single `<div tabIndex={0}>` wraps the TipTap `EditorContent`. The editor is mounted in `editable: false` mode by default, so it renders as a styled preview.
+- On `focus` (capture phase, or on click), call `editor.setEditable(true)` and `editor.commands.focus()`.
+- On `blur` (when `relatedTarget` is outside the wrapper — to avoid flipping while the user clicks a toolbar button), call `editor.setEditable(false)` and invoke `onBlur` which the parent uses to `flushPendingSave()`.
+- `onChange` fires from TipTap's `onUpdate` callback, which calls `editor.storage.markdown.getMarkdown()` and pushes the string through the same `setMarkdown` setter the pages use today. The existing 1500ms autosave debounce keeps working unchanged.
+
+Toolbar (optional, only visible in edit mode): bold / italic / heading level / bullet list. Hidden when `editable === false`.
+
+## 5. Migration cost
+
+- **API**: zero changes. The PATCH endpoint already accepts `{ markdown: string }`, the lint pipeline runs unchanged, the docx render already keys off `payload_md`.
+- **Frontend**: in `ResumeReviewPage.tsx` and `CoverLetterReviewPage.tsx`, replace the `<textarea …>` block (resume lines ~713–740, cover-letter lines ~679–705) with `<MarkdownPreviewEditor value={markdown} onChange={…} onBlur={flushPendingSave} disabled={isApproved} ariaLabel="…" />`. The surrounding "save status" UI, lint warnings banner, dropdown actions, and version history all stay as-is.
+- **Tests**: both `__tests__/*ReviewPage.spec.tsx` use jest + RTL and only assert on toast/state — not on the textarea itself. Two small updates: replace the `aria-label='Resume markdown'` query with the new wrapper's `aria-label`, and add a smoke test for the preview→edit→blur flip. TipTap needs `jest-environment-jsdom` (already in use) plus a `contentEditable` shim — a known small jest config tweak.
+- **Bundle**: ~100–130KB gzipped added to the `(app)/jobs/[id]/resume` and `…/cover-letter` route chunks. Acceptable for behind-auth routes; should not affect the marketing/blog Lighthouse budget on `apps/root`.
+- **Dependencies to add** to `apps/wyrdfold/package.json`: `@tiptap/react`, `@tiptap/starter-kit`, `@tiptap/extension-link`, `tiptap-markdown`. All ship ESM and are tree-shake-friendly.
+
+## 6. Risks
+
+- **Autosave vs approve-version model**: TipTap's `onUpdate` fires on every keystroke and can be noisier than `<textarea onChange>`. The 1500ms debounce in `useEffect` already gates this — but we must throttle `onUpdate` to avoid React state thrash. Mitigation: feed `onUpdate` through `requestAnimationFrame` or compare against the last serialized markdown before calling `onChange`.
+- **Markdown round-trip drift**: `tiptap-markdown` may normalize whitespace, ordered-list markers, or smart quotes. If the user opens, blurs without editing, and an autosave fires with normalized markdown, the server may re-emit it and silently mutate version history. Mitigation: skip the autosave if `serialized === lastLoadedMarkdown`; only fire `onChange` on **actual** content change (TipTap exposes `editor.isFocused` and a transaction `docChanged` flag).
+- **Lint compatibility**: the schema must exclude everything the ATS linter forbids — tables, images, inline HTML, and headings deeper than `###`. If the schema and linter diverge, users get a 422 from a UI element they thought was safe. Mitigation: write a single-source-of-truth list of allowed nodes and unit-test it against `lint_markdown` fixtures.
+- **`LintViolation` surface**: violations come back from the server in the existing banner. No editor-side change required, but we could decorate offending ranges later — out of scope for v1.
+- **Locked (approved) state**: with `editable: false` permanently set when `isApproved`, the editor renders as a preview and the click-to-edit affordance must be suppressed. Already covered by the `disabled` prop.
+- **Restore-version flow**: `restoreVersion()` calls `setMarkdown(md)` directly. TipTap needs `editor.commands.setContent(md)` to mirror. Wrap this in a `useEffect` that syncs `value` → editor when the prop changes externally.
+- **Diff against base resume**: out of scope for the editor itself; a future "show diff vs source" feature would need a separate component but is not blocked by this work.
+
+---
+
+**Word count**: ~1180.

--- a/.claude/docs/research-wyrdfold-relevance-feedback-loop.md
+++ b/.claude/docs/research-wyrdfold-relevance-feedback-loop.md
@@ -1,0 +1,171 @@
+# Research: Wyrdfold Dynamic Relevance Feedback Loop
+
+Status: design proposal, not implemented. Grounded in the codebase as of 2026-05-31.
+
+## 1. Current world (so we know what we're plugging into)
+
+- Targets live in `job_targets` (`supabase/migrations/20260424120001_create_job_targets.sql`) with `scoring_profile JSONB` and (later) `search_keywords TEXT[]`, `profile_version INT`, `activation_status`, etc.
+- Per-target job scores live in `job_target_scores` (`supabase/migrations/20260424120005_create_job_target_scores.sql`): `(job_posting_id, target_id, score, score_breakdown, matched_keywords, excluded)` with a unique `(job_posting_id, target_id)`.
+- `ScoringProfile` shape — see `apps/wyrdfold-api/app/models/targets.py`:
+  ```
+  ScoringProfile {
+    categories: { [name]: { keywords: {kw: 1..3}, weight: float } },  // core_skills, secondary_skills, nice_to_have
+    seniority: { level, signals[] },
+    domain:    { signals[], weight },
+    negative:  { keywords[], weight: -10 }
+  }
+  ```
+- `search_keywords: list[str]` lives alongside the profile and drives ATS queries (Greenhouse `q=`, etc.) — distinct from the scoring keywords.
+- Scoring entry point: `apps/wyrdfold-api/app/services/target_scoring.py` — `score_title_and_upsert` (Stage 1, title-only) and async Stage 2 (full JD). Re-score endpoint is already a noted consumer.
+- LLM: Anthropic SDK via `app/services/llm/client.py` (`LLMClient`, `complete_json`); existing derivation pipelines (`derive_profile_from_label.py`, `derive_profile.py`, `merge.py`) already produce the JSON shape above and log to `cost_log`.
+- UI surfaces: `apps/wyrdfold/src/app/(app)/jobs/JobCard.tsx` (list row with `Dropdown` of actions: Open, View original, Delete) and `apps/wyrdfold/src/app/(app)/jobs/[id]/JobDetailPage.tsx` + `JobDetailPanel.tsx` (status changes, analyze, delete).
+
+## 2. UX design
+
+### Jobs list (`JobCard.tsx`)
+
+Add two dropdown items above Delete:
+
+- `Mark irrelevant` (thumbs-down icon) — closes the row's `Dropdown`, shows an inline 1-line textarea ("Why? (optional, e.g. 'sales role')") with `Skip` / `Submit`. Submit fires `POST /api/jobs/{id}/feedback`. The row gets a muted state + an Undo affordance (toast with 5s timer).
+- `Mark highly relevant` (thumbs-up) — same pattern, optional reason.
+
+For batch mode, extend `BatchActionBar.tsx` with `Mark all irrelevant` (with reason prompt that applies to all selected). This is the highest-leverage entry point for cleaning up a noisy poll.
+
+### Job detail (`JobDetailPanel.tsx`)
+
+Add a `Feedback` sub-section under the score breakdown:
+
+- Two buttons: `Not for me` / `Great match`.
+- After click, expand a textarea for reason; submit on blur or Enter.
+- Show the user's prior feedback if any ("You marked this irrelevant 3d ago — reason: …") with an Undo.
+- No hard confirm modal — Undo via toast (existing `useToast`) is cheaper and matches the existing Delete flow.
+
+Reason is **always optional**. Don't gate the signal on reasoning.
+
+## 3. Data model
+
+New table:
+
+```sql
+CREATE TABLE job_feedback (
+  id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id      TEXT NOT NULL,
+  job_posting_id UUID NOT NULL REFERENCES job_postings(id) ON DELETE CASCADE,
+  target_id    UUID NOT NULL REFERENCES job_targets(id) ON DELETE CASCADE,
+  signal       TEXT NOT NULL CHECK (signal IN ('irrelevant','relevant')),
+  reason       TEXT,
+  applied_at   TIMESTAMPTZ,        -- when the learner consumed it
+  applied_run_id UUID,             -- groups feedback that produced one mutation
+  created_at   TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE (user_id, job_posting_id, target_id)  -- latest wins on conflict
+);
+CREATE INDEX idx_job_feedback_target_unapplied
+  ON job_feedback(target_id) WHERE applied_at IS NULL;
+```
+
+Notes:
+
+- `target_id` is mandatory because feedback is _about a target's lens_, not about jobs in the abstract. A job marked irrelevant for "Senior FE" can still be relevant for "Eng Manager".
+- Store learner-inferred keywords inside the existing `scoring_profile` JSONB rather than new columns. Two reasons: it keeps the merge/derive code (`apps/wyrdfold-api/app/services/targets/merge.py`) as the single source of truth, and `profile_version` already bumps on changes (used by `score_title_and_upsert`'s `scored_profile_version`).
+  - Negative keywords append into `scoring_profile.negative.keywords` (with provenance tracked in a sibling `learned_meta` block: `{kw: {source: 'feedback', n: 3, last: ts}}` — see guardrails).
+  - Positive keywords append into `scoring_profile.categories.secondary_skills.keywords` with weight 1, unless they already exist in `core_skills`.
+- Optionally add `target_learning_log` (`target_id, run_id, prev_profile, next_profile, diff, signals_consumed`) for rollback/audit.
+
+## 4. LLM inference pipeline
+
+Triggers (cheap path first):
+
+1. **Synchronous shallow update** on every feedback submit: a deterministic Python step (no LLM) appends/removes any _literal_ keywords the user typed in `reason` that already exist in the profile. Zero cost, instant feedback signal.
+2. **Batched LLM inference** runs when _either_ threshold trips per `(user_id, target_id)`:
+   - N >= 3 unapplied irrelevant signals, OR
+   - any unapplied signal older than 24h, OR
+   - explicit manual trigger from settings.
+     This runs as a `BackgroundTasks` job from the feedback endpoint (same pattern as `_activate_pipeline` in `routers/targets.py`) or as a separate worker invoked by `POST /targets/{id}/learn`.
+
+Prompt input:
+
+- Current `scoring_profile` JSON.
+- The N feedback rows: `{job title, company, signal, reason}` (titles only — keep tokens cheap; pull JD text only if reason is empty AND signals >= 5).
+- System prompt mirrors `derive_profile_from_label.SYSTEM_PROMPT` and returns a `ProfilePatch`:
+  ```
+  { add_negative: [str], remove_negative: [str],
+    add_secondary: {kw: int}, demote_keywords: [str],
+    confidence: 0..1, rationale: str }
+  ```
+- Use `complete_json` against a Pydantic `ProfilePatch` model, log via `cost_log` with `purpose='target.learn_from_feedback'`.
+
+Application:
+
+- Merge the patch into `scoring_profile` using a new `apply_patch` in `app/services/targets/merge.py` (keeps merge logic centralized).
+- Bump `profile_version`. Stamp every consumed `job_feedback.applied_at` + shared `applied_run_id`.
+- If `confidence < 0.6`, **stage** the patch in `target_learning_log` without applying; show it on a settings page for the user to approve.
+
+## 5. Re-scoring trigger
+
+Profile changes already invalidate stage-2 scores via `scored_profile_version`. On apply:
+
+1. Re-run **Stage 1** for every job in the target (the cheap title-only path — `_retro_score_existing_jobs` in `routers/targets.py` already does this in batches of 500). No LLM cost.
+2. Mark `job_target_scores.scoring_status = 'stage1'` for affected rows so the existing async Stage 2 worker re-picks them on demand (lazy — only re-do Stage 2 for jobs the user actually opens, or for the top K by Stage 1 score).
+3. **Do not re-poll adapters.** Polling is keyword-driven; only re-poll if `search_keywords` changed, and only on the next scheduled tick. Adding entries to `search_keywords` is a learner action only when positive feedback repeatedly surfaces a title pattern that isn't already in the list — guardrail behind manual approval for v1.
+
+Cost: 1 patch LLM call per batch (sonnet-4-6, ~2-4k tokens in, ~500 out → cents). Stage 1 re-score is pure Python.
+
+## 6. API surface
+
+All routes in `apps/wyrdfold-api/app/routers/`. Auth via existing `verify_api_key_or_jwt`.
+
+- `POST /jobs/{job_id}/feedback` → body `{signal: 'irrelevant'|'relevant', reason?: str, target_id: uuid}` → 201 `{feedback_id, queued_learn_run: bool}`. Upserts on the unique key. Triggers the batched learner via `BackgroundTasks` if the threshold trips.
+- `DELETE /jobs/{job_id}/feedback?target_id=...` → 204. Undo.
+- `GET /targets/{target_id}/feedback?limit=&cursor=` → list for the settings UI.
+- `POST /targets/{target_id}/learn` → force-run the learner now; returns the staged or applied patch + diff.
+- `POST /targets/{target_id}/learn/{run_id}/apply` and `.../reject` → for staged patches (low confidence path).
+- Frontend route handlers in `apps/wyrdfold/src/app/api/jobs/[id]/feedback/route.ts` proxy to wyrdfold-api (matches existing pattern under `apps/wyrdfold/src/app/api/`).
+
+## 7. Phasing
+
+**v1 (1-2 days, no LLM)**
+
+- `job_feedback` table + endpoints + UI affordances on list and detail.
+- Deterministic-only learner: literal-keyword extraction from `reason`, append to `scoring_profile.negative.keywords` when N>=3 marks share a token.
+- Manual `Re-score now` button on the target settings page.
+- Ship just this — it already moves the needle for noisy targets.
+
+**v2 (~3 days, batched LLM)**
+
+- Add `ProfilePatch` LLM step behind threshold + cron.
+- `target_learning_log` for audit/rollback.
+- Auto Stage-1 re-score on apply.
+
+**v3 (poller adapts)**
+
+- Learner can propose changes to `search_keywords` (additions for positive patterns, removals if a search term turns out to surface mostly noise).
+- Approval-gated by default; auto-apply only above a confidence threshold and after M weeks of stable feedback.
+- Optional per-adapter filters (e.g., Greenhouse `--exclude-titles`) sourced from `scoring_profile.negative.keywords`.
+
+## 8. Risks & guardrails
+
+- **Overfitting to one bad signal.** Require N>=3 feedback items before any non-literal mutation; weight by `confidence` from the LLM; never let one click rewrite a category.
+- **Drift away from the user's actual goal.** Show a diff (`prev_profile` → `next_profile`) in the toast/settings whenever a patch is applied. Keep `target_learning_log` for one-click rollback.
+- **Adversarial echo chamber.** Cap learned-negative keywords at ~20 per target; LRU-evict on next learn run. Mark every learned keyword with `learned_meta` provenance so we can distinguish from user-derived ones.
+- **Cross-user contamination.** Targets are shared (see `apps/wyrdfold-api/app/services/targets/merge.py` corpus-building). Feedback must be per `(user_id, target_id)` and must not mutate the shared profile when the target has >1 active user — instead, fork into a per-user override layer applied at score read time. For v1, restrict learning to single-user targets and gate multi-user with a TODO.
+- **Score thrash for the user.** `profile_version` bump invalidates Stage 2 but we keep Stage 1 results visible; the UI should toast "Your list updated based on 3 marks" so it's not silent.
+- **Cost runaway.** Reuse `enforce_llm_budget` dependency from `routers/targets.py` on `/learn` endpoints. Cap learn runs to once/hour per target.
+
+## 9. Open questions
+
+- Should "Mark irrelevant" also auto-hide the row, or just deprioritize? Suggest deprioritize for v1 — hiding feels destructive and we already have Delete.
+- Surface positive feedback in `core_skills` (weight 2-3) or `secondary_skills` (weight 1-2)? Default secondary; promote to core only on repeat positive signal for the same keyword across 3+ jobs.
+- Where does the learner live operationally — inline `BackgroundTasks` (matches `_activate_pipeline`) or a Supabase cron + worker? Inline is simpler for v1; revisit if learn-run latency gets noticed.
+
+## Key files referenced
+
+- `apps/wyrdfold-api/app/services/target_scoring.py`
+- `apps/wyrdfold-api/app/services/targets/{merge,derive_profile,derive_profile_from_label,crud}.py`
+- `apps/wyrdfold-api/app/routers/targets.py` (`_activate_pipeline`, `_retro_score_existing_jobs`)
+- `apps/wyrdfold-api/app/models/targets.py` (`ScoringProfile`, `JobTarget`)
+- `apps/wyrdfold-api/app/services/llm/client.py` (`complete_json`, `cost_log`)
+- `supabase/migrations/20260424120001_create_job_targets.sql`
+- `supabase/migrations/20260424120005_create_job_target_scores.sql`
+- `supabase/migrations/20260426120005_add_llm_score_columns.sql`
+- `apps/wyrdfold/src/app/(app)/jobs/JobCard.tsx`, `BatchActionBar.tsx`
+- `apps/wyrdfold/src/app/(app)/jobs/[id]/JobDetailPage.tsx`, `JobDetailPanel.tsx`

--- a/.claude/docs/research-wyrdfold-relevance-matcher.md
+++ b/.claude/docs/research-wyrdfold-relevance-matcher.md
@@ -1,0 +1,81 @@
+# Wyrdfold Job Relevance Matcher — Research Report
+
+**Symptom:** A director-level target is being served junior roles ("rep", "representative").
+**Date:** 2026-05-31
+
+---
+
+## 1. Current Architecture
+
+End-to-end scoring is a **three-stage pipeline** orchestrated by the poller and re-used by manual-job ingestion. All stages are pure-keyword today; no embeddings are involved in matching.
+
+**Ingestion gate (poller).** For each ATS posting, `_title_matches_any_target()` (`apps/wyrdfold-api/app/services/poller.py:172-182`) calls `score_title_against_profile()` against every active target's `ScoringProfile`. If **any** keyword matches or a negative keyword fires (`excluded`), the job is admitted. Note that `search_keywords` (`targets.search_keywords` JSONB, migration `20260426064755_add_target_search_keywords.sql`) and the token-overlap helper `_title_matches_target` (`poller.py:211-244`) exist but are **not wired into the poll loop** — only `score_title_against_profile` is. So `search_keywords` is effectively dead code on the ingestion path.
+
+**Stage 1 — title-only score.** `score_title_against_profile()` (`apps/wyrdfold-api/app/services/scoring.py:342-399`) walks every category keyword + seniority signal and applies `_keyword_or_alias_in_text` (`scoring.py:118-143`), which is a **plain `kw_lower in text` substring check** for any keyword >3 chars (`_keyword_in_text` at `scoring.py:24-36`). Score is normalised against `_calc_title_max_possible` (`scoring.py:332-339`).
+
+**Stage 2 — full JD score.** `score_job_with_profile()` (`scoring.py:195-326`) parses the JD into weighted sections, applies the same `_keyword_or_alias_in_text` check across title + sections, and a `_TITLE_WEIGHT` of `2.0` (`scoring.py:176`). Negatives only fire in `requirements`/`default` sections + title (`scoring.py:288-304`).
+
+**Stage 3 — LLM analysis.** Triggered when stage-2 score ≥ `LLM_SCORE_THRESHOLD = 40` (`poller.py:74-75`). `analyze_job` + `blend_scores` overlay an LLM scorecard onto the keyword score. Below the threshold, scoring is keyword-only.
+
+The Postgres RPC `get_target_jobs` (`supabase/migrations/20260426120003_create_get_target_jobs_rpc.sql`) only reads from `job_target_scores`, filters by `excluded = FALSE` + `score >= p_min_score`, and paginates — it does **no scoring of its own**. The jobs router (`apps/wyrdfold-api/app/routers/jobs.py`) just overlays target scores onto postings.
+
+---
+
+## 2. Root-cause Hypothesis: why "Director" matches "Sales Rep"
+
+The substring matcher in `_keyword_in_text` (`scoring.py:24-36`) uses a length check (`len(kw_lower) <= 3 and kw_lower.isalpha()`) to decide between word-boundary regex and raw `in`. Since `"director"` is 8 chars, it falls through to plain `in text`. This in itself does not produce "rep" matches — but combine it with how the LLM populates the profile:
+
+1. **Seniority signals are weak strings, not gating.** `derive_profile_from_label.py` instructs the LLM to emit signals like `["5+ years", "lead", "mentor"]` (`derive_profile_from_label.py` SYSTEM_PROMPT, ~line 50-70). For a director target it will typically emit signals like `"director"`, `"vp"`, `"head of"`, `"5+ years"`, `"lead"`. **`"lead"` is a substring of `"leadership"`, `"leader"`, `"leads"`** — extremely common JD filler. So any "Sales Representative — Leads Outbound Pipeline" title (or even just a category keyword like `"sales"` for a sales-leadership target) triggers a stage-1 match.
+
+2. **Match-OR semantics, not match-AND.** Stage-1 admission is "any keyword matched" (`poller.py:180`: `if result.matched_keywords or result.excluded`). A title-level match on **a single weak signal** (e.g. `"sales"` as a category keyword, or `"lead"` as a seniority signal) is enough to ingest the row and to produce a non-zero stage-1 score.
+
+3. **Seniority is never enforced as a hard gate.** `SeniorityProfile.level` (`apps/wyrdfold-api/app/models/targets.py`, `class SeniorityProfile`) holds the level string (`"director"`) but **nothing in `scoring.py` or `poller.py` reads `.level`** — it only reads `.signals`. So the seniority level is decorative; only the textual signals fire, and they fire as substring matches.
+
+4. **Negatives are LLM-suggested and incomplete.** `derive_profile_from_label.py` example negatives are `["junior", "intern", "entry-level"]`. Common junior-IC titles ("representative", "rep", "associate", "coordinator", "specialist", "I", "II") are typically **not** in the negative list, so they don't trigger `excluded = True`. Result: the row passes the gate at a low-but-nonzero stage-1 score and surfaces in the list, especially when sorted by `created_at`.
+
+5. **Stage-2 inherits the same matcher.** The 2x `_TITLE_WEIGHT` boost (`scoring.py:237, 258, 276`) compounds title-token false positives. The LLM safety net (stage 3) only fires above score 40, so weak-but-not-zero matches stay keyword-only.
+
+**TL;DR:** seniority is treated as a soft scoring nudge, not a filter; substring matching means weak tokens like `"lead"` or `"sales"` admit junior IC roles; and `search_keywords` (which could enforce role-title tokens) isn't actually used during polling.
+
+---
+
+## 3. Strengthening Options (effort × impact)
+
+| #   | Option                                                                  | Effort               | Impact   | Notes                                                                                                                                                                                                                                                                                                                                                |
+| --- | ----------------------------------------------------------------------- | -------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| A   | **Domain anti-patterns / hard-exclude title tokens for senior targets** | XS (1 file, ~30 LOC) | High     | When `seniority.level in {"director","vp","head","principal","staff"}`, prepend `["representative","rep","associate","coordinator","specialist","assistant","junior","intern","entry-level","i","ii","iii"]` to `profile.negative.keywords`. Enforce as **word-boundary** matches (fix `_keyword_in_text` length gate). Ships today.                 |
+| B   | **Wire `search_keywords` into the poll gate**                           | S                    | High     | `_title_matches_target` (`poller.py:211-244`) already exists but is unreferenced. Change `_title_matches_any_target` to require BOTH a `search_keywords` token-overlap AND a profile keyword hit (currently `OR` semantics admit too much). Removes "Sales Rep" because no director target's `search_keywords` contains "rep" or "representative".   |
+| C   | **Seniority-aware title scoring (boost + penalty)**                     | S                    | High     | Inside `score_title_against_profile`, after matching, compute a seniority delta: detect the title's own seniority tier (regex on `{director, vp, head, principal, staff, senior, mid, junior, intern, assistant, rep, associate, ...}`) and add a large negative if it's >1 tier below `profile.seniority.level`. Single function, no schema change. |
+| D   | **Per-target must-include / must-exclude title tokens**                 | S-M                  | Med-High | Add `must_include_title_tokens` and `must_exclude_title_tokens` to `ScoringProfile`. Migration is JSONB additive (no schema-table change). Overlaps with the next investigation (per-target overrides) — coordinate.                                                                                                                                 |
+| E   | **Voyage embedding similarity on titles**                               | M                    | Med      | Voyage client is already wired (`apps/wyrdfold-api/app/services/embeddings/voyage_client.py`, `voyage-3-lite` available at 512 dims). Compute cosine(title_embedding, target_label_embedding) once per posting; multiply into stage-1 score. Cheap (`voyage-3-lite` ~$0.02/1M tokens) but adds infra: cache, cost log, batch.                        |
+| F   | **Stage-1.5 LLM title classification**                                  | M                    | Med      | Cheap Haiku call per admitted title: "Is this title at the {target.seniority.level} level for {target.label}? yes/no/maybe". Gate stage-2 on yes/maybe. Adds latency + cost to ingestion.                                                                                                                                                            |
+
+Options A, B, C are independent and stackable. D is a schema/UX change. E and F are last-mile precision and only worth shipping once A-C land.
+
+---
+
+## 4. Recommendation — what to ship first
+
+**Ship A + C together in a single PR.** Together they fix the failure deterministically:
+
+- **A** prevents "Representative", "Rep", "Associate", "Coordinator" from ever scoring against a director target — implemented as word-boundary regex in `_keyword_in_text` (also fixing the silent "lead" → "leadership" substring bug) and as an automatic prepend of a `_JUNIOR_TITLE_TOKENS` constant to `profile.negative.keywords` at scoring time when `profile.seniority.level` is in the senior tier.
+- **C** adds a seniority-tier delta so even untagged junior titles ("SDR", "BDR", "Coordinator I") get pushed below the `min_score` threshold instead of squeaking through.
+
+**Migration impact:** zero. Both are pure code changes in `apps/wyrdfold-api/app/services/scoring.py` and a small constant table. **Re-scoring impact:** bump `targets.profile_version` so `bulk_score_for_target` (`target_scoring.py`) lazily re-scores existing rows on next poll. The `scores` table schema is unchanged; only score values flip. Existing director targets will see junior rows drop out of the list within one poll cycle.
+
+**Then ship B in a follow-up** (wire `search_keywords` into the poller gate) — this is the structurally correct fix and makes the LLM-derived `search_keywords` column actually load-bearing. **Defer D** until the per-target override UI is designed (next investigation). **Defer E/F** until A-C are measured in production.
+
+---
+
+### Key citations
+
+- `apps/wyrdfold-api/app/services/scoring.py:24-36` — substring vs word-boundary length gate (the silent-substring bug)
+- `apps/wyrdfold-api/app/services/scoring.py:118-143` — `_keyword_or_alias_in_text`
+- `apps/wyrdfold-api/app/services/scoring.py:342-399` — stage-1 title scoring
+- `apps/wyrdfold-api/app/services/scoring.py:195-326` — stage-2 JD scoring
+- `apps/wyrdfold-api/app/services/poller.py:172-182` — ingestion gate (`or` semantics)
+- `apps/wyrdfold-api/app/services/poller.py:211-244` — unused `_title_matches_target`
+- `apps/wyrdfold-api/app/models/targets.py` — `SeniorityProfile.level` (read nowhere in scoring)
+- `apps/wyrdfold-api/app/services/targets/derive_profile_from_label.py` — LLM prompt seeding the profile
+- `supabase/migrations/20260426120003_create_get_target_jobs_rpc.sql` — RPC does no scoring, only filtering
+- `supabase/migrations/20260426064755_add_target_search_keywords.sql` — `search_keywords` column origin

--- a/.claude/docs/research-wyrdfold-resume-templates.md
+++ b/.claude/docs/research-wyrdfold-resume-templates.md
@@ -1,0 +1,82 @@
+# Wyrdfold Resume Templates — Research
+
+_Date: 2026-05-31. Parallel investigation; scoped to templates (not markdown editor, not docx styling)._
+
+## 1. Current generation flow
+
+A click on **Generate Resume** in `apps/wyrdfold/src/app/(app)/jobs/ResumeSection.tsx` (`handleGenerate`, lines ~60–120; both compact and full variants render a `name='generate-resume'` button) fetches `description_html` from the job detail and POSTs `{ job_description, job_posting_id }` to the Next proxy route `apps/wyrdfold/src/app/api/jobs/tailor/resume/route.ts`, which forwards to the FastAPI endpoint `POST /tailor/resume` in `apps/wyrdfold-api/app/routers/tailor.py` (`create_tailored_resume`). That router resolves the latest `OptimizedPayload`, checks `gap_tracker`, optionally short-circuits via `reuse.find_reusable_resume`, then calls `run_tailor_pipeline` in `apps/wyrdfold-api/app/services/tailor/pipeline.py`. The pipeline calls `tailor_resume` (`apps/wyrdfold-api/app/services/tailor/tailor.py`), which composes a user message via `build_user_message` and submits it with the static `TAILOR_SYSTEM` constant defined in `apps/wyrdfold-api/app/services/tailor/prompts.py` (cached as a prompt-cache target). The LLM returns a `TailoredResume`, which is trace-validated, markdown-rendered (`markdown_render.py`), linted, docx-rendered via Pandoc, persisted to the `documents` table, and returned as a `TailorResponse`.
+
+Today, "rules" live **entirely hard-coded in `TAILOR_SYSTEM`** — section list (Summary/Experience/Skills/Education), bullet caps (4/3/2 across recency), style ("no em dashes", "≤ 280 chars", action verbs, no filler list), ATS constraints, summary length, and a fixed skills cap of 20. Per-user `PreferencesPayload` (`rules`, `avoid`, `tone_notes`) and per-target annotations layer in as user-message sections, but nothing structurally varies the **shape** of the resume. A `resume_type` field already exists end-to-end (`Literal["senior-frontend", "fullstack", "frontend-lead", "generic"]` in `apps/wyrdfold-api/app/models/tailor.py` line 25), is accepted by `TailorRequest` and `BatchRequest`, is forwarded into the user message as `[ResumeType] {value}`, is persisted on the row, and is exposed on the frontend `TailoredResumeRecord` (`apps/wyrdfold/src/app/(app)/jobs/types.ts` line 157). **But the UI never sets it** — `handleGenerate` omits it, so every resume is `"generic"`, and the system prompt has zero instructions keyed off it. `resume_type` is a vestigial slot waiting for a real template system.
+
+## 2. What a template actually is
+
+Proposed shape (TypeScript-flavored; mirror with a Pydantic `ResumeTemplate`):
+
+```ts
+interface ResumeTemplate {
+  id: string; // 'engineering-conservative'
+  label: string; // 'Engineering — Conservative'
+  description: string; // shown in picker tooltip
+  audience_hint: string; // 'Big-tech, Fortune 500, regulated industries'
+
+  // Structure: ordered sections with optional per-section caps
+  sections: TemplateSection[];
+
+  // Style metadata consumed by docx renderer (overlaps with docx-styling investigation)
+  style: {
+    tone: 'conservative' | 'modern' | 'minimal' | 'executive';
+    docx_theme_id: string; // resolves to a styles.xml variant; out of scope here
+  };
+
+  // Per-template prompt overrides + additions
+  prompt_fragment: string; // injected into TAILOR_SYSTEM after the constant
+  bullet_caps: { recent: number; mid: number; old: number };
+  summary_sentences: [number, number]; // e.g. [2, 3]
+  skills_cap: number;
+  allow_first_person: boolean;
+}
+
+interface TemplateSection {
+  kind:
+    | 'summary'
+    | 'experience'
+    | 'skills'
+    | 'education'
+    | 'projects'
+    | 'certifications';
+  required: boolean;
+  order: number;
+  rules: string[]; // ["Lead with metric", "≤ 2 lines per bullet"]
+}
+```
+
+**Structure** drives section ordering in `markdown_render.to_markdown` (currently linear/hard-coded — needs to iterate `template.sections`). **Rules** are flattened into the per-section block of the prompt fragment. **Style metadata** is read by the docx renderer (separate investigation owns that). **Prompt fragment** is appended to `TAILOR_SYSTEM` as the variable tail and breaks prompt caching for the appended chunk — see §6.
+
+## 3. Storage
+
+**Recommended: markdown files checked into the repo with YAML frontmatter**, loaded at FastAPI startup into an in-memory dict keyed by `id`. Place them at `apps/wyrdfold-api/app/services/tailor/templates/*.md`. Frontmatter holds the structured fields (sections, bullet_caps, style); body is the `prompt_fragment` (easier to author and diff than a JSON blob with `\n` escapes). Rationale: v1 templates are author-curated, change infrequently, ship with releases, are visible in PR review, are testable as fixtures, and need no migration. The existing `resume_type` column on `documents` is repurposed to store the template `id` (string already — no schema change). A `resume_templates` DB table is only needed at v3 when users edit their own.
+
+## 4. UI affordance
+
+Default behavior should not regress: `handleGenerate` resolves `default_template_id` in order: (1) per-target default on `targets.default_template_id` (v2), (2) per-user default on `user_profiles.default_template_id` (v2), (3) global `'engineering-modern'`. The CTA stays a single button by default; clicking it generates with the resolved default. Add a small caret-disclosure adjacent to the button (`<Button name='generate-resume' />` + `<Dropdown />` from `@danieljoffe.com/shared-ui`) listing templates with a checkmark on the resolved default. The detail panel shows the template badge on the `TailoredResumeRecord` (using `record.resume_type` — already present). Cover-letter generation gets the same picker for parity.
+
+## 5. API surface
+
+- **`GET /tailor/templates`** — list `ResumeTemplate` summaries (`id`, `label`, `description`, `audience_hint`). Add to `apps/wyrdfold-api/app/routers/tailor.py`. Public to authed users; cached client-side since templates are static.
+- **`GET /tailor/templates/{id}`** — full template (sections + rules + prompt_fragment). Optional; only needed if UI previews rules.
+- **Overload existing `POST /tailor/resume`** by adding `template_id: str | None = None` to `TailorRequest`. Same for `BatchRequest`. Backward-compatible — null falls through to `'generic'` (today's behavior). Reject unknown IDs with 422.
+- No new endpoints for resumes — `TailoredResumeRecord.resume_type` already round-trips the chosen template.
+
+## 6. Migration cost
+
+**Prompt lift is moderate.** `TAILOR_SYSTEM` currently inlines the entire rules surface; the template work refactors it into a base (hallucination containment, ATS, output format — universally true) plus a per-template fragment appended to the static system message. The base stays cacheable; the fragment lives in the user message under `[TemplateRules]` to preserve the existing cache hit. That maps cleanly onto how `[ResumeType]`, `[Preferences]`, `[Annotations]` already work in `build_user_message` (`tailor.py` lines 34–62). **Re-tuning is required** for v1 templates: each gets a few sample JDs run through it during authoring; outputs reviewed; rules iterated. Budget ~1 day per template. **Existing resumes are untouched** — `documents` rows keep their `resume_type` (now meaning template id; old rows = `'generic'`, which v1 ships as a real template alias). Versioned `ResumeVersion` history is also unaffected since templates only influence new LLM generations.
+
+## 7. Phasing
+
+- **v1 (~3 days)**: 2–3 curated markdown templates checked in (`engineering-modern`, `engineering-conservative`, `executive-brief`). `GET /tailor/templates` list endpoint. `template_id` field on `TailorRequest`/`BatchRequest`. UI: dropdown next to the "Generate Resume" button on `JobDetailPanel`/`ResumeSection`; default = `engineering-modern`. Prompt refactor splits `TAILOR_SYSTEM` into base + per-template fragment. `markdown_render.to_markdown` iterates `template.sections` instead of hard-coding section order.
+- **v2 (~1 day)**: `targets.default_template_id` and `user_profiles.default_template_id` columns + settings UI. Resolution order in `handleGenerate`.
+- **v3 (~1 week)**: `resume_templates` DB table for user-authored variants (clone-and-edit a curated one). Lint guard against runaway rules; preview mode that shows the rendered prompt fragment.
+
+---
+
+**Cited code**: `apps/wyrdfold-api/app/services/tailor/{prompts.py, tailor.py, pipeline.py, markdown_render.py, persistence.py, reuse.py}`, `apps/wyrdfold-api/app/models/{tailor.py, batch.py}`, `apps/wyrdfold-api/app/routers/tailor.py`, `apps/wyrdfold/src/app/(app)/jobs/{ResumeSection.tsx, BatchActionBar.tsx, types.ts}`, `apps/wyrdfold/src/app/(app)/jobs/[id]/resume/ResumeReviewPage.tsx`, `apps/wyrdfold/src/app/api/jobs/tailor/resume/route.ts`.


### PR DESCRIPTION
## Summary

Research reports for the 5 feature investigations you queued. Each is independent — read whichever, implement in any order. No code changes here, just proposals to triage.

## Reports

### \`research-wyrdfold-relevance-matcher.md\`
Root-cause: \`_keyword_in_text\` uses substring match (\`scoring.py:24-36\`) so \`"lead"\` matches \`"leadership"\` / \`"leads"\` in junior titles; \`SeniorityProfile.level\` is never read as a gate; \`search_keywords\` is dead on the poll path. Recommends word-boundary regex + auto-inject junior negatives for senior targets + seniority-tier delta. Bump \`profile_version\` for lazy re-scoring. Zero migration cost. ~3-day lift.

### \`research-wyrdfold-relevance-feedback-loop.md\`
Mark-irrelevant / mark-relevant affordance on jobs list + detail page. v1 is deterministic only — extract literal keywords from user-supplied reason, threshold at N≥3 signals, manual \"re-score now\". v2 adds LLM inference. v3 = poller adapts. Reuse \`scoring_profile\` JSONB (no new columns); restrict learning to single-user targets in v1 to dodge the shared-target trap.

### \`research-wyrdfold-markdown-editor.md\`
Resume + cover letter review pages currently use raw \`<textarea>\`. Replace with TipTap v3 + tiptap-markdown at \`apps/wyrdfold/src/components/MarkdownPreviewEditor/\`. NOT shared-ui — ProseMirror is heavy and Next.js-aware. API is already markdown-native (\`payload_md\` + PATCH \`{markdown}\`); zero backend changes. Editor schema must mirror the ATS lint rules (no tables/images/inline HTML).

### \`research-wyrdfold-resume-templates.md\`
The \`resume_type\` field is **already plumbed end-to-end** (\`apps/wyrdfold-api/app/models/tailor.py:25\`) but vestigial — UI never sets it, system prompt doesn't key off it. This slot is the natural home for \`template_id\`. v1: 2-3 curated markdown templates in the repo + \`GET /tailor/templates\` + dropdown on the Generate button. Preserve prompt cache hit rate by injecting template rules via a new \`[TemplateRules]\` user-message block (not by editing the cached system prompt).

### \`research-wyrdfold-docx-styling.md\`
Two coexisting renderers in \`apps/wyrdfold-api/app/services/docx/\`: \`pandoc_render.py\` (active) and \`renderer.py\` (legacy python-docx, marked \"going away\"). Revive python-docx for direct font/size/color/spacing control. Storage: \`user_profiles.resume_style_settings\` JSONB (default) + \`tailored_resumes.style_settings\` JSONB (per-record snapshot for determinism). Skip in-browser docx preview; ship HTML/CSS sample mimic + optional LibreOffice→PDF later.

## Test plan

- [x] Files render clean as markdown
- [ ] You triage which to implement; spin up per-feature PRs as decided

🤖 Generated with [Claude Code](https://claude.com/claude-code)