### PR TITLE
fix(wyrdfold-api): retune prefilter threshold + fix backfill paging bugs

### DIFF
--- a/apps/wyrdfold-api/app/services/relevance_prefilter.py
+++ b/apps/wyrdfold-api/app/services/relevance_prefilter.py
@@ -43,13 +43,27 @@ PREFILTER_MODEL: EmbeddingModelId = "voyage-3-lite"
 # ``vector(512)`` to match (see migration 20260601160000).
 PREFILTER_VECTOR_DIMS = 512
 
-# Cosine threshold. ``voyage-3-lite`` cosines on related job titles
-# typically land in 0.55-0.85 range; tangential ones in 0.35-0.55;
-# completely off-topic below 0.35. 0.55 catches the obvious off-topic
-# noise (Pharmacy Tech vs Director of CX) without dropping near-misses
-# the keyword scorer can still rank. Tune after observing precision on
-# Melissa's corpus.
-PREFILTER_THRESHOLD: float = 0.55
+# Cosine threshold. Calibrated against a 500-job sample under Melissa's
+# "Director of CX Operations & Transformation" target:
+#
+#   threshold 0.55: excludes  1% of jobs  (effectively pass-through)
+#   threshold 0.65: excludes 12%
+#   threshold 0.70: excludes 36%
+#   threshold 0.75: excludes 75%
+#   threshold 0.78: excludes 91%  <- chosen
+#   threshold 0.82: excludes 99%  (starts dropping legitimate matches
+#                                   like "Director of Customer Success"
+#                                   which sits at 0.85)
+#
+# Short job titles cluster tighter in voyage-3-lite than the docs
+# suggest — corporate Director-level roles all sit in 0.75-0.85 vs each
+# other regardless of domain. 0.78 strikes the best balance we found:
+# trims out "Senior Software Engineer" / "Pharmacy Technician" / "Sales
+# Rep" cleanly while keeping near-matches like "Head of Customer
+# Operations". The residual noise (Director of GTM Systems etc., which
+# also sit around 0.80) is the next iteration's problem — feedback
+# loop, asymmetric query/document embeddings, or full-JD context.
+PREFILTER_THRESHOLD: float = 0.78
 
 
 def cosine_similarity(a: Sequence[float], b: Sequence[float]) -> float:

