### PR TITLE
feat(wyrdfold-api): Phase 2 scaffold — derive_job_fit + AxisScores

### DIFF
--- a/apps/wyrdfold-api/app/services/fit/__init__.py
+++ b/apps/wyrdfold-api/app/services/fit/__init__.py
@@ -1,0 +1,30 @@
+"""Shared fit-grading primitives.
+
+Two LLM-backed grading flows share this package:
+
+- ``user_target_fit``: how well does THIS USER match THIS TARGET
+  (delegate today is ``app.services.targets.fit_score.derive_fit_score``
+  — kept where it is until we collapse the schema with job-fit in a
+  follow-up).
+- ``job_fit``: how well does THIS JOB match THIS (user, target) pair —
+  the Phase 2 scorer. Replaces the deterministic keyword pipeline as
+  the primary signal once the poller integration ships.
+
+Both produce structured scorecards on the same 0-100 scale so the UI
+can render consistent breakdowns. Phase 1 (``relevance.title_triage``)
+gates which jobs reach the Phase 2 grader at all.
+"""
+
+from app.services.fit.job_fit import (
+    JOB_FIT_PURPOSE,
+    AxisScores,
+    JobFitResult,
+    derive_job_fit,
+)
+
+__all__ = [
+    "JOB_FIT_PURPOSE",
+    "AxisScores",
+    "JobFitResult",
+    "derive_job_fit",
+]

