### PR TITLE
feat(wyrdfold-api): cap active targets per user at 5 (409 ACTIVE_LIMIT)

### DIFF
--- a/apps/wyrdfold-api/app/routers/targets.py
+++ b/apps/wyrdfold-api/app/routers/targets.py
@@ -411,9 +411,27 @@ async def activate_target(
     if target is None:
         raise HTTPException(status_code=404, detail="Target not found")
 
-    crud.link_user_to_target(
-        supabase, user_id=user_id, target_id=target_id, is_active=True
-    )
+    try:
+        crud.link_user_to_target(
+            supabase, user_id=user_id, target_id=target_id, is_active=True
+        )
+    except crud.ActiveTargetLimitError as e:
+        # 409 Conflict — the request was well-formed but conflicts with
+        # current state (the user is already at the active-target cap).
+        # Frontend reads ``error`` to switch on this case specifically and
+        # offers a deactivate picker rather than a generic toast.
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "error": "ACTIVE_LIMIT",
+                "limit": e.limit,
+                "active_count": e.current_count,
+                "message": (
+                    f"You already have {e.current_count} active targets "
+                    f"(limit {e.limit}) — deactivate one first."
+                ),
+            },
+        ) from e
     refreshed = crud.get(supabase, target_id) or target
 
     background_tasks.add_task(
@@ -511,13 +529,27 @@ async def link_target(
         fit_score = fit_result.fit_score
         fit_reasoning = fit_result.reasoning
 
-    return crud.link_user_to_target(
-        supabase,
-        user_id=user_id,
-        target_id=target_id,
-        fit_score=fit_score,
-        fit_score_reasoning=fit_reasoning,
-    )
+    try:
+        return crud.link_user_to_target(
+            supabase,
+            user_id=user_id,
+            target_id=target_id,
+            fit_score=fit_score,
+            fit_score_reasoning=fit_reasoning,
+        )
+    except crud.ActiveTargetLimitError as e:
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "error": "ACTIVE_LIMIT",
+                "limit": e.limit,
+                "active_count": e.current_count,
+                "message": (
+                    f"You already have {e.current_count} active targets "
+                    f"(limit {e.limit}) — deactivate one first."
+                ),
+            },
+        ) from e
 
 
 @router.post(
@@ -727,9 +759,23 @@ async def create_target_from_posting(
     # (cron) callers where ``user_id is None`` — they don't have a
     # user identity to link.
     if user_id is not None:
-        crud.link_user_to_target(
-            supabase, user_id=user_id, target_id=target.id, is_active=True
-        )
+        try:
+            crud.link_user_to_target(
+                supabase, user_id=user_id, target_id=target.id, is_active=True
+            )
+        except crud.ActiveTargetLimitError as e:
+            raise HTTPException(
+                status_code=409,
+                detail={
+                    "error": "ACTIVE_LIMIT",
+                    "limit": e.limit,
+                    "active_count": e.current_count,
+                    "message": (
+                        f"You already have {e.current_count} active targets "
+                        f"(limit {e.limit}) — deactivate one first."
+                    ),
+                },
+            ) from e
         # Re-read the target row so the response carries the
         # trigger-synced ``is_active``.
         refreshed = crud.get(supabase, target.id)

--- a/apps/wyrdfold-api/app/services/targets/crud.py
+++ b/apps/wyrdfold-api/app/services/targets/crud.py
@@ -308,6 +308,41 @@ def list_user_targets_with_targets(
 # ---- User-Target junction CRUD ----------------------------------------------
 
 
+MAX_ACTIVE_TARGETS_PER_USER = 5
+"""Per-user cap on simultaneously active targets.
+
+Caps fan-out of the upcoming LLM scoring pipeline (Phase 1/2 spend
+scales with active targets) and keeps a single user from scattering
+attention across a long list of marginal targets. Inactive targets are
+not counted — a user can keep arbitrarily many as "saved searches" they
+cycle between.
+"""
+
+
+class ActiveTargetLimitError(Exception):
+    """Raised when activating a target would exceed the per-user cap."""
+
+    def __init__(self, current_count: int, limit: int) -> None:
+        self.current_count = current_count
+        self.limit = limit
+        super().__init__(
+            f"Active target limit ({limit}) reached; currently {current_count} active"
+        )
+
+
+def count_active_for_user(supabase: Client, user_id: str) -> int:
+    """Return the number of user_targets rows with ``is_active=True`` for this user."""
+    resp = (
+        supabase.table(USER_TARGETS_TABLE)
+        .select("id", count="exact")  # type: ignore[arg-type]
+        .eq("user_id", user_id)
+        .eq("is_active", True)
+        .limit(1)
+        .execute()
+    )
+    return resp.count or 0
+
+
 def link_user_to_target(
     supabase: Client,
     *,
@@ -316,8 +351,39 @@ def link_user_to_target(
     is_active: bool = True,
     fit_score: int | None = None,
     fit_score_reasoning: str | None = None,
+    enforce_active_limit: bool = True,
 ) -> UserTarget:
-    """Link a user to a target (upsert). The DB trigger syncs targets.is_active."""
+    """Link a user to a target (upsert). The DB trigger syncs targets.is_active.
+
+    Raises ``ActiveTargetLimitError`` when ``is_active=True`` would push
+    the user above ``MAX_ACTIVE_TARGETS_PER_USER`` — but ONLY when this
+    call introduces a new active link. Re-upserting an already-active
+    link (e.g., refreshing fit_score on a row the user already has
+    active) is exempt because no net change happens.
+
+    Pass ``enforce_active_limit=False`` for internal callers that need
+    to bypass the cap — e.g., a future migration backfilling
+    user_targets rows from a different source.
+    """
+    if is_active and enforce_active_limit:
+        # Determine whether this upsert will INCREASE the active count
+        # or just refresh an already-active row. Skip the count check
+        # for the latter to keep idempotent updates free.
+        existing_resp = (
+            supabase.table(USER_TARGETS_TABLE)
+            .select("is_active")
+            .eq("user_id", user_id)
+            .eq("target_id", target_id)
+            .limit(1)
+            .execute()
+        )
+        existing = cast(list[dict[str, Any]], existing_resp.data or [])
+        already_active = bool(existing and existing[0].get("is_active"))
+        if not already_active:
+            current = count_active_for_user(supabase, user_id)
+            if current >= MAX_ACTIVE_TARGETS_PER_USER:
+                raise ActiveTargetLimitError(current, MAX_ACTIVE_TARGETS_PER_USER)
+
     row: dict[str, Any] = {
         "user_id": user_id,
         "target_id": target_id,

--- a/apps/wyrdfold-api/tests/test_targets_user_links.py
+++ b/apps/wyrdfold-api/tests/test_targets_user_links.py
@@ -116,3 +116,141 @@ def test_fit_score_result_enforces_score_bounds() -> None:
         FitScoreResult(fit_score=101, reasoning="ok")
     with pytest.raises(ValueError):
         FitScoreResult(fit_score=-1, reasoning="ok")
+
+
+# ---------------------------------------------------------------------------
+# (3) Active-target limit
+# ---------------------------------------------------------------------------
+
+
+def _mock_supabase_for_link(
+    *,
+    existing_row: dict[str, Any] | None,
+    active_count: int,
+) -> MagicMock:
+    """Build a Supabase mock that returns deterministic answers for the
+    two reads link_user_to_target performs before its upsert: (1) "is
+    this (user, target) pair already linked, and was it active?" and
+    (2) "how many active links does this user already have?".
+    """
+    supabase = MagicMock()
+    table = supabase.table.return_value
+
+    # Existing-row check: select().eq().eq().limit().execute()
+    existing_chain = table.select.return_value.eq.return_value.eq.return_value.limit.return_value.execute
+    existing_chain.return_value.data = [existing_row] if existing_row else []
+
+    # Count check: select().eq().eq().limit().execute() — same chain in
+    # MagicMock, so we shim ``.count`` on the same return value.
+    existing_chain.return_value.count = active_count
+
+    # Upsert: returns a row that matches what we wrote.
+    table.upsert.return_value.execute.return_value.data = [
+        _user_target_row(is_active=True)
+    ]
+    return supabase
+
+
+def test_link_user_to_target_allows_when_under_limit() -> None:
+    supabase = _mock_supabase_for_link(existing_row=None, active_count=2)
+
+    result = crud.link_user_to_target(
+        supabase, user_id="user-1", target_id="target-1", is_active=True
+    )
+
+    assert result.is_active is True
+
+
+def test_link_user_to_target_raises_when_at_limit_and_new_target() -> None:
+    """At the cap, activating a NEW target raises."""
+    supabase = _mock_supabase_for_link(
+        existing_row=None,
+        active_count=crud.MAX_ACTIVE_TARGETS_PER_USER,
+    )
+
+    with pytest.raises(crud.ActiveTargetLimitError) as ex:
+        crud.link_user_to_target(
+            supabase, user_id="user-1", target_id="new-target", is_active=True
+        )
+    assert ex.value.current_count == crud.MAX_ACTIVE_TARGETS_PER_USER
+    assert ex.value.limit == crud.MAX_ACTIVE_TARGETS_PER_USER
+    # And critically: no upsert fired.
+    supabase.table.return_value.upsert.assert_not_called()
+
+
+def test_link_user_to_target_allows_reupsert_of_already_active_row() -> None:
+    """At the cap, re-upserting an ALREADY-ACTIVE row is fine — no net
+    change. Lets callers refresh ``fit_score`` on the row without
+    tripping the limit.
+    """
+    supabase = _mock_supabase_for_link(
+        existing_row=_user_target_row(is_active=True),
+        active_count=crud.MAX_ACTIVE_TARGETS_PER_USER,
+    )
+
+    # Doesn't raise.
+    result = crud.link_user_to_target(
+        supabase,
+        user_id="user-1",
+        target_id="target-1",
+        is_active=True,
+        fit_score=85,
+    )
+    assert result is not None
+    # Upsert fired as expected.
+    supabase.table.return_value.upsert.assert_called_once()
+
+
+def test_link_user_to_target_with_enforce_active_limit_false_bypasses_cap() -> None:
+    """Internal callers (future backfill scripts) can opt out of the
+    cap. Defaults to ``True`` so the path remains safe by default.
+    """
+    supabase = _mock_supabase_for_link(
+        existing_row=None,
+        active_count=crud.MAX_ACTIVE_TARGETS_PER_USER + 10,
+    )
+
+    result = crud.link_user_to_target(
+        supabase,
+        user_id="user-1",
+        target_id="target-1",
+        is_active=True,
+        enforce_active_limit=False,
+    )
+    assert result is not None
+
+
+def test_link_user_to_target_skips_count_when_is_active_false() -> None:
+    """Deactivation never trips the cap — we're removing an active
+    target, not adding one.
+    """
+    supabase = MagicMock()
+    supabase.table.return_value.upsert.return_value.execute.return_value.data = [
+        _user_target_row(is_active=False)
+    ]
+
+    result = crud.link_user_to_target(
+        supabase, user_id="user-1", target_id="target-1", is_active=False
+    )
+
+    assert result.is_active is False
+    # The "existing row" / "count" reads never happened — only the
+    # upsert. (Verified by checking that .select() wasn't called.)
+    supabase.table.return_value.select.assert_not_called()
+
+
+def test_count_active_for_user_uses_exact_count_head() -> None:
+    """``count_active_for_user`` only needs a row count, not the rows
+    themselves — verify it asks Supabase for ``count='exact'`` with a
+    ``limit(1)`` so we don't ship a payload we don't use.
+    """
+    supabase = MagicMock()
+    chain = supabase.table.return_value.select.return_value.eq.return_value.eq.return_value.limit.return_value.execute
+    chain.return_value.count = 3
+
+    n = crud.count_active_for_user(supabase, "user-1")
+
+    assert n == 3
+    select_args = supabase.table.return_value.select.call_args
+    # First positional arg or 'count' kwarg should signal exact-count semantics.
+    assert select_args.kwargs.get("count") == "exact"


### PR DESCRIPTION
## Summary

Backend enforcement of the 5-active-target cap discussed in tonight's relevance-redesign session. Frontend deactivate-picker UI follows separately.

## Why the cap

- LLM scoring cost (Phase 1 + Phase 2 once the redesign lands) scales with \`active_targets × jobs\`. 5 active × 8k jobs caps a user's monthly LLM spend at a tractable number.
- More importantly: >5 active targets = scattered attention. The UX argument is bigger than the cost one.
- **Inactive targets are NOT counted** — users can keep arbitrarily many as "saved searches" they cycle between.

## Behavior

| Scenario | Result |
|---|---|
| Activate when under cap | ✅ succeeds |
| Activate a NEW target when at cap | ❌ 409 \`ACTIVE_LIMIT\`; upsert never fires |
| Re-link an already-active target at cap (e.g., refreshing \`fit_score\`) | ✅ succeeds (no net change) |
| Deactivate | ✅ always allowed (frees a slot) |
| Internal caller with \`enforce_active_limit=False\` | ✅ bypasses cap (future backfill scripts) |

## Routes affected (raise 409 at cap)

- \`POST /targets/{id}/activate\`
- \`POST /targets/{id}/link\`
- \`POST /targets/from-input\` (the activate side after target creation)

Frontend reads \`error: "ACTIVE_LIMIT"\` from the 409 body to branch the UX.

## Race condition note

Two concurrent activates can both pass the count check and both succeed, exceeding the cap by 1. App-level check, not a DB constraint. Acceptable now (rare, low blast radius); a partial unique index or CHECK trigger is the real fix once we see this matter.

## Tests (6 new in \`test_targets_user_links.py\`)

- Under the limit: link succeeds.
- At the limit + new target: link raises \`ActiveTargetLimitError\`; upsert never fires.
- At the limit + re-upserting an already-active row: succeeds (idempotent path).
- \`enforce_active_limit=False\`: bypasses cap.
- \`is_active=False\`: skips count check entirely.
- \`count_active_for_user\` uses \`count='exact'\` + \`limit(1)\` (header-only count, no payload).

## Verification

- ruff: clean
- mypy strict: clean (124 source files)
- pytest: 994 passed (988 + 6 new)

## Test plan

- [ ] CI green
- [ ] After merge: activate 5 targets, try a 6th → 409 with structured error body
- [ ] At the cap, deactivate one + activate another → succeeds
- [ ] At the cap, hit \`/targets/{id}/link\` for an already-active target (e.g., from a fit-score refresh path) → succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)