### PR TITLE
feat(wyrdfold): decouple list_min_score from notification thresholds + reorder settings

### DIFF
--- a/apps/wyrdfold-api/app/models/user_profile.py
+++ b/apps/wyrdfold-api/app/models/user_profile.py
@@ -30,13 +30,22 @@ def _normalize_phone(value: str | None) -> str | None:
 
 
 class NotificationPreferences(BaseModel):
-    """Read model for notification preferences."""
+    """Read model for notification + jobs-list preferences.
+
+    ``list_min_score`` is intentionally separate from
+    ``job_score_threshold`` (email) and ``sms_score_threshold`` —
+    historically the email threshold was reused as the list filter, but
+    the email/SMS UIs are disabled until SMTP + Twilio are configured,
+    leaving users no way to control the list view. NULL means "no
+    auto-filter" — caller must pass ``min_score`` explicitly via chip.
+    """
 
     job_notifications_enabled: bool = False
     job_score_threshold: int = 100
     sms_notifications_enabled: bool = False
     sms_score_threshold: int = 100
     sms_daily_limit: int = 5
+    list_min_score: int | None = None
     phone_number: str | None = None
     email: str | None = None
     # Server-derived: false when the operator hasn't configured the
@@ -55,6 +64,10 @@ class NotificationPreferencesUpdate(BaseModel):
     sms_notifications_enabled: bool | None = None
     sms_score_threshold: int | None = Field(default=None, ge=0, le=200)
     sms_daily_limit: int | None = Field(default=None, ge=1, le=50)
+    # 0..100 matches the score range. ``None`` here means "don't touch
+    # the column" (default for partial PATCH); to clear an existing
+    # value the caller passes 0 (semantically "no floor").
+    list_min_score: int | None = Field(default=None, ge=0, le=100)
     phone_number: str | None = Field(default=None, max_length=20)
 
     @field_validator("phone_number", mode="before")

--- a/apps/wyrdfold-api/app/routers/jobs.py
+++ b/apps/wyrdfold-api/app/routers/jobs.py
@@ -112,13 +112,21 @@ _IN_CHUNK_SIZE = 200
 def _default_min_score_for_user(
     supabase: Client, user_id: str
 ) -> int | None:
