### PR TITLE
feat(wyrdfold-api): auto-generate few-shot title pools at target creation

### DIFF
--- a/apps/wyrdfold-api/app/models/targets.py
+++ b/apps/wyrdfold-api/app/models/targets.py
@@ -76,6 +76,12 @@ class JobTarget(BaseModel):
     # ingestion-time relevance pre-filter in the poller. Computed
     # lazily on first poll if NULL; recomputed if ``label`` changes.
     label_embedding: list[float] | None = None
+    # Few-shot title pools for the upcoming Phase 1 LLM triage. Seeded
+    # at target creation from the same LLM call that derives the
+    # scoring profile; later (Phase 1 PR) augmented from user 👍/👎
+    # feedback once enough labels accumulate per target.
+    example_promising_titles: list[str] = Field(default_factory=list)
+    example_unpromising_titles: list[str] = Field(default_factory=list)
     created_at: datetime
     updated_at: datetime
 
@@ -173,6 +179,8 @@ class TargetUpdate(BaseModel):
     activation_status: str | None = None
     is_active: bool | None = None
     profile_version: int | None = None
+    example_promising_titles: list[str] | None = None
+    example_unpromising_titles: list[str] | None = None
 
 
 class TargetFromManual(BaseModel):
@@ -222,10 +230,21 @@ class ReferenceJDAdd(BaseModel):
 
 
 class DerivedTarget(BaseModel):
-    """LLM output: scoring profile + search keywords derived from a target."""
+    """LLM output: scoring profile + search keywords + few-shot title
+    pools derived from a target.
+
+    The example_*_titles lists seed the Phase 1 binary triage prompt:
+    promising = positive few-shot anchors, unpromising = negative
+    anchors. Both default to empty so legacy LLM outputs that pre-date
+    the prompt extension still validate cleanly (the Phase 1 grader
+    treats empty lists as "no examples available" and degrades to
+    label-only grading).
+    """
 
     scoring_profile: ScoringProfile
     search_keywords: list[str] = Field(default_factory=list)
+    example_promising_titles: list[str] = Field(default_factory=list)
+    example_unpromising_titles: list[str] = Field(default_factory=list)
 
 
 class TargetSuggestion(BaseModel):

--- a/apps/wyrdfold-api/app/routers/targets.py
+++ b/apps/wyrdfold-api/app/routers/targets.py
@@ -166,6 +166,8 @@ async def _activate_pipeline(
                 TargetUpdate(
                     scoring_profile=derived.scoring_profile,
                     search_keywords=derived.search_keywords,
+                    example_promising_titles=derived.example_promising_titles,
+                    example_unpromising_titles=derived.example_unpromising_titles,
                 ),
             )
             if updated is None:
@@ -558,6 +560,8 @@ async def derive_target_profile(
         TargetUpdate(
             scoring_profile=derived.scoring_profile,
             search_keywords=derived.search_keywords,
+            example_promising_titles=derived.example_promising_titles,
+            example_unpromising_titles=derived.example_unpromising_titles,
             profile_version=target.profile_version + 1,
         ),
     )
@@ -708,6 +712,8 @@ async def create_target_from_posting(
                 TargetUpdate(
                     scoring_profile=derived.scoring_profile,
                     search_keywords=derived.search_keywords,
+                    example_promising_titles=derived.example_promising_titles,
+                    example_unpromising_titles=derived.example_unpromising_titles,
                 ),
             )
         except Exception:
@@ -890,13 +896,18 @@ async def add_reference_jd(
     all_ref_jds = crud.list_reference_jds(supabase, target_id)
     composite = merge_profiles([jd.extracted_profile for jd in all_ref_jds])
 
-    # Update target with merged profile + search keywords, bump version for re-scoring
+    # Update target with merged profile + search keywords, bump version for re-scoring.
+    # Example title pools come from the LATEST JD only — these are concrete
+    # examples not weighted aggregates, and merging across JDs would dilute
+    # the few-shot signal. The latest JD overwrites; pools stay coherent.
     updated = crud.update(
         supabase,
         target_id,
         TargetUpdate(
             scoring_profile=composite,
             search_keywords=derived.search_keywords,
+            example_promising_titles=derived.example_promising_titles,
+            example_unpromising_titles=derived.example_unpromising_titles,
             profile_version=target.profile_version + 1,
         ),
     )

--- a/apps/wyrdfold-api/app/services/targets/crud.py
+++ b/apps/wyrdfold-api/app/services/targets/crud.py
@@ -53,6 +53,8 @@ def _parse_target(row: dict[str, Any]) -> JobTarget:
         profile_version=row.get("profile_version", 1),
         is_active=row["is_active"],
         label_embedding=embedding,
+        example_promising_titles=row.get("example_promising_titles") or [],
+        example_unpromising_titles=row.get("example_unpromising_titles") or [],
         created_at=row["created_at"],
         updated_at=row["updated_at"],
     )
