### PR TITLE
feat(wyrdfold-api): backfill script for pre-filter embeddings + exclusions

### DIFF
--- a/apps/wyrdfold-api/scripts/backfill_relevance_prefilter.py
+++ b/apps/wyrdfold-api/scripts/backfill_relevance_prefilter.py
@@ -1,0 +1,412 @@
+"""Backfill embeddings + exclude cosine-failing scores rows.
+
+PR #780 added the ingestion-time relevance pre-filter so every NEW job
+gets its title embedded and gated against active target labels. The
+~8k rows already in ``jobs`` from before that PR never got embedded, so
+the gate doesn't help with them — Melissa's "Director of CX Operations
+& Transformation" target still shows 287 pages of off-topic noise.
+
+This script runs the gate retroactively:
+
+1. Back-fill ``targets.label_embedding`` for any target that's missing
+   one (mirrors the lazy back-fill in ``prepare_prefilter``).
+2. Back-fill ``jobs.title_embedding`` for every job whose column is NULL.
+3. For each ``scores`` row whose target has a label embedding AND whose
+   job has a title embedding, mark ``excluded=true`` when the cosine
+   sits below ``PREFILTER_THRESHOLD``.
+
+Idempotent — only touches rows that need it. Safe to re-run after a
+partial failure: previously-embedded rows are skipped, previously-
+excluded rows aren't touched (we never flip excluded back to false; the
+poller's gate is what gates new rows).
+
+Usage::
+
+    cd apps/wyrdfold-api
+    uv run python scripts/backfill_relevance_prefilter.py --dry-run
+    uv run python scripts/backfill_relevance_prefilter.py --target-id <uuid>
+    uv run python scripts/backfill_relevance_prefilter.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+from typing import Any, cast
+
+from supabase import Client
+
+from app.config import settings
+from app.services.embeddings import get_default_client
+from app.services.llm.cost_log import record_embedding
+from app.services.relevance_prefilter import (
+    PREFILTER_MODEL,
+    PREFILTER_THRESHOLD,
+    cosine_similarity,
+)
+from app.supabase_pool import get_supabase_pool, init_supabase
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+logger = logging.getLogger("backfill_prefilter")
+
+# Page size for Supabase ``range()`` reads. PostgREST caps single-row
+# response sizes; 1000 is well within limits and minimises round trips.
+PAGE_SIZE = 1000
+
+# How many job-title updates we batch before reporting progress. The
+# Voyage client parallelises internally (128 inputs per sub-call), but
+# the per-row UPDATEs are sequential — keep the chunk small enough that
+# a partial failure doesn't lose much work.
+UPDATE_BATCH = 200
+
+
+def _parse_pgvector(value: Any) -> list[float] | None:
+    """PostgREST returns ``vector(N)`` columns as either a JSON list or a
+    Postgres-style ``"[0.1,0.2,...]"`` string depending on encoder
+    configuration. Normalise both to a plain ``list[float]`` so callers
+    can ``cosine_similarity`` without caring.
+    """
+    if value is None:
+        return None
+    if isinstance(value, list):
+        return [float(x) for x in value]
+    if isinstance(value, str):
+        s = value.strip().lstrip("[").rstrip("]")
+        if not s:
+            return None
+        return [float(x) for x in s.split(",")]
+    return None
+
+
+async def backfill_target_label_embeddings(
+    supabase: Client, *, dry_run: bool
+) -> dict[str, list[float]]:
+    """Ensure every target has ``label_embedding``. Returns
+    ``{target_id: embedding}`` for every target that ends up with one
+    (newly back-filled or already present).
+    """
+    resp = supabase.table("targets").select("id, label, label_embedding").execute()
+    rows = cast(list[dict[str, Any]], resp.data or [])
+
+    needs_embed = [r for r in rows if _parse_pgvector(r.get("label_embedding")) is None]
+    logger.info(
+        "targets: %d total, %d need label_embedding backfill",
+        len(rows),
+        len(needs_embed),
+    )
+
+    if needs_embed and not dry_run:
+        client = get_default_client()
+        labels = [r["label"] for r in needs_embed]
+        result = await client.embed(
+            model=PREFILTER_MODEL,
+            inputs=labels,
+            purpose="embed.target_label.backfill",
+        )
+        try:
+            record_embedding(
+                supabase,
+                user_id=None,
+                purpose="embed.target_label.backfill",
+                result=result,
+            )
+        except Exception:
+            logger.exception("cost log failed (target labels)")
+
+        for row, embed in zip(needs_embed, result.embeddings, strict=False):
+            embed_list = list(embed)
+            try:
+                supabase.table("targets").update(
+                    {"label_embedding": embed_list}
+                ).eq("id", row["id"]).execute()
+                row["label_embedding"] = embed_list
+            except Exception:
+                logger.exception(
+                    "failed to persist label_embedding for target %s", row["id"]
+                )
+
+    out: dict[str, list[float]] = {}
+    for r in rows:
+        parsed = _parse_pgvector(r.get("label_embedding"))
+        if parsed is not None:
+            out[r["id"]] = parsed
+    logger.info("targets with label_embedding available: %d", len(out))
+    return out
+
+
+async def backfill_job_title_embeddings(
+    supabase: Client, *, dry_run: bool
+) -> dict[str, list[float]]:
+    """Embed every ``jobs`` row whose ``title_embedding`` is NULL. Returns
+    ``{job_id: embedding}`` for rows back-filled in this run; rows that
+    were already populated are NOT in the dict (the cosine pass loads
+    those lazily so we don't pay for a full-table read up front).
+    """
+    rows: list[dict[str, Any]] = []
+    offset = 0
+    while True:
+        resp = (
+            supabase.table("jobs")
+            .select("id, title")
+            .is_("title_embedding", "null")
+            .range(offset, offset + PAGE_SIZE - 1)
+            .execute()
+        )
+        page = cast(list[dict[str, Any]], resp.data or [])
+        rows.extend(page)
+        if len(page) < PAGE_SIZE:
+            break
+        offset += PAGE_SIZE
+
+    logger.info("jobs needing title_embedding backfill: %d", len(rows))
+    if dry_run or not rows:
+        return {}
+
+    client = get_default_client()
+    out: dict[str, list[float]] = {}
+
+    for start in range(0, len(rows), UPDATE_BATCH):
+        chunk = rows[start : start + UPDATE_BATCH]
+        # Voyage rejects empty/whitespace-only strings. Drop them from the
+        # request payload and preserve positional mapping so the embeddings
+        # land on the right jobs.
+        sanitized = [(j["id"], (j.get("title") or "").strip()) for j in chunk]
+        payload = [t for _, t in sanitized if t]
+        if not payload:
+            continue
+
+        result = await client.embed(
+            model=PREFILTER_MODEL,
+            inputs=payload,
+            purpose="embed.job_title.backfill",
+        )
+        try:
+            record_embedding(
+                supabase,
+                user_id=None,
+                purpose="embed.job_title.backfill",
+                result=result,
+            )
+        except Exception:
+            logger.exception("cost log failed (job titles)")
+
+        it = iter(result.embeddings)
+        for job_id, title in sanitized:
+            if not title:
+                continue
+            embed = list(next(it))
+            try:
+                supabase.table("jobs").update(
+                    {"title_embedding": embed}
+                ).eq("id", job_id).execute()
+                out[job_id] = embed
+            except Exception:
+                logger.exception(
+                    "failed to persist title_embedding for job %s", job_id
+                )
+
+        logger.info(
+            "  embedded %d/%d jobs (%.1f%%)",
+            min(start + UPDATE_BATCH, len(rows)),
+            len(rows),
+            100.0 * min(start + UPDATE_BATCH, len(rows)) / len(rows),
+        )
+
+    return out
+
+
+def exclude_cosine_failures(
+    supabase: Client,
+    *,
+    target_embeds: dict[str, list[float]],
+    job_embeds: dict[str, list[float]],
+    threshold: float,
+    target_id_filter: str | None,
+    dry_run: bool,
+) -> dict[str, int]:
+    """For each non-excluded ``scores`` row whose (target, job) pair has
+    embeddings on both sides AND cosine < ``threshold``, set
+    ``excluded=true``. Never flips ``excluded`` back to false.
+    """
+    base = (
+        supabase.table("scores")
+        .select("id, job_posting_id, target_id")
+        .eq("excluded", False)
+    )
+    if target_id_filter:
+        base = base.eq("target_id", target_id_filter)
+
+    rows: list[dict[str, Any]] = []
+    offset = 0
+    while True:
+        resp = base.range(offset, offset + PAGE_SIZE - 1).execute()
+        page = cast(list[dict[str, Any]], resp.data or [])
+        rows.extend(page)
+        if len(page) < PAGE_SIZE:
+            break
+        offset += PAGE_SIZE
+
+    logger.info("non-excluded scores rows to evaluate: %d", len(rows))
+
+    # Lazy-load title_embedding for jobs we don't already have in memory
+    # (rows back-filled in this run are pre-populated by step 2; the rest
+    # were already embedded by a prior backfill or by the poller).
+    missing = list({r["job_posting_id"] for r in rows} - set(job_embeds))
+    if missing:
+        logger.info(
+            "loading title_embedding for %d jobs not seen in this run", len(missing)
+        )
+        for i in range(0, len(missing), PAGE_SIZE):
+            chunk_ids = missing[i : i + PAGE_SIZE]
+            resp = (
+                supabase.table("jobs")
+                .select("id, title_embedding")
+                .in_("id", chunk_ids)
+                .execute()
+            )
+            for j in cast(list[dict[str, Any]], resp.data or []):
+                embed = _parse_pgvector(j.get("title_embedding"))
+                if embed is not None:
+                    job_embeds[j["id"]] = embed
+
+    to_exclude: list[str] = []
+    no_target_embed = 0
+    no_job_embed = 0
+    for r in rows:
+        t_embed = target_embeds.get(r["target_id"])
+        j_embed = job_embeds.get(r["job_posting_id"])
+        if t_embed is None:
+            no_target_embed += 1
+            continue
+        if j_embed is None:
+            no_job_embed += 1
+            continue
+        if cosine_similarity(t_embed, j_embed) < threshold:
+            to_exclude.append(r["id"])
+
+    logger.info(
+        "would exclude %d / %d scores rows (skipped: no_target_embed=%d, no_job_embed=%d)",
+        len(to_exclude),
+        len(rows),
+        no_target_embed,
+        no_job_embed,
+    )
+
+    if not dry_run and to_exclude:
+        for i in range(0, len(to_exclude), 500):
+            chunk = to_exclude[i : i + 500]
+            try:
+                supabase.table("scores").update({"excluded": True}).in_(
+                    "id", chunk
+                ).execute()
+            except Exception:
+                logger.exception("failed to mark scores excluded (chunk %d)", i)
+            logger.info(
+                "  excluded %d/%d", min(i + 500, len(to_exclude)), len(to_exclude)
+            )
+
+    return {
+        "evaluated": len(rows),
+        "to_exclude": len(to_exclude),
+        "no_target_embed": no_target_embed,
+        "no_job_embed": no_job_embed,
+    }
+
+
+async def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report counts without writing to the DB.",
+    )
+    parser.add_argument(
+        "--target-id",
+        help=(
+            "Only evaluate scores for this target_id. Embeddings are still "
+            "back-filled for all targets/jobs."
+        ),
+    )
+    parser.add_argument(
+        "--threshold",
+        type=float,
+        default=PREFILTER_THRESHOLD,
+        help=f"Cosine threshold below which to exclude. Default {PREFILTER_THRESHOLD}.",
+    )
+    parser.add_argument(
+        "--skip-target-embed",
+        action="store_true",
+        help="Skip step 1 (target label backfill).",
+    )
+    parser.add_argument(
+        "--skip-job-embed",
+        action="store_true",
+        help="Skip step 2 (job title backfill).",
+    )
+    parser.add_argument(
+        "--skip-exclude",
+        action="store_true",
+        help="Skip step 3 (mark scores excluded). Useful for embedding-only runs.",
+    )
+    args = parser.parse_args()
+
+    if settings.embeddings_provider != "voyage":
+        raise SystemExit(
+            "ERROR: EMBEDDINGS_PROVIDER must be 'voyage' (currently "
+            f"{settings.embeddings_provider!r}). Aborting to avoid writing "
+            "mock embeddings to the DB."
+        )
+
+    init_supabase()
+    supabase = get_supabase_pool()
+    if supabase is None:
+        raise SystemExit(
+            "ERROR: Supabase not configured — check SUPABASE_URL and "
+            "SUPABASE_SERVICE_ROLE_KEY in apps/wyrdfold-api/.env"
+        )
+
+    logger.info("dry_run=%s target_id=%s threshold=%s",
+                args.dry_run, args.target_id, args.threshold)
+    logger.info("---")
+
+    target_embeds: dict[str, list[float]] = {}
+    job_embeds: dict[str, list[float]] = {}
+
+    if not args.skip_target_embed:
+        logger.info(">> step 1: backfill target.label_embedding")
+        target_embeds = await backfill_target_label_embeddings(
+            supabase, dry_run=args.dry_run
+        )
+    else:
+        logger.info(">> step 1: skipped")
+        # Still load existing target embeds so step 3 can run.
+        resp = supabase.table("targets").select("id, label_embedding").execute()
+        for r in cast(list[dict[str, Any]], resp.data or []):
+            embed = _parse_pgvector(r.get("label_embedding"))
+            if embed is not None:
+                target_embeds[r["id"]] = embed
+
+    if not args.skip_job_embed:
+        logger.info(">> step 2: backfill jobs.title_embedding")
+        job_embeds = await backfill_job_title_embeddings(supabase, dry_run=args.dry_run)
+    else:
+        logger.info(">> step 2: skipped")
+
+    if not args.skip_exclude:
+        logger.info(">> step 3: mark cosine-failing scores rows as excluded")
+        summary = exclude_cosine_failures(
+            supabase,
+            target_embeds=target_embeds,
+            job_embeds=job_embeds,
+            threshold=args.threshold,
+            target_id_filter=args.target_id,
+            dry_run=args.dry_run,
+        )
+        logger.info("summary: %s", summary)
+    else:
+        logger.info(">> step 3: skipped")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/apps/wyrdfold-api/tests/test_backfill_relevance_prefilter.py
+++ b/apps/wyrdfold-api/tests/test_backfill_relevance_prefilter.py
@@ -1,0 +1,262 @@
+"""Tests for the relevance-prefilter backfill script.
+
+The two ``backfill_*_embeddings`` functions are integration-heavy
+(real Voyage + Supabase), so they're covered by the script's
+``--dry-run`` flag in operator workflow rather than unit tests. The
+logic that needs guarding is:
+
+- ``_parse_pgvector`` — both PostgREST encodings must round-trip
+  cleanly, otherwise the cosine step silently no-ops.
+- ``exclude_cosine_failures`` — this is the one piece that mutates
+  many rows. The threshold, fail-open semantics, target-id filter,
+  and dry-run guard all have to behave.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from scripts.backfill_relevance_prefilter import (
+    _parse_pgvector,
+    exclude_cosine_failures,
+)
+
+# ---- _parse_pgvector -----------------------------------------------------
+
+
+class TestParsePgvector:
+    def test_none_returns_none(self) -> None:
+        assert _parse_pgvector(None) is None
+
+    def test_list_returns_floats(self) -> None:
+        assert _parse_pgvector([1, 2, 3]) == [1.0, 2.0, 3.0]
+
+    def test_pgvector_string_returns_floats(self) -> None:
+        assert _parse_pgvector("[0.1,0.2,0.3]") == [0.1, 0.2, 0.3]
+
+    def test_empty_bracket_string_returns_none(self) -> None:
+        # PostgREST sometimes emits "[]" for a NULL-ish vector; treat
+        # it as missing so the gate's fail-open path kicks in instead
+        # of comparing against a zero-length vector.
+        assert _parse_pgvector("[]") is None
+
+    def test_unknown_type_returns_none(self) -> None:
+        assert _parse_pgvector(42) is None
+
+
+# ---- in-memory Supabase fake --------------------------------------------
+
+
+class _FakeQuery:
+    def __init__(
+        self,
+        store: dict[str, list[dict[str, Any]]],
+        log: list[dict[str, Any]],
+        table: str,
+    ) -> None:
+        self._store = store
+        self._log = log
+        self._table = table
+        self._filters: list[tuple[str, str, Any]] = []
+        self._op: str | None = None
+        self._payload: Any = None
+        self._range: tuple[int, int] | None = None
+
+    # ---- builder methods ----
+    def select(self, *_a: Any, **_k: Any) -> _FakeQuery:
+        self._op = "select"
+        return self
+
+    def update(self, payload: Any) -> _FakeQuery:
+        self._op = "update"
+        self._payload = payload
+        return self
+
+    def eq(self, col: str, val: Any) -> _FakeQuery:
+        self._filters.append(("eq", col, val))
+        return self
+
+    def in_(self, col: str, vals: list[Any]) -> _FakeQuery:
+        self._filters.append(("in", col, vals))
+        return self
+
+    def range(self, lo: int, hi: int) -> _FakeQuery:
+        self._range = (lo, hi)
+        return self
+
+    def is_(self, col: str, val: Any) -> _FakeQuery:
+        # Only used by jobs.title_embedding NULL filter — not exercised by
+        # the tests in this module but kept here to match the script's
+        # builder usage so a Read-against-jobs call wouldn't NPE.
+        self._filters.append(("is", col, val))
+        return self
+
+    # ---- execution ----
+    def _matches(self, row: dict[str, Any]) -> bool:
+        for op, col, val in self._filters:
+            if op == "eq" and row.get(col) != val:
+                return False
+            if op == "in" and row.get(col) not in val:
+                return False
+            if op == "is" and val == "null" and row.get(col) is not None:
+                return False
+        return True
+
+    def execute(self) -> Any:
+        rows = self._store.get(self._table, [])
+        matched = [r for r in rows if self._matches(r)]
+        if self._op == "select":
+            data = matched
+            if self._range is not None:
+                lo, hi = self._range
+                data = data[lo : hi + 1]
+            self._log.append(
+                {"table": self._table, "op": "select", "n": len(data)}
+            )
+            return type("Resp", (), {"data": data, "count": len(matched)})()
+        if self._op == "update":
+            updated_ids = []
+            for r in matched:
+                r.update(self._payload)
+                updated_ids.append(r.get("id"))
+            self._log.append(
+                {
+                    "table": self._table,
+                    "op": "update",
+                    "payload": self._payload,
+                    "ids": updated_ids,
+                }
+            )
+            return type("Resp", (), {"data": matched, "count": len(matched)})()
+        return type("Resp", (), {"data": [], "count": 0})()
+
+
+class _FakeSupabase:
+    def __init__(self, store: dict[str, list[dict[str, Any]]]) -> None:
+        self.store = store
+        self.log: list[dict[str, Any]] = []
+
+    def table(self, name: str) -> _FakeQuery:
+        return _FakeQuery(self.store, self.log, name)
+
+
+# ---- exclude_cosine_failures --------------------------------------------
+
+
+def _make_store() -> dict[str, list[dict[str, Any]]]:
+    """Two targets, three jobs, six scores rows.
+
+    target T1 (engineering) ~= job J1 (engineering); orthogonal to J2,J3.
+    target T2 (CX)          ~= job J2 (CX);          orthogonal to J1,J3.
+    job J3 has no embedding (e.g. embed failed on empty title).
+    """
+    return {
+        "scores": [
+            {"id": "s1", "job_posting_id": "J1", "target_id": "T1", "excluded": False},
+            {"id": "s2", "job_posting_id": "J2", "target_id": "T1", "excluded": False},
+            {"id": "s3", "job_posting_id": "J3", "target_id": "T1", "excluded": False},
+            {"id": "s4", "job_posting_id": "J1", "target_id": "T2", "excluded": False},
+            {"id": "s5", "job_posting_id": "J2", "target_id": "T2", "excluded": False},
+            # already excluded — must not be touched.
+            {"id": "s6", "job_posting_id": "J1", "target_id": "T2", "excluded": True},
+        ],
+    }
+
+
+class TestExcludeCosineFailures:
+    def test_excludes_rows_below_threshold(self) -> None:
+        supabase = _FakeSupabase(_make_store())
+        target_embeds = {"T1": [1.0, 0.0], "T2": [0.0, 1.0]}
+        job_embeds = {"J1": [1.0, 0.0], "J2": [0.0, 1.0]}
+
+        summary = exclude_cosine_failures(
+            supabase,  # type: ignore[arg-type]
+            target_embeds=target_embeds,
+            job_embeds=job_embeds,
+            threshold=0.5,
+            target_id_filter=None,
+            dry_run=False,
+        )
+
+        # s1 (T1/J1): cosine=1.0 keep
+        # s2 (T1/J2): cosine=0.0 EXCLUDE
+        # s3 (T1/J3): no job embed, skipped
+        # s4 (T2/J1): cosine=0.0 EXCLUDE
+        # s5 (T2/J2): cosine=1.0 keep
+        # s6 (T2/J1): already excluded, not in base query
+        assert summary["evaluated"] == 5
+        assert summary["to_exclude"] == 2
+        assert summary["no_job_embed"] == 1
+
+        # Inspect the persisted state in the fake store.
+        scores = {r["id"]: r["excluded"] for r in supabase.store["scores"]}
+        assert scores == {
+            "s1": False,
+            "s2": True,
+            "s3": False,
+            "s4": True,
+            "s5": False,
+            "s6": True,
+        }
+
+    def test_dry_run_does_not_write(self) -> None:
+        supabase = _FakeSupabase(_make_store())
+        summary = exclude_cosine_failures(
+            supabase,  # type: ignore[arg-type]
+            target_embeds={"T1": [1.0, 0.0]},
+            job_embeds={"J2": [0.0, 1.0]},
+            threshold=0.5,
+            target_id_filter=None,
+            dry_run=True,
+        )
+
+        # s2 (T1/J2) is the only row with both embeds where cosine<0.5.
+        # Everything else either has no target embed (T2) or no job embed
+        # (J1, J3 in the lookup we passed).
+        assert summary["to_exclude"] == 1
+
+        # The store must be untouched apart from existing s6 exclusion.
+        scores = {r["id"]: r["excluded"] for r in supabase.store["scores"]}
+        assert scores == {
+            "s1": False, "s2": False, "s3": False,
+            "s4": False, "s5": False, "s6": True,
+        }
+        # And no UPDATE call should appear in the log.
+        assert not [r for r in supabase.log if r["op"] == "update"]
+
+    def test_target_id_filter_narrows_evaluation_scope(self) -> None:
+        supabase = _FakeSupabase(_make_store())
+        target_embeds = {"T1": [1.0, 0.0], "T2": [0.0, 1.0]}
+        job_embeds = {"J1": [1.0, 0.0], "J2": [0.0, 1.0]}
+
+        summary = exclude_cosine_failures(
+            supabase,  # type: ignore[arg-type]
+            target_embeds=target_embeds,
+            job_embeds=job_embeds,
+            threshold=0.5,
+            target_id_filter="T2",
+            dry_run=False,
+        )
+
+        # Only s4 and s5 belong to T2 (s6 is already excluded). Of those,
+        # s4 (T2/J1) has cosine 0.0 → exclude; s5 (T2/J2) cosine 1.0 keep.
+        assert summary["evaluated"] == 2
+        assert summary["to_exclude"] == 1
+        # s1 must NOT be touched even though it would also fail cosine vs T2.
+        assert supabase.store["scores"][0]["excluded"] is False  # s1 untouched
+
+    def test_skips_when_target_embedding_missing(self) -> None:
+        """Fail-open: target without an embedding does NOT cause exclusions."""
+        supabase = _FakeSupabase(_make_store())
+        summary = exclude_cosine_failures(
+            supabase,  # type: ignore[arg-type]
+            target_embeds={},  # no target embeddings at all
+            job_embeds={"J1": [1.0, 0.0], "J2": [0.0, 1.0]},
+            threshold=0.5,
+            target_id_filter=None,
+            dry_run=False,
+        )
+        assert summary["to_exclude"] == 0
+        assert summary["no_target_embed"] == 5
+        scores = {r["id"]: r["excluded"] for r in supabase.store["scores"]}
+        assert all(v is False for k, v in scores.items() if k != "s6")


### PR DESCRIPTION
## Summary

PR #780 wired the ingestion-time relevance gate so every NEW job gets its title embedded and cosine-checked against active target labels. The ~8k rows already in `jobs` from before that PR never got embedded, so Melissa's CX target still showed 287 pages of off-topic noise even though the gate was now structurally in place.

This PR adds a one-shot script that runs the gate retroactively over the existing corpus:

1. **Target label backfill** — embeds any `target.label` whose `label_embedding` is NULL (mirrors the lazy backfill in `prepare_prefilter`).
2. **Job title backfill** — embeds every `jobs.title_embedding IS NULL` row, in 200-row batches with per-batch persistence so a partial failure only loses ~200 rows of work.
3. **Cosine exclusion pass** — for each non-excluded `scores` row whose target AND job have embeddings, marks `excluded=true` when cosine < `PREFILTER_THRESHOLD`.

## Expected impact

Against today's DEV state (measured pre-PR):
- Melissa's CX target: **5738 non-excluded rows → expected ~10–50** after the script runs (cosine ≥ 0.55 against "Director of CX Operations & Transformation").
- Cost: ~\$0.001 in voyage-3-lite tokens for the full 8261-job corpus.

## Idempotency

- Step 1: skips targets that already have an embedding.
- Step 2: `WHERE title_embedding IS NULL` filters to unprocessed rows only.
- Step 3: `WHERE excluded = false` — we never flip an exclusion back to false. Re-running can only ever exclude more rows.

## Fail-open semantics

Carry through from the prefilter module: if a target or job has no embedding (Voyage outage during partial backfill, mock client), the corresponding scores rows are **skipped, not excluded**. The operator log line reports skipped counts so partial-run gaps are visible.

## Safety rails

- Refuses to start if `EMBEDDINGS_PROVIDER != voyage` (would write mock zero-vectors to the DB otherwise).
- `--dry-run` reports counts without writing.
- `--target-id <uuid>` scopes exclusions to one target for cautious phased rollout (embeddings still back-fill for all).
- `--threshold <float>` lets us tune away from 0.55 without code changes.
- `--skip-target-embed` / `--skip-job-embed` / `--skip-exclude` for piecemeal re-runs.

## Tests

Cover the two logic-bearing pieces (the two `backfill_*` functions are integration-heavy and `--dry-run` is the validation path):

- `_parse_pgvector` — both PostgREST encodings (list + `"[0.1,…]"` string), `"[]"` treated as missing.
- `exclude_cosine_failures` against an in-memory Supabase fake — excludes below threshold, leaves above-threshold alone, respects `dry_run` (no UPDATEs logged), honours `target_id` filter, fails open when target/job embed missing.

## Operator usage

```bash
cd apps/wyrdfold-api
uv run python scripts/backfill_relevance_prefilter.py --dry-run
uv run python scripts/backfill_relevance_prefilter.py --target-id <uuid>
uv run python scripts/backfill_relevance_prefilter.py
```

## Verification

- ruff: clean
- mypy strict: clean (132 source files — adds `scripts/` to the typed graph via new `__init__.py`)
- pytest: 985 passed (976 from #780 + 9 new backfill tests)

## Test plan

- [ ] CI green
- [ ] After merge: dry-run locally first (`--dry-run`) to confirm row counts match expectations
- [ ] Then run targeted on Melissa's CX target (`--target-id 4195d651-2009-4c43-bc6b-beec4d3fca0b`) before opening it up to all targets
- [ ] Open Melissa's "Director of CX Operations & Transformation" list in the wyrdfold UI — expect a sharp drop from 287 pages
- [ ] Spot-check that genuinely-related titles ("Director of Customer Success", "Head of Customer Operations") survive the cull

🤖 Generated with [Claude Code](https://claude.com/claude-code)