### PR TITLE
fix(wyrdfold-api): senior-target precision (word-boundary + junior-exclude + tier penalty)

### DIFF
--- a/apps/wyrdfold-api/app/services/scoring.py
+++ b/apps/wyrdfold-api/app/services/scoring.py
@@ -24,12 +24,18 @@ _WORD_BOUNDARY_CACHE: dict[str, re.Pattern[str]] = {}
 def _keyword_in_text(keyword: str, text: str) -> bool:
     """Match a keyword against lowered text.
 
-    Short alphabetic keywords (≤3 chars) use word-boundary regex to avoid
-    false positives (e.g., "Go" matching "Google"). Non-alphabetic short
-    keywords ("c#", "c++") and longer keywords use fast substring match.
+    Alphabetic single-word keywords ALWAYS use word-boundary regex so
+    "lead" does not match "leadership", "rep" does not match "repository",
+    "go" does not match "google". The prior 3-char gate let everything
+    longer than 3 chars fall through to substring match, which silently
+    produced director-vs-rep false positives in the wild.
+
+    Non-alphabetic ("c#", "c++") and multi-word ("director of cx") keywords
+    fall back to substring match since regex word-boundaries don't reliably
+    handle non-alpha tokens and ATS authors rarely mirror our exact spacing.
     """
     kw_lower = keyword.lower()
-    if len(kw_lower) <= 3 and kw_lower.isalpha():
+    if kw_lower.isalpha():
         if kw_lower not in _WORD_BOUNDARY_CACHE:
             _WORD_BOUNDARY_CACHE[kw_lower] = re.compile(rf"\b{re.escape(kw_lower)}\b")
         return bool(_WORD_BOUNDARY_CACHE[kw_lower].search(text))
@@ -183,6 +189,142 @@ _DEFAULT_NORMALIZER = 30.0
 # ``_TITLE_WEIGHT`` boost the category keywords use when matched in title.
 _ROLE_TITLE_WEIGHT = 15.0
 
