### PR TITLE
feat(wyrdfold-api): Phase 2 infrastructure — daily cap + score persistence

### DIFF
--- a/apps/wyrdfold-api/app/services/fit/__init__.py
+++ b/apps/wyrdfold-api/app/services/fit/__init__.py
@@ -15,16 +15,24 @@ can render consistent breakdowns. Phase 1 (``relevance.title_triage``)
 gates which jobs reach the Phase 2 grader at all.
 """
 
+from app.services.fit.daily_cap import (
+    DEFAULT_DAILY_CAP,
+    phase2_quota_remaining,
+)
 from app.services.fit.job_fit import (
     JOB_FIT_PURPOSE,
     AxisScores,
     JobFitResult,
     derive_job_fit,
 )
+from app.services.fit.score_persistence import score_with_phase2_and_persist
 
 __all__ = [
+    "DEFAULT_DAILY_CAP",
     "JOB_FIT_PURPOSE",
     "AxisScores",
     "JobFitResult",
     "derive_job_fit",
+    "phase2_quota_remaining",
+    "score_with_phase2_and_persist",
 ]

--- a/apps/wyrdfold-api/app/services/fit/daily_cap.py
+++ b/apps/wyrdfold-api/app/services/fit/daily_cap.py
@@ -1,0 +1,77 @@
+"""Per-target daily cap on Phase 2 LLM calls.
+
+Phase 2 (Sonnet at ~$0.0035 per call) is the dominant cost line in the
+LLM scoring pipeline. With 5 active targets × ~100 promising jobs per
+poll cycle × ~12 polls/day, an uncapped Phase 2 would burn ~$21/day
+worst case. The cap holds each active target to a sustainable daily
+budget; rows that don't fit stay ``promising=true, score=NULL`` and
+either get scored on the next day's quota or on user click-through.
+
+The counter sources its truth from ``llm_costs`` so we don't need a
+separate counter table — every Phase 2 call already writes a row
+there with ``purpose='fit.job'`` + ``metadata.target_id``. UTC midnight
+is the rollover.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime, time
+
+from supabase import Client
+
+from app.services.fit.job_fit import JOB_FIT_PURPOSE
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_DAILY_CAP = 100
+"""Default per-target Phase 2 quota per UTC day.
+
+Tuned for: 5 active targets * 100 calls/day * $0.0035 = ~$1.75/day
+ceiling on Phase 2 spend across the system. Per-target quota matches
+"first page renders fast + rest defer" semantics — the user always
+gets some fresh Phase 2 grades, even when a high-volume poll cycle
+would otherwise blow the entire budget on one target.
+"""
+
+
+def _utc_day_start() -> str:
+    """ISO-8601 UTC midnight of today."""
+    return datetime.combine(
+        datetime.now(UTC).date(), time.min, tzinfo=UTC
+    ).isoformat()
+
+
+def phase2_quota_remaining(
+    supabase: Client,
+    target_id: str,
+    cap: int = DEFAULT_DAILY_CAP,
+) -> int:
+    """Return how many more Phase 2 calls this target can issue today.
+
+    Counts ``llm_costs`` entries with ``purpose='fit.job'`` and
+    ``metadata.target_id`` matching, since UTC midnight. Returns
+    ``max(0, cap - used)``.
+
+    On any DB error returns ``0`` (refuse to spend rather than risk
+    blowing past the cap). Logged so an operator sees the refusal.
+    """
+    try:
+        resp = (
+            supabase.table("llm_costs")
+            .select("id", count="exact")  # type: ignore[arg-type]
+            .eq("purpose", JOB_FIT_PURPOSE)
+            .eq("metadata->>target_id", target_id)
+            .gte("created_at", _utc_day_start())
+            .limit(1)
+            .execute()
+        )
+    except Exception:
+        logger.exception(
+            "phase2_quota_remaining: count failed for target %s; "
+            "refusing to spend",
+            target_id,
+        )
+        return 0
+    used = resp.count or 0
+    return max(0, cap - used)

