### PR TITLE
chore(wyrdfold): genericize user-facing example data

### DIFF
--- a/apps/wyrdfold/src/app/(app)/settings/ResumeStylePreview.tsx
+++ b/apps/wyrdfold/src/app/(app)/settings/ResumeStylePreview.tsx
@@ -42,10 +42,10 @@ export function ResumeStylePreview({
       }}
     >
       <div style={{ fontSize: px(p.namePt), color, fontWeight: 700 }}>
-        Daniel Joffe
+        Name LastName
       </div>
       <div style={{ fontSize: px(p.bodyPt), color: '#555555' }}>
-        San Francisco, CA · daniel@example.com
+        Remote, USA · user@example.com
       </div>
       <div
         style={{

--- a/apps/wyrdfold/src/app/(app)/settings/SettingsPage.tsx
+++ b/apps/wyrdfold/src/app/(app)/settings/SettingsPage.tsx
@@ -444,7 +444,7 @@ export default function SettingsPage() {
       {/* Identity (contact header used on generated resumes + cover letters)
           lives on /profile now — see ProfileIdentityCard.
 
-          Card order matches Daniel's spec (most-used first):
+          Card order (most-used first):
           1. Resume style — touched every download
           2. Score threshold — touched whenever the list feels noisy
           3. SMS notifications — disabled until Twilio is configured

--- a/apps/wyrdfold/src/app/onboarding/IdentityStep.tsx
+++ b/apps/wyrdfold/src/app/onboarding/IdentityStep.tsx
@@ -109,7 +109,7 @@ export default function IdentityStep({
           required
           value={name}
           onChange={e => setName(e.target.value)}
-          placeholder='Daniel Joffe'
+          placeholder='Name LastName'
           autoComplete='name'
           autoFocus
           disabled={loading || saving}


### PR DESCRIPTION
## Summary

Three spots leaked the founder's name / email into the UI as placeholder/preview content. Swapping to bare-bones generic strings so the app doesn't accidentally surface personal data to other users.

## Changes

- **``ResumeStylePreview``** (Settings → Resume style card)
  - ``Daniel Joffe`` → ``Name LastName``
  - ``San Francisco, CA · daniel@example.com`` → ``Remote, USA · user@example.com``
- **``onboarding/IdentityStep``** (post-magic-link first screen)
  - Name input ``placeholder='Daniel Joffe'`` → ``'Name LastName'``
- **``SettingsPage``** comment hygiene
  - Dropped the ``Daniel's spec`` reference in a code comment. Not user-visible, just no reason to keep it.

## Out of scope on purpose

- ``apps/wyrdfold/src/app/(public)/layout.tsx`` footer **"Built by Daniel Joffe © year"** is real authorship attribution — stays.
- Test fixtures (``promptForMissingContactName.spec.ts``, ``MarkdownPreviewEditor.drift.spec.ts``) keep the original strings — not user-visible, useful for git-blame continuity.
- ``@danieljoffe.com/shared-ui`` npm-scope imports are the workspace's package namespace, not user data.

## Test plan

- [x] Visual: Settings → Resume style card now shows ``Name LastName / Remote, USA · user@example.com``
- [x] Visual: onboarding name input shows ``Name LastName`` placeholder when empty
- [x] No tests assert on the old strings (only the drift / contact-prompt specs, neither user-facing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)