### PR TITLE
feat(wyrdfold): feedback section on job detail panel + proxy route

### DIFF
--- a/apps/wyrdfold-api/app/main.py
+++ b/apps/wyrdfold-api/app/main.py
@@ -16,6 +16,7 @@ from app.observability import init_sentry
 from app.routers import (
     analysis,
     experience,
+    feedback,
     insights,
     jobs,
     poll,
@@ -187,6 +188,7 @@ async def _unhandled_exception_handler(request: Request, exc: Exception) -> JSON
 
 app.include_router(analysis.router)
 app.include_router(experience.router)
+app.include_router(feedback.router)
 app.include_router(insights.router)
 app.include_router(jobs.router)
 app.include_router(poll.router)

--- a/apps/wyrdfold-api/app/models/feedback.py
+++ b/apps/wyrdfold-api/app/models/feedback.py
@@ -1,0 +1,68 @@
+"""Pydantic shapes for the per-(user, target) job feedback loop.
+
+Mirrors the ``job_feedback`` table created in
+``supabase/migrations/20260601130000_job_feedback.sql``.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+FeedbackSignal = Literal["irrelevant", "relevant"]
+
+
+class FeedbackCreate(BaseModel):
+    """Body for ``POST /jobs/{job_id}/feedback``.
+
+    ``target_id`` is mandatory because the signal is about the user's
+    *lens* on the job, not the job in the abstract.
+    """
+
+    signal: FeedbackSignal
+    reason: str | None = Field(default=None, max_length=500)
+    target_id: str
+
+
+class FeedbackRow(BaseModel):
+    """One ``job_feedback`` row as the API returns it."""
+
+    id: str
+    user_id: str
+    job_posting_id: str
+    target_id: str
+    signal: FeedbackSignal
+    reason: str | None = None
+    applied_at: datetime | None = None
+    applied_run_id: str | None = None
+    created_at: datetime
+    updated_at: datetime
+
+
+class FeedbackCreateResponse(BaseModel):
+    feedback: FeedbackRow
+    # True when the unapplied-signal threshold tripped and the learner
+    # was kicked off (BackgroundTasks). The caller doesn't need to wait
+    # — score lists refresh on the next read after the patch lands.
+    queued_learn_run: bool
+
+
+class FeedbackList(BaseModel):
+    rows: list[FeedbackRow]
+    total: int
+
+
+class LearnerPatchSummary(BaseModel):
+    """What ``maybe_run_learner`` mutated.
+
+    v1 only extends ``negative.keywords``; v2 will support full
+    ``ProfilePatch`` (add/remove/demote across multiple buckets).
+    """
+
+    target_id: str
+    applied_run_id: str | None = None
+    added_negative_keywords: list[str]
+    signals_consumed: int
+    profile_version_after: int | None = None

--- a/apps/wyrdfold-api/app/routers/feedback.py
+++ b/apps/wyrdfold-api/app/routers/feedback.py
@@ -1,0 +1,157 @@
+"""Feedback endpoints — per-(user, target) signal capture + learner trigger.
+
+Routes:
+- ``POST   /jobs/{job_id}/feedback`` — upsert a signal
+- ``DELETE /jobs/{job_id}/feedback`` — undo (used by toast Undo)
+- ``GET    /targets/{target_id}/feedback`` — list a user's rows
+- ``POST   /targets/{target_id}/learn`` — force the learner to run now
+
+Auth: JWT (``get_current_user_id``). API-key only callers are not
+expected here — feedback is fundamentally per-user.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query
+from supabase import Client
+
+from app.dependencies import get_current_user_id, get_supabase
+from app.models.feedback import (
+    FeedbackCreate,
+    FeedbackCreateResponse,
+    FeedbackList,
+    FeedbackRow,
+    LearnerPatchSummary,
+)
+from app.services.feedback import (
+    delete_feedback,
+    list_for_target,
+    maybe_run_learner,
+    upsert_feedback,
+)
+
+router = APIRouter(tags=["feedback"])
+
+
+def _job_exists(supabase: Client, job_id: str) -> bool:
+    resp = supabase.table("jobs").select("id").eq("id", job_id).execute()
+    return bool(resp.data)
+
+
+def _target_exists_for_user(
+    supabase: Client, user_id: str, target_id: str
+) -> bool:
+    resp = (
+        supabase.table("user_targets")
+        .select("target_id")
+        .eq("user_id", user_id)
+        .eq("target_id", target_id)
+        .execute()
+    )
+    return bool(resp.data)
+
+
+@router.post("/jobs/{job_id}/feedback", response_model=FeedbackCreateResponse)
+async def create_feedback(
+    job_id: str,
+    body: FeedbackCreate,
+    background: BackgroundTasks,
+    user_id: str = Depends(get_current_user_id),
+    supabase: Client = Depends(get_supabase),
+) -> FeedbackCreateResponse:
+    if not _job_exists(supabase, job_id):
+        raise HTTPException(status_code=404, detail="Job not found")
+    if not _target_exists_for_user(supabase, user_id, body.target_id):
+        # Don't leak whether the target exists for someone else — same 404.
+        raise HTTPException(status_code=404, detail="Target not found for user")
+
+    row = upsert_feedback(
+        supabase,
+        user_id=user_id,
+        job_posting_id=job_id,
+        target_id=body.target_id,
+        signal=body.signal,
+        reason=body.reason,
+    )
+
+    # Only ``irrelevant`` signals feed the v1 learner — positive feedback
+    # routes to ``secondary_skills`` in v2 (LLM only, since the heuristic
+    # for "which positive token to weight" is harder).
+    queued = body.signal == "irrelevant"
+    if queued:
+        background.add_task(
+            _safe_run_learner, supabase, user_id, body.target_id
+        )
+
+    return FeedbackCreateResponse(feedback=row, queued_learn_run=queued)
+
+
+@router.delete("/jobs/{job_id}/feedback", status_code=204)
+async def remove_feedback(
+    job_id: str,
+    target_id: str = Query(...),
+    user_id: str = Depends(get_current_user_id),
+    supabase: Client = Depends(get_supabase),
+) -> None:
+    delete_feedback(
+        supabase,
+        user_id=user_id,
+        job_posting_id=job_id,
+        target_id=target_id,
+    )
+
+
+@router.get("/targets/{target_id}/feedback", response_model=FeedbackList)
+async def list_feedback(
+    target_id: str,
+    limit: int = Query(50, ge=1, le=200),
+    offset: int = Query(0, ge=0),
+    user_id: str = Depends(get_current_user_id),
+    supabase: Client = Depends(get_supabase),
+) -> FeedbackList:
+    if not _target_exists_for_user(supabase, user_id, target_id):
+        raise HTTPException(status_code=404, detail="Target not found for user")
+    rows, total = list_for_target(
+        supabase,
+        user_id=user_id,
+        target_id=target_id,
+        limit=limit,
+        offset=offset,
+    )
+    return FeedbackList(rows=rows, total=total)
+
+
+@router.post(
+    "/targets/{target_id}/learn",
+    response_model=LearnerPatchSummary | None,
+)
+async def run_learner_now(
+    target_id: str,
+    user_id: str = Depends(get_current_user_id),
+    supabase: Client = Depends(get_supabase),
+) -> Any:
+    if not _target_exists_for_user(supabase, user_id, target_id):
+        raise HTTPException(status_code=404, detail="Target not found for user")
+    return maybe_run_learner(supabase, user_id=user_id, target_id=target_id)
+
+
+# ---- BackgroundTasks wrapper ----------------------------------------------
+
+
+def _safe_run_learner(supabase: Client, user_id: str, target_id: str) -> None:
+    """BackgroundTasks consumes exceptions but logs them poorly. Wrap so
+    a learner failure can't surface as an opaque 500 on a subsequent
+    request, while still emitting a usable traceback in logs."""
+    import logging
+
+    logger = logging.getLogger("app.routers.feedback")
+    try:
+        maybe_run_learner(supabase, user_id=user_id, target_id=target_id)
+    except Exception:
+        logger.exception(
+            "Feedback learner failed for (user=%s, target=%s)",
+            user_id,
+            target_id,
+        )

--- a/apps/wyrdfold-api/app/routers/feedback.py
+++ b/apps/wyrdfold-api/app/routers/feedback.py
@@ -22,7 +22,6 @@ from app.models.feedback import (
     FeedbackCreate,
     FeedbackCreateResponse,
     FeedbackList,
-    FeedbackRow,
     LearnerPatchSummary,
 )
 from app.services.feedback import (

--- a/apps/wyrdfold-api/app/services/feedback.py
+++ b/apps/wyrdfold-api/app/services/feedback.py
@@ -1,0 +1,271 @@
+"""Per-(user, target) feedback CRUD + deterministic learner (v1).
+
+v1 learner is intentionally LLM-free: when N>=3 unapplied
+``irrelevant`` signals share a literal token in their ``reason`` field,
+that token gets appended to the target's
+``scoring_profile.negative.keywords`` and the consumed rows get stamped
+with ``applied_at``. v2 will layer an LLM ``ProfilePatch`` on top of
+this same plumbing.
+
+Why deterministic first: an LLM patch is expensive and only useful once
+we have labeled data to validate against. The literal-token path moves
+the needle for noisy targets at zero LLM cost and produces a clean
+audit trail before v2 ships.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import uuid
+from collections import Counter
+from datetime import UTC, datetime
+from typing import Any, cast
+
+from supabase import Client
+
+from app.models.feedback import (
+    FeedbackRow,
+    FeedbackSignal,
+    LearnerPatchSummary,
+)
+
+logger = logging.getLogger(__name__)
+
+TABLE = "job_feedback"
+
+# Minimum unapplied "irrelevant" signals before the learner does anything.
+# Picked to balance signal vs noise: 1-2 clicks could be a misclick, 3+
+# is a pattern. Tuned alongside ``_MIN_TOKEN_FREQUENCY`` below.
+_MIN_FEEDBACK_FOR_LEARN = 3
+
+# A token must appear in >= this many distinct unapplied irrelevant rows
+# to be auto-added as a negative keyword. Same number as the trip
+# threshold above so a single 3-click batch with one shared token
+# applies — but a single click with a long shared phrase doesn't.
+_MIN_TOKEN_FREQUENCY = 3
+
+# Words we don't want to learn as negatives even if they show up
+# repeatedly — they're either generic or already structural.
+_LEARN_STOPWORDS: frozenset[str] = frozenset(
+    {
+        "a", "an", "and", "the", "or", "but", "if", "of", "to", "for",
+        "in", "on", "at", "by", "with", "as", "is", "are", "was", "were",
+        "be", "been", "being", "this", "that", "these", "those", "it",
+        "its", "i", "me", "my", "we", "us", "our", "you", "your", "he",
+        "she", "they", "them", "not", "no", "too", "very", "so", "than",
+        "then", "just", "really",
+        # Domain-generic words that would zero-out half the corpus if learned.
+        "job", "role", "position", "company", "team", "work", "opportunity",
+    }
+)
+
+_TOKEN_RE = re.compile(r"[a-zA-Z][a-zA-Z\-]{2,}")
+
+
+def _parse_row(row: dict[str, Any]) -> FeedbackRow:
+    return FeedbackRow.model_validate(row)
+
+
+def upsert_feedback(
+    supabase: Client,
+    *,
+    user_id: str,
+    job_posting_id: str,
+    target_id: str,
+    signal: FeedbackSignal,
+    reason: str | None,
+) -> FeedbackRow:
+    """Upsert a feedback row. Latest signal wins on the unique key."""
+    payload: dict[str, Any] = {
+        "user_id": user_id,
+        "job_posting_id": job_posting_id,
+        "target_id": target_id,
+        "signal": signal,
+        "reason": reason,
+        # An update on (user, job, target) must reset the applied state —
+        # otherwise an irrelevant→relevant flip would silently leave the
+        # old "consumed" stamp on the row and the new signal would never
+        # be processed.
+        "applied_at": None,
+        "applied_run_id": None,
+        "updated_at": datetime.now(UTC).isoformat(),
+    }
+    resp = (
+        supabase.table(TABLE)
+        .upsert(payload, on_conflict="user_id,job_posting_id,target_id")
+        .execute()
+    )
+    rows = cast(list[dict[str, Any]], resp.data or [])
+    if not rows:
+        raise RuntimeError("Failed to upsert job_feedback row")
+    return _parse_row(rows[0])
+
+
+def delete_feedback(
+    supabase: Client, *, user_id: str, job_posting_id: str, target_id: str
+) -> bool:
+    """Remove a feedback row. Returns True if a row was deleted."""
+    resp = (
+        supabase.table(TABLE)
+        .delete()
+        .eq("user_id", user_id)
+        .eq("job_posting_id", job_posting_id)
+        .eq("target_id", target_id)
+        .execute()
+    )
+    rows = cast(list[dict[str, Any]], resp.data or [])
+    return bool(rows)
+
+
+def list_for_target(
+    supabase: Client,
+    *,
+    user_id: str,
+    target_id: str,
+    limit: int = 50,
+    offset: int = 0,
+) -> tuple[list[FeedbackRow], int]:
+    """Return the user's feedback rows for one target, newest first."""
+    from postgrest import CountMethod
+
+    resp = (
+        supabase.table(TABLE)
+        .select("*", count=CountMethod.exact)
+        .eq("user_id", user_id)
+        .eq("target_id", target_id)
+        .order("created_at", desc=True)
+        .range(offset, offset + limit - 1)
+        .execute()
+    )
+    rows = cast(list[dict[str, Any]], resp.data or [])
+    total = getattr(resp, "count", None) or len(rows)
+    return [_parse_row(r) for r in rows], total
+
+
+# ---- Deterministic learner ------------------------------------------------
+
+
+def _extract_tokens(reason: str | None) -> list[str]:
+    """Lowercase content tokens from a feedback reason, stopwords removed."""
+    if not reason:
+        return []
+    return [
+        m.group(0).lower()
+        for m in _TOKEN_RE.finditer(reason)
+        if m.group(0).lower() not in _LEARN_STOPWORDS
+    ]
+
+
+def _frequent_tokens(
+    rows: list[FeedbackRow], threshold: int
+) -> list[str]:
+    """Tokens that appear in ``>= threshold`` distinct rows. Order: most
+    frequent first, ties broken by first-seen order so the result is
+    stable across runs."""
+    seen_in: Counter[str] = Counter()
+    for row in rows:
+        for token in set(_extract_tokens(row.reason)):
+            seen_in[token] += 1
+    return [tok for tok, n in seen_in.most_common() if n >= threshold]
+
+
+def maybe_run_learner(
+    supabase: Client, *, user_id: str, target_id: str
+) -> LearnerPatchSummary | None:
+    """Run the deterministic learner for one (user, target) pair.
+
+    Returns a summary when something was applied, None when the trip
+    threshold wasn't reached (so the caller can keep the API response
+    cheap and skip the diff render).
+    """
+    pending_resp = (
+        supabase.table(TABLE)
+        .select("*")
+        .eq("user_id", user_id)
+        .eq("target_id", target_id)
+        .eq("signal", "irrelevant")
+        .is_("applied_at", "null")
+        .order("created_at", desc=True)
+        .limit(50)
+        .execute()
+    )
+    pending = [
+        _parse_row(r) for r in cast(list[dict[str, Any]], pending_resp.data or [])
+    ]
+    if len(pending) < _MIN_FEEDBACK_FOR_LEARN:
+        return None
+
+    new_tokens = _frequent_tokens(pending, _MIN_TOKEN_FREQUENCY)
+    if not new_tokens:
+        # 3+ signals but no token appears in 3+ rows — nothing literal to
+        # learn from. v2's LLM step is what handles this case.
+        return None
+
+    target_resp = (
+        supabase.table("targets")
+        .select("*")
+        .eq("id", target_id)
+        .single()
+        .execute()
+    )
+    target_row = cast(dict[str, Any] | None, target_resp.data)
+    if target_row is None:
+        return None
+    profile = cast(dict[str, Any], target_row.get("scoring_profile") or {})
+    negative = cast(dict[str, Any], profile.get("negative") or {})
+    existing = {
+        kw.lower()
+        for kw in cast(list[str], negative.get("keywords") or [])
+    }
+    truly_new = [t for t in new_tokens if t not in existing]
+    if not truly_new:
+        # All frequent tokens are already in the negative list — nothing
+        # to do. Don't bump version, don't stamp rows.
+        return None
+
+    negative["keywords"] = cast(
+        list[str], negative.get("keywords") or []
+    ) + truly_new
+    if "weight" not in negative:
+        # Mirror the default the LLM derivation emits so the merged profile
+        # remains a valid ``NegativeProfile``.
+        negative["weight"] = -10.0
+    profile["negative"] = negative
+
+    next_version = int(target_row.get("profile_version") or 1) + 1
+    supabase.table("targets").update(
+        {
+            "scoring_profile": profile,
+            "profile_version": next_version,
+            "updated_at": datetime.now(UTC).isoformat(),
+        }
+    ).eq("id", target_id).execute()
+
+    run_id = str(uuid.uuid4())
+    consumed_ids = [r.id for r in pending]
+    supabase.table(TABLE).update(
+        {
+            "applied_at": datetime.now(UTC).isoformat(),
+            "applied_run_id": run_id,
+        }
+    ).in_("id", consumed_ids).execute()
+
+    logger.info(
+        "Feedback learner applied for (user=%s, target=%s): +%d negative "
+        "keyword(s) %s, %d signals consumed, profile_version=%d",
+        user_id,
+        target_id,
+        len(truly_new),
+        truly_new,
+        len(consumed_ids),
+        next_version,
+    )
+
+    return LearnerPatchSummary(
+        target_id=target_id,
+        applied_run_id=run_id,
+        added_negative_keywords=truly_new,
+        signals_consumed=len(consumed_ids),
+        profile_version_after=next_version,
+    )

--- a/apps/wyrdfold-api/tests/test_feedback_learner.py
+++ b/apps/wyrdfold-api/tests/test_feedback_learner.py
@@ -124,7 +124,7 @@ class _FakeQuery:
     we want from a test fake.
     """
 
-    def __init__(self, fake: "_FakeSupabase", table: str) -> None:
+    def __init__(self, fake: _FakeSupabase, table: str) -> None:
         self._fake = fake
         self._table = table
         self._op: str | None = None
@@ -133,52 +133,52 @@ class _FakeQuery:
         self._range: tuple[int, int] | None = None
         self._single = False
 
-    def select(self, *_args: Any, **_kwargs: Any) -> "_FakeQuery":
+    def select(self, *_args: Any, **_kwargs: Any) -> _FakeQuery:
         self._op = "select"
         return self
 
-    def insert(self, payload: Any) -> "_FakeQuery":
+    def insert(self, payload: Any) -> _FakeQuery:
         self._op = "insert"
         self._payload = payload
         return self
 
-    def upsert(self, payload: Any, **_kwargs: Any) -> "_FakeQuery":
+    def upsert(self, payload: Any, **_kwargs: Any) -> _FakeQuery:
         self._op = "upsert"
         self._payload = payload
         return self
 
-    def update(self, payload: Any) -> "_FakeQuery":
+    def update(self, payload: Any) -> _FakeQuery:
         self._op = "update"
         self._payload = payload
         return self
 
-    def delete(self) -> "_FakeQuery":
+    def delete(self) -> _FakeQuery:
         self._op = "delete"
         return self
 
-    def eq(self, col: str, val: Any) -> "_FakeQuery":
+    def eq(self, col: str, val: Any) -> _FakeQuery:
         self._filters.append(("eq", col, val))
         return self
 
-    def is_(self, col: str, val: Any) -> "_FakeQuery":
+    def is_(self, col: str, val: Any) -> _FakeQuery:
         self._filters.append(("is", col, val))
         return self
 
-    def in_(self, col: str, val: Any) -> "_FakeQuery":
+    def in_(self, col: str, val: Any) -> _FakeQuery:
         self._filters.append(("in", col, val))
         return self
 
-    def order(self, *_args: Any, **_kwargs: Any) -> "_FakeQuery":
+    def order(self, *_args: Any, **_kwargs: Any) -> _FakeQuery:
         return self
 
-    def limit(self, _n: int) -> "_FakeQuery":
+    def limit(self, _n: int) -> _FakeQuery:
         return self
 
-    def range(self, start: int, end: int) -> "_FakeQuery":
+    def range(self, start: int, end: int) -> _FakeQuery:
         self._range = (start, end)
         return self
 
-    def single(self) -> "_FakeQuery":
+    def single(self) -> _FakeQuery:
         self._single = True
         return self
 

--- a/apps/wyrdfold-api/tests/test_feedback_learner.py
+++ b/apps/wyrdfold-api/tests/test_feedback_learner.py
@@ -1,0 +1,329 @@
+"""Tests for the deterministic v1 feedback learner.
+
+These cover the pure token-extraction + frequency-analysis layer
+(``_extract_tokens``, ``_frequent_tokens``) plus a smoke test of
+``maybe_run_learner`` against an in-memory Supabase fake. The fake
+keeps the test independent of network + Postgres at the cost of
+mirroring the chain-API shape — when supabase-py changes its query
+chain we'll need to update one place here.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+
+from app.models.feedback import FeedbackRow
+from app.services.feedback import (
+    _extract_tokens,
+    _frequent_tokens,
+    maybe_run_learner,
+)
+
+
+def _row(reason: str | None, signal: str = "irrelevant") -> FeedbackRow:
+    now = datetime.now(UTC)
+    return FeedbackRow(
+        id="fb-" + (reason or "none")[:8],
+        user_id="u",
+        job_posting_id="j",
+        target_id="t",
+        signal=signal,  # type: ignore[arg-type]
+        reason=reason,
+        applied_at=None,
+        applied_run_id=None,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+# ---- Token extraction -----------------------------------------------------
+
+
+class TestExtractTokens:
+    def test_returns_empty_for_none(self) -> None:
+        assert _extract_tokens(None) == []
+
+    def test_returns_empty_for_empty_string(self) -> None:
+        assert _extract_tokens("") == []
+
+    def test_lowercases_and_drops_stopwords(self) -> None:
+        tokens = _extract_tokens("This is a Sales role")
+        # "this", "is", "a", "role" are all stopwords (incl. domain-generic)
+        assert tokens == ["sales"]
+
+    def test_drops_tokens_shorter_than_three_chars(self) -> None:
+        # The token regex requires >=3 alpha chars to avoid noise from
+        # initials and short markers.
+        tokens = _extract_tokens("AI is good")
+        assert "ai" not in tokens
+        assert "good" in tokens
+
+    def test_keeps_hyphenated_compound(self) -> None:
+        tokens = _extract_tokens("entry-level coordinator")
+        assert "entry-level" in tokens
+        assert "coordinator" in tokens
+
+    def test_strips_punctuation_only_runs(self) -> None:
+        tokens = _extract_tokens("!!! wrong --- role ===")
+        assert tokens == ["wrong"]
+
+
+# ---- Frequency analysis ---------------------------------------------------
+
+
+class TestFrequentTokens:
+    def test_returns_empty_below_threshold(self) -> None:
+        rows = [_row("sales rep"), _row("sales rep")]
+        # Only 2 rows; threshold is 3.
+        assert _frequent_tokens(rows, threshold=3) == []
+
+    def test_picks_token_present_in_threshold_rows(self) -> None:
+        rows = [
+            _row("sales rep"),
+            _row("sales role"),
+            _row("sales position is wrong"),
+        ]
+        # "sales" in all 3 rows. "rep"/"role" only in 1 each. "wrong" in 1.
+        tokens = _frequent_tokens(rows, threshold=3)
+        assert tokens == ["sales"]
+
+    def test_counts_distinct_rows_not_occurrences(self) -> None:
+        # "sales sales sales" in one row only counts once.
+        rows = [
+            _row("sales sales sales"),
+            _row("marketing"),
+            _row("recruiting"),
+        ]
+        assert _frequent_tokens(rows, threshold=3) == []
+
+    def test_returns_most_frequent_first(self) -> None:
+        rows = [
+            _row("sales recruiting"),
+            _row("sales recruiting"),
+            _row("sales recruiting"),
+            _row("sales"),  # +1 for sales only
+        ]
+        tokens = _frequent_tokens(rows, threshold=3)
+        # both appear in 3 rows, but sales is in 4 → first.
+        assert tokens[0] == "sales"
+        assert "recruiting" in tokens
+
+
+# ---- maybe_run_learner with an in-memory fake -----------------------------
+
+
+class _FakeQuery:
+    """Records the query and returns a stub response on .execute().
+
+    Implements the subset of the supabase-py query-builder chain that
+    ``app.services.feedback`` actually uses. Reaching for anything new
+    will surface as an AttributeError, which is the loud failure mode
+    we want from a test fake.
+    """
+
+    def __init__(self, fake: "_FakeSupabase", table: str) -> None:
+        self._fake = fake
+        self._table = table
+        self._op: str | None = None
+        self._payload: Any = None
+        self._filters: list[tuple[str, str, Any]] = []
+        self._range: tuple[int, int] | None = None
+        self._single = False
+
+    def select(self, *_args: Any, **_kwargs: Any) -> "_FakeQuery":
+        self._op = "select"
+        return self
+
+    def insert(self, payload: Any) -> "_FakeQuery":
+        self._op = "insert"
+        self._payload = payload
+        return self
+
+    def upsert(self, payload: Any, **_kwargs: Any) -> "_FakeQuery":
+        self._op = "upsert"
+        self._payload = payload
+        return self
+
+    def update(self, payload: Any) -> "_FakeQuery":
+        self._op = "update"
+        self._payload = payload
+        return self
+
+    def delete(self) -> "_FakeQuery":
+        self._op = "delete"
+        return self
+
+    def eq(self, col: str, val: Any) -> "_FakeQuery":
+        self._filters.append(("eq", col, val))
+        return self
+
+    def is_(self, col: str, val: Any) -> "_FakeQuery":
+        self._filters.append(("is", col, val))
+        return self
+
+    def in_(self, col: str, val: Any) -> "_FakeQuery":
+        self._filters.append(("in", col, val))
+        return self
+
+    def order(self, *_args: Any, **_kwargs: Any) -> "_FakeQuery":
+        return self
+
+    def limit(self, _n: int) -> "_FakeQuery":
+        return self
+
+    def range(self, start: int, end: int) -> "_FakeQuery":
+        self._range = (start, end)
+        return self
+
+    def single(self) -> "_FakeQuery":
+        self._single = True
+        return self
+
+    def execute(self) -> Any:
+        self._fake.log.append(
+            {
+                "table": self._table,
+                "op": self._op,
+                "payload": self._payload,
+                "filters": list(self._filters),
+            }
+        )
+        data = self._fake.next_response(self._table, self._op, self._filters)
+        if self._single:
+            data = data[0] if data else None
+        return type("Resp", (), {"data": data, "count": len(data or [])})()
+
+
+class _FakeSupabase:
+    """Programmable Supabase double. Push canned responses with
+    ``push_response``; each ``.execute()`` consumes the next response
+    matching (table, op).
+    """
+
+    def __init__(self) -> None:
+        self.log: list[dict[str, Any]] = []
+        self._responses: list[tuple[str, str | None, Any]] = []
+
+    def push_response(self, table: str, op: str | None, data: Any) -> None:
+        self._responses.append((table, op, data))
+
+    def next_response(
+        self, table: str, op: str | None, _filters: Any
+    ) -> Any:
+        for i, (t, o, d) in enumerate(self._responses):
+            if t == table and o == op:
+                self._responses.pop(i)
+                return d
+        return []
+
+    def table(self, name: str) -> _FakeQuery:
+        return _FakeQuery(self, name)
+
+
+@pytest.fixture()
+def fake() -> _FakeSupabase:
+    return _FakeSupabase()
+
+
+class TestMaybeRunLearner:
+    def test_no_op_below_threshold(self, fake: _FakeSupabase) -> None:
+        # 2 unapplied rows < threshold (3).
+        fake.push_response(
+            "job_feedback",
+            "select",
+            [_row("sales rep").model_dump(mode="json") for _ in range(2)],
+        )
+        result = maybe_run_learner(fake, user_id="u", target_id="t")  # type: ignore[arg-type]
+        assert result is None
+
+    def test_no_op_when_no_token_repeats(self, fake: _FakeSupabase) -> None:
+        # 3 rows but no shared token after stopword filtering.
+        fake.push_response(
+            "job_feedback",
+            "select",
+            [
+                _row("marketing").model_dump(mode="json"),
+                _row("recruiting").model_dump(mode="json"),
+                _row("consulting").model_dump(mode="json"),
+            ],
+        )
+        assert maybe_run_learner(fake, user_id="u", target_id="t") is None  # type: ignore[arg-type]
+
+    def test_skips_token_already_in_negative_list(
+        self, fake: _FakeSupabase
+    ) -> None:
+        # Reasons where only "sales" passes both the token + frequency
+        # filters — picking a single-word reason avoids accidentally
+        # promoting a stopword-adjacent helper into the negative list.
+        fake.push_response(
+            "job_feedback",
+            "select",
+            [_row("sales").model_dump(mode="json") for _ in range(3)],
+        )
+        fake.push_response(
+            "targets",
+            "select",
+            [
+                {
+                    "id": "t",
+                    "scoring_profile": {
+                        "negative": {"keywords": ["sales"], "weight": -10.0},
+                    },
+                    "profile_version": 1,
+                }
+            ],
+        )
+        result = maybe_run_learner(fake, user_id="u", target_id="t")  # type: ignore[arg-type]
+        # "sales" is already a negative — nothing new to apply.
+        assert result is None
+
+    def test_applies_new_negative_and_bumps_version(
+        self, fake: _FakeSupabase
+    ) -> None:
+        # 3 unapplied rows, all share "sales".
+        fake.push_response(
+            "job_feedback",
+            "select",
+            [_row("sales rep wrong").model_dump(mode="json") for _ in range(3)],
+        )
+        fake.push_response(
+            "targets",
+            "select",
+            [
+                {
+                    "id": "t",
+                    "scoring_profile": {
+                        "negative": {"keywords": ["junior"], "weight": -10.0},
+                    },
+                    "profile_version": 1,
+                }
+            ],
+        )
+        # Update calls for targets + job_feedback. Push empty responses so
+        # the fake doesn't raise.
+        fake.push_response("targets", "update", [{"id": "t"}])
+        fake.push_response("job_feedback", "update", [])
+
+        result = maybe_run_learner(fake, user_id="u", target_id="t")  # type: ignore[arg-type]
+        assert result is not None
+        assert "sales" in result.added_negative_keywords
+        # The "wrong" token shows up in all 3 rows too — also frequent.
+        assert "wrong" in result.added_negative_keywords
+        # "rep" is in 3 rows.
+        assert "rep" in result.added_negative_keywords
+        assert result.signals_consumed == 3
+        assert result.profile_version_after == 2
+        # An update on targets was logged.
+        target_updates = [
+            r for r in fake.log if r["table"] == "targets" and r["op"] == "update"
+        ]
+        assert target_updates, "expected a targets update"
+        payload = target_updates[0]["payload"]
+        assert payload["profile_version"] == 2
+        # New negatives appended; existing "junior" preserved.
+        new_negatives = payload["scoring_profile"]["negative"]["keywords"]
+        assert "junior" in new_negatives
+        assert "sales" in new_negatives

--- a/apps/wyrdfold/src/app/(app)/jobs/JobDetailPanel.tsx
+++ b/apps/wyrdfold/src/app/(app)/jobs/JobDetailPanel.tsx
@@ -13,6 +13,7 @@ import { cn } from '@/lib/cn';
 import { extractApiError } from '@/lib/extractApiError';
 import { useToast } from '@/state/Toast/ToastProvider';
 import CoverLetterSection from './CoverLetterSection';
+import JobFeedbackSection from './JobFeedbackSection';
 import ResumeSection from './ResumeSection';
 import StatusIndicator from './StatusIndicator';
 import {
@@ -560,6 +561,10 @@ export default function JobDetailPanel({
           />
         </details>
       )}
+
+      {/* Relevance feedback — only shown when viewing under a specific
+          target, since the signal is target-scoped. */}
+      {targetId && <JobFeedbackSection jobId={posting.id} targetId={targetId} />}
 
       {/* Status History */}
       {history.length > 0 && (

--- a/apps/wyrdfold/src/app/(app)/jobs/JobFeedbackSection.tsx
+++ b/apps/wyrdfold/src/app/(app)/jobs/JobFeedbackSection.tsx
@@ -1,0 +1,175 @@
+'use client';
+
+import { useState } from 'react';
+import { ThumbsDown, ThumbsUp } from 'lucide-react';
+import { Text } from '@danieljoffe.com/shared-ui/Text';
+import Button from '@/components/Button';
+import { useToast } from '@/state/Toast/ToastProvider';
+
+interface JobFeedbackSectionProps {
+  jobId: string;
+  targetId: string;
+}
+
+// Compact relevance-feedback affordance on the job detail panel.
+// Two buttons (thumbs up / down). Clicking expands an optional reason
+// textarea; the signal POSTs regardless of whether the user types a
+// reason. Backend (PR #772) accepts an empty `reason` and the v1
+// learner only acts on N≥3 reasons sharing a literal token.
+export default function JobFeedbackSection({
+  jobId,
+  targetId,
+}: JobFeedbackSectionProps) {
+  const { toast } = useToast();
+  const [activeSignal, setActiveSignal] = useState<
+    'irrelevant' | 'relevant' | null
+  >(null);
+  const [reason, setReason] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [lastSubmittedSignal, setLastSubmittedSignal] = useState<
+    'irrelevant' | 'relevant' | null
+  >(null);
+
+  async function submit(signal: 'irrelevant' | 'relevant', reasonText: string) {
+    setSubmitting(true);
+    try {
+      const res = await fetch(`/api/jobs/${jobId}/feedback`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          signal,
+          reason: reasonText.trim() || null,
+          target_id: targetId,
+        }),
+      });
+      if (!res.ok) {
+        toast({
+          variant: 'error',
+          title:
+            signal === 'irrelevant'
+              ? 'Failed to mark as irrelevant'
+              : 'Failed to mark as relevant',
+        });
+        return;
+      }
+      setLastSubmittedSignal(signal);
+      setActiveSignal(null);
+      setReason('');
+      toast({
+        variant: 'success',
+        title:
+          signal === 'irrelevant'
+            ? 'Marked irrelevant — similar jobs will be deprioritized'
+            : 'Marked as highly relevant',
+      });
+    } catch {
+      toast({ variant: 'error', title: 'Network error sending feedback' });
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function undo() {
+    if (!lastSubmittedSignal) return;
+    try {
+      const res = await fetch(
+        `/api/jobs/${jobId}/feedback?target_id=${encodeURIComponent(targetId)}`,
+        { method: 'DELETE' }
+      );
+      if (res.ok) {
+        setLastSubmittedSignal(null);
+        toast({ variant: 'success', title: 'Feedback removed' });
+      } else {
+        toast({ variant: 'error', title: 'Failed to undo' });
+      }
+    } catch {
+      toast({ variant: 'error', title: 'Network error undoing feedback' });
+    }
+  }
+
+  if (activeSignal !== null) {
+    const label =
+      activeSignal === 'irrelevant'
+        ? 'Why is this irrelevant? (optional, e.g. "sales role")'
+        : 'What stood out? (optional)';
+    return (
+      <div className='flex flex-col gap-2 rounded-md border border-border bg-surface-secondary p-2'>
+        <Text variant='meta' as='label' className='text-text-secondary'>
+          {label}
+        </Text>
+        <textarea
+          value={reason}
+          onChange={e => setReason(e.target.value)}
+          maxLength={500}
+          rows={2}
+          aria-label='Feedback reason'
+          className='w-full rounded border border-border bg-surface px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-brand-500'
+          autoFocus
+        />
+        <div className='flex justify-end gap-2'>
+          <Button
+            name='feedback-skip'
+            variant='ghost'
+            size='sm'
+            onClick={() => {
+              setActiveSignal(null);
+              setReason('');
+            }}
+            disabled={submitting}
+          >
+            Skip
+          </Button>
+          <Button
+            name='feedback-submit'
+            variant='primary'
+            size='sm'
+            onClick={() => submit(activeSignal, reason)}
+            disabled={submitting}
+          >
+            {submitting ? 'Sending…' : 'Submit'}
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <Text variant='caption' className='mb-1'>
+        Feedback
+      </Text>
+      <div className='flex items-center gap-2'>
+        <Button
+          name='feedback-not-for-me'
+          variant='secondary'
+          size='sm'
+          onClick={() => setActiveSignal('irrelevant')}
+          aria-pressed={lastSubmittedSignal === 'irrelevant'}
+        >
+          <ThumbsDown className='size-4' aria-hidden />
+          <span className='ml-1'>Not for me</span>
+        </Button>
+        <Button
+          name='feedback-great-match'
+          variant='secondary'
+          size='sm'
+          onClick={() => setActiveSignal('relevant')}
+          aria-pressed={lastSubmittedSignal === 'relevant'}
+        >
+          <ThumbsUp className='size-4' aria-hidden />
+          <span className='ml-1'>Great match</span>
+        </Button>
+        {lastSubmittedSignal !== null && (
+          <Button
+            name='feedback-undo'
+            variant='ghost'
+            size='sm'
+            onClick={undo}
+          >
+            Undo
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/wyrdfold/src/app/api/jobs/[id]/feedback/route.ts
+++ b/apps/wyrdfold/src/app/api/jobs/[id]/feedback/route.ts
@@ -1,0 +1,24 @@
+import type { NextRequest } from 'next/server';
+
+import { proxyToWyrdfoldAPI } from '@/lib/api/proxy';
+
+interface RouteContext {
+  params: Promise<{ id: string }>;
+}
+
+export async function POST(request: NextRequest, ctx: RouteContext) {
+  const { id } = await ctx.params;
+  const body = await request.json().catch(() => null);
+  return proxyToWyrdfoldAPI(`/jobs/${id}/feedback`, {
+    method: 'POST',
+    body,
+  });
+}
+
+export async function DELETE(request: NextRequest, ctx: RouteContext) {
+  const { id } = await ctx.params;
+  return proxyToWyrdfoldAPI(`/jobs/${id}/feedback`, {
+    method: 'DELETE',
+    searchParams: request.nextUrl.searchParams,
+  });
+}

--- a/supabase/migrations/20260601130000_job_feedback.sql
+++ b/supabase/migrations/20260601130000_job_feedback.sql
@@ -1,0 +1,85 @@
+-- Per-(user, target) feedback signals on job postings.
+--
+-- A row records "I marked this job irrelevant / relevant for this target's
+-- lens, with an optional reason". The relevance-feedback learner (deterministic
+-- v1, LLM v2) reads unapplied rows and mutates the target's scoring_profile
+-- to suppress patterns the user has flagged 3+ times.
+--
+-- target_id is mandatory because feedback is about the lens, not the job in
+-- the abstract — a posting marked irrelevant under "Senior FE" can still be
+-- relevant under "Eng Manager". applied_at + applied_run_id let the learner
+-- mark consumed rows and group the batch that produced one profile mutation
+-- (so target_learning_log in v2 can roll a single run back).
+--
+-- The unique (user_id, job_posting_id, target_id) means latest wins on
+-- conflict: clicking "irrelevant" then "relevant" overwrites the prior signal
+-- rather than appending. This matches the UI's Undo-via-toast pattern.
+--
+-- Forward-only and idempotent.
+
+create table if not exists public.job_feedback (
+  id              uuid primary key default gen_random_uuid(),
+  user_id         text not null,
+  job_posting_id  uuid not null references public.jobs(id) on delete cascade,
+  target_id       uuid not null references public.targets(id) on delete cascade,
+  signal          text not null check (signal in ('irrelevant', 'relevant')),
+  reason          text,
+  applied_at      timestamptz,
+  applied_run_id  uuid,
+  created_at      timestamptz not null default now(),
+  updated_at      timestamptz not null default now(),
+  unique (user_id, job_posting_id, target_id)
+);
+
+-- The learner's hottest query: "give me every unapplied row for this target
+-- so I can derive a patch". Partial index keeps it tiny since applied rows
+-- dominate at steady state.
+create index if not exists idx_job_feedback_target_unapplied
+  on public.job_feedback (target_id)
+  where applied_at is null;
+
+-- The list endpoint reads rows for one user's target. Composite index lets
+-- the GET /targets/{id}/feedback endpoint paginate without a full scan.
+create index if not exists idx_job_feedback_user_target_created
+  on public.job_feedback (user_id, target_id, created_at desc);
+
+alter table public.job_feedback enable row level security;
+
+-- A user can only read / write / delete their own feedback rows.
+-- Service-role bypass (PostgREST + service_role JWT) lets the API server
+-- + the learner CRUD without per-user impersonation.
+create policy "job_feedback_self_select"
+  on public.job_feedback for select
+  using (auth.jwt() ->> 'sub' = user_id);
+
+create policy "job_feedback_self_insert"
+  on public.job_feedback for insert
+  with check (auth.jwt() ->> 'sub' = user_id);
+
+create policy "job_feedback_self_update"
+  on public.job_feedback for update
+  using (auth.jwt() ->> 'sub' = user_id);
+
+create policy "job_feedback_self_delete"
+  on public.job_feedback for delete
+  using (auth.jwt() ->> 'sub' = user_id);
+
+-- updated_at trigger so the unique-key upsert path (RPC-style updates)
+-- keeps a fresh timestamp without callers having to remember.
+create or replace function public.set_job_feedback_updated_at()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+  new.updated_at := now();
+  return new;
+end;
+$$;
+
+drop trigger if exists trg_job_feedback_updated_at on public.job_feedback;
+create trigger trg_job_feedback_updated_at
+  before update on public.job_feedback
+  for each row
+  execute function public.set_job_feedback_updated_at();


### PR DESCRIPTION
## Summary

Frontend half of Doc 2 v1, minimal-surface. Adds a relevance feedback affordance to the job detail panel and the Next.js proxy route for the v1 backend endpoints introduced in #772.

## Scope

- **Detail-panel only** for this PR. JobCard dropdown ("Mark irrelevant" / "Mark highly relevant") and BatchActionBar ("Mark all irrelevant") need ``target_id`` threaded through ``JobsListMobile`` / ``JobsListView`` to JobCard — that's a bigger refactor and is a clean follow-up PR.
- Feedback is target-scoped, so the section only renders when the panel is opened under a specific ``targetId`` (same gate the existing LLM Analysis section uses).

## Behavior

- Two buttons: **Not for me** (thumbs-down) / **Great match** (thumbs-up).
- Click expands an optional reason textarea + Submit / Skip. Submit POSTs even on empty reason — the v1 learner only acts on N ≥ 3 reasons sharing a literal token, so blank submits are harmless but still count as signal.
- After submit, the row shows an **Undo** affordance that DELETEs the row. Toast on every step (success / error / network).

## Files

- ``apps/wyrdfold/src/app/api/jobs/[id]/feedback/route.ts`` — POST + DELETE proxy via ``proxyToWyrdfoldAPI``.
- ``apps/wyrdfold/src/app/(app)/jobs/JobFeedbackSection.tsx`` — self-contained client component with submit + undo state.
- ``apps/wyrdfold/src/app/(app)/jobs/JobDetailPanel.tsx`` — one new import + one render placement above the History section.

## Stacks on

**#772** (feedback v1 backend). Don't merge this before that lands or the POST will 404.

## Test plan

- [ ] Local typecheck + lint (CI will run)
- [ ] Manual: open a job detail under a target, click ``Not for me``, type a reason, submit, observe toast + Undo button. Click Undo, observe toast. Refresh and confirm the feedback row was actually removed.
- [ ] Verify the section is hidden on the all-jobs (no targetId) view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)