--- a/apps/wyrdfold-api/app/services/fit/score_persistence.py
+++ b/apps/wyrdfold-api/app/services/fit/score_persistence.py
@@ -1,0 +1,119 @@
+"""Phase 2 scorer + persistence helper.
+
+Wraps ``derive_job_fit`` (PR #791) with the bits the poller integration
+will need:
+
+- Cost logging via ``llm_costs`` (so ``phase2_quota_remaining`` can see
+  the spend).
+- Persistence to ``scores`` (score / axis_scores / fit_reasoning) via
+  UPDATE on the existing (job_posting_id, target_id) row.
+- Fail-safe: any LLM or DB error returns ``None`` and the existing
+  scores row is left untouched (the row stays "Phase 2 pending" and
+  retries on the next poll).
+
+Doesn't enforce the daily cap itself — the caller (poller) consults
+``daily_cap.phase2_quota_remaining`` before invoking this. Keeps the
+helper composable for non-poller call sites (on-demand grading from
+the UI, retro-backfill scripts).
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+
+from supabase import Client
+
+from app.models.experience import OptimizedPayload
+from app.models.targets import JobTarget
+from app.services.fit.job_fit import JOB_FIT_PURPOSE, JobFitResult, derive_job_fit
+from app.services.llm.client import LLMClient
+from app.services.llm.cost_log import record as record_llm_cost
+
+logger = logging.getLogger(__name__)
+
+
+async def score_with_phase2_and_persist(
+    supabase: Client,
+    llm: LLMClient,
+    *,
+    payload: OptimizedPayload,
+    target: JobTarget,
+    job_posting_id: str,
+    title: str,
+    jd_text: str,
+    user_id: str | None = None,
+) -> JobFitResult | None:
+    """Call Phase 2 grader, persist the result on the scores row.
+
+    Returns the ``JobFitResult`` on success; ``None`` on LLM error or
+    persistence error. The poller treats ``None`` as "row stays as-is"
+    — the existing scores row (with whatever score the keyword pipeline
+    set) keeps its value. A retry happens on the next poll cycle.
+
+    Updates the scores row identified by ``(job_posting_id, target_id)``.
+    Caller is expected to have already created the row (via Phase 1 or
+    keyword Stage 1/2); Phase 2 only ever UPDATES.
+
+    Pass ``user_id`` for cost-log attribution. ``None`` is fine for
+    system-driven invocations (poll cycles); on-demand calls from the
+    UI should pass the requesting user's id so per-user spend audits
+    work.
+    """
+    try:
+        fit, llm_result = await derive_job_fit(
+            llm,
+            payload=payload,
+            target=target,
+            job_title=title,
+            jd_text=jd_text,
+        )
+    except Exception:
+        logger.exception(
+            "Phase 2 derive_job_fit failed for job %s / target %s",
+            job_posting_id,
+            target.id,
+        )
+        return None
+
+    # Log cost BEFORE the DB update so quota counting stays accurate
+    # even if the persistence step fails (we did spend the tokens).
+    try:
+        record_llm_cost(
+            supabase,
+            user_id=user_id,
+            purpose=JOB_FIT_PURPOSE,
+            result=llm_result,
+            metadata={
+                "target_id": target.id,
+                "job_posting_id": job_posting_id,
+            },
+        )
+    except Exception:
+        logger.exception(
+            "Phase 2 cost log failed for job %s / target %s",
+            job_posting_id,
+            target.id,
+        )
+
+    try:
+        supabase.table("scores").update(
+            {
+                "score": fit.fit_score,
+                "axis_scores": fit.axes.model_dump(),
+                "fit_reasoning": fit.reasoning,
+                "scoring_status": "complete",
+                "updated_at": datetime.now(UTC).isoformat(),
+            }
+        ).eq("job_posting_id", job_posting_id).eq(
+            "target_id", target.id
+        ).execute()
+    except Exception:
+        logger.exception(
+            "Phase 2 persist failed for job %s / target %s",
+            job_posting_id,
+            target.id,
+        )
+        return None
+
+    return fit

--- a/apps/wyrdfold-api/tests/test_fit_daily_cap.py
+++ b/apps/wyrdfold-api/tests/test_fit_daily_cap.py
@@ -1,0 +1,83 @@
+"""Tests for the Phase 2 per-target daily cap.
+
+The cap reads ``llm_costs`` to count how many Phase 2 calls a target
+has made since UTC midnight. Tests mock the Supabase call chain and
+assert the math + the "refuse on error" semantics.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from app.services.fit.daily_cap import (
+    DEFAULT_DAILY_CAP,
+    phase2_quota_remaining,
+)
+from app.services.fit.job_fit import JOB_FIT_PURPOSE
+
+
+def _supabase_with_count(count: int) -> MagicMock:
+    """Build a mock whose Phase 2 cost query returns ``count`` entries."""
+    supabase = MagicMock()
+    chain = (
+        supabase.table.return_value
+        .select.return_value
+        .eq.return_value
+        .eq.return_value
+        .gte.return_value
+        .limit.return_value
+        .execute
+    )
+    chain.return_value.count = count
+    return supabase
+
+
+def test_quota_remaining_at_zero_used_returns_full_cap() -> None:
+    supabase = _supabase_with_count(0)
+    assert phase2_quota_remaining(supabase, "t-1") == DEFAULT_DAILY_CAP
+
+
+def test_quota_remaining_subtracts_used_from_cap() -> None:
+    supabase = _supabase_with_count(30)
+    assert phase2_quota_remaining(supabase, "t-1") == DEFAULT_DAILY_CAP - 30
+
+
+def test_quota_remaining_floors_at_zero_when_over_cap() -> None:
+    """Defensive: if something blew past the cap (concurrent races,
+    backfill scripts), the function returns 0 not a negative number."""
+    supabase = _supabase_with_count(DEFAULT_DAILY_CAP + 50)
+    assert phase2_quota_remaining(supabase, "t-1") == 0
+
+
+def test_quota_remaining_honors_custom_cap_arg() -> None:
+    supabase = _supabase_with_count(10)
+    assert phase2_quota_remaining(supabase, "t-1", cap=20) == 10
+
+
+def test_quota_remaining_returns_zero_on_db_error() -> None:
+    """Refuse to spend rather than risk blowing past the cap.
+
+    A transient Supabase error shouldn't suddenly let us spend an
+    unbounded amount on LLM calls; better to defer this poll cycle's
+    Phase 2 work than to fail-open.
+    """
+    supabase = MagicMock()
+    supabase.table.return_value.select.side_effect = RuntimeError("boom")
+    assert phase2_quota_remaining(supabase, "t-1") == 0
+
+
+def test_quota_remaining_filters_by_target_and_purpose() -> None:
+    """Sanity that the query targets the right scoping. We don't
+    want a different target's Phase 2 spend to deplete this target's
+    quota.
+    """
+    supabase = _supabase_with_count(5)
+    phase2_quota_remaining(supabase, "t-1")
+    # First .eq() chains in: ``.eq("purpose", JOB_FIT_PURPOSE)``.
+    first_eq = supabase.table.return_value.select.return_value.eq.call_args
+    assert first_eq.args[0] == "purpose"
+    assert first_eq.args[1] == JOB_FIT_PURPOSE
+    # Second .eq() filters by target_id via the metadata JSONB selector.
+    second_eq = supabase.table.return_value.select.return_value.eq.return_value.eq.call_args
+    assert second_eq.args[0] == "metadata->>target_id"
+    assert second_eq.args[1] == "t-1"