@@ -157,6 +159,10 @@ def update(
         updates["is_active"] = payload.is_active
     if payload.profile_version is not None:
         updates["profile_version"] = payload.profile_version
+    if payload.example_promising_titles is not None:
+        updates["example_promising_titles"] = payload.example_promising_titles
+    if payload.example_unpromising_titles is not None:
+        updates["example_unpromising_titles"] = payload.example_unpromising_titles
 
     resp = (
         supabase.table(TARGETS_TABLE).update(updates).eq("id", target_id).execute()

--- a/apps/wyrdfold-api/app/services/targets/derive_profile.py
+++ b/apps/wyrdfold-api/app/services/targets/derive_profile.py
@@ -55,6 +55,22 @@ extract a scoring profile and search keywords as JSON matching this exact schema
     "front-end engineer",
     "ui engineer",
     "react developer"
+  ],
+  "example_promising_titles": [
+    "Senior Frontend Engineer",
+    "Staff Web Engineer",
+    "Principal Frontend Engineer",
+    "Senior UI Engineer",
+    "Staff Full-Stack Engineer",
+    "Frontend Platform Engineer"
+  ],
+  "example_unpromising_titles": [
+    "Senior Product Designer",
+    "Product Marketing Manager",
+    "Data Scientist",
+    "Security Engineer",
+    "Customer Success Manager",
+    "Backend Engineer"
   ]
 }
 
@@ -79,6 +95,24 @@ Rules for search_keywords:
 - These are used for substring matching against job titles, so be broad.
 - Do NOT include technology names — only role titles.
 - Do NOT include seniority prefixes — the system handles seniority separately.
+
+Rules for example_promising_titles:
+- 6-10 concrete, properly-cased job titles that match the role this JD \
+describes. Include realistic seniority prefixes (Senior, Staff, Principal) \
+— these are full titles a hiring page would post.
+- Span the range of acceptable seniorities. If this JD is a staff role, \
+include senior + staff + principal variants — same career direction.
+- Include close-adjacent role variants the user would still pursue.
+- These become POSITIVE few-shot anchors for a downstream binary \
+classifier that gates which new postings to score deeply.
+
+Rules for example_unpromising_titles:
+- 6-10 concrete job titles that look adjacent but are NOT what this JD \
+is about. Same seniority, different role function — the hard cases.
+- Avoid obvious negatives. Pick close-but-wrong roles that share \
+keywords (TypeScript, accessibility, design system, cross-functional) \
+but a different ROLE FUNCTION.
+- These become NEGATIVE few-shot anchors.
 
 Return ONLY the JSON object. No prose, no markdown, no code fences."""
 

--- a/apps/wyrdfold-api/app/services/targets/derive_profile_from_label.py
+++ b/apps/wyrdfold-api/app/services/targets/derive_profile_from_label.py
@@ -65,6 +65,26 @@ Return JSON matching this exact schema:
     "react developer",
     "frontend developer",
     "web developer"
+  ],
+  "example_promising_titles": [
+    "Senior Frontend Engineer",
+    "Staff Web Engineer",
+    "Principal Frontend Engineer",
+    "Senior UI Engineer",
+    "Staff Full-Stack Engineer",
+    "Frontend Platform Engineer",
+    "Senior React Engineer",
+    "Web Platform Engineer"
+  ],
+  "example_unpromising_titles": [
+    "Senior Product Designer",
+    "Product Marketing Manager",
+    "Data Scientist",
+    "Security Engineer",
+    "Customer Success Manager",
+    "Sales Development Representative",
+    "Backend Engineer",
+    "Mobile Engineer"
   ]
 }
 
@@ -94,6 +114,35 @@ career pages, so be broad: include both formal and informal variations.
 - Do NOT include technology names — only role titles.
 - Do NOT include seniority prefixes (no "senior", "staff", "lead") — \
 the system handles seniority matching separately.
+
+Rules for example_promising_titles:
+- 6-10 concrete, properly-cased job titles a user pursuing this target \
+would consider strong matches. Include realistic seniority prefixes \
+(Senior, Staff, Principal) — these are full titles a hiring page would \
+post, not search keywords.
+- Span the range of acceptable seniorities for the target. If the \
+target is a senior+ role, include staff/principal variants too — same \
+career direction, slightly different rung.
+- Include close-adjacent role variants the user would still pursue \
+(e.g., for a Frontend Engineer target: also "Full-Stack Engineer", \
+"Web Platform Engineer").
+- These titles become POSITIVE few-shot anchors for a downstream binary \
+classifier that decides which new job postings to evaluate deeply, so \
+choose titles whose meaning is unambiguous.
+
+Rules for example_unpromising_titles:
+- 6-10 concrete job titles that look adjacent but are NOT what the user \
+wants. The harder cases — same seniority, same company-type, different \
+role function — are the most valuable.
+- Examples for a Frontend Engineer target: "Senior Product Designer", \
+"Product Marketing Manager", "Data Scientist", "Sales Engineer". These \
+share keywords (TypeScript, accessibility, design system) but the \
+ROLE itself is different.
+- Avoid obvious negatives ("Nurse", "Truck Driver") — those waste prompt \
+space. Pick close-but-wrong roles that the keyword scorer alone would \
+admit on incidental matches.
+- These become NEGATIVE few-shot anchors. Be precise about role \
+function, not technology overlap.
 
 Return ONLY the JSON object. No prose, no markdown, no code fences."""
 