+# Senior-tier seniority levels. When ``profile.seniority.level`` is one of
+# these, common junior-IC title tokens get auto-prepended to the negative
+# keyword list, so a Director target never scores a Rep / Associate /
+# Coordinator title above zero regardless of how many JD-side keywords
+# happen to incidentally match.
+_SENIOR_LEVELS: frozenset[str] = frozenset(
+    {
+        "director",
+        "vp",
+        "vice president",
+        "head",
+        "head of",
+        "principal",
+        "staff",
+        "executive",
+        "chief",
+    }
+)
+
+# Junior-IC title tokens that are noise for senior targets. Single-word,
+# alpha-only so the word-boundary matcher catches them cleanly without
+# accidentally hitting phrases like "agentic" (-> "agent").
+_JUNIOR_TITLE_TOKENS: tuple[str, ...] = (
+    "junior",
+    "jr",
+    "intern",
+    "internship",
+    "trainee",
+    "apprentice",
+    "associate",
+    "rep",
+    "representative",
+    "coordinator",
+    "specialist",
+    "assistant",
+    "agent",
+)
+
+# Coarse seniority tier ladder. Higher number = more senior. A title
+# ranked >1 tier below the profile's level earns a heavy penalty
+# (``_TIER_PENALTY_PER_DELTA`` per tier of gap beyond the first).
+# Word-boundary matching means "senior" doesn't hit "seniors" and
+# "director" doesn't hit "directorate".
+_TITLE_TIERS: dict[int, tuple[str, ...]] = {
+    0: ("intern", "internship", "trainee", "apprentice"),
+    1: (
+        "junior",
+        "jr",
+        "associate",
+        "rep",
+        "representative",
+        "coordinator",
+        "specialist",
+        "assistant",
+        "agent",
+    ),
+    2: ("analyst",),
+    3: ("engineer", "designer", "manager", "developer"),
+    4: ("senior", "sr", "lead"),
+    5: ("staff", "principal"),
+    6: ("director",),
+    7: ("head", "vp"),
+    8: ("chief", "executive"),
+}
+
+_LEVEL_TO_TIER: dict[str, int] = {
+    level.lower(): tier
+    for tier, levels in _TITLE_TIERS.items()
+    for level in levels
+}
+# Multi-word level aliases the LLM emits for ``profile.seniority.level``.
+_LEVEL_TO_TIER["vice president"] = 7
+_LEVEL_TO_TIER["head of"] = 7
+
+_TIER_PENALTY_PER_DELTA = -10.0
+
+
+def _is_senior_target(profile: ScoringProfile) -> bool:
+    """True if this profile targets a senior-tier role (director+)."""
+    level = (profile.seniority.level or "").strip().lower()
+    return bool(level) and level in _SENIOR_LEVELS
+
+
+def _effective_negative_keywords(profile: ScoringProfile) -> list[str]:
+    """Return user-set negatives plus auto-junior tokens for senior targets.
+
+    Junior tokens get folded in deterministically rather than asked from
+    the LLM during profile derivation — the LLM was inconsistent about
+    listing them (only emitted "junior" / "intern" / "entry-level"),
+    which meant "Customer Service Representative" titles still slipped
+    through to a Director target.
+    """
+    base = list(profile.negative.keywords)
+    if _is_senior_target(profile):
+        existing = {kw.lower() for kw in base}
+        for kw in _JUNIOR_TITLE_TOKENS:
+            if kw not in existing:
+                base.append(kw)
+    return base
+
+
+def _highest_title_tier(title_lower: str) -> int | None:
+    """Return the highest seniority tier any token in the title matches."""
+    for tier in sorted(_TITLE_TIERS.keys(), reverse=True):
+        for token in _TITLE_TIERS[tier]:
+            if _keyword_in_text(token, title_lower):
+                return tier
+    return None
+
+
+def _seniority_tier_penalty(
+    title_lower: str, profile_level: str | None
+) -> float:
+    """Penalty when the title sits more than one tier below the profile.
+
+    Same tier or one below = no penalty (e.g. a Manager title for a
+    Director target is a soft mismatch, not noise). Two or more tiers
+    below scales linearly: Manager-for-Director = 0, Engineer-for-Director
+    = -10, Rep-for-Director = -40.
+
+    Returns 0.0 when the profile has no level set or no seniority signal
+    appears in the title at all — we can't penalize what we can't classify.
+    """
+    if not profile_level:
+        return 0.0
+    target_tier = _LEVEL_TO_TIER.get(profile_level.strip().lower())
+    if target_tier is None:
+        return 0.0
+    title_tier = _highest_title_tier(title_lower)
+    if title_tier is None:
+        return 0.0
+    delta = title_tier - target_tier
+    if delta >= -1:
+        return 0.0
+    return _TIER_PENALTY_PER_DELTA * abs(delta + 1)
+
 
 def _score_role_titles(
     search_keywords: list[str] | None, title_lower: str
@@ -327,7 +469,7 @@ def score_job_with_profile(
 
     # ---- Negative keywords (only in title + requirements sections) ----
     negative_sections = {"requirements", "default"}
-    for keyword in profile.negative.keywords:
+    for keyword in _effective_negative_keywords(profile):
         # Check title
         if _keyword_or_alias_in_text(keyword, title_lower):
             breakdown.negative += profile.negative.weight
@@ -342,6 +484,14 @@ def score_job_with_profile(
                 breakdown.negative += profile.negative.weight
                 excluded = True
                 break
+
+    # ---- Seniority-tier penalty ----
+    # Pushes "Engineer" / "Rep" titles below the floor for a Director
+    # target even when no explicit negative-keyword matches. Stacks
+    # additively with the negative bucket since both are deductions.
+    breakdown.negative += _seniority_tier_penalty(
+        title_lower, profile.seniority.level
+    )
 
     # Dynamic normalization
     raw = (
@@ -428,11 +578,16 @@ def score_title_against_profile(
         breakdown.role_titles += role_title_points
         all_matched.extend(role_title_matches)
 
-    # Negative keywords
-    for keyword in profile.negative.keywords:
+    # Negative keywords (user-set + auto-junior for senior targets)
+    for keyword in _effective_negative_keywords(profile):
         if _keyword_or_alias_in_text(keyword, title_lower):
             breakdown.negative += profile.negative.weight
             excluded = True
+
+    # Seniority-tier penalty — see _seniority_tier_penalty docstring
+    breakdown.negative += _seniority_tier_penalty(
+        title_lower, profile.seniority.level
+    )
 
     raw = (
         breakdown.role_titles

--- a/apps/wyrdfold-api/tests/test_scoring.py
+++ b/apps/wyrdfold-api/tests/test_scoring.py
@@ -28,6 +28,7 @@ def _profile(
     *,
     core: dict[str, int] | None = None,
     core_weight: float = 2.0,
+    seniority_level: str | None = None,
     seniority_signals: list[str] | None = None,
     negative_keywords: list[str] | None = None,
 ) -> ScoringProfile:
@@ -36,7 +37,9 @@ def _profile(
         cats["core_skills"] = CategoryProfile(keywords=core, weight=core_weight)
     return ScoringProfile(
         categories=cats,
-        seniority=SeniorityProfile(signals=seniority_signals or []),
+        seniority=SeniorityProfile(
+            level=seniority_level, signals=seniority_signals or []
+        ),
         negative=NegativeProfile(keywords=negative_keywords or []),
     )
 
@@ -104,6 +107,129 @@ def test_title_multiple_keywords():
     result = score_title_against_profile("React TypeScript Engineer", profile)
     assert len(result.matched_keywords) >= 2
     assert result.score > 0
+
+
+# ---- Word-boundary regression for the "lead → leadership" silent bug ------
+
+
+def test_word_boundary_lead_does_not_match_leadership():
+    """``"lead"`` (4 chars) used to fall through to substring match and
+    silently hit "leadership", "leader", "leads" anywhere in a JD body.
+    With word-boundary matching for all alpha keywords, only standalone
+    occurrences of "lead" should match.
+    """
+    profile = _profile(seniority_signals=["lead"])
+    # "leadership" embeds "lead" but is a different concept — must not match.
+    no_match = score_title_against_profile("Senior Sales Leadership", profile)
+    yes_match = score_title_against_profile("Senior Lead Engineer", profile)
+    assert "lead" not in no_match.matched_keywords
+    assert "lead" in yes_match.matched_keywords
+
+
+def test_word_boundary_director_does_not_match_directorate():
+    profile = _profile(seniority_signals=["director"])
+    result = score_title_against_profile("Directorate Liaison", profile)
+    assert "director" not in result.matched_keywords
+
+
+# ---- Option A: junior-IC tokens auto-excluded for senior targets ----------
+
+
+def test_senior_target_excludes_customer_service_representative():
+    """A Director-level target should reject 'Customer Service Representative'
+    titles even when the user's profile.negative.keywords list doesn't
+    explicitly include 'representative' — the auto-junior list handles it.
+    """
+    profile = _profile(
+        core={"Zendesk": 3},
+        seniority_level="director",
+        # user only listed the LLM-default negatives
+        negative_keywords=["junior", "intern"],
+    )
+    result = score_title_against_profile(
+        "Customer Service Representative", profile
+    )
+    assert result.excluded is True
+    assert result.score == 0
+
+
+def test_senior_target_excludes_self_storage_manager_via_associate():
+    """One of Melissa's flagged jobs: PublicStorage 'Customer Service -
+    Self Storage Manager'. 'Manager' isn't on the junior list (it's tier
+    3 in the ladder), so this should NOT auto-exclude — but the
+    seniority-tier penalty must still push the score below zero raw.
+    """
+    profile = _profile(
+        core={"Zendesk": 3, "AI Chatbots": 3},
+        seniority_level="director",
+    )
+    result = score_title_against_profile(
+        "Customer Service - Self Storage Manager", profile
+    )
+    # Manager is tier 3, Director is tier 6 → delta -3 → -20 raw points.
+    assert result.score == 0
+
+
+def test_non_senior_target_does_not_auto_exclude_associate():
+    """A mid-level target should NOT auto-exclude 'Associate' titles —
+    the auto-junior list only fires when level is in the senior tier.
+    """
+    profile = _profile(
+        core={"React": 3},
+        seniority_level="senior",
+    )
+    result = score_title_against_profile("Associate React Engineer", profile)
+    assert result.excluded is False
+
+
+def test_senior_target_keeps_user_set_negatives_in_addition():
+    """User-set negatives must still fire alongside the auto-junior list."""
+    profile = _profile(
+        core={"Zendesk": 3},
+        seniority_level="director",
+        negative_keywords=["consulting"],
+    )
+    result = score_title_against_profile("Director, Consulting Practice", profile)
+    assert result.excluded is True
+
+
+# ---- Option C: seniority-tier penalty -------------------------------------
+
+
+def test_seniority_penalty_kills_engineer_for_director_target():
+    """An Engineer title (tier 3) for a Director profile (tier 6) is a
+    3-tier gap; (gap - 1) * -10 = -20 raw, which after normalization
+    floors at 0. Without the penalty this used to surface in Melissa's
+    list at score ~28.
+    """
+    profile = _profile(
+        core={"React": 3},
+        seniority_level="director",
+    )
+    result = score_title_against_profile("Senior Software Engineer", profile)
+    # "Senior" puts the title at tier 4 vs Director tier 6 → delta -2 → -10.
+    # Combined with the React-not-in-title scoring → 0.
+    assert result.score == 0
+
+
+def test_seniority_penalty_no_op_for_same_tier():
+    profile = _profile(
+        core={"React": 3},
+        seniority_level="director",
+    )
+    result = score_title_against_profile("Director of Engineering", profile)
+    # Director title = tier 6 = same as profile → no penalty.
+    # "director" seniority is the level not a signal — score may still be
+    # low because no core keyword in title, but it must NOT be excluded.
+    assert result.excluded is False
+
+
+def test_seniority_penalty_no_op_when_profile_level_unset():
+    """Profiles without a level set (legacy / draft) skip the penalty."""
+    profile = _profile(core={"React": 3})  # no seniority_level
+    result = score_title_against_profile("Junior React Developer", profile)
+    # No penalty triggered — junior gets caught by the existing logic, not C.
+    assert result.score >= 0  # score doesn't crash
 
 
 def test_title_search_keywords_lift_role_intent():


### PR DESCRIPTION
## Summary

Three deterministic precision fixes from the relevance-matcher research doc (Options A + C). All in ``scoring.py``, no schema change. Net effect: senior-tier targets stop returning Reps / Associates / Coordinators / Self-Storage Managers as anything other than score-0.

## 1. Word-boundary matcher (the silent substring bug)

``_keyword_in_text`` used word-boundary regex only for keywords ≤3 chars + alpha. Everything longer fell through to ``kw_lower in text``. That meant a seniority signal of ``\"lead\"`` (4 chars) silently matched ``\"leadership\"``, ``\"leader\"``, ``\"leads\"`` — the doc's call-out at §2.1. Same applies to ``\"director\"`` matching ``\"directorate\"``, ``\"rep\"`` matching ``\"repository\"``, etc.

Now: any *single-word alpha* keyword uses word boundaries. Multi-word (``\"director of cx operations\"``) and non-alpha (``\"c#\"``, ``\"next.js\"``) still substring-match because regex boundaries don't reliably handle those tokens and authors don't mirror our exact spacing.

## 2. Auto-junior negative keywords for senior targets (Option A)

New ``_JUNIOR_TITLE_TOKENS`` tuple gets auto-prepended to ``profile.negative.keywords`` when ``profile.seniority.level ∈ _SENIOR_LEVELS`` (director / vp / head / staff / principal / chief / executive). Tokens: junior, jr, intern, internship, trainee, apprentice, associate, rep, representative, coordinator, specialist, assistant, agent.

LLM profile derivation only ever emitted ``[\"junior\", \"intern\", \"entry-level\"]`` — so ``\"Customer Service Representative\"`` slipped through to Melissa's Director target. Now it's a hard exclude regardless of JD-side noise.

## 3. Seniority-tier penalty (Option C)

``_seniority_tier_penalty`` classifies the job title into a coarse tier (intern=0 → chief=8) via highest-tier match of standalone tokens, then compares against the profile's ``seniority.level``. Same tier or one below = no penalty. Two-or-more tiers below = ``-10`` raw per tier of gap beyond the first. Stacks additively in the negative bucket; clamp-to-zero absorbs the result.

Example: ``\"Senior Software Engineer\"`` (tier 4) for a Director profile (tier 6) → delta -2 → -10 raw → suppresses one-tier-off matches that the auto-junior list doesn't catch.

## Why ship A and C together

A is binary (exclude / don't), C is graded. A kills the obvious junk (Rep, Coordinator) deterministically. C dampens one-tier-off near-misses (Senior Engineer for a Director) that A doesn't see. Independently both are useful; together they handle the long tail.

## Re-score impact

Targets need ``profile_version`` bumped so ``bulk_score_for_target`` lazily re-scores existing rows. The backfill script ran during PR #768 (post-merge) already polled 8127 new jobs through the updated scorer — those are already accurate. Existing pre-PR-768 rows will pick up the new logic when ``profile_version`` is bumped next.

## Test plan

- [x] ``pytest apps/wyrdfold-api -q`` → 931 passed (922 before + 9 new)
- [x] New unit tests: word-boundary regression (lead→leadership, director→directorate), Customer Service Rep auto-excluded for director, Self-Storage Manager floored at 0 via tier penalty, mid-level target does NOT auto-exclude associate, user-set negatives still fire alongside auto list, same-tier title no penalty, profile level=None no penalty (legacy safe)
- [ ] Post-merge: re-poll + manually inspect Melissa's top 10 jobs against the Director target — Customer Service Reps should be gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)