--- a/apps/wyrdfold-api/tests/test_fit_score_persistence.py
+++ b/apps/wyrdfold-api/tests/test_fit_score_persistence.py
@@ -1,0 +1,195 @@
+"""Tests for the Phase 2 score-and-persist helper.
+
+Mocks ``derive_job_fit`` to assert:
+- LLM success: scores row gets UPDATE with score + axis_scores +
+  fit_reasoning + scoring_status; cost log entry recorded.
+- LLM failure: returns None, no DB update, no cost log (we didn't
+  spend tokens).
+- DB persist failure after successful LLM call: still returns None
+  but the cost log entry WAS recorded (we did spend the tokens, so
+  the daily cap should account for them).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.models.experience import OptimizedPayload
+from app.models.targets import (
+    CategoryProfile,
+    JobTarget,
+    ScoringProfile,
+    SeniorityProfile,
+)
+from app.services.fit.job_fit import AxisScores, JobFitResult
+from app.services.fit.score_persistence import score_with_phase2_and_persist
+
+
+def _target() -> JobTarget:
+    return JobTarget(
+        id="t-1",
+        label="Staff Frontend Engineer",
+        scoring_profile=ScoringProfile(
+            categories={"core_skills": CategoryProfile(keywords={"x": 1}, weight=2.0)},
+            seniority=SeniorityProfile(signals=["staff"]),
+        ),
+        is_active=True,
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
+    )
+
+
+def _payload() -> OptimizedPayload:
+    return OptimizedPayload(summary="...", roles=[], skills=[], outcomes=[])
+
+
+def _fake_fit() -> JobFitResult:
+    return JobFitResult(
+        fit_score=82,
+        axes=AxisScores(
+            title_fit=95, skills_fit=80, seniority_fit=85, domain_fit=70
+        ),
+        reasoning="Strong title + skills match; missing e-commerce domain.",
+    )
+
+
+@pytest.mark.asyncio
+async def test_success_updates_scores_row_with_full_phase2_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Happy path: LLM returns a fit, cost is logged, scores row UPDATE
+    carries the four Phase 2 fields (score, axis_scores, fit_reasoning,
+    scoring_status='complete')."""
+    supabase = MagicMock()
+    llm = MagicMock()
+
+    async def fake_derive(*args: object, **kwargs: object) -> object:
+        return (_fake_fit(), MagicMock())
+
+    cost_calls: list[dict[str, object]] = []
+
+    def fake_cost(supabase, *, user_id, purpose, result, metadata=None) -> object:
+        cost_calls.append(
+            {"purpose": purpose, "metadata": metadata, "user_id": user_id}
+        )
+        return MagicMock()
+
+    monkeypatch.setattr(
+        "app.services.fit.score_persistence.derive_job_fit", fake_derive
+    )
+    monkeypatch.setattr(
+        "app.services.fit.score_persistence.record_llm_cost", fake_cost
+    )
+
+    result = await score_with_phase2_and_persist(
+        supabase,
+        llm,
+        payload=_payload(),
+        target=_target(),
+        job_posting_id="job-1",
+        title="Senior FE",
+        jd_text="JD body",
+    )
+
+    assert result is not None
+    assert result.fit_score == 82
+
+    # Cost log fired exactly once with the right scoping.
+    assert len(cost_calls) == 1
+    assert cost_calls[0]["purpose"] == "fit.job"
+    assert cost_calls[0]["metadata"] == {
+        "target_id": "t-1",
+        "job_posting_id": "job-1",
+    }
+
+    # UPDATE fired with all four Phase 2 fields.
+    update_args = supabase.table.return_value.update.call_args.args[0]
+    assert update_args["score"] == 82
+    assert update_args["axis_scores"] == {
+        "title_fit": 95,
+        "skills_fit": 80,
+        "seniority_fit": 85,
+        "domain_fit": 70,
+    }
+    assert update_args["fit_reasoning"].startswith("Strong title")
+    assert update_args["scoring_status"] == "complete"
+    assert "updated_at" in update_args
+
+
+@pytest.mark.asyncio
+async def test_llm_failure_returns_none_and_skips_db_and_cost(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """LLM threw → we didn't spend tokens, so no cost log fires, and the
+    scores row stays exactly as Phase 1 (or prior runs) left it."""
+    supabase = MagicMock()
+    llm = MagicMock()
+
+    async def boom(*args: object, **kwargs: object) -> object:
+        raise RuntimeError("anthropic-503")
+
+    cost_calls: list[object] = []
+    monkeypatch.setattr(
+        "app.services.fit.score_persistence.derive_job_fit", boom
+    )
+    monkeypatch.setattr(
+        "app.services.fit.score_persistence.record_llm_cost",
+        lambda *a, **k: cost_calls.append(1),
+    )
+
+    result = await score_with_phase2_and_persist(
+        supabase,
+        llm,
+        payload=_payload(),
+        target=_target(),
+        job_posting_id="job-1",
+        title="x",
+        jd_text="x",
+    )
+
+    assert result is None
+    assert cost_calls == []
+    supabase.table.return_value.update.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_persist_failure_still_records_cost(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If the DB UPDATE fails AFTER a successful LLM call, we still
+    record the cost — we DID spend the tokens. The daily cap counter
+    needs to know.
+    """
+    supabase = MagicMock()
+    supabase.table.return_value.update.return_value.eq.return_value.eq.return_value.execute.side_effect = RuntimeError(
+        "supabase-503"
+    )
+    llm = MagicMock()
+
+    async def fake_derive(*args: object, **kwargs: object) -> object:
+        return (_fake_fit(), MagicMock())
+
+    cost_calls: list[int] = []
+    monkeypatch.setattr(
+        "app.services.fit.score_persistence.derive_job_fit", fake_derive
+    )
+    monkeypatch.setattr(
+        "app.services.fit.score_persistence.record_llm_cost",
+        lambda *a, **k: cost_calls.append(1),
+    )
+
+    result = await score_with_phase2_and_persist(
+        supabase,
+        llm,
+        payload=_payload(),
+        target=_target(),
+        job_posting_id="job-1",
+        title="x",
+        jd_text="x",
+    )
+
+    assert result is None
+    assert cost_calls == [1]

--- a/supabase/migrations/20260603030000_scores_phase2_fields.sql
+++ b/supabase/migrations/20260603030000_scores_phase2_fields.sql
@@ -1,0 +1,35 @@
+-- Phase 2 LLM job-fit grader output fields.
+--
+-- ``derive_job_fit`` (PR #791) returns a ``JobFitResult`` with
+-- overall fit_score + four axis scores + a short reasoning string.
+-- This migration adds the persistence target for the two new pieces:
+--
+--   axis_scores    — JSONB ``{"title_fit":N, "skills_fit":N,
+--                    "seniority_fit":N, "domain_fit":N}``. UI uses
+--                    this to render the per-axis breakdown alongside
+--                    the overall score.
+--
+--   fit_reasoning  — 1-2 sentence explanation of the grade. Surfaced
+--                    on the job card hover / detail panel.
+--
+-- The overall fit_score lands in the existing ``scores.score`` INT
+-- column (repurposed from keyword-derived to LLM-derived). NULL there
+-- now means "Phase 2 not yet run" (was "no keyword match" pre-Phase-2).
+--
+-- Both columns are nullable so legacy rows that pre-date Phase 2 (or
+-- promising=true rows that haven't been graded yet because of the
+-- per-target daily cap) work as "pending" — UI sorts them to the
+-- bottom of the list.
+
+alter table public.scores
+  add column if not exists axis_scores jsonb,
+  add column if not exists fit_reasoning text;
+
+comment on column public.scores.axis_scores is
+  'Phase 2 LLM grader output: {title_fit, skills_fit, seniority_fit, '
+  'domain_fit} each 0-100. NULL when Phase 2 has not run for this row '
+  '(legacy / pending / Phase 2 failed).';
+
+comment on column public.scores.fit_reasoning is
+  'Phase 2 LLM grader output: 1-2 sentence reasoning. Surfaced on the '
+  'job detail panel. NULL when Phase 2 has not run.';


### PR DESCRIPTION
## Summary

Scope was originally "Phase 2 integration into the poller" but I retitled to **infrastructure only** — the behavioral change (replacing the keyword scorer with Phase 2 in the live poll loop) deserves explicit user review rather than landing autonomously overnight.

This PR adds the helpers + migration the integration will need. No callsite changes; no behavior change.

## What's in

### Migration

\`scores.axis_scores\` (JSONB) + \`scores.fit_reasoning\` (text), both nullable. Overall fit_score lands in the existing \`scores.score\` INT (repurposed from keyword to LLM).

### \`app/services/fit/daily_cap.py\`

- \`DEFAULT_DAILY_CAP = 100\` per target.
- \`phase2_quota_remaining(supabase, target_id, cap=...) -> int\` counts \`llm_costs\` entries with \`purpose='fit.job'\` + \`metadata.target_id\` matching since UTC midnight.
- DB error → returns \`0\` (refuse-to-spend rather than risk blowing past cap).

### \`app/services/fit/score_persistence.py\`

\`score_with_phase2_and_persist(supabase, llm, payload, target, job_posting_id, title, jd_text, user_id=None) -> JobFitResult | None\`

Flow:
1. Call \`derive_job_fit\` (PR #791)
2. Record cost in \`llm_costs\` (BEFORE the DB update — see "Why" below)
3. UPDATE the scores row with score + axis_scores + fit_reasoning + scoring_status='complete'

Returns \`None\` on:
- LLM failure → no spend, no DB change
- Persistence failure → spend recorded, DB unchanged (retry next poll)

**Why cost log fires BEFORE the DB update**: if the DB UPDATE fails AFTER a successful LLM call, we still want the daily cap counter to see the call. Otherwise a flapping Supabase connection could let us spend unbounded tokens.

## Tests (9 new)

- **daily_cap**: 0 used → full cap, subtract used, floor at 0, custom cap, DB error → 0, filter scoping
- **score_persistence**: happy path, LLM failure, persist-after-LLM failure

## Verification

- ruff: clean
- mypy strict: clean (129 source files)
- pytest: 1007 passed

## What's NOT in (the actual integration — next PR for you to direct)

- Wire \`score_with_phase2_and_persist\` into the poller's Stage 3 (\`_run_llm_scoring_for_row\`) — replaces \`analyze_job\` + \`blend_scores\`
- Per-target daily cap check before invoking
- Progressive batching (first 20 promising eagerly, rest in 50-chunk batches) — needs design for the background scheduler since FastAPI \`BackgroundTasks\` is request-scoped
- Keyword pipeline rip-out

## Test plan

- [ ] CI green
- [ ] After merge: \`pnpm db:push\` to apply the new columns
- [ ] Sanity-check the schema in DEV (run the test script to confirm columns are nullable, JSONB shape works)
- [ ] Direct me on the integration PR scope when you're ready

🤖 Generated with [Claude Code](https://claude.com/claude-code)