### PR TITLE
fix(wyrdfold-api): skip scoring + polling for inactive targets

### DIFF
--- a/apps/wyrdfold-api/app/services/poller.py
+++ b/apps/wyrdfold-api/app/services/poller.py
@@ -1188,7 +1188,25 @@ async def _poll_one_source_for_target(
 
 
 async def poll_sources_for_target(supabase: Client, target: JobTarget) -> PollResult:
-    """Poll all enabled sources, filtering for jobs matching a target's search keywords."""
+    """Poll all enabled sources, filtering for jobs matching a target's search keywords.
+
+    Skips inactive targets entirely (returns an empty ``PollResult``).
+    The ``targets.is_active`` flag is the OR across all users via the
+    user_targets trigger; if it's ``False`` no one currently has the
+    target enabled, so a per-target poll would fan out work nobody
+    will see. The /activate endpoint sets ``is_active`` to ``True``
+    before calling this, so the activation pipeline still works.
+    """
+    if not target.is_active:
+        logger.info(
+            "poll_sources_for_target: skipping inactive target %s (%s)",
+            target.id,
+            target.label,
+        )
+        return PollResult(
+            sources_polled=0, new_jobs=0, updated_jobs=0, archived_jobs=0, errors=[]
+        )
+
     if not target.search_keywords:
         return PollResult(
             sources_polled=0, new_jobs=0, updated_jobs=0, archived_jobs=0,

--- a/apps/wyrdfold-api/app/services/target_scoring.py
+++ b/apps/wyrdfold-api/app/services/target_scoring.py
@@ -184,7 +184,20 @@ def bulk_score_for_target(supabase: Client, target: JobTarget) -> int:
     ``scored_profile_version`` is less than the target's current
     ``profile_version`` (lazy re-scoring). Used by the re-score endpoint
     when a target's profile changes.
+
+    Skips inactive targets entirely. The ``targets.is_active`` flag is
+    the OR across all users via the user_targets trigger; if it's
+    ``False`` nobody currently has this target enabled, so the
+    re-score would just burn LLM/CPU on rows nobody will see.
     """
+    if not target.is_active:
+        logger.info(
+            "bulk_score_for_target: skipping inactive target %s (%s)",
+            target.id,
+            target.label,
+        )
+        return 0
+
     batch_size = 500
     offset = 0
     total_scored = 0

--- a/apps/wyrdfold-api/tests/test_poller.py
+++ b/apps/wyrdfold-api/tests/test_poller.py
@@ -242,3 +242,53 @@ def test_and_semantics_admits_excluded_for_audit():
     # The title hits 'junior' (negative) but no search-keyword overlap.
     # Excluded path admits regardless.
     assert _title_matches_any_target("Junior Random Role", [target]) is True
+
+
+# ---- poll_sources_for_target: inactive-target guard -----------------------
+
+
+def _full_target(*, is_active: bool, search_keywords: list[str]) -> JobTarget:
+    """Build a target with a real search_keywords list so the inactive
+    guard is exercised in isolation from the 'empty keywords' guard.
+    """
+    return JobTarget(
+        id="t-1",
+        label="Staff Frontend Engineer",
+        scoring_profile=ScoringProfile(
+            categories={
+                "core_skills": CategoryProfile(keywords={"react": 3}, weight=2.0),
+            },
+            seniority=SeniorityProfile(signals=["staff"]),
+        ),
+        search_keywords=search_keywords,
+        is_active=is_active,
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
+    )
+
+
+def test_poll_sources_for_target_skips_inactive_target() -> None:
+    """Inactive targets short-circuit before any sources query.
+
+    ``targets.is_active=False`` means no user currently has the target
+    enabled (trigger OR across user_targets). Fanning out a per-target
+    poll across every ATS source for a target nobody will see is pure
+    waste — return an empty PollResult immediately.
+    """
+    import asyncio
+    from unittest.mock import MagicMock
+
+    from app.services.poller import poll_sources_for_target
+
+    supabase = MagicMock()
+    target = _full_target(is_active=False, search_keywords=["frontend engineer"])
+
+    result = asyncio.run(poll_sources_for_target(supabase, target))
+
+    assert result.sources_polled == 0
+    assert result.new_jobs == 0
+    assert result.updated_jobs == 0
+    assert result.archived_jobs == 0
+    assert result.errors == []
+    # Critically: no DB traffic.
+    supabase.table.assert_not_called()

--- a/apps/wyrdfold-api/tests/test_target_scoring.py
+++ b/apps/wyrdfold-api/tests/test_target_scoring.py
@@ -38,6 +38,7 @@ def _target(
     *,
     target_id: str = "target-1",
     core: dict[str, int] | None = None,
+    is_active: bool = True,
 ) -> JobTarget:
     cats: dict[str, CategoryProfile] = {}
     if core is not None:
@@ -51,7 +52,7 @@ def _target(
             domain=DomainProfile(signals=["fintech"], weight=0.5),
             negative=NegativeProfile(keywords=["junior"], weight=-10.0),
         ),
-        is_active=True,
+        is_active=is_active,
         created_at=datetime.now(UTC),
         updated_at=datetime.now(UTC),
     )
@@ -312,6 +313,23 @@ def test_bulk_score_for_target_handles_no_stale_jobs() -> None:
     count = bulk_score_for_target(supabase, target)
 
     assert count == 0
+
+
+def test_bulk_score_for_target_skips_inactive_target() -> None:
+    """Inactive targets short-circuit before any DB read.
+
+    ``targets.is_active=False`` means no user currently has this target
+    enabled (the trigger off ``user_targets`` ORs across users). Re-scoring
+    would just burn LLM/CPU on rows nobody will see in the list view.
+    """
+    supabase = MagicMock()
+    target = _target(core={"React": 3}, is_active=False)
+
+    count = bulk_score_for_target(supabase, target)
+
+    assert count == 0
+    # And critically: zero DB traffic — no select, no upsert.
+    supabase.table.assert_not_called()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Two per-target scoring entry points didn't honor \`targets.is_active=False\` and could burn LLM/CPU on rows nobody will see. Adding the guard now (a) saves cost today and (b) sets the right pattern for the upcoming LLM scoring migration which will lean on these same entry points.

## What's not changed

The poller's source-level loop (\`_poll_one_source\`) already filters to active targets via \`get_active_target()\` — that path was already correct.

## What's changed

| Function | Before | After |
|---|---|---|
| \`bulk_score_for_target\` | Re-scores every stale row regardless of target state | Returns \`0\` immediately if \`not target.is_active\` |
| \`poll_sources_for_target\` | Fans out across every ATS source regardless of target state | Returns empty \`PollResult\` immediately if \`not target.is_active\` |

Both log a breadcrumb on skip so operators see it in Railway logs.

## Safety / activation flow

The activate pipeline (\`POST /targets/{id}/activate\`) flips \`user_targets.is_active=True\` BEFORE calling \`_activate_pipeline → poll_sources_for_target(refreshed)\`. The trigger updates \`targets.is_active=True\` before the refresh, so by the time the poll runs, the target IS active. Activation pipeline still works.

\`targets.is_active\` is the OR across all users — only \`False\` when **nobody** currently has the target enabled.

## Tests

- \`test_bulk_score_for_target_skips_inactive_target\` — returns 0, asserts zero \`supabase.table()\` calls
- \`test_poll_sources_for_target_skips_inactive_target\` — returns empty PollResult, asserts zero \`supabase.table()\` calls

## Verification

- ruff: clean
- mypy strict: clean (124 source files)
- pytest: 990 passed (988 + 2 new)

## Test plan

- [ ] CI green
- [ ] After merge + redeploy: confirm Railway logs show \`skipping inactive target\` if anyone hits \`/jobs/rescore\` or \`/targets/{id}/poll\` on a deactivated target

## Why this lands first

This is the foundation guard for the LLM scoring migration documented in \`.claude/docs/plan-llm-scoring-migration.md\`. The upcoming Phase 1/2 LLM passes will plug into these same per-target entry points; this guard means we won't have to remember the \`is_active\` check at every new call site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)