### PR TITLE
feat(wyrdfold): feedback triggers re-grade + section divider + (i) icon

### DIFF
--- a/apps/wyrdfold-api/app/routers/feedback.py
+++ b/apps/wyrdfold-api/app/routers/feedback.py
@@ -248,12 +248,37 @@ async def reject_learning_run(
 def _safe_run_learner(supabase: Client, user_id: str, target_id: str) -> None:
     """BackgroundTasks consumes exceptions but logs them poorly. Wrap so
     a learner failure can't surface as an opaque 500 on a subsequent
-    request, while still emitting a usable traceback in logs."""
+    request, while still emitting a usable traceback in logs.
+
+    When the deterministic learner actually mutated the profile (returned
+    a ``LearnerPatchSummary``), follow up with a ``bulk_score_for_target``
+    pass so the user sees the lifted/lowered scores on their next page
+    load instead of having to wait for the next poll cycle. The patch
+    bumped ``profile_version`` already, so ``bulk_score_for_target`` only
+    touches rows whose ``scored_profile_version`` is now stale.
+    """
     import logging
+
+    from app.services.target_scoring import bulk_score_for_target
+    from app.services.targets.crud import get as get_target
 
     logger = logging.getLogger("app.routers.feedback")
     try:
-        maybe_run_learner(supabase, user_id=user_id, target_id=target_id)
+        patch = maybe_run_learner(supabase, user_id=user_id, target_id=target_id)
+        if patch is None:
+            return
+        target = get_target(supabase, target_id)
+        if target is None:
+            return
+        n = bulk_score_for_target(supabase, target)
+        logger.info(
+            "Feedback learner triggered re-score for target=%s: "
+            "+%d negatives %s, %d rows re-scored",
+            target_id,
+            len(patch.added_negative_keywords),
+            patch.added_negative_keywords,
+            n,
+        )
     except Exception:
         logger.exception(
             "Feedback learner failed for (user=%s, target=%s)",

--- a/apps/wyrdfold/src/app/(app)/jobs/JobFeedbackSection.tsx
+++ b/apps/wyrdfold/src/app/(app)/jobs/JobFeedbackSection.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import { ThumbsDown, ThumbsUp } from 'lucide-react';
+import { Info, ThumbsDown, ThumbsUp } from 'lucide-react';
 import { Text } from '@danieljoffe.com/shared-ui/Text';
 import Button from '@/components/Button';
 import { useToast } from '@/state/Toast/ToastProvider';
@@ -11,11 +11,17 @@ interface JobFeedbackSectionProps {
   targetId: string;
 }
 
-// Compact relevance-feedback affordance on the job detail panel.
+// Relevance-feedback affordance on the job detail panel. Divider +
+// (i) icon above the section make it discoverable — the section
+// controls a real learning loop (auto-mutates the target's negative
+// keywords + re-scores in the background), not just an "I liked it"
+// reaction, so the explanation matters.
+//
 // Two buttons (thumbs up / down). Clicking expands an optional reason
 // textarea; the signal POSTs regardless of whether the user types a
 // reason. Backend (PR #772) accepts an empty `reason` and the v1
-// learner only acts on N≥3 reasons sharing a literal token.
+// learner only acts on N≥3 reasons sharing a literal token; the v2
+// LLM learner consumes the same rows once enough are queued.
 export default function JobFeedbackSection({
   jobId,
   targetId,
@@ -29,6 +35,7 @@ export default function JobFeedbackSection({
   const [lastSubmittedSignal, setLastSubmittedSignal] = useState<
     'irrelevant' | 'relevant' | null
   >(null);
+  const [showInfo, setShowInfo] = useState(false);
 
   async function submit(signal: 'irrelevant' | 'relevant', reasonText: string) {
     setSubmitting(true);
@@ -87,89 +94,116 @@ export default function JobFeedbackSection({
     }
   }
 
-  if (activeSignal !== null) {
-    const label =
-      activeSignal === 'irrelevant'
-        ? 'Why is this irrelevant? (optional, e.g. "sales role")'
-        : 'What stood out? (optional)';
-    return (
-      <div className='flex flex-col gap-2 rounded-md border border-border bg-surface-secondary p-2'>
-        <Text variant='meta' as='label' className='text-text-secondary'>
-          {label}
-        </Text>
-        <textarea
-          value={reason}
-          onChange={e => setReason(e.target.value)}
-          maxLength={500}
-          rows={2}
-          aria-label='Feedback reason'
-          className='w-full rounded border border-border bg-surface px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-brand-500'
-          autoFocus
-        />
-        <div className='flex justify-end gap-2'>
-          <Button
-            name='feedback-skip'
-            variant='ghost'
-            size='sm'
-            onClick={() => {
-              setActiveSignal(null);
-              setReason('');
-            }}
-            disabled={submitting}
-          >
-            Skip
-          </Button>
-          <Button
-            name='feedback-submit'
-            variant='primary'
-            size='sm'
-            onClick={() => submit(activeSignal, reason)}
-            disabled={submitting}
-          >
-            {submitting ? 'Sending…' : 'Submit'}
-          </Button>
-        </div>
-      </div>
-    );
-  }
+  const header = (
+    <div className='mb-2 flex items-center gap-1'>
+      <Text variant='caption'>Feedback</Text>
+      <button
+        type='button'
+        onClick={() => setShowInfo(open => !open)}
+        aria-label='About feedback'
+        aria-expanded={showInfo}
+        title='About feedback'
+        className='inline-flex h-5 w-5 items-center justify-center rounded text-text-tertiary hover:bg-surface-tertiary hover:text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500'
+      >
+        <Info className='h-3.5 w-3.5' aria-hidden />
+      </button>
+    </div>
+  );
+
+  const infoPanel = showInfo ? (
+    <div
+      role='region'
+      aria-label='How feedback works'
+      className='mb-3 rounded-md border border-border bg-surface-secondary p-3'
+    >
+      <Text variant='meta' className='text-text-secondary'>
+        Your feedback affects how we grade jobs for this target. We learn
+        from patterns across your marks — when several jobs share an
+        irrelevant token we auto-add it to the target&rsquo;s negative
+        keywords and re-score the list in the background. You can also
+        manually edit the target&rsquo;s scoring profile from Settings.
+      </Text>
+    </div>
+  ) : null;
 
   return (
-    <div>
-      <Text variant='caption' className='mb-1'>
-        Feedback
-      </Text>
-      <div className='flex items-center gap-2'>
-        <Button
-          name='feedback-not-for-me'
-          variant='secondary'
-          size='sm'
-          onClick={() => setActiveSignal('irrelevant')}
-          aria-pressed={lastSubmittedSignal === 'irrelevant'}
-        >
-          <ThumbsDown className='size-4' aria-hidden />
-          <span className='ml-1'>Not for me</span>
-        </Button>
-        <Button
-          name='feedback-great-match'
-          variant='secondary'
-          size='sm'
-          onClick={() => setActiveSignal('relevant')}
-          aria-pressed={lastSubmittedSignal === 'relevant'}
-        >
-          <ThumbsUp className='size-4' aria-hidden />
-          <span className='ml-1'>Great match</span>
-        </Button>
-        {lastSubmittedSignal !== null && (
+    <section className='border-t border-border pt-4'>
+      {header}
+      {infoPanel}
+      {activeSignal !== null ? (
+        <div className='flex flex-col gap-2 rounded-md border border-border bg-surface-secondary p-2'>
+          <Text variant='meta' as='label' className='text-text-secondary'>
+            {activeSignal === 'irrelevant'
+              ? 'Why is this irrelevant? (optional, e.g. "sales role")'
+              : 'What stood out? (optional)'}
+          </Text>
+          <textarea
+            value={reason}
+            onChange={e => setReason(e.target.value)}
+            maxLength={500}
+            rows={2}
+            aria-label='Feedback reason'
+            className='w-full rounded border border-border bg-surface px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-brand-500'
+            autoFocus
+          />
+          <div className='flex justify-end gap-2'>
+            <Button
+              name='feedback-skip'
+              variant='ghost'
+              size='sm'
+              onClick={() => {
+                setActiveSignal(null);
+                setReason('');
+              }}
+              disabled={submitting}
+            >
+              Skip
+            </Button>
+            <Button
+              name='feedback-submit'
+              variant='primary'
+              size='sm'
+              onClick={() => submit(activeSignal, reason)}
+              disabled={submitting}
+            >
+              {submitting ? 'Sending…' : 'Submit'}
+            </Button>
+          </div>
+        </div>
+      ) : (
+        <div className='flex items-center gap-2'>
           <Button
-            name='feedback-undo'
-            variant='ghost'
+            name='feedback-not-for-me'
+            variant='secondary'
             size='sm'
-            onClick={undo}
+            onClick={() => setActiveSignal('irrelevant')}
+            aria-pressed={lastSubmittedSignal === 'irrelevant'}
           >
-            Undo
+            <ThumbsDown className='size-4' aria-hidden />
+            <span className='ml-1'>Not for me</span>
           </Button>
-        )}
-      </div>
-    </div>
+          <Button
+            name='feedback-great-match'
+            variant='secondary'
+            size='sm'
+            onClick={() => setActiveSignal('relevant')}
+            aria-pressed={lastSubmittedSignal === 'relevant'}
+          >
+            <ThumbsUp className='size-4' aria-hidden />
+            <span className='ml-1'>Great match</span>
+          </Button>
+          {lastSubmittedSignal !== null && (
+            <Button
+              name='feedback-undo'
+              variant='ghost'
+              size='sm'
+              onClick={undo}
+            >
+              Undo
+            </Button>
+          )}
+        </div>
+      )}
+    </section>
   );
 }


### PR DESCRIPTION
## Summary

Connects the relevance-feedback section to its actual learning effect. Three changes in one PR.

### 1. Backend: feedback submit → background re-grade

``_safe_run_learner`` already ran the deterministic v1 learner in BackgroundTasks. When it returns a ``LearnerPatchSummary`` (3+ irrelevant signals shared a token → negatives mutated + ``profile_version`` bumped), the wrapper now also calls ``bulk_score_for_target`` on the same target so the lifted/lowered scores show up on the user's next page load — instead of waiting for the next poll cycle.

- ~30s for an 8k-row target.
- Runs only when the learner mutated → most feedback clicks remain instant.
- ``profile_version`` was already bumped, so ``bulk_score_for_target`` only touches stale rows.

### 2. Frontend: visual divider above the section

``border-t border-border pt-4`` on the wrapping ``<section>`` so the feedback block reads as its own thing instead of running into the LLM analysis summary above.

### 3. Frontend: (i) icon with explanation

Small ``Info`` button next to "Feedback" toggles a region with:

> Your feedback affects how we grade jobs for this target. We learn from patterns across your marks — when several jobs share an irrelevant token we auto-add it to the target's negative keywords and re-score the list in the background. You can also manually edit the target's scoring profile from Settings.

aria-expanded + aria-label set on the button; the region carries a ``role='region'`` + label so screen readers announce it as its own landmark.

## Test plan

- [x] ``pytest apps/wyrdfold-api -q`` → 961 pass, mypy + ruff clean
- [ ] Manual: click "Not for me" on 3 jobs sharing a token (e.g. "deployment"). Observe toast on the third. Wait ~30s, reload the list — the affected jobs should have dropped.
- [ ] Manual: click the (i) icon, see the explanation panel. Click again, see it collapse.

## Next up

Embedding pre-filter as the structural precision lever (separate PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)