--- a/apps/wyrdfold-api/app/services/fit/job_fit.py
+++ b/apps/wyrdfold-api/app/services/fit/job_fit.py
@@ -1,0 +1,225 @@
+"""Phase 2: per-(user, target, job) LLM fit grader.
+
+Sonnet-backed scorer that produces a 0-100 fit score plus a four-axis
+scorecard (title / skills / seniority / domain) plus a 1-2 sentence
+reasoning string. Same rubric shape as the existing
+``derive_fit_score`` (which scores user-vs-target) so the UI can render
+consistent breakdowns regardless of which scope is being shown.
+
+Phase 1 (``relevance.title_triage``) decides WHICH jobs reach this
+grader. Phase 2 decides HOW WELL each promising job actually fits;
+this output is what the user sees as the score on their /jobs page.
+
+No callsite changes in this PR — this module is the scaffold the
+follow-up poller-integration PR plugs into.
+
+Pricing context
+- Sonnet 4.6 at ~$3/1M input + ~$15/1M output.
+- Per call: ~500 input tokens (target context + user profile + JD
+  snippet) + ~150 output tokens (scorecard JSON).
+- Effective per-job cost: ~$0.0035. With Phase 1 already culling
+  ~80-90% of off-topic postings, that's ~$0.10 per poll cycle per
+  active target — sustainable.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from pydantic import BaseModel, Field
+
+from app.models.experience import OptimizedPayload
+from app.models.llm import LLMResult, Message, ModelId
+from app.models.targets import JobTarget
+from app.services.llm.client import LLMClient, complete_json
+from app.services.targets.suggest import _build_user_message as _profile_summary
+
+logger = logging.getLogger(__name__)
+
+JOB_FIT_MODEL: ModelId = "claude-sonnet-4-6"
+JOB_FIT_PURPOSE = "fit.job"
+
+# Cap the JD context we send. Most JDs are 1-5 KB of HTML stripped to
+# 500-3000 tokens; the long-tail ones (10K+ tokens) inflate cost
+# without adding signal — the relevance verdict is decided in the
+# first half. Trim to first ~2000 chars after strip-html.
+_JD_CONTEXT_CHAR_CAP = 2000
+
+
+class AxisScores(BaseModel):
+    """Per-axis breakdown of the overall fit score.
+
+    Each axis is 0-100 on the same scale as ``fit_score``. The overall
+    score is NOT a strict average — the LLM weights axes by relevance to
+    the target. For example, a "Staff Frontend Engineer" target weights
+    title + skills heavily and seniority + domain moderately; a "VP of
+    CX" target weights title + seniority heavily and skills moderately.
+    """
+
+    title_fit: int = Field(ge=0, le=100)
+    skills_fit: int = Field(ge=0, le=100)
+    seniority_fit: int = Field(ge=0, le=100)
+    domain_fit: int = Field(ge=0, le=100)
+
+
+class JobFitResult(BaseModel):
+    """LLM output: overall fit + axis breakdown + reasoning.
+
+    Phase 3 (user-triggered deep dive) emits the same shape with a
+    stronger model + full JD context, expected within ±20 points of
+    Phase 2 — that's the "variance you can trust" the user sees when
+    they click in for the deep analysis.
+    """
+
+    fit_score: int = Field(ge=0, le=100)
+    axes: AxisScores
+    reasoning: str = Field(max_length=1500)
+
+
+_SYSTEM_PROMPT = """\
+You grade how well a job posting fits a specific user pursuing a \
+specific target role. Return a 0-100 overall fit score plus per-axis \
+scores and a short reasoning string.
+
+Scoring axes (each 0-100)
+- title_fit: does the job's title match the role the user is hunting? \
+A Staff Frontend Engineer target wants Frontend / Full-Stack / Web / \
+UI / React titles. Treat adjacent IC roles (Full-Stack for Frontend) \
+generously; treat off-discipline titles (Sales, Marketing, Design for \
+an Engineer target) harshly.
+- skills_fit: does the JD's required skills overlap with the user's \
+demonstrated skills (in the user profile) AND with the target's \
+scoring profile? Reward concrete overlap; discount tech keywords that \
+are mentioned in passing.
+- seniority_fit: does the job's seniority match the target's level? \
+One rung up or down is fine; further is not.
+- domain_fit: does the company's domain / business align with what the \
+user has done before? Greater weight for targets where domain is part \
+of the user's intent (e.g., "Director of CX Operations" in a SaaS \
+context); lighter weight when the target is domain-agnostic.
+
+Overall fit_score guidance
+- 85-100: excellent across the board; title squarely matches, skills \
+overlap is strong, seniority lines up. Strong recommend.
+- 70-84: solid match with one minor gap (e.g., right title + skills, \
+seniority slightly off; or right title + seniority, missing a tech).
+- 50-69: meaningful overlap but a significant gap (different specialty \
+within the same role family; one full seniority rung off; missing a \
+core skill).
+- 30-49: same general direction but several gaps (wrong specialty, \
+weak skills overlap, off seniority).
+- 0-29: wrong role function or domain entirely. Should not have \
+reached you if Phase 1 was working — flag it loudly.
+
+Reasoning rules
+- 1-2 sentences. Lead with the strongest match dimension; close with \
+the biggest gap. Mention specific skills / titles / seniority cues — \
+no generic phrases like "good cultural fit".
+- Anchor in evidence from the JD and the user profile. Don't speculate \
+about the company or invent skills the user didn't list.
+
+Return JSON matching this exact schema:
+
+{
+  "fit_score": 82,
+  "axes": {
+    "title_fit": 95,
+    "skills_fit": 80,
+    "seniority_fit": 85,
+    "domain_fit": 70
+  },
+  "reasoning": "Title and seniority squarely match a Staff Frontend role; \
+React/TypeScript/Storybook all present in your profile. Missing the \
+e-commerce domain experience the JD emphasises."
+}
+
+Return ONLY the JSON object. No prose, no markdown, no code fences."""
+
+
+def _build_user_message(
+    *,
+    payload: OptimizedPayload,
+    target: JobTarget,
+    job_title: str,
+    jd_text: str,
+) -> str:
+    """Compose the per-call user message.
+
+    Order matters for prompt caching: stable per-(user, target) context
+    first, variable per-job context last. The static system prompt sits
+    above this entirely.
+    """
+    parts: list[str] = []
+
+    # User profile summary — reuses the same serializer the
+    # target-suggest flow uses so the prompt sees a consistent shape.
+    parts.append("## User profile")
+    parts.append(_profile_summary(payload))
+
+    # Target context.
+    target_lines = [f"## Target: {target.label}"]
+    if target.description:
+        target_lines.append(target.description)
+
+    profile = target.scoring_profile
+    if profile.seniority.level:
+        target_lines.append(f"Seniority level: {profile.seniority.level}")
+    if profile.categories:
+        for cat_name, cat in profile.categories.items():
+            if cat.keywords:
+                top_kws = list(cat.keywords.keys())[:10]
+                target_lines.append(
+                    f"{cat_name} (weight {cat.weight}x): {', '.join(top_kws)}"
+                )
+    if profile.domain.signals:
+        target_lines.append(f"Domain signals: {', '.join(profile.domain.signals)}")
+    if profile.negative.keywords:
+        target_lines.append(
+            f"Negative keywords: {', '.join(profile.negative.keywords)}"
+        )
+    parts.append("\n".join(target_lines))
+
+    # Job posting (last — cache-unfriendly, varies per call).
+    jd_snippet = jd_text[:_JD_CONTEXT_CHAR_CAP]
+    if len(jd_text) > _JD_CONTEXT_CHAR_CAP:
+        jd_snippet += " [truncated]"
+    parts.append(f"## Job posting\n**Title:** {job_title}\n\n{jd_snippet}")
+
+    return "\n\n".join(parts)
+
+
+async def derive_job_fit(
+    llm: LLMClient,
+    *,
+    payload: OptimizedPayload,
+    target: JobTarget,
+    job_title: str,
+    jd_text: str,
+    model: ModelId = JOB_FIT_MODEL,
+    purpose: str = JOB_FIT_PURPOSE,
+) -> tuple[JobFitResult, LLMResult]:
+    """Grade a single (user, target, job) tuple.
+
+    Returns ``(fit_result, llm_result)`` so callers can log cost.
+    Errors propagate (unlike Phase 1's fail-open semantics) — the
+    poller catches them and falls back to ``promising=True, score=None``
+    so the UI shows a "Pending" badge instead of grinding to a halt.
+
+    Caller is responsible for batching / rate-limiting; this is one
+    call per (job, target). The progressive batching policy (first 20
+    eagerly, rest in 50-chunk background batches) lives in the poller.
+    """
+    user_message = _build_user_message(
+        payload=payload, target=target, job_title=job_title, jd_text=jd_text
+    )
+
+    return await complete_json(
+        llm,
+        model=model,
+        system=_SYSTEM_PROMPT,
+        messages=[Message(role="user", content=user_message)],
+        schema=JobFitResult,
+        purpose=purpose,
+        max_tokens=512,
+        cache_system=True,
+    )

--- a/apps/wyrdfold-api/tests/test_fit_job_fit.py
+++ b/apps/wyrdfold-api/tests/test_fit_job_fit.py
@@ -1,0 +1,190 @@
+"""Tests for the Phase 2 derive_job_fit scaffold.
+
+Schema-level tests (no LLM): the JobFitResult / AxisScores bounds and
+the user-message builder. The integration of derive_job_fit into the
+poller's Stage 2 lands in a follow-up; tests there mock the LLM.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from pydantic import ValidationError
+
+from app.models.experience import OptimizedPayload, Role, Skill
+from app.models.targets import (
+    CategoryProfile,
+    DomainProfile,
+    JobTarget,
+    NegativeProfile,
+    ScoringProfile,
+    SeniorityProfile,
+)
+from app.services.fit.job_fit import (
+    AxisScores,
+    JobFitResult,
+    _build_user_message,
+)
+
+
+def _payload() -> OptimizedPayload:
+    return OptimizedPayload(
+        summary="Senior frontend engineer with 8+ years at SaaS startups.",
+        roles=[
+            Role(
+                id="r-1",
+                title="Senior Frontend Engineer",
+                company="Acme",
+                start="2022",
+                end=None,
+                skills=["React", "TypeScript", "Webpack"],
+            ),
+        ],
+        skills=[
+            Skill(name="React", years=8),
+            Skill(name="TypeScript", years=6),
+        ],
+        outcomes=[],
+    )
+
+
+def _target() -> JobTarget:
+    return JobTarget(
+        id="t-1",
+        label="Staff Frontend Engineer",
+        description="Web platform leadership at a consumer SaaS.",
+        scoring_profile=ScoringProfile(
+            categories={
+                "core_skills": CategoryProfile(
+                    keywords={"React": 3, "TypeScript": 3, "Webpack": 2},
+                    weight=2.0,
+                ),
+            },
+            seniority=SeniorityProfile(level="staff", signals=["8+ years", "mentor"]),
+            domain=DomainProfile(signals=["saas", "consumer"], weight=0.5),
+            negative=NegativeProfile(keywords=["junior", "intern"], weight=-10.0),
+        ),
+        is_active=True,
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
+    )
+
+
+# ---- AxisScores / JobFitResult schema -------------------------------------
+
+
+class TestSchemas:
+    def test_axis_scores_bounds(self) -> None:
+        AxisScores(title_fit=0, skills_fit=0, seniority_fit=0, domain_fit=0)
+        AxisScores(title_fit=100, skills_fit=100, seniority_fit=100, domain_fit=100)
+        with pytest.raises(ValidationError):
+            AxisScores(title_fit=-1, skills_fit=50, seniority_fit=50, domain_fit=50)
+        with pytest.raises(ValidationError):
+            AxisScores(title_fit=101, skills_fit=50, seniority_fit=50, domain_fit=50)
+
+    def test_job_fit_result_round_trip(self) -> None:
+        result = JobFitResult(
+            fit_score=82,
+            axes=AxisScores(
+                title_fit=95, skills_fit=80, seniority_fit=85, domain_fit=70
+            ),
+            reasoning="Title squarely matches; missing e-commerce domain.",
+        )
+        # Round-trip preserves both the overall score and the axes.
+        dumped = result.model_dump()
+        re = JobFitResult.model_validate(dumped)
+        assert re.fit_score == 82
+        assert re.axes.title_fit == 95
+        assert re.reasoning.startswith("Title squarely")
+
+    def test_job_fit_result_rejects_oversized_reasoning(self) -> None:
+        # Mirror the 1500-char cap on the existing target-level
+        # FitScoreResult — keeps the UI's reasoning block bounded.
+        with pytest.raises(ValidationError):
+            JobFitResult(
+                fit_score=50,
+                axes=AxisScores(
+                    title_fit=50, skills_fit=50, seniority_fit=50, domain_fit=50
+                ),
+                reasoning="x" * 1501,
+            )
+
+    def test_job_fit_result_requires_axes(self) -> None:
+        # Unlike the legacy FitScoreResult (no axes), the new shape
+        # makes axes mandatory — every Phase 2 grade carries the
+        # breakdown so the UI can render it.
+        with pytest.raises(ValidationError):
+            JobFitResult.model_validate({"fit_score": 50, "reasoning": "ok"})
+
+
+# ---- _build_user_message -------------------------------------------------
+
+
+class TestBuildUserMessage:
+    def test_includes_user_profile_section(self) -> None:
+        msg = _build_user_message(
+            payload=_payload(),
+            target=_target(),
+            job_title="Senior Frontend Engineer",
+            jd_text="<p>React shop.</p>",
+        )
+        assert "## User profile" in msg
+        # The profile serializer surfaces summary + roles + skills.
+        assert "8+ years" in msg
+        assert "React" in msg
+
+    def test_includes_target_section_with_keywords(self) -> None:
+        msg = _build_user_message(
+            payload=_payload(),
+            target=_target(),
+            job_title="Senior Frontend Engineer",
+            jd_text="<p>React shop.</p>",
+        )
+        assert "## Target: Staff Frontend Engineer" in msg
+        # Core keywords surface; seniority + domain + negatives too.
+        assert "core_skills" in msg
+        assert "staff" in msg
+        assert "saas" in msg
+        assert "junior" in msg
+
+    def test_includes_job_posting_section_last(self) -> None:
+        msg = _build_user_message(
+            payload=_payload(),
+            target=_target(),
+            job_title="Senior Frontend Engineer",
+            jd_text="We need a Frontend engineer for our React stack.",
+        )
+        # Job section is the cache-unfriendly tail — should appear after
+        # both the user and target sections. Order matters for prompt
+        # caching to hit on the per-(user, target) prefix.
+        user_idx = msg.index("## User profile")
+        target_idx = msg.index("## Target")
+        job_idx = msg.index("## Job posting")
+        assert user_idx < target_idx < job_idx
+
+    def test_truncates_long_jd_with_marker(self) -> None:
+        long_jd = "A" * 5000
+        msg = _build_user_message(
+            payload=_payload(),
+            target=_target(),
+            job_title="x",
+            jd_text=long_jd,
+        )
+        # Long JDs are capped and tagged so a downstream reviewer can
+        # tell the model saw a trimmed copy.
+        assert "[truncated]" in msg
+        # Sanity-check the cap is roughly in the expected range
+        # (~2000 chars + envelope). Not asserting an exact number
+        # because the envelope evolves.
+        assert len(msg) < 6000
+
+    def test_does_not_truncate_short_jd(self) -> None:
+        msg = _build_user_message(
+            payload=_payload(),
+            target=_target(),
+            job_title="x",
+            jd_text="Short JD body.",
+        )
+        assert "[truncated]" not in msg
+        assert "Short JD body." in msg


### PR DESCRIPTION
## Summary

Phase 2 LLM scorer scaffold. Additive only — adds the function + schema; no callsite changes. The integration PR plugs this into the poller's Stage 2 next.

This is the second half of the LLM scoring migration from \`.claude/docs/plan-llm-scoring-migration.md\`. Phase 1 (PR #790, awaiting merge) gates which jobs reach this grader; Phase 2 decides how well each promising job actually fits.

## Module

\`\`\`
app/services/fit/
  __init__.py      # re-exports
  job_fit.py       # derive_job_fit, JobFitResult, AxisScores
\`\`\`

\`derive_job_fit(llm, payload, target, job_title, jd_text) -> (JobFitResult, LLMResult)\` — Sonnet 4.6-backed, schema-validated, prompt-cached system message.

## Schema

| Field | Type | Notes |
|---|---|---|
| \`fit_score\` | \`int 0-100\` | Overall — NOT a strict axis average; the LLM weights axes by target relevance |
| \`axes.title_fit\` | \`int 0-100\` | Required |
| \`axes.skills_fit\` | \`int 0-100\` | Required |
| \`axes.seniority_fit\` | \`int 0-100\` | Required |
| \`axes.domain_fit\` | \`int 0-100\` | Required |
| \`reasoning\` | \`str ≤1500 chars\` | 1-2 sentences, anchored in evidence |

Phase 3 (deep dive) will return the same shape with a stronger model + full JD, giving the user the "±20 variance you can trust" they expected from the design discussion.

## Prompt design

- **System**: per-axis grading rules + overall fit_score bands (85+ excellent / 70-84 solid / 50-69 meaningful / 30-49 weak / 0-29 wrong). Cached.
- **User message order**: user profile → target context → job posting last. Stable per-(user, target) prefix sits ahead of the variable per-job tail so prompt caching hits across batches of the same target.
- **JD truncation**: ~2000 chars + \`[truncated]\` marker. Long-tail 10K-token JDs inflate cost without adding signal.

## Cost

- Sonnet 4.6: ~\$3/1M input + ~\$15/1M output
- ~500 input + ~150 output tokens per call → ~\$0.0035 per (job, target)
- With Phase 1 culling 80-90% of off-topic postings, ~\$0.10 per poll cycle per active target

## Tests (9 new)

- AxisScores bounds: 0/100 ok, -1/101 rejected
- JobFitResult round-trip preserves score + axes + reasoning
- JobFitResult rejects >1500 char reasoning
- JobFitResult requires axes (the legacy target-level shape didn't)
- \`_build_user_message\` includes profile + target sections (with seniority/keywords/domain/negatives)
- Job posting section is LAST (prompt-cache friendly)
- Long JD truncates with marker
- Short JD passes through verbatim

## Verification

- ruff: clean
- mypy strict: clean (126 source files)
- pytest: 1010 passed (1001 baseline post-#790-merge equivalent + 9 new)

## What's next

- **Poller integration**: \`_full_score_one\` calls \`derive_job_fit\` for each promising job. Replaces the keyword scorer call. Same \`promising\` and \`excluded_by_prefilter\` plumbing as #790 set up.
- **Progressive batching**: first 20 promising eagerly per target (user gets first page fast), rest in 50-chunk background batches. Per the user's instruction in the design chat.
- **Per-target daily cap**: top 100 promising automatic, rest on-demand when user clicks (deferred score for those rows).
- **Backfill script**: once Phase 2 is live, retro-score existing \`promising=true\` rows.

## Test plan

- [ ] CI green
- [ ] After merge: ad-hoc-call \`derive_job_fit\` against one of Daniel's targets + one of Melissa's targets with a few sample jobs (good fit, bad fit, edge cases) and eyeball the scorecard — sanity-check the rubric before wiring into the poller

🤖 Generated with [Claude Code](https://claude.com/claude-code)