### PR TITLE
fix(wyrdfold-api): AND-semantics ingestion gate (search_keywords + profile keyword)

### DIFF
--- a/apps/wyrdfold-api/app/services/poller.py
+++ b/apps/wyrdfold-api/app/services/poller.py
@@ -170,10 +170,20 @@ _NON_US_HINTS: tuple[str, ...] = (
 
 
 def _title_matches_any_target(title: str, targets: list[JobTarget]) -> bool:
-    """Check if a job title matches any active target's scoring profile.
+    """Check if a job title is worth ingesting for at least one target.
 
-    Uses stage 1 title scoring — if any target's keywords match the title,
-    the job is worth ingesting.
+    Admission rules per target (any one target admitting → admit):
+      1. Excluded by negative keywords → admit anyway, so the scoring
+         pipeline records the rejection (excluded=True) for audit.
+         Without this, junior-vs-director hits would silently vanish
+         instead of being explainable in the UI.
+      2. Matched scoring keywords AND (search_keywords overlap matches
+         the title, OR the target has no search_keywords). This is the
+         AND-semantics fix from the relevance-matcher research doc:
+         a title that only hits incidental skill/seniority tokens but
+         doesn't look like the *kind* of role the user is hunting for
+         (no search-keyword overlap) is rejected at the door rather
+         than ingested as low-score noise.
     """
     for target in targets:
         result = score_title_against_profile(
@@ -181,8 +191,18 @@ def _title_matches_any_target(title: str, targets: list[JobTarget]) -> bool:
             target.scoring_profile,
             search_keywords=target.search_keywords,
         )
-        if result.matched_keywords or result.excluded:
+        if result.excluded:
             return True
+        if not result.matched_keywords:
+            continue
+        # Empty search_keywords means we can't gate on role-title intent;
+        # fall back to legacy "any keyword match admits" semantics so a
+        # draft / legacy profile doesn't ingestion-block itself.
+        if target.search_keywords and not _title_matches_target(
+            title, target.search_keywords
+        ):
+            continue
+        return True
     return False
 
 

--- a/apps/wyrdfold-api/tests/test_poller.py
+++ b/apps/wyrdfold-api/tests/test_poller.py
@@ -170,3 +170,75 @@ class TestIsUsLocation:
     def test_case_insensitive(self):
         assert _is_us_location("BERLIN, GERMANY") is False
         assert _is_us_location("berlin") is False
+
+
+# ---- AND-semantics ingestion gate ------------------------------------------
+#
+# The gate used to admit on (matched_keywords or excluded). When a target
+# has search_keywords set, admission now also requires a search-keyword
+# token-overlap with the title — so incidental keyword hits don't ingest
+# off-topic postings into the user's list.
+
+
+def _target_with_keywords(
+    core_keywords: dict[str, int],
+    search_keywords: list[str],
+) -> JobTarget:
+    return JobTarget(
+        id="t-with-kw",
+        label="Director CX",
+        scoring_profile=ScoringProfile(
+            categories={
+                "core_skills": CategoryProfile(
+                    keywords=core_keywords, weight=2.0
+                ),
+            },
+            seniority=SeniorityProfile(signals=["director", "head of"]),
+        ),
+        search_keywords=search_keywords,
+        is_active=True,
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
+    )
+
+
+def test_and_semantics_admits_when_search_keyword_overlaps():
+    target = _target_with_keywords(
+        {"Zendesk": 3},
+        ["director of customer experience", "head of cx"],
+    )
+    # Title has a search-keyword overlap AND a seniority signal hit
+    # ("director"), so it passes both halves of the AND.
+    assert _title_matches_any_target("Director of Customer Experience", [target]) is True
+
+
+def test_and_semantics_rejects_keyword_match_without_search_overlap():
+    """Regression: a job whose title only matches a generic profile signal
+    ('director') but has no search-keyword overlap should NOT be ingested."""
+    target = _target_with_keywords(
+        {"Zendesk": 3},
+        ["director of customer experience"],
+    )
+    # "Director of Engineering" hits the "director" seniority signal but
+    # is not a customer-experience role — rejected at the door.
+    assert _title_matches_any_target("Director of Engineering", [target]) is False
+
+
+def test_and_semantics_falls_back_when_search_keywords_empty():
+    """Targets with empty search_keywords (legacy/draft profiles) keep
+    the old OR semantics so they don't accidentally ingestion-block."""
+    legacy_target = _make_target({"react": 3})  # search_keywords=[]
+    assert _title_matches_any_target("Senior React Engineer", [legacy_target]) is True
+
+
+def test_and_semantics_admits_excluded_for_audit():
+    """Hard-exclude (negative keyword) still admits so the scorer can
+    record excluded=True — preserves the audit trail."""
+    target = _target_with_keywords(
+        {"Zendesk": 3},
+        ["director of cx"],
+    )
+    target.scoring_profile.negative.keywords = ["junior"]
+    # The title hits 'junior' (negative) but no search-keyword overlap.
+    # Excluded path admits regardless.
+    assert _title_matches_any_target("Junior Random Role", [target]) is True


### PR DESCRIPTION
## Summary

Doc 1 **Option B** from the relevance-matcher research: change the poller's ingestion gate from OR semantics (``matched_keywords or excluded``) to AND semantics (``matched_keywords AND search_keywords_overlap``).

Previously a "Director of Engineering" title would be ingested into Melissa's *Director of CX Operations* target because ``"director"`` (a seniority signal in the profile) matched. Now the title also has to overlap with the target's ``search_keywords`` (``["director of customer experience", "head of cx", ...]``) — so off-topic Director roles get rejected at the door instead of becoming low-score noise downstream.

## Logic

```python
for target in targets:
    result = score_title_against_profile(title, profile, search_keywords=...)
    if result.excluded:
        return True  # admit so the scorer records excluded=True for audit
    if not result.matched_keywords:
        continue
    if target.search_keywords and not _title_matches_target(title, target.search_keywords):
        continue  # AND filter — no search-keyword overlap = not the kind of role
    return True
return False
```

Note the legacy-safe path: targets with empty ``search_keywords`` (draft profiles, pre-#768 rows) fall back to the old "any keyword match admits" behavior so this doesn't accidentally ingestion-block users whose profiles never got their keywords derived.

Excluded titles still admit on purpose — the ``excluded=True`` row in ``scores`` is the audit trail. Without it, a junior-vs-director hit would silently vanish instead of being explainable in the UI.

## Test plan

- [x] ``pytest apps/wyrdfold-api -q`` → 926 passed (922 + 4 new)
- [x] Tests cover: admit on search-keyword overlap + keyword hit (positive case), reject on keyword hit without search overlap (the regression), legacy fallback when ``search_keywords=[]``, excluded admits for audit even without overlap

## Sequencing

This stacks on top of **#768** (which wired ``search_keywords`` into the scorer) and **#770** (junior-exclude / tier penalty). Land in any order; they don't conflict on files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)