--- a/apps/wyrdfold-api/tests/test_targets_models.py
+++ b/apps/wyrdfold-api/tests/test_targets_models.py
@@ -127,3 +127,95 @@ def test_target_reference_jd_from_dict():
     }
     jd = TargetReferenceJD.model_validate(raw)
     assert jd.extracted_profile.categories["core_skills"].keywords["React"] == 3
+
+
+# ---- Example title pools (Phase 1 LLM triage seed) ------------------------
+
+
+def test_job_target_defaults_example_title_pools_to_empty():
+    """Targets created before the Phase 1 LLM triage migration have NULL
+    columns in the DB → JobTarget should fall back to empty lists so
+    the Phase 1 grader can run "no examples available" path cleanly.
+    """
+    raw = {
+        "id": "t-1",
+        "label": "Director of CX Operations",
+        "scoring_profile": {"categories": {}},
+        "is_active": True,
+        "created_at": "2026-06-01T00:00:00Z",
+        "updated_at": "2026-06-01T00:00:00Z",
+        # NO example_promising_titles, NO example_unpromising_titles.
+    }
+    t = JobTarget.model_validate(raw)
+    assert t.example_promising_titles == []
+    assert t.example_unpromising_titles == []
+
+
+def test_job_target_round_trips_example_title_pools():
+    raw = {
+        "id": "t-1",
+        "label": "Director of CX Operations",
+        "scoring_profile": {"categories": {}},
+        "is_active": True,
+        "created_at": "2026-06-01T00:00:00Z",
+        "updated_at": "2026-06-01T00:00:00Z",
+        "example_promising_titles": [
+            "Director of Customer Success",
+            "Head of CS Operations",
+            "VP Customer Experience",
+        ],
+        "example_unpromising_titles": [
+            "Director of Sales Operations",
+            "Marketing Director",
+        ],
+    }
+    t = JobTarget.model_validate(raw)
+    assert "Director of Customer Success" in t.example_promising_titles
+    assert "Marketing Director" in t.example_unpromising_titles
+
+
+def test_derived_target_defaults_example_title_pools_to_empty():
+    """The LLM-output schema: legacy outputs that pre-date the prompt
+    extension still validate (fields default to empty lists). Phase 1
+    treats empty pools as "fall back to label-only grading"."""
+    from app.models.targets import DerivedTarget
+
+    raw = {
+        "scoring_profile": {"categories": {}},
+        "search_keywords": ["frontend engineer"],
+    }
+    d = DerivedTarget.model_validate(raw)
+    assert d.example_promising_titles == []
+    assert d.example_unpromising_titles == []
+
+
+def test_derived_target_with_example_title_pools():
+    from app.models.targets import DerivedTarget
+
+    raw = {
+        "scoring_profile": {"categories": {}},
+        "search_keywords": ["frontend engineer"],
+        "example_promising_titles": ["Senior Frontend Engineer", "Staff Web Engineer"],
+        "example_unpromising_titles": ["Senior Product Designer"],
+    }
+    d = DerivedTarget.model_validate(raw)
+    assert len(d.example_promising_titles) == 2
+    assert d.example_unpromising_titles == ["Senior Product Designer"]
+
+
+def test_target_update_passes_through_example_title_pools():
+    """``TargetUpdate`` must carry the new fields through so derive →
+    update flows can persist them. Both fields are ``None`` by default
+    so unrelated updates don't accidentally null out the pool."""
+    from app.models.targets import TargetUpdate
+
+    upd = TargetUpdate(
+        example_promising_titles=["Senior Frontend Engineer"],
+        example_unpromising_titles=["Senior Product Designer"],
+    )
+    assert upd.example_promising_titles == ["Senior Frontend Engineer"]
+    assert upd.example_unpromising_titles == ["Senior Product Designer"]
+    # Unrelated update: pools stay None (= "don't touch").
+    upd2 = TargetUpdate(label="Renamed Target")
+    assert upd2.example_promising_titles is None
+    assert upd2.example_unpromising_titles is None

