### PR TITLE
chore(wyrdfold-api): drop cosine prefilter columns + indexes

### DIFF
--- a/apps/wyrdfold-api/app/models/targets.py
+++ b/apps/wyrdfold-api/app/models/targets.py
@@ -72,10 +72,6 @@ class JobTarget(BaseModel):
     )
     profile_version: int = 1
     is_active: bool
-    # Voyage-3-lite (512 dim) embedding of ``label``. Used by the
-    # ingestion-time relevance pre-filter in the poller. Computed
-    # lazily on first poll if NULL; recomputed if ``label`` changes.
-    label_embedding: list[float] | None = None
     # Few-shot title pools for the upcoming Phase 1 LLM triage. Seeded
     # at target creation from the same LLM call that derives the
     # scoring profile; later (Phase 1 PR) augmented from user 👍/👎

--- a/apps/wyrdfold-api/app/services/targets/crud.py
+++ b/apps/wyrdfold-api/app/services/targets/crud.py
@@ -27,21 +27,6 @@ REF_JDS_TABLE = "reference_jds"
 
 def _parse_target(row: dict[str, Any]) -> JobTarget:
     """Parse a raw Supabase row into a JobTarget, handling JSONB fields."""
-    # PostgREST returns pgvector columns as either a list of floats or a
-    # ``[0.1,0.2,...]`` string depending on the encoder. Normalize both
-    # shapes to list[float] | None so callers can treat it uniformly.
-    raw_embed = row.get("label_embedding")
-    embedding: list[float] | None
-    if raw_embed is None:
-        embedding = None
-    elif isinstance(raw_embed, list):
-        embedding = [float(x) for x in raw_embed]
-    elif isinstance(raw_embed, str):
-        stripped = raw_embed.strip().lstrip("[").rstrip("]")
-        embedding = [float(x) for x in stripped.split(",") if x.strip()] if stripped else None
-    else:
-        embedding = None
-
     return JobTarget(
         id=row["id"],
         label=row["label"],
@@ -52,7 +37,6 @@ def _parse_target(row: dict[str, Any]) -> JobTarget:
         activation_status=row.get("activation_status") or "idle",
         profile_version=row.get("profile_version", 1),
         is_active=row["is_active"],
-        label_embedding=embedding,
         example_promising_titles=row.get("example_promising_titles") or [],
         example_unpromising_titles=row.get("example_unpromising_titles") or [],
         created_at=row["created_at"],

--- a/supabase/migrations/20260603040000_drop_cosine_prefilter_columns.sql
+++ b/supabase/migrations/20260603040000_drop_cosine_prefilter_columns.sql
@@ -1,0 +1,23 @@
+-- Drop the cosine-prefilter columns + HNSW indexes added in
+-- ``20260601160000_relevance_prefilter_embeddings.sql``.
+--
+-- The cosine-based prefilter (``app/services/relevance_prefilter.py``)
+-- was removed in PR #790 when Phase 1 LLM triage took over the
+-- ingestion gate. The columns + indexes have sat unused since then —
+-- this cleans them up to recover storage + index maintenance overhead.
+--
+-- Safe to run idempotently: ``drop ... if exists`` guards each
+-- statement so re-running on an already-cleaned DB is a no-op.
+--
+-- pgvector extension stays. The ``experience_chunks`` resume-search
+-- path still uses ``vector`` columns for retrieval, so we keep the
+-- extension installed; only the prefilter-specific columns go.
+
+drop index if exists public.idx_targets_label_embedding;
+drop index if exists public.idx_jobs_title_embedding;
+
+alter table public.targets
+  drop column if exists label_embedding;
+
+alter table public.jobs
+  drop column if exists title_embedding;


### PR DESCRIPTION
## Summary

PR #790 replaced the cosine prefilter with Phase 1 LLM triage and removed all the code that read the prefilter columns. The columns + HNSW indexes have been sitting unused since — this drops them.

## Migration

\`20260603040000_drop_cosine_prefilter_columns.sql\`:

- DROP INDEX \`idx_targets_label_embedding\`
- DROP INDEX \`idx_jobs_title_embedding\`
- ALTER TABLE \`targets\` DROP COLUMN \`label_embedding\`
- ALTER TABLE \`jobs\` DROP COLUMN \`title_embedding\`

Idempotent — \`IF EXISTS\` everywhere.

## Code

- \`models/targets.py\`: removed \`label_embedding\` from \`JobTarget\`
- \`services/targets/crud.py\`: dropped the pgvector parsing block from \`_parse_target\` and the constructor kwarg

## What's NOT touched

- **pgvector extension stays** — \`experience_chunks\` (resume search) still uses \`vector\` columns
- **\`app/services/embeddings/\` stays** — same reason
- **Voyage settings stay** (\`voyage_api_key\`, \`embeddings_provider\`, etc.) — same reason

Once Daniel confirms the experience-chunks path can also be decommissioned, a follow-up can drop those too.

## Verification

- ruff: clean
- mypy strict: clean (127 source files)
- pytest: 998 passed (no test changes)

## Test plan

- [ ] CI green
- [ ] Supabase Preview applies the migration
- [ ] After merge + DEV migration: confirm columns are gone via direct SELECT (should error)
- [ ] Confirm resume search (experience chunks) still works — that's the path we deliberately left alone

🤖 Generated with [Claude Code](https://claude.com/claude-code)