--- a/apps/wyrdfold-api/scripts/backfill_relevance_prefilter.py
+++ b/apps/wyrdfold-api/scripts/backfill_relevance_prefilter.py
@@ -229,18 +229,21 @@ def exclude_cosine_failures(
     embeddings on both sides AND cosine < ``threshold``, set
     ``excluded=true``. Never flips ``excluded`` back to false.
     """
-    base = (
-        supabase.table("scores")
-        .select("id, job_posting_id, target_id")
-        .eq("excluded", False)
-    )
-    if target_id_filter:
-        base = base.eq("target_id", target_id_filter)
-
     rows: list[dict[str, Any]] = []
     offset = 0
     while True:
-        resp = base.range(offset, offset + PAGE_SIZE - 1).execute()
+        # Rebuild each iteration — PostgREST builder methods accumulate
+        # URL params rather than replacing them, so reusing one builder
+        # across paged ``.range()`` calls produces ``?offset=0&offset=1000&...``
+        # and a 400 once the URL exceeds the row-count limit.
+        query = (
+            supabase.table("scores")
+            .select("id, job_posting_id, target_id")
+            .eq("excluded", False)
+        )
+        if target_id_filter:
+            query = query.eq("target_id", target_id_filter)
+        resp = query.range(offset, offset + PAGE_SIZE - 1).execute()
         page = cast(list[dict[str, Any]], resp.data or [])
         rows.extend(page)
         if len(page) < PAGE_SIZE:
@@ -257,8 +260,12 @@ def exclude_cosine_failures(
         logger.info(
             "loading title_embedding for %d jobs not seen in this run", len(missing)
         )
-        for i in range(0, len(missing), PAGE_SIZE):
-            chunk_ids = missing[i : i + PAGE_SIZE]
+        # PostgREST encodes ``in_`` as ``id=in.(uuid1,uuid2,...)``.
+        # 1000 UUIDs ~= 36 KB, well past typical proxy URL limits
+        # (8-16 KB). 100 UUIDs is ~3.6 KB, comfortably under.
+        in_chunk = 100
+        for i in range(0, len(missing), in_chunk):
+            chunk_ids = missing[i : i + in_chunk]
             resp = (
                 supabase.table("jobs")
                 .select("id, title_embedding")

--- a/apps/wyrdfold-api/tests/test_relevance_prefilter.py
+++ b/apps/wyrdfold-api/tests/test_relevance_prefilter.py
@@ -86,17 +86,16 @@ class TestTitlePassesPrefilter:
         targets: list[list[float] | None] = [[0.0, 1.0], [0.0, -1.0]]
         assert title_passes_prefilter(title, targets, threshold=0.5) is False
 
-    def test_default_threshold_is_the_module_constant(self) -> None:
-        # Sanity: a slightly-related title should pass at the module
-        # default but fail at a higher threshold. Locks the calibration
-        # we shipped with.
-        title = [1.0, 0.5]
-        target = [1.0, 0.6]
-        passes_default = title_passes_prefilter(title, [target])
-        passes_stricter = title_passes_prefilter(title, [target], threshold=0.999)
-        assert passes_default is True
-        assert passes_stricter is False
-        assert PREFILTER_THRESHOLD < 1.0  # guard against degenerate retune
+    def test_default_threshold_in_expected_range(self) -> None:
+        # Calibration guardrail. We shipped with 0.55, learned voyage-3-lite
+        # cosines run hot on short job titles (most Director-level corporate
+        # roles cluster 0.75-0.85 regardless of domain), and retuned to 0.78.
+        # If a future change drops below 0.6 we're effectively letting
+        # everything through; above 0.85 we start dropping legit near-matches
+        # like "Director of Customer Success" (which sits at ~0.85 vs
+        # "Director of CX Operations & Transformation"). Either direction
+        # warrants a code review.
+        assert 0.6 <= PREFILTER_THRESHOLD <= 0.85
 
 
 # ---- prepare_prefilter (mock client + fake supabase) ---------------------


### PR DESCRIPTION
## Summary

Three fixes from running #781's backfill script for real against Melissa's "Director of CX Operations & Transformation" corpus.

### 1. Bump `PREFILTER_THRESHOLD` 0.55 → 0.78

Shipped 0.55 based on Voyage's docs which suggest related-title cosines land in 0.55-0.85. The docs don't hold for *short* job titles — **all** corporate Director-level roles cluster 0.75-0.85 vs each other in voyage-3-lite, regardless of domain. Measured against Melissa's CX target on a 500-job sample:

| Threshold | Excludes | Notes |
|---|---|---|
| 0.55 | 1% | effectively pass-through |
| 0.65 | 12% | |
| 0.70 | 36% | |
| 0.75 | 75% | |
| **0.78** | **91%** | **chosen** |
| 0.82 | 99% | starts dropping legit matches like "Director of Customer Success" (cos 0.85) |

At 0.78, Melissa goes from **287 pages → ~23 pages** of noise. The residual ("Director of GTM Systems", "Executive Communications Manager") sits at 0.78-0.82 and can't be cleanly separated from her real targets without a different model or more context — that's deferred to the feedback-loop work.

The lock-in test for 0.55 is replaced with a band guard (0.6 ≤ x ≤ 0.85) so future retunes have a sanity floor/ceiling without re-litigating the exact value each time.

### 2. Fix PostgREST builder accumulation in `exclude_cosine_failures`

```python
base = supabase.table("scores").select(...).eq("excluded", False)
while True:
    resp = base.range(offset, offset + PAGE_SIZE - 1).execute()  # BUG
```

`base.range(...)` **APPENDS** `offset`/`limit` to the same builder rather than replacing them — produces `?offset=0&offset=1000&offset=2000&...` and a 400 once the URL exceeds the row-count limit. Rebuild the query inside the loop instead.

### 3. Fix URL-length overflow on the `in_("id", chunk_ids)` lookup

`in.(uuid1,uuid2,...)` URL-encodes at ~36 bytes per UUID. The previous `PAGE_SIZE = 1000` chunk produced a ~36 KB URL — well past most proxy limits (8-16 KB). Dropped the chunk size to 100 (~3.6 KB).

Both #2 and #3 only surfaced when the script ran with a real corpus — the in-memory Supabase fake in the unit tests doesn't model PostgREST URL encoding, so the unit tests passed both before and after.

## Operator note

This PR only touches the live threshold + script. The actual exclusion sweep against the DB has already been run manually for Melissa's CX target (and all targets) using `--threshold 0.78` against the local script. Future poll cycles use the new constant directly.

A separate issue surfaced during this investigation: Railway's `wyrdfold-api` defaulted `EMBEDDINGS_PROVIDER` to `mock`, so the first poller back-fill after #780 wrote MOCK random vectors for 5 target labels. Those were re-embedded with real Voyage out-of-band and `EMBEDDINGS_PROVIDER=voyage` is now set in the Railway env to prevent recurrence — no code change needed for that.

## Verification

- ruff: clean
- mypy strict: clean (131 source files)
- pytest: 985 passed

## Test plan

- [ ] CI green
- [ ] After merge: confirm the next /poll cycle prefilters at 0.78 (Railway logs)
- [ ] Spot-check Melissa's UI stays ~23 pages, not regressing to 287

🤖 Generated with [Claude Code](https://claude.com/claude-code)