-    """Return the user's ``job_score_threshold`` for use as the default
-    list filter. ``None`` when the profile row is missing or the
-    threshold is 0 (the user explicitly opted out of any floor).
+    """Return the user's ``list_min_score`` for use as the default list
+    filter when no ``min_score`` chip is set. ``None`` when:
+
+    - the profile row is missing,
+    - the column is NULL (user hasn't opted in to a default), or
+    - the stored value is 0 (semantic clear — caller wants no floor).
+
+    Decoupled from ``job_score_threshold`` (email notifications) and
+    ``sms_score_threshold`` (SMS) because those notification UIs are
+    disabled until SMTP / Twilio are configured, leaving users no way
+    to tune the list view if it were piggybacked on those fields.
     """
     resp = (
         supabase.table("user_profiles")
-        .select("job_score_threshold")
+        .select("list_min_score")
         .eq("user_id", user_id)
         .maybe_single()
         .execute()
@@ -128,10 +136,10 @@ def _default_min_score_for_user(
     row = cast(dict[str, Any] | None, resp.data)
     if row is None:
         return None
-    threshold = row.get("job_score_threshold")
-    if not isinstance(threshold, int) or threshold <= 0:
+    value = row.get("list_min_score")
+    if not isinstance(value, int) or value <= 0:
         return None
-    return threshold
+    return value
 
 
 def _fetch_jobs_chunked(

--- a/apps/wyrdfold-api/app/routers/user_profile.py
+++ b/apps/wyrdfold-api/app/routers/user_profile.py
@@ -58,7 +58,7 @@ router = APIRouter(
 _PREFS_COLUMNS = (
     "job_notifications_enabled, job_score_threshold,"
     " sms_notifications_enabled, sms_score_threshold,"
-    " sms_daily_limit, phone_number, email"
+    " sms_daily_limit, list_min_score, phone_number, email"
 )
 
 _IDENTITY_COLUMNS = "name, email, phone_number, location, linkedin_url, website_url"

--- a/apps/wyrdfold/src/app/(app)/settings/SettingsPage.tsx
+++ b/apps/wyrdfold/src/app/(app)/settings/SettingsPage.tsx
@@ -437,7 +437,7 @@ export default function SettingsPage() {
           Settings
         </Heading>
         <Text variant='body' className='mt-1 text-text-secondary'>
-          Resume style, list filtering, and notification alerts
+          Preferences for downloads, the jobs list, and alerts
         </Text>
       </div>
 

--- a/apps/wyrdfold/src/app/(app)/settings/SettingsPage.tsx
+++ b/apps/wyrdfold/src/app/(app)/settings/SettingsPage.tsx
@@ -34,6 +34,7 @@ interface NotificationPreferences {
   sms_notifications_enabled: boolean;
   sms_score_threshold: number;
   sms_daily_limit: number;
+  list_min_score: number | null;
   phone_number: string | null;
   email: string | null;
   email_available: boolean;
@@ -42,7 +43,7 @@ interface NotificationPreferences {
 
 // Identity fields moved to apps/wyrdfold/src/app/(app)/profile/ProfileIdentityCard.tsx.
 
-type Section = 'email' | 'sms';
+type Section = 'list' | 'email' | 'sms';
 
 function emailSig(enabled: boolean, threshold: number): string {
   return JSON.stringify({
@@ -63,6 +64,10 @@ function smsSig(
     sms_daily_limit: dailyLimit,
     phone_number: phone,
   });
+}
+
+function listSig(value: number | null): string {
+  return JSON.stringify({ list_min_score: value });
 }
 
 function styleSig(
@@ -87,6 +92,16 @@ function SavingIndicator({ active }: { active: boolean }) {
   );
 }
 
+// Parses the score-threshold input. Empty / non-numeric / 0 → null
+// (semantic clear — caller wants no floor). Otherwise clamps to 0-100.
+function parseListThreshold(raw: string): number | null {
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  const n = parseInt(trimmed, 10);
+  if (Number.isNaN(n) || n <= 0) return null;
+  return Math.min(100, Math.max(0, n));
+}
+
 export default function SettingsPage() {
   const [loading, setLoading] = useState(true);
   const [savingSection, setSavingSection] = useState<Section | null>(null);
@@ -100,6 +115,7 @@ export default function SettingsPage() {
   const [smsThreshold, setSmsThreshold] = useState('100');
   const [smsDailyLimit, setSmsDailyLimit] = useState('5');
   const [phoneNumber, setPhoneNumber] = useState('');
+  const [listMinScoreRaw, setListMinScoreRaw] = useState('');
   const [savingStyle, setSavingStyle] = useState(false);
   const [stylePreset, setStylePreset] = useState<ResumeStylePreset>(
     DEFAULT_RESUME_STYLE.preset
@@ -112,8 +128,10 @@ export default function SettingsPage() {
   // Failed-sigs prevent retry-loops when the server rejects a value.
   const lastEmailSigRef = useRef<string | null>(null);
   const lastSmsSigRef = useRef<string | null>(null);
+  const lastListSigRef = useRef<string | null>(null);
   const lastFailedEmailSigRef = useRef<string | null>(null);
   const lastFailedSmsSigRef = useRef<string | null>(null);
+  const lastFailedListSigRef = useRef<string | null>(null);
   const lastStyleSigRef = useRef<string | null>(null);
   const lastFailedStyleSigRef = useRef<string | null>(null);
 
@@ -132,6 +150,11 @@ export default function SettingsPage() {
         setSmsThreshold(String(data.sms_score_threshold));
         setSmsDailyLimit(String(data.sms_daily_limit));
         setPhoneNumber(data.phone_number ?? '');
+        setListMinScoreRaw(
+          data.list_min_score !== null && data.list_min_score !== undefined
+            ? String(data.list_min_score)
+            : ''
+        );
         lastEmailSigRef.current = emailSig(
           data.job_notifications_enabled,
           data.job_score_threshold
@@ -142,6 +165,7 @@ export default function SettingsPage() {
           data.sms_daily_limit,
           data.phone_number ?? null
         );
+        lastListSigRef.current = listSig(data.list_min_score ?? null);
       }
       if (styleRes.ok) {
         const style = (await styleRes.json()) as ResumeStyleSettings;
@@ -164,6 +188,46 @@ export default function SettingsPage() {
   }, [fetchPrefs]);
 
   // -- Save handlers ----------------------------------------------------------
+
+  const handleSaveList = useCallback(async () => {
+    const parsed = parseListThreshold(listMinScoreRaw);
+    const sig = listSig(parsed);
+    setSavingSection('list');
+    try {
+      // ``null`` → clear semantics — send 0 to indicate "no floor" per the
+      // backend contract (the API rejects negative values and treats 0 as
+      // "remove the default-min-score filter").
+      const res = await fetch('/api/profile/notifications', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ list_min_score: parsed ?? 0 }),
+      });
+      if (!res.ok) {
+        const message = await extractApiError(
+          res,
+          'Failed to save score threshold'
+        );
+        toast({ variant: 'error', title: message });
+        lastFailedListSigRef.current = sig;
+        return;
+      }
+      const data = (await res.json()) as NotificationPreferences;
+      setPrefs(data);
+      setListMinScoreRaw(
+        data.list_min_score !== null && data.list_min_score !== undefined
+          ? String(data.list_min_score)
+          : ''
+      );
+      lastListSigRef.current = listSig(data.list_min_score ?? null);
+      lastFailedListSigRef.current = null;
+      toast({ variant: 'success', title: 'Score threshold saved' });
+    } catch {
+      toast({ variant: 'error', title: 'Failed to save score threshold' });
+      lastFailedListSigRef.current = sig;
+    } finally {
+      setSavingSection(null);
+    }
+  }, [listMinScoreRaw, toast]);
 
   const handleSaveEmail = useCallback(async () => {
     const threshold = parseInt(emailThreshold, 10) || 100;
@@ -291,6 +355,18 @@ export default function SettingsPage() {
   // -- Autosave effects -------------------------------------------------------
 
   useEffect(() => {
+    if (lastListSigRef.current === null) return;
+    if (savingSection === 'list') return;
+    const sig = listSig(parseListThreshold(listMinScoreRaw));
+    if (sig === lastListSigRef.current) return;
+    if (sig === lastFailedListSigRef.current) return;
+    const handle = setTimeout(() => {
+      handleSaveList();
+    }, AUTOSAVE_DEBOUNCE_MS);
+    return () => clearTimeout(handle);
+  }, [listMinScoreRaw, savingSection, handleSaveList]);
+
+  useEffect(() => {
     if (lastEmailSigRef.current === null) return;
     if (savingSection === 'email') return;
     const sig = emailSig(emailEnabled, parseInt(emailThreshold, 10) || 100);
@@ -361,55 +437,78 @@ export default function SettingsPage() {
           Settings
         </Heading>
         <Text variant='body' className='mt-1 text-text-secondary'>
-          Notification preferences and alerts
+          Resume style, list filtering, and notification alerts
         </Text>
       </div>
 
       {/* Identity (contact header used on generated resumes + cover letters)
-          lives on /profile now — see ProfileIdentityCard. */}
+          lives on /profile now — see ProfileIdentityCard.
 
-      {/* Email Notifications */}
+          Card order matches Daniel's spec (most-used first):
+          1. Resume style — touched every download
+          2. Score threshold — touched whenever the list feels noisy
+          3. SMS notifications — disabled until Twilio is configured
+          4. Email notifications — disabled until SMTP is configured */}
+
+      {/* Resume style */}
       <Card>
         <CardHeader>
-          <div className='flex flex-wrap items-center justify-between gap-3'>
-            <div className='flex items-center gap-3'>
-              <CardTitle>Email Notifications</CardTitle>
-              <SavingIndicator active={savingSection === 'email'} />
-            </div>
-            <Switch
-              checked={emailEnabled && emailAvailable}
-              onChange={setEmailEnabled}
-              label='Enabled'
-              disabled={!emailAvailable}
-            />
+          <div className='flex items-center gap-3'>
+            <CardTitle>Resume style</CardTitle>
+            <SavingIndicator active={savingStyle} />
           </div>
         </CardHeader>
         <CardContent className='flex flex-col gap-4'>
           <Text variant='caption' className='text-text-secondary'>
-            Get email alerts when new jobs score above your threshold. Powered
-            by Resend.
+            Pick how your tailored resume and cover-letter .docx exports look.
+            Applies to every new download — no regeneration needed.
           </Text>
-          {!emailAvailable && (
-            <Text variant='meta' className='text-text-tertiary'>
-              Email notifications are unavailable until the operator configures
-              the email provider credentials.
-            </Text>
-          )}
-          {emailAvailable && prefs?.email && (
-            <Text variant='meta' className='text-text-tertiary'>
-              Sending to: {prefs.email}
-            </Text>
-          )}
+          <div className='grid gap-4 sm:grid-cols-2'>
+            <Select
+              label='Style'
+              value={stylePreset}
+              onChange={e =>
+                setStylePreset(e.target.value as ResumeStylePreset)
+              }
+              options={PRESET_OPTIONS}
+            />
+            <Select
+              label='Accent color'
+              value={styleAccent}
+              onChange={e =>
+                setStyleAccent(e.target.value as ResumeStyleAccent)
+              }
+              options={ACCENT_OPTIONS}
+            />
+          </div>
+          <ResumeStylePreview preset={stylePreset} accent={styleAccent} />
+        </CardContent>
+      </Card>
+
+      {/* Score threshold (jobs-list default filter) */}
+      <Card>
+        <CardHeader>
+          <div className='flex items-center gap-3'>
+            <CardTitle>Score threshold</CardTitle>
+            <SavingIndicator active={savingSection === 'list'} />
+          </div>
+        </CardHeader>
+        <CardContent className='flex flex-col gap-4'>
+          <Text variant='caption' className='text-text-secondary'>
+            Hide jobs scoring below this value from the list. Leave empty to
+            show everything — your chip filters still work. Independent of
+            email and SMS notification thresholds.
+          </Text>
           <div className='max-w-xs'>
             <Input
-              label='Score threshold'
+              label='Minimum score'
               type='number'
-              value={emailThreshold}
-              onChange={e => setEmailThreshold(e.target.value)}
+              value={listMinScoreRaw}
+              onChange={e => setListMinScoreRaw(e.target.value)}
               min={0}
               max={100}
-              helperText='Minimum job score to trigger an email alert (0-100)'
-              disabled={!emailEnabled || !emailAvailable}
+              placeholder='No filter'
+              helperText='0 or empty = show all jobs'
             />
           </div>
         </CardContent>
@@ -479,38 +578,50 @@ export default function SettingsPage() {
         </CardContent>
       </Card>
 
-      {/* Resume style */}
+      {/* Email Notifications */}
       <Card>
         <CardHeader>
-          <div className='flex items-center gap-3'>
-            <CardTitle>Resume style</CardTitle>
-            <SavingIndicator active={savingStyle} />
+          <div className='flex flex-wrap items-center justify-between gap-3'>
+            <div className='flex items-center gap-3'>
+              <CardTitle>Email Notifications</CardTitle>
+              <SavingIndicator active={savingSection === 'email'} />
+            </div>
+            <Switch
+              checked={emailEnabled && emailAvailable}
+              onChange={setEmailEnabled}
+              label='Enabled'
+              disabled={!emailAvailable}
+            />
           </div>
         </CardHeader>
         <CardContent className='flex flex-col gap-4'>
           <Text variant='caption' className='text-text-secondary'>
-            Pick how your tailored resume and cover-letter .docx exports look.
-            Applies to every new download — no regeneration needed.
+            Get email alerts when new jobs score above your threshold. Powered
+            by Resend.
           </Text>
-          <div className='grid gap-4 sm:grid-cols-2'>
-            <Select
-              label='Style'
-              value={stylePreset}
-              onChange={e =>
-                setStylePreset(e.target.value as ResumeStylePreset)
-              }
-              options={PRESET_OPTIONS}
-            />
-            <Select
-              label='Accent color'
-              value={styleAccent}
-              onChange={e =>
-                setStyleAccent(e.target.value as ResumeStyleAccent)
-              }
-              options={ACCENT_OPTIONS}
+          {!emailAvailable && (
+            <Text variant='meta' className='text-text-tertiary'>
+              Email notifications are unavailable until the operator configures
+              the email provider credentials.
+            </Text>
+          )}
+          {emailAvailable && prefs?.email && (
+            <Text variant='meta' className='text-text-tertiary'>
+              Sending to: {prefs.email}
+            </Text>
+          )}
+          <div className='max-w-xs'>
+            <Input
+              label='Score threshold'
+              type='number'
+              value={emailThreshold}
+              onChange={e => setEmailThreshold(e.target.value)}
+              min={0}
+              max={100}
+              helperText='Minimum job score to trigger an email alert (0-100)'
+              disabled={!emailEnabled || !emailAvailable}
             />
           </div>
-          <ResumeStylePreview preset={stylePreset} accent={styleAccent} />
         </CardContent>
       </Card>
     </div>

--- a/apps/wyrdfold/src/app/(app)/settings/__tests__/SettingsPage.spec.tsx
+++ b/apps/wyrdfold/src/app/(app)/settings/__tests__/SettingsPage.spec.tsx
@@ -19,6 +19,7 @@ const NOTIFICATIONS = {
   sms_notifications_enabled: false,
   sms_score_threshold: 90,
   sms_daily_limit: 5,
+  list_min_score: null,
   phone_number: null,
   email: 'me@example.com',
   email_available: true,

--- a/supabase/migrations/20260601150000_list_min_score.sql
+++ b/supabase/migrations/20260601150000_list_min_score.sql
@@ -1,0 +1,18 @@
+-- Decouple the jobs-list filter from the email-notification threshold.
+--
+-- ``user_profiles.job_score_threshold`` has historically gated email
+-- alerts only — but the email/SMS settings UI is disabled until SMTP +
+-- Twilio are configured, so users have no way to change the value. PR
+-- #776 mistakenly auto-applied ``job_score_threshold`` as the default
+-- ``min_score`` on ``GET /jobs``, locking senior-tier users into an
+-- empty list view until they manually set a chip every time.
+--
+-- New ``list_min_score`` is a separate, user-controlled score floor for
+-- the jobs list. NULL means "no auto-filter" (status-quo behaviour
+-- before #776); any positive integer applies as the default
+-- ``min_score`` when the caller doesn't pass one. The settings UI
+-- exposes this knob even while the email/SMS sections stay disabled.
+
+alter table public.user_profiles
+  add column if not exists list_min_score integer
+  check (list_min_score is null or (list_min_score >= 0 and list_min_score <= 100));


### PR DESCRIPTION
## Summary

PR #776 auto-applied ``user_profiles.job_score_threshold`` (the **email** notification threshold) as the default ``min_score`` on ``GET /jobs``. That field's input is disabled until SMTP/Twilio are configured — so senior-tier users like Melissa had no way to lower their list filter and were stuck looking at an empty page (threshold 70, top score 44 today).

This PR introduces a separate ``user_profiles.list_min_score`` column with its own enabled UI affordance and points the jobs router at it.

## Three-field model (matching the existing email/SMS split)

| field | role | UI status |
|---|---|---|
| ``job_score_threshold`` | email notifications | disabled until SMTP |
| ``sms_score_threshold`` | SMS notifications | disabled until Twilio |
| ``list_min_score`` *(new)* | jobs-list filter | **enabled now** |

## Backend

- **Migration** ``20260601150000_list_min_score.sql`` — nullable column with a CHECK on 0..100. NULL = "no auto-filter" (status-quo before #776). Backward-compatible.
- **Models** ``app/models/user_profile.py`` — ``list_min_score: int | None`` on both read + write; write side validates 0..100. On the wire 0 means "clear the default" per the existing ``not isinstance(value, int) or value <= 0`` semantics.
- **Router** ``app/routers/user_profile.py`` — adds the column to ``_PREFS_COLUMNS`` so GET/PATCH ``/profile/notifications`` round-trip it.
- **``_default_min_score_for_user``** in ``app/routers/jobs.py`` now reads ``list_min_score`` instead of ``job_score_threshold``. The behaviour is the same (None when missing/0/non-int), so PR #776's ``applied_min_score`` response field carries over unchanged.

## Frontend

- New **Score threshold** card on the settings page. ENABLED regardless of SMTP/Twilio. Single numeric input (0–100); empty or 0 means "show all jobs". Autosaves with the same 800ms debounce as other sections.
- Cards re-ordered per your spec (most-used first):
  1. Resume style — touched every download
  2. **Score threshold** — touched whenever the list feels noisy
  3. SMS Notifications — disabled until Twilio
  4. Email Notifications — disabled until SMTP

## Test plan

- [x] ``pytest apps/wyrdfold-api -q`` → 961 pass, mypy + ruff clean
- [x] ``nx test wyrdfold --testPathPatterns=SettingsPage`` → pass (fixture updated with the new field)
- [x] ``pnpm tsc --noEmit`` → clean
- [ ] Post-merge: confirm Melissa's view defaults to "no filter" (NULL ``list_min_score``) until she opts in via the new Settings card. Top results unchanged from PR #776.

## Sequencing

Stacks on **#776** (which introduced ``_default_min_score_for_user`` against the wrong column). No schema conflicts with merged migrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)