### PR TITLE
fix(wyrdfold-api): relevance knobs A+B (role_title weight + auto-threshold)

### DIFF
--- a/apps/wyrdfold-api/app/routers/jobs.py
+++ b/apps/wyrdfold-api/app/routers/jobs.py
@@ -109,6 +109,31 @@ def _tokenize_search(raw: str | None) -> list[str]:
 _IN_CHUNK_SIZE = 200
 
 
+def _default_min_score_for_user(
+    supabase: Client, user_id: str
+) -> int | None:
+    """Return the user's ``job_score_threshold`` for use as the default
+    list filter. ``None`` when the profile row is missing or the
+    threshold is 0 (the user explicitly opted out of any floor).
+    """
+    resp = (
+        supabase.table("user_profiles")
+        .select("job_score_threshold")
+        .eq("user_id", user_id)
+        .maybe_single()
+        .execute()
+    )
+    if resp is None:
+        return None
+    row = cast(dict[str, Any] | None, resp.data)
+    if row is None:
+        return None
+    threshold = row.get("job_score_threshold")
+    if not isinstance(threshold, int) or threshold <= 0:
+        return None
+    return threshold
+
+
 def _fetch_jobs_chunked(
     supabase: Client,
     page_ids: list[str],
@@ -616,6 +641,7 @@ def list_jobs(
                 "total": 0,
                 "page": page,
                 "page_size": page_size,
+                "applied_min_score": min_score,
             }
             job_list_cache.set(cache_key, empty)
             return empty
@@ -625,9 +651,20 @@ def list_jobs(
                 "total": 0,
                 "page": page,
                 "page_size": page_size,
+                "applied_min_score": min_score,
             }
             job_list_cache.set(cache_key, empty)
             return empty
+
+    # When no chip is set, fall back to the user's stored threshold —
+    # historically ``user_profiles.job_score_threshold`` only gated SMS
+    # notifications, so a senior user with threshold 70 still saw 5k+
+    # rows of noise in the list. Caller can pass ``min_score=0`` to
+    # explicitly opt out of the default; ``applied_min_score`` is
+    # echoed in the response so the UI can render a "filtered to ≥N"
+    # chip with a clear affordance.
+    if min_score is None and user_id is not None:
+        min_score = _default_min_score_for_user(supabase, user_id)
 
     # Target view: sort/paginate by target-specific scores
     if target_id:
@@ -646,6 +683,7 @@ def list_jobs(
             exclude_terms=exclude_terms,
             only_terms=only_terms,
         )
+        result["applied_min_score"] = min_score
         job_list_cache.set(cache_key, result)
         return result
 
@@ -669,6 +707,7 @@ def list_jobs(
             exclude_terms=exclude_terms,
             only_terms=only_terms,
         )
+        result["applied_min_score"] = min_score
         job_list_cache.set(cache_key, result)
         return result
 
@@ -715,6 +754,7 @@ def list_jobs(
             "total": resp.count or 0,
             "page": page,
             "page_size": page_size,
+            "applied_min_score": min_score,
         }
     job_list_cache.set(cache_key, operator_result)
     return operator_result

--- a/apps/wyrdfold-api/app/services/scoring.py
+++ b/apps/wyrdfold-api/app/services/scoring.py
@@ -182,12 +182,19 @@ _SENIORITY_SIGNAL_WEIGHT = 2.0
 _TITLE_WEIGHT = 2.0
 _DEFAULT_NORMALIZER = 30.0
 # Per-target ``search_keywords`` are the user's role-title intent (e.g.
-# "director of customer experience"). They were previously only used by
-# the poller to fetch jobs from boards — never scored. A title that hits
-# any of them is the single strongest signal of "this is the right kind
-# of role", so we credit it once at a high weight, applied via the same
-# ``_TITLE_WEIGHT`` boost the category keywords use when matched in title.
-_ROLE_TITLE_WEIGHT = 15.0
+# "director of customer experience"). A title that hits any of them is
+# the single strongest signal of "this is the right kind of role", so
+# the credit needs to *dominate* — not just contribute alongside 40
+# other keyword buckets that pad ``_calc_max_possible``.
+#
+# 15.0 (the original from PR #768) put a perfect title match at only
+# ~19% of a senior profile's max-possible — Checkr's "Director of
+# Customer Success" scored 27 against Melissa's Director target,
+# ranking behind "Executive Communications Manager" (33) which is
+# wholly off-topic. 40.0 puts a title-intent match at roughly half a
+# senior profile's max-possible solo, and combined with any JD-side
+# matches genuinely relevant postings push past the 70 threshold.
+_ROLE_TITLE_WEIGHT = 40.0
 
 # Senior-tier seniority levels. When ``profile.seniority.level`` is one of
 # these, common junior-IC title tokens get auto-prepended to the negative

--- a/apps/wyrdfold-api/tests/test_scoring_with_profile.py
+++ b/apps/wyrdfold-api/tests/test_scoring_with_profile.py
@@ -274,8 +274,8 @@ def test_role_title_credit_is_capped_per_match():
     # but the role_titles bucket is a single fixed credit.
     matched_role_keywords = [m for m in result.matched_keywords if m in keywords]
     assert len(matched_role_keywords) == 3
-    # Fixed credit is _ROLE_TITLE_WEIGHT * _TITLE_WEIGHT = 15 * 2 = 30.0
-    assert result.breakdown.role_titles == 30.0
+    # Fixed credit is _ROLE_TITLE_WEIGHT * _TITLE_WEIGHT = 40 * 2 = 80.0
+    assert result.breakdown.role_titles == 80.0
 
 
 def test_role_title_does_not_override_negative_keyword():


### PR DESCRIPTION
## Summary

Two targeted knobs to fix Melissa's **265-page Director CX list with 0 jobs above her 70 threshold**.

### A. Role-title weight 15 → 40

PR #768 wired ``target.search_keywords`` into the scorer with weight **15.0** — but on a senior profile with ~40 keyword buckets that put a perfect title-intent match at only ~19% of max-possible. Concrete prod evidence: Checkr's *"Director of Customer Success"* — a textbook fit for Melissa's Director target — scored **27**, ranking behind *"Executive Communications Manager"* (33) which is wholly off-topic.

**40.0** puts a title-intent match at roughly half a senior profile's max-possible solo. Combined with any JD-side hits, the genuinely relevant postings should push past the 70 threshold.

### B. Auto-apply ``user_profiles.job_score_threshold`` as default ``min_score``

The threshold has historically only gated SMS notifications; the list view ignored it. Melissa's threshold of 70 still left her with 5295 non-excluded rows (265 pages of 20) because no chip was applied.

Now, when a JWT caller hits ``GET /jobs`` without ``min_score`` set, the API looks up their stored threshold and uses it. Threshold ``0`` or a missing profile row falls through to "no filter" (unchanged). The effective threshold is echoed in the response as ``applied_min_score`` so the UI can render a "filtered to ≥N" chip with a clear affordance. **api-key callers (cron / poller) keep the old "no default" semantics** — they need raw access for backfill / re-score.

## Post-merge required: re-score Melissa's targets

A only takes effect on newly-scored rows. Existing rows need a re-score. Run:

```bash
cd apps/wyrdfold-api
uv run python ../../.tmp/rescore_melissa.py
```

(or bump ``targets.profile_version`` + call ``bulk_score_for_target`` directly). After re-score the top scores for the Director target should move from 33 → 70+ for the genuinely relevant Director-of-Customer-Success-style postings.

## Test plan

- [x] ``pytest apps/wyrdfold-api -q`` → 961 pass
- [x] mypy + ruff clean
- [x] Updated ``test_role_title_credit_is_capped_per_match`` to assert the new 80.0 fixed credit (= 40 × _TITLE_WEIGHT)
- [ ] Post-merge re-score + check Melissa sees < 5 pages with relevant Director-of-CX postings at top

🤖 Generated with [Claude Code](https://claude.com/claude-code)