### PR TITLE
fix(wyrdfold-api): per-user optimized doc lookup in poller stage 3

### DIFF
--- a/apps/wyrdfold-api/app/services/poller.py
+++ b/apps/wyrdfold-api/app/services/poller.py
@@ -427,6 +427,58 @@ async def _run_llm_scoring_for_row(
             await asyncio.to_thread(mark_target_scores_complete, supabase, job_id)
 
 
+async def _resolve_user_targets_for_stage3(
+    supabase: Client,
+    active_targets: list[JobTarget],
+    company_name: str,
+) -> tuple[dict[str, JobTarget], dict[str, OptimizedDoc]]:
+    """Pair each user with a primary active target + their optimized doc.
+
+    Targets are global; ``user_targets`` is the junction. We fetch the
+    junction once, build (user_id → first active target) and (user_id →
+    optimized doc) maps, and skip users whose optimized doc hasn't been
+    generated yet (onboarding incomplete) — keyword scoring still runs
+    for them via stage 1 + stage 2.
+
+    Returns ``(primary_by_user, user_optimized)``. ``company_name`` is
+    used only for the skip-log message.
+    """
+    if not active_targets:
+        return {}, {}
+
+    target_ids = [t.id for t in active_targets]
+    junction_resp = await asyncio.to_thread(
+        supabase.table("user_targets")
+        .select("target_id, user_id")
+        .eq("is_active", True)
+        .in_("target_id", target_ids)
+        .execute
+    )
+    junction_rows = cast(list[dict[str, Any]], junction_resp.data or [])
+    users_by_target: dict[str, list[str]] = {}
+    for row in junction_rows:
+        users_by_target.setdefault(row["target_id"], []).append(row["user_id"])
+
+    primary_by_user: dict[str, JobTarget] = {}
+    user_optimized: dict[str, OptimizedDoc] = {}
+    for t in active_targets:
+        for user_id in users_by_target.get(t.id, []):
+            if user_id in primary_by_user:
+                continue
+            doc = await asyncio.to_thread(get_latest_optimized, supabase, user_id)
+            if doc is None:
+                logger.info(
+                    "No optimized doc for user %s; skipping stage 3 for %s",
+                    user_id,
+                    company_name,
+                )
+                continue
+            primary_by_user[user_id] = t
+            user_optimized[user_id] = doc
+
+    return primary_by_user, user_optimized
+
+
 async def _poll_one_source(
     source: dict[str, Any],
     supabase: Client,
@@ -619,31 +671,19 @@ async def _poll_one_source(
                     logger.exception("Batch global score update failed after stage 2")
 
             # ---- Stage 3: LLM scoring for qualified jobs (concurrent) ----
-            # Each user gets one LLM analysis per job against their primary
-            # active target, using their personal optimized doc. Previously
-            # this fetched a single ``user_id IS NULL`` optimized doc which
-            # has never existed in production — so stage 3 silently no-op'd
-            # since the multi-user migration. ``get_latest`` caches per
-            # user_id so repeated lookups within a poll are free.
-            user_optimized: dict[str, OptimizedDoc] = {}
-            primary_by_user: dict[str, JobTarget] = {}
-            for t in active_targets:
-                if t.user_id in primary_by_user:
-                    continue
-                doc = await asyncio.to_thread(
-                    get_latest_optimized, supabase, t.user_id
-                )
-                if doc is None:
-                    # User has no optimized doc yet (onboarding incomplete)
-                    # — skip stage 3 for them but keep stage 2 results.
-                    logger.info(
-                        "No optimized doc for user %s; skipping stage 3 for %s",
-                        t.user_id,
-                        company_name,
-                    )
-                    continue
-                user_optimized[t.user_id] = doc
-                primary_by_user[t.user_id] = t
+            # Each user with an active target gets one LLM analysis per
+            # job, using their personal optimized doc. Previously this
+            # fetched a single ``user_id IS NULL`` optimized doc which
+            # has never existed in production — so stage 3 silently
+            # no-op'd since the multi-user migration.
+            #
+            # Targets are global rows (no user_id column); the user link
+            # lives on ``user_targets``. One query maps active target IDs
+            # to their owning users, then we group: per user pick the
+            # first active target and that user's latest optimized doc.
+            primary_by_user, user_optimized = await _resolve_user_targets_for_stage3(
+                supabase, active_targets, company_name
+            )
 
             if primary_by_user:
                 llm = get_default_llm_client()
@@ -982,33 +1022,33 @@ async def _poll_one_source_for_target(
                     logger.exception("Batch global score update failed after stage 2")
 
             # Stage 3: LLM scoring for qualified jobs (concurrent).
-            # Fetch the optimized doc for the target's owning user — the
-            # ``get_latest(None)`` pre-fix never returned anything since
-            # no system-wide doc exists in the multi-user schema.
-            optimized_doc = await asyncio.to_thread(
-                get_latest_optimized, supabase, target.user_id
+            # JobTarget is a global row with no user_id — resolve owning
+            # users via the user_targets junction, then fetch each user's
+            # optimized doc. The pre-fix ``get_latest(None)`` returned
+            # nothing since no system-wide doc exists in the multi-user
+            # schema.
+            primary_by_user, user_optimized = await _resolve_user_targets_for_stage3(
+                supabase, [target], company_name
             )
-            if optimized_doc is not None:
+            if primary_by_user:
                 llm = get_default_llm_client()
                 llm_sem = asyncio.Semaphore(LLM_CONCURRENCY)
 
-                async def _llm_one_t(row_data: dict[str, Any]) -> None:
+                async def _llm_one_t(
+                    row_data: dict[str, Any],
+                    doc: OptimizedDoc,
+                ) -> None:
                     async with llm_sem:
                         await _run_llm_scoring_for_row(
-                            supabase, row_data, optimized_doc, llm, target
+                            supabase, row_data, doc, llm, target
                         )
 
                 await asyncio.gather(
                     *(
-                        _llm_one_t(cast(dict[str, Any], r))
+                        _llm_one_t(cast(dict[str, Any], r), user_optimized[uid])
                         for r in upsert_resp.data or []
+                        for uid in primary_by_user
                     )
-                )
-            else:
-                logger.info(
-                    "No optimized doc for user %s; skipping stage 3 for target %s",
-                    target.user_id,
-                    target.label,
                 )
 
     except Exception:

--- a/apps/wyrdfold-api/app/services/poller.py
+++ b/apps/wyrdfold-api/app/services/poller.py
@@ -430,7 +430,6 @@ async def _run_llm_scoring_for_row(
 async def _poll_one_source(
     source: dict[str, Any],
     supabase: Client,
-    optimized_doc: OptimizedDoc | None = None,
 ) -> dict[str, Any]:
     """Poll a single job source. Returns a per-source summary dict.
 
@@ -620,26 +619,55 @@ async def _poll_one_source(
                     logger.exception("Batch global score update failed after stage 2")
 
             # ---- Stage 3: LLM scoring for qualified jobs (concurrent) ----
-            # Cache key is (job, target, optimized) — pick the first active
-            # target as the canonical one for the poller's cache row. The
-            # user-facing analysis flow re-uses the same row when viewing
-            # the job under that target, and runs its own LLM call for
-            # other targets on demand.
-            if optimized_doc is not None and active_targets:
+            # Each user gets one LLM analysis per job against their primary
+            # active target, using their personal optimized doc. Previously
+            # this fetched a single ``user_id IS NULL`` optimized doc which
+            # has never existed in production — so stage 3 silently no-op'd
+            # since the multi-user migration. ``get_latest`` caches per
+            # user_id so repeated lookups within a poll are free.
+            user_optimized: dict[str, OptimizedDoc] = {}
+            primary_by_user: dict[str, JobTarget] = {}
+            for t in active_targets:
+                if t.user_id in primary_by_user:
+                    continue
+                doc = await asyncio.to_thread(
+                    get_latest_optimized, supabase, t.user_id
+                )
+                if doc is None:
+                    # User has no optimized doc yet (onboarding incomplete)
+                    # — skip stage 3 for them but keep stage 2 results.
+                    logger.info(
+                        "No optimized doc for user %s; skipping stage 3 for %s",
+                        t.user_id,
+                        company_name,
+                    )
+                    continue
+                user_optimized[t.user_id] = doc
+                primary_by_user[t.user_id] = t
+
+            if primary_by_user:
                 llm = get_default_llm_client()
                 llm_sem = asyncio.Semaphore(LLM_CONCURRENCY)
-                primary_target = active_targets[0]
 
-                async def _llm_one(row_data: dict[str, Any]) -> None:
+                async def _llm_one(
+                    row_data: dict[str, Any],
+                    target: JobTarget,
+                    doc: OptimizedDoc,
+                ) -> None:
                     async with llm_sem:
                         await _run_llm_scoring_for_row(
-                            supabase, row_data, optimized_doc, llm, primary_target
+                            supabase, row_data, doc, llm, target
                         )
 
                 await asyncio.gather(
                     *(
-                        _llm_one(cast(dict[str, Any], r))
+                        _llm_one(
+                            cast(dict[str, Any], r),
+                            primary_by_user[uid],
+                            user_optimized[uid],
+                        )
                         for r in upsert_resp.data or []
+                        for uid in primary_by_user
                     )
                 )
         else:
@@ -719,15 +747,16 @@ async def poll_all_sources(supabase: Client) -> PollResult:
     sources_resp = await asyncio.to_thread(sources_query.execute)
     sources = sources_resp.data or []
 
-    # Fetch optimized doc once for all sources
-    optimized_doc = await asyncio.to_thread(get_latest_optimized, supabase, None)
+    # Optimized doc is fetched per-user inside ``_poll_one_source`` now —
+    # the previous shared-doc fetch (``user_id=None``) never returned a
+    # row in the multi-user schema, silently disabling stage 3.
 
     semaphore = asyncio.Semaphore(POLL_CONCURRENCY)
 
     async def _worker(raw_source: Any) -> dict[str, Any]:
         async with semaphore:
             return await _poll_one_source(
-                cast(dict[str, Any], raw_source), supabase, optimized_doc
+                cast(dict[str, Any], raw_source), supabase
             )
 
     summaries = await asyncio.gather(*(_worker(s) for s in sources))
@@ -806,13 +835,11 @@ async def poll_due_sources(supabase: Client) -> PollResult:
             sources_polled=0, new_jobs=0, updated_jobs=0, archived_jobs=0, errors=[]
         )
 
-    optimized_doc = await asyncio.to_thread(get_latest_optimized, supabase, None)
-
     semaphore = asyncio.Semaphore(POLL_CONCURRENCY)
 
     async def _worker(source: dict[str, Any]) -> dict[str, Any]:
         async with semaphore:
-            return await _poll_one_source(source, supabase, optimized_doc)
+            return await _poll_one_source(source, supabase)
 
     summaries = await asyncio.gather(*(_worker(s) for s in due))
 
@@ -837,7 +864,6 @@ async def _poll_one_source_for_target(
     source: dict[str, Any],
     supabase: Client,
     target: JobTarget,
-    optimized_doc: OptimizedDoc | None = None,
 ) -> dict[str, Any]:
     """Poll a single source for a specific target. Three-stage pipeline."""
     summary: dict[str, Any] = {"polled": False, "new": 0, "updated": 0, "error": None}
@@ -955,7 +981,13 @@ async def _poll_one_source_for_target(
                 except Exception:
                     logger.exception("Batch global score update failed after stage 2")
 
-            # Stage 3: LLM scoring for qualified jobs (concurrent)
+            # Stage 3: LLM scoring for qualified jobs (concurrent).
+            # Fetch the optimized doc for the target's owning user — the
+            # ``get_latest(None)`` pre-fix never returned anything since
+            # no system-wide doc exists in the multi-user schema.
+            optimized_doc = await asyncio.to_thread(
+                get_latest_optimized, supabase, target.user_id
+            )
             if optimized_doc is not None:
                 llm = get_default_llm_client()
                 llm_sem = asyncio.Semaphore(LLM_CONCURRENCY)
@@ -971,6 +1003,12 @@ async def _poll_one_source_for_target(
                         _llm_one_t(cast(dict[str, Any], r))
                         for r in upsert_resp.data or []
                     )
+                )
+            else:
+                logger.info(
+                    "No optimized doc for user %s; skipping stage 3 for target %s",
+                    target.user_id,
+                    target.label,
                 )
 
     except Exception:
@@ -1016,15 +1054,16 @@ async def poll_sources_for_target(supabase: Client, target: JobTarget) -> PollRe
     sources_resp = await asyncio.to_thread(sources_query.execute)
     sources = sources_resp.data or []
 
-    # Fetch optimized doc once for all sources
-    optimized_doc = await asyncio.to_thread(get_latest_optimized, supabase, None)
+    # Optimized doc is fetched per-user inside
+    # ``_poll_one_source_for_target`` now — the previous shared-doc fetch
+    # (``user_id=None``) never returned a row in the multi-user schema.
 
     semaphore = asyncio.Semaphore(POLL_CONCURRENCY)
 
     async def _worker(raw_source: Any) -> dict[str, Any]:
         async with semaphore:
             return await _poll_one_source_for_target(
-                cast(dict[str, Any], raw_source), supabase, target, optimized_doc
+                cast(dict[str, Any], raw_source), supabase, target
             )
 
     summaries = await asyncio.gather(*(_worker(s) for s in sources))


### PR DESCRIPTION
## Summary

Stage 3 LLM scoring has been silently no-op'ing since the multi-user migration. Three poll entry points fetched `get_latest_optimized(supabase, None)` which queries for `user_id IS NULL` rows — no such row exists in this schema. So `optimized_doc` was always `None`, the `if optimized_doc is not None` guard always failed, and the entire stage 3 block was unreachable. No error, no log, just a silent skip on every poll for 30+ days.

**Smoking gun**: `purpose=\"poll_scoring\"` (the cost-log tag emitted by the stage 3 call site, `poller.py:375`) does not appear in any of 228 `llm_costs` rows over the last 30 days. Meanwhile `job_analysis` (the on-demand user-facing analysis) fires fine — it's a separate path that reads `user_id` correctly.

## What changes

- **Drop** the three broken top-level `get_latest_optimized(supabase, None)` fetches in `poll_all_sources`, `poll_due_sources`, `poll_sources_for_target`.
- **`_poll_one_source`** — group active targets by `user_id`, fetch each user's latest optimized doc once (the `get_latest` helper already caches per-user), and run one LLM call per (job, user) pair against that user's primary active target. Each user gets their own analysis against their own optimized doc — what the original shared-doc approach was silently *trying* to do.
- **`_poll_one_source_for_target`** — fetch the doc for `target.user_id`.
- Users without an optimized doc (onboarding incomplete) are logged and skipped — stage 1 + stage 2 still run for them.

## Cost note

A job ingested while N users have active targets and optimized docs now incurs N LLM analyses instead of one. For the current 2-user product (~$0.05/call × jobs above the `LLM_SCORE_THRESHOLD=40` cap) this is acceptable. If user count grows, `get_cached_analysis` would need smarter dedup (e.g., reuse analysis across users with sufficiently similar docs).

## Validation expected

After this merges, a poll cycle on any source should produce one or more new rows in `llm_costs` with `purpose=\"poll_scoring\"`. Following queries should both rise:

```sql
select count(*) from llm_costs where purpose = 'poll_scoring' and created_at > now() - interval '24 hours';
select count(*) from scores where scoring_status = 'complete' and target_id = '4195d651-2009-4c43-bc6b-beec4d3fca0b';
```

Combined with PR #768 (role_titles fix, already merged), Melissa should see real director/head-of-CX matches start crossing her 70 threshold once new postings are ingested. **Existing 337 stale rows still won't update from this PR** — those need a separate backfill (rescore endpoint + LLM, scoped out).

## Test plan

- [x] `pytest apps/wyrdfold-api -q` — 889 passed
- [x] Type signatures: `_poll_one_source` and `_poll_one_source_for_target` lose their `optimized_doc` param (only called from within the module, no external callers)
- [ ] Post-merge: confirm `llm_costs.purpose='poll_scoring'` appears within ~4 hours of any source poll cycle

## Coverage gap (follow-up)

Full integration coverage for the stage 3 path would require substantial Supabase + LLM client mocking and is deliberately out of scope. The fix surfaces via the LLM cost telemetry above; if that doesn't fire within 24 hours, escalate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)