--- a/supabase/migrations/20260603010000_target_example_title_pools.sql
+++ b/supabase/migrations/20260603010000_target_example_title_pools.sql
@@ -1,0 +1,30 @@
+-- Few-shot example pools for the upcoming Phase 1 LLM title triage.
+--
+-- When a target is created (label-driven or JD-driven), the existing
+-- ``derive_profile_from_label`` / ``derive_profile_from_jd`` LLM call
+-- gets extended to emit two title lists alongside the scoring profile:
+--
+--   example_promising_titles   — ~8 titles the LLM considers good
+--                                matches for the target. Used as
+--                                positive few-shot examples when the
+--                                cheap Phase 1 grader decides which
+--                                new postings are worth scoring.
+--
+--   example_unpromising_titles — ~8 titles the LLM considers off-topic
+--                                for the target. Negative few-shot
+--                                examples — they sharpen the binary
+--                                gate by giving the grader explicit
+--                                "this is NOT it" anchors.
+--
+-- The pools are seeded once at target creation, persist through the
+-- target's lifetime, and (in a follow-up PR) start incorporating user
+-- thumbs-up / thumbs-down feedback once ≥5 labels per side accumulate
+-- for a given target.
+--
+-- Both columns default to an empty array so existing rows don't break
+-- and Phase 1 fail-opens cleanly (no examples → grader has only the
+-- target label, still operable).
+
+alter table public.targets
+  add column if not exists example_promising_titles text[] not null default '{}',
+  add column if not exists example_unpromising_titles text[] not null default '{}';


### PR DESCRIPTION
## Summary

Foundation for the upcoming Phase 1 LLM title triage (see \`.claude/docs/plan-llm-scoring-migration.md\`). When a target is created — either from a label or from a JD — the existing derive-profile LLM call now also emits two short title lists used as few-shot anchors:

| Field | Purpose |
|---|---|
| \`example_promising_titles\` | ~6-10 concrete titles the LLM considers strong matches. Positive anchors for the binary Phase 1 grader. |
| \`example_unpromising_titles\` | ~6-10 close-but-wrong titles (same seniority, different role function). Negative anchors. |

Phase 1 (next PR) will prompt a cheap LLM with \`target.label\` + both pools + a batch of new postings and return per-job \`is_promising: bool\`. The pools sharpen the gate without us maintaining a global role taxonomy — works for any profession.

## Files

| File | Change |
|---|---|
| Migration \`20260603010000_target_example_title_pools.sql\` | Adds two \`text[]\` columns with \`default '{}'\`, \`not null\`. |
| \`models/targets.py\` | \`JobTarget\`, \`DerivedTarget\`, \`TargetUpdate\` carry both fields. Defaults preserve forward-compat. |
| \`services/targets/crud.py\` | \`_parse_target\` reads both columns; \`update()\` writes when set. |
| \`services/targets/derive_profile_from_label.py\` | Prompt extended with schema + per-field rules. |
| \`services/targets/derive_profile.py\` | JD-based prompt extended (symmetric). |
| \`routers/targets.py\` | Three derive call sites pass pools through to \`crud.update\`. |

## Prompt design

The prompts emphasize:

- **Positive anchors**: concrete full titles a hiring page would post — with seniority prefixes ("Senior Frontend Engineer", "Staff Web Engineer"). NOT keywords. The full hiring-board form is what Phase 1 will pattern-match against.
- **Negative anchors**: close-but-wrong roles, NOT obvious negatives. The hard cases (e.g., for a Frontend target: "Senior Product Designer", "Product Marketing Manager") — roles that share tech keywords with the target but a different ROLE FUNCTION. The easy negatives ("Nurse", "Truck Driver") waste prompt space.

## Tests (5 new)

- \`JobTarget\` defaults pools to \`[]\` when columns absent (legacy rows).
- \`JobTarget\` round-trips populated pools.
- \`DerivedTarget\` defaults pools to \`[]\` (legacy LLM outputs validate).
- \`DerivedTarget\` accepts populated pools.
- \`TargetUpdate\` carries pools through; unrelated updates leave them \`None\` so they don't accidentally null the column.

## Verification

- ruff: clean
- mypy strict: clean (124 source files)
- pytest: 993 passed (988 + 5 new)

## Test plan

- [ ] CI green
- [ ] Supabase Preview applies the migration
- [ ] After merge + deploy: create a new target via \`/targets/{id}/derive-profile\` → verify the two columns are populated with 6-10 entries each
- [ ] Re-derive an existing target → pools refresh; old pools overwritten
- [ ] Inspect the LLM-generated pools for one or two real targets — sanity-check the negative anchors are "close-but-wrong" not "obvious"

## What's next

This is foundation 3/3 for the LLM scoring migration. Next PR: **Phase 1 binary title triage** — wires the cheap LLM call into the poller, uses these pools as few-shot examples, replaces the cosine prefilter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)