### PR TITLE
fix(wyrdfold-api): preserve prefilter exclusions across re-scores

### DIFF
--- a/apps/wyrdfold-api/app/services/poller.py
+++ b/apps/wyrdfold-api/app/services/poller.py
@@ -35,6 +35,7 @@ from app.services.llm import get_default_client as get_default_llm_client
 from app.services.llm.client import LLMClient
 from app.services.llm.cost_log import enqueue as enqueue_llm_cost
 from app.services.relevance_prefilter import (
+    parse_pgvector,
     prepare_prefilter,
     title_passes_prefilter,
 )
@@ -687,12 +688,31 @@ async def _poll_one_source(
                 rd = cast(dict[str, Any], raw_row)
                 jd_cache[rd["id"]] = parse_jd(rd.get("description_html") or "")
 
-            for active_target in active_targets:
+            for ti, active_target in enumerate(active_targets):
+                # Per-target cosine: the source-level gate at line 577
+                # admits a posting that passes cosine for ANY active
+                # target, but Stage 2 scores it against ALL targets.
+                # Without this per-(target, job) check, a software-eng
+                # posting that passes for Daniel's target gets a
+                # ``excluded=false`` scores row for Melissa's CX target.
+                t_embed = (
+                    target_label_embeddings[ti]
+                    if ti < len(target_label_embeddings)
+                    else None
+                )
 
                 async def _full_score_one(
-                    row_data: dict[str, Any], target: JobTarget = active_target
+                    row_data: dict[str, Any],
+                    target: JobTarget = active_target,
+                    target_embed: list[float] | None = t_embed,
                 ) -> None:
                     try:
+                        title_embed = parse_pgvector(
+                            row_data.get("title_embedding")
+                        )
+                        prefilter_excluded = not title_passes_prefilter(
+                            title_embed, [target_embed]
+                        )
                         await asyncio.to_thread(
                             target_score_and_upsert,
                             supabase,
@@ -701,6 +721,7 @@ async def _poll_one_source(
                             description_html=row_data.get("description_html", ""),
                             target=target,
                             parsed_jd=jd_cache.get(row_data["id"]),
+                            excluded_by_prefilter=prefilter_excluded,
                         )
                     except Exception:
                         logger.exception(

--- a/apps/wyrdfold-api/app/services/relevance_prefilter.py
+++ b/apps/wyrdfold-api/app/services/relevance_prefilter.py
@@ -28,10 +28,33 @@ from __future__ import annotations
 import logging
 import math
 from collections.abc import Sequence
+from typing import Any
 
 from app.models.embeddings import EmbeddingModelId
 
 logger = logging.getLogger(__name__)
+
+
+def parse_pgvector(value: Any) -> list[float] | None:
+    """Normalize a PostgREST-returned ``vector(N)`` column to
+    ``list[float] | None``.
+
+    PostgREST encodes pgvector columns inconsistently depending on
+    encoder config — sometimes a JSON array, sometimes a Postgres
+    bracketed string ``"[0.1,0.2,...]"``. Empty-bracket ``"[]"``
+    collapses to ``None`` so the gate's fail-open branch kicks in
+    rather than comparing against a zero-length vector.
+    """
+    if value is None:
+        return None
+    if isinstance(value, list):
+        return [float(x) for x in value]
+    if isinstance(value, str):
+        s = value.strip().lstrip("[").rstrip("]")
+        if not s:
+            return None
+        return [float(x) for x in s.split(",")]
+    return None
 
 # Model used for both target labels and job titles. Same model on both
 # sides is required for cosine to be meaningful — different model

--- a/apps/wyrdfold-api/app/services/target_scoring.py
+++ b/apps/wyrdfold-api/app/services/target_scoring.py
@@ -26,6 +26,10 @@ from supabase import Client
 from app.models.schemas import JobTargetScore, ScoreBreakdown, ScoringStatus
 from app.models.targets import JobTarget
 from app.services.jd_parser import ParsedJD, parse_jd
+from app.services.relevance_prefilter import (
+    parse_pgvector,
+    title_passes_prefilter,
+)
 from app.services.scoring import score_job_with_profile, score_title_against_profile
 from app.services.supabase_retry import execute_with_retry_sync
 
@@ -138,10 +142,19 @@ def score_and_upsert(
     description_html: str,
     target: JobTarget,
     parsed_jd: ParsedJD | None = None,
+    excluded_by_prefilter: bool = False,
 ) -> JobTargetScore:
     """Stage 2: Score one job's full JD against one target and upsert.
 
     Pass ``parsed_jd`` to reuse a pre-parsed JD across multiple targets.
+
+    ``excluded_by_prefilter`` is OR-ed with the scorer's own ``excluded``
+    flag. The poller pre-computes cosine(target_label, job_title) once
+    per (target, job) pair and passes the result here, so a re-score
+    triggered by anything (cron, deploy, learner) preserves the prefilter
+    exclusion the same way the ingestion path does. Without this, the
+    scorer's negative-keyword-only ``excluded`` overwrites cosine-based
+    exclusions on every re-score and the noise floor walks back up.
     """
     result = score_job_with_profile(
         title,
@@ -158,7 +171,7 @@ def score_and_upsert(
         score=result.score,
         breakdown=result.breakdown,
         matched_keywords=result.matched_keywords,
-        excluded=result.excluded,
+        excluded=result.excluded or excluded_by_prefilter,
         scoring_status="stage2",
         scored_profile_version=target.profile_version,
     )
@@ -198,12 +211,17 @@ def bulk_score_for_target(supabase: Client, target: JobTarget) -> int:
     if not all_job_ids:
         return 0
 
+    # Resolve the target's cosine prefilter once per bulk run.
+    # Fail-open: if the target has no embedding yet, the prefilter check
+    # below returns True for every job, matching ingestion-path semantics.
+    target_label_embedding = parse_pgvector(target.label_embedding)
+
     # Score those jobs in batches
     for i in range(0, len(all_job_ids), batch_size):
         batch_ids = all_job_ids[i : i + batch_size]
         resp = (
             supabase.table("jobs")
-            .select("id, title, description_html")
+            .select("id, title, description_html, title_embedding")
             .in_("id", batch_ids)
             .execute()
         )
@@ -223,6 +241,13 @@ def bulk_score_for_target(supabase: Client, target: JobTarget) -> int:
                 parsed_jd=parsed,
                 search_keywords=target.search_keywords,
             )
+            # OR with the cosine gate so a bulk rescore preserves
+            # prefilter exclusions; otherwise scorer-only ``excluded``
+            # overwrites them and the noise floor walks back up.
+            title_embedding = parse_pgvector(job.get("title_embedding"))
+            excluded_by_prefilter = not title_passes_prefilter(
+                title_embedding, [target_label_embedding]
+            )
             rows_to_upsert.append(
                 {
                     "job_posting_id": job["id"],
@@ -230,7 +255,7 @@ def bulk_score_for_target(supabase: Client, target: JobTarget) -> int:
                     "score": result.score,
                     "score_breakdown": result.breakdown.model_dump(),
                     "matched_keywords": result.matched_keywords,
-                    "excluded": result.excluded,
+                    "excluded": result.excluded or excluded_by_prefilter,
                     "scoring_status": "stage2",
                     "scored_profile_version": target.profile_version,
                     "updated_at": now,

--- a/apps/wyrdfold-api/scripts/backfill_relevance_prefilter.py
+++ b/apps/wyrdfold-api/scripts/backfill_relevance_prefilter.py
@@ -45,6 +45,9 @@ from app.services.relevance_prefilter import (
     PREFILTER_THRESHOLD,
     cosine_similarity,
 )
+from app.services.relevance_prefilter import (
+    parse_pgvector as _parse_pgvector,  # re-export for tests
+)
 from app.supabase_pool import get_supabase_pool, init_supabase
 
 logging.basicConfig(level=logging.INFO, format="%(message)s")
@@ -59,24 +62,6 @@ PAGE_SIZE = 1000
 # the per-row UPDATEs are sequential — keep the chunk small enough that
 # a partial failure doesn't lose much work.
 UPDATE_BATCH = 200
-
-
-def _parse_pgvector(value: Any) -> list[float] | None:
-    """PostgREST returns ``vector(N)`` columns as either a JSON list or a
-    Postgres-style ``"[0.1,0.2,...]"`` string depending on encoder
-    configuration. Normalise both to a plain ``list[float]`` so callers
-    can ``cosine_similarity`` without caring.
-    """
-    if value is None:
-        return None
-    if isinstance(value, list):
-        return [float(x) for x in value]
-    if isinstance(value, str):
-        s = value.strip().lstrip("[").rstrip("]")
-        if not s:
-            return None
-        return [float(x) for x in s.split(",")]
-    return None
 
 
 async def backfill_target_label_embeddings(

--- a/apps/wyrdfold-api/tests/test_target_scoring.py
+++ b/apps/wyrdfold-api/tests/test_target_scoring.py
@@ -141,6 +141,51 @@ def test_score_and_upsert_raises_on_empty_response() -> None:
         )
 
 
+def test_score_and_upsert_excluded_by_prefilter_forces_true() -> None:
+    """When the caller signals a prefilter rejection, the upserted row
+    must carry ``excluded=True`` regardless of what the keyword scorer
+    decided. This is the contract the poller relies on so that re-scores
+    preserve cosine exclusions.
+    """
+    supabase = _make_supabase_mock(upsert_data=[_upserted_score_row()])
+    # A target with NO negative keywords — the scorer would normally
+    # leave ``excluded=False`` for any input.
+    target = _target(core={"React": 3})
+
+    score_and_upsert(
+        supabase,
+        job_posting_id="job-1",
+        title="Pharmacy Technician",
+        description_html="<p>Filling prescriptions.</p>",
+        target=target,
+        excluded_by_prefilter=True,
+    )
+
+    payload = supabase.table.return_value.upsert.call_args.args[0]
+    assert payload["excluded"] is True
+
+
+def test_score_and_upsert_excluded_by_prefilter_false_preserves_scorer() -> None:
+    """``excluded_by_prefilter=False`` is the default and must not change
+    the scorer's verdict — negative keyword matches still exclude the row.
+    """
+    supabase = _make_supabase_mock(upsert_data=[_upserted_score_row()])
+    # ``junior`` is in the negative list (see ``_target`` fixture).
+    target = _target(core={"React": 3})
+
+    score_and_upsert(
+        supabase,
+        job_posting_id="job-1",
+        title="Junior React Developer",
+        description_html="<p>Junior role on the React team.</p>",
+        target=target,
+        excluded_by_prefilter=False,
+    )
+
+    payload = supabase.table.return_value.upsert.call_args.args[0]
+    assert payload["excluded"] is True  # scorer excluded via negative keyword
+
+
 # ---------------------------------------------------------------------------
 # bulk_score_for_target
 # ---------------------------------------------------------------------------
@@ -192,6 +237,69 @@ def test_bulk_score_for_target_scores_stage1_jobs(
     count = bulk_score_for_target(supabase, target)
 
     assert count == 2
+
+
+def test_bulk_score_for_target_excludes_cosine_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Bulk re-score must apply the same prefilter the ingestion path
+    does. Without this guarantee, every re-score (cron, deploy, learner
+    bump) wipes cosine exclusions and the noise floor walks back up — the
+    regression we hit after the post-PR-#782 Railway deploy.
+    """
+    monkeypatch.setattr(_BATCH_UPDATE_PATH, MagicMock())
+
+    jts_rows = [{"job_posting_id": "good"}, {"job_posting_id": "bad"}]
+    jobs = [
+        {
+            "id": "good",
+            "title": "Senior Frontend Engineer",
+            "description_html": "<p>React.</p>",
+            "title_embedding": [1.0, 0.0],  # parallel to target embedding
+        },
+        {
+            "id": "bad",
+            "title": "Sales Development Representative",
+            "description_html": "<p>Outbound sales.</p>",
+            "title_embedding": [0.0, 1.0],  # orthogonal -> cosine 0 -> excludes
+        },
+    ]
+    upsert_rows = [
+        _upserted_score_row(job_posting_id="good"),
+        _upserted_score_row(job_posting_id="bad"),
+    ]
+
+    supabase = MagicMock()
+    range_calls = {"n": 0}
+
+    def range_side_effect(*args: Any, **kwargs: Any) -> MagicMock:
+        range_calls["n"] += 1
+        mock = MagicMock()
+        mock.execute.return_value.data = jts_rows if range_calls["n"] == 1 else []
+        return mock
+
+    supabase.table.return_value.select.return_value.eq.return_value.lt.return_value.range.side_effect = (
+        range_side_effect
+    )
+    supabase.table.return_value.select.return_value.in_.return_value.execute.return_value.data = (
+        jobs
+    )
+    supabase.table.return_value.upsert.return_value.execute.return_value.data = (
+        upsert_rows
+    )
+
+    target = _target(core={"React": 3})
+    # Make the target's label embedding parallel to "good" job's title
+    # embedding (cosine 1.0) and orthogonal to "bad" (cosine 0).
+    target.label_embedding = [1.0, 0.0]
+
+    count = bulk_score_for_target(supabase, target)
+
+    assert count == 2
+    payload = supabase.table.return_value.upsert.call_args.args[0]
+    by_id = {row["job_posting_id"]: row for row in payload}
+    assert by_id["good"]["excluded"] is False, "above-threshold cosine kept"
+    assert by_id["bad"]["excluded"] is True, "below-threshold cosine excluded"
 
 
 def test_bulk_score_for_target_handles_no_stale_jobs() -> None:


### PR DESCRIPTION
## Summary

After #782 deployed at 06:14 UTC, Melissa's Director of CX target walked back from 23 pages to 104 in a single poll cycle. The cosine prefilter only ran on the **ingestion** path; every re-score (deploy-triggered poll, feedback learner, /rescore endpoint) wrote \`excluded\` from the keyword scorer alone and overwrote the cosine-based exclusions the backfill had set.

## Root cause

Two related leaks:

1. **\`_poll_one_source\`** gates posting **ingestion** by *"passes cosine for ANY active target"*, then Stage 2 scores the upserted row against **ALL** targets. A software-eng posting that passes cosine for Daniel's Senior FE target ends up with an \`excluded=false\` scores row for Melissa's CX target purely because the keyword negative list doesn't cover that case. Per-target cosine check at scoring time is what was missing.

2. **\`bulk_score_for_target\`** (called by \`/rescore\` and the feedback learner) re-scores stale rows directly via the keyword scorer without consulting the prefilter at all. Same overwrite issue.

## Fix

- \`score_and_upsert\` grows an \`excluded_by_prefilter: bool = False\` param. OR-ed with the scorer's own \`excluded\` before upsert so callers can preserve the cosine verdict.
- \`_poll_one_source._full_score_one\` computes per-(target, job) cosine using the embeddings the source-level prefilter already loaded into scope (\`target_label_embeddings[ti]\` + \`row_data['title_embedding']\`).
- \`bulk_score_for_target\` fetches \`title_embedding\` alongside the existing SELECT, parses the target's \`label_embedding\` once, computes cosine per row, ORs with scorer \`excluded\`.
- \`_poll_one_source_for_target\` (single-target path) doesn't need the fix — its gate at line 1029 is already per-target, so jobs that reach Stage 2 there already passed cosine.

## Refactor

Moved \`_parse_pgvector\` from \`scripts/backfill_relevance_prefilter.py\` to \`app/services/relevance_prefilter.py\` as the public \`parse_pgvector\`. Both the new scoring callsites and the existing backfill script use it.

## Tests

| Test | What it locks |
|---|---|
| \`test_score_and_upsert_excluded_by_prefilter_forces_true\` | Caller-signaled prefilter rejection forces \`excluded=True\` even when the scorer would admit |
| \`test_score_and_upsert_excluded_by_prefilter_false_preserves_scorer\` | Default \`False\` doesn't invert the OR — scorer's True still wins |
| \`test_bulk_score_for_target_excludes_cosine_failures\` | Bulk path against a target with \`label_embedding=[1,0]\` excludes the orthogonal-titled job and keeps the parallel-titled one |

## What this unlocks

Future Railway redeploys (which auto-trigger \`/poll/due\` on startup) will preserve the cosine exclusions the backfill set, instead of resetting them to the keyword-only state. The same applies to feedback-learner-triggered re-scores and manual \`/rescore\` calls.

## Verification

- ruff: clean
- mypy strict: clean (131 source files)
- pytest: 988 passed (985 + 3 new)

## Test plan

- [ ] CI green
- [ ] After merge + Railway redeploy: confirm Melissa's CX target stays at ~23 pages (not 104+)
- [ ] Run a manual \`/rescore\` against any active target and confirm row counts don't change drastically

🤖 Generated with [Claude Code](https://claude.com/claude-code)