### PR TITLE
fix(wyrdfold-api): chunk /jobs in_() to avoid PostgREST URL overflow

### DIFF
--- a/apps/wyrdfold-api/app/routers/jobs.py
+++ b/apps/wyrdfold-api/app/routers/jobs.py
@@ -98,6 +98,45 @@ def _tokenize_search(raw: str | None) -> list[str]:
     return out
 
 
+# PostgREST `id=in.(uuid,uuid,...)` is URL-encoded into the query string.
+# 200 UUIDs (36 chars each, plus commas and the `id.in.()` wrapper) lands
+# around 7.5 KB — well under the proxy + nginx + supabase defaults of
+# 8-16 KB. Above ~250 the URL silently truncates and the upstream
+# returns plain ``Bad Request`` (not JSON), which then crashes the
+# postgrest-py error decoder. ``has_location_filter`` and ``search``
+# both force ``page_ids = list(score_lookup.keys())`` — a few thousand
+# UUIDs after the May poll-cycle ingest. Chunked.
+_IN_CHUNK_SIZE = 200
+
+
+def _fetch_jobs_chunked(
+    supabase: Client,
+    page_ids: list[str],
+    *,
+    status: str | None,
+    company: str | None,
+    search: str | None,
+) -> list[dict[str, Any]]:
+    """Fetch ``jobs`` rows for many IDs in chunks, applying the
+    status/company/title filters per request. Caller is responsible for
+    re-sorting by score after the merge (chunk order is not preserved).
+    """
+    if not page_ids:
+        return []
+    out: list[dict[str, Any]] = []
+    for i in range(0, len(page_ids), _IN_CHUNK_SIZE):
+        chunk = page_ids[i : i + _IN_CHUNK_SIZE]
+        q = supabase.table("jobs").select(_JP_SELECT_COLS).in_("id", chunk)
+        if status:
+            q = q.eq("status", status)
+        if company:
+            q = q.eq("company_name", company)
+        q = _apply_title_search(q, search)
+        resp = q.execute()
+        out.extend(cast(list[dict[str, Any]], resp.data or []))
+    return out
+
+
 def _apply_title_search(query: Any, search: str | None) -> Any:
     """Apply a search filter to a query against the jobs.title column.
 
@@ -246,23 +285,12 @@ def _list_jobs_for_target_two_query(
         page_ids = list(score_lookup.keys())
         total = None  # will be computed after posting-level filters
 
-    jp_query = (
-        supabase.table("jobs")
-        .select(_JP_SELECT_COLS)
-        .in_("id", page_ids)
+    postings: list[dict[str, Any]] = _fetch_jobs_chunked(
+        supabase, page_ids, status=status, company=company, search=search
     )
-    if status:
-        jp_query = jp_query.eq("status", status)
-    if company:
-        jp_query = jp_query.eq("company_name", company)
-    jp_query = _apply_title_search(jp_query, search)
-
-    jp_resp = jp_query.execute()
-    postings = list(jp_resp.data or [])
 
     # Overlay target scores
-    for posting in postings:
-        p = cast(dict[str, Any], posting)
+    for p in postings:
         ts = score_lookup.get(p["id"])
         if ts:
             p["score"] = ts["score"]
@@ -272,17 +300,14 @@ def _list_jobs_for_target_two_query(
     # Sort + paginate in Python only when we couldn't do it server-side
     if total is None or sort_col != "score":
         if has_location_filter:
-            postings = cast(
-                Any,
-                _apply_location_filter(
-                    cast(list[dict[str, Any]], postings),
-                    exclude_terms=exclude_terms,
-                    only_terms=only_terms,
-                ),
+            postings = _apply_location_filter(
+                postings,
+                exclude_terms=exclude_terms,
+                only_terms=only_terms,
             )
 
-        def _sort_key(p: Any) -> Any:
-            val = cast(dict[str, Any], p).get(sort)
+        def _sort_key(p: dict[str, Any]) -> Any:
+            val = p.get(sort)
             if val is None:
                 return 0 if sort == "score" else ""
             return val
@@ -298,7 +323,7 @@ def _list_jobs_for_target_two_query(
         order_index = {jid: i for i, jid in enumerate(page_ids)}
         postings.sort(
             key=lambda p: order_index.get(
-                cast(dict[str, Any], p)["id"], len(page_ids)
+                p["id"], len(page_ids)
             )
         )
 
@@ -429,17 +454,11 @@ def _list_jobs_across_user_targets(
     if not page_ids:
         return {"postings": [], "total": total or 0, "page": page, "page_size": page_size}
 
-    jp_query = supabase.table("jobs").select(_JP_SELECT_COLS).in_("id", page_ids)
-    if status:
-        jp_query = jp_query.eq("status", status)
-    if company:
-        jp_query = jp_query.eq("company_name", company)
-    jp_query = _apply_title_search(jp_query, search)
-    jp_resp = jp_query.execute()
-    postings = list(jp_resp.data or [])
+    postings: list[dict[str, Any]] = _fetch_jobs_chunked(
+        supabase, page_ids, status=status, company=company, search=search
+    )
 
-    for posting in postings:
-        p = cast(dict[str, Any], posting)
+    for p in postings:
         ts = best.get(p["id"])
         if ts:
             p["score"] = ts["score"]
@@ -448,17 +467,14 @@ def _list_jobs_across_user_targets(
 
     if total is None or sort_col != "score":
         if has_location_filter:
-            postings = cast(
-                Any,
-                _apply_location_filter(
-                    cast(list[dict[str, Any]], postings),
-                    exclude_terms=exclude_terms,
-                    only_terms=only_terms,
-                ),
+            postings = _apply_location_filter(
+                postings,
+                exclude_terms=exclude_terms,
+                only_terms=only_terms,
             )
 
-        def _sort_key(p: Any) -> Any:
-            val = cast(dict[str, Any], p).get(sort)
+        def _sort_key(p: dict[str, Any]) -> Any:
+            val = p.get(sort)
             if val is None:
                 return 0 if sort == "score" else ""
             return val
@@ -474,7 +490,7 @@ def _list_jobs_across_user_targets(
         order_index = {jid: i for i, jid in enumerate(page_ids)}
         postings.sort(
             key=lambda p: order_index.get(
-                cast(dict[str, Any], p)["id"], len(page_ids)
+                p["id"], len(page_ids)
             )
         )
 


### PR DESCRIPTION
## Summary

Hot-fix: ``GET /jobs`` returned 500 whenever ``search`` or ``only_locations`` / ``exclude_locations`` was set on a target with a large score set. Production repro:

```
GET /jobs?target_id=4195d651-…&search=customer&only_locations=remote
```

## Root cause

Both filters force ``page_ids = list(score_lookup.keys())`` — every scored row's id (8127+ after the May ingest). The follow-up ``supabase.table('jobs').in_('id', page_ids)`` packs every UUID into one PostgREST URL, which exceeds the upstream proxy's URL-length cap. The upstream returns plain ``Bad Request`` (not JSON), and postgrest-py's ``APIErrorFromJSON`` validator then explodes trying to decode the error body — that's the secondary ``ValidationError: Invalid JSON`` in the trace.

## Fix

Extract ``_fetch_jobs_chunked`` and call it from both ``_list_jobs_for_target_two_query`` and the all-targets sibling. Chunk size is **200 UUIDs (~7.5 KB URL)** — comfortably under the 8–16 KB proxy/nginx defaults. Filters (``status`` / ``company`` / title-search) apply per chunk so each request stays small.

Also dropped a few dead ``cast(dict[str, Any], …)`` calls now that ``postings`` is statically typed from the helper.

## Test plan

- [x] ``pytest apps/wyrdfold-api -q`` → **949 passed**
- [x] Ruff + mypy clean
- [ ] Post-merge: hit the repro URL on prod; expect 200 instead of 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)