### PR TITLE
feat(wyrdfold-api): recency decay sort + Phase 2 LLM grading wired into the poller

### DIFF
--- a/.claude/docs/plan-llm-scoring-migration.md
+++ b/.claude/docs/plan-llm-scoring-migration.md
@@ -1,0 +1,215 @@
+# LLM Scoring Migration — Implementation Plan
+
+**Author:** Claude (overnight session, 2026-06-02)
+**Status:** Active. Foundation PRs landing through the night; user reviews in the morning.
+
+## Context
+
+Tonight we diagnosed that the current 4-signal scoring pipeline (Stage 1 title keyword + Stage 2 full-JD keyword + Stage 3 LLM blend + cosine prefilter) doesn't produce coherent relevance — see [decisions.md] entry for 2026-06-02. The pipeline grew organically and each stage can override the others. Voyage-3-lite cosine clusters all senior corporate roles 0.75-0.85 regardless of domain; keyword scoring rewards incidental tech matches; Stage 3 LLM boosts off-topic roles via lenient prompts.
+
+Daniel's observation made it concrete: "Senior Product Designer" scoring 92 for a Staff Frontend Engineer target while actual frontend titles sit at 62.
+
+## Target architecture
+
+```
+NEW JOB INGESTED (per active target)
+  ↓
+PHASE 1: Per-target LLM binary triage (Haiku 4.5, batched 250/call)
+  Input: target.label + example_promising_titles + example_unpromising_titles + batch
+  Output: {job_id: is_promising: bool}
+  Persist: scores.promising + scores.excluded=NOT promising
+  Cost: ~$0.40 per 8k-row backfill; ~$0.01 per poll cycle
+  Bias: lean PROMISING on close calls — Phase 2 catches FPs; FNs are lost
+
+PHASE 2: Per-target LLM fit grading (Sonnet 4.6, progressive batching)
+  Runs ONLY on promising jobs, ordered by Phase 1 confidence (or first_seen_at)
+  Batching: FIRST batch = 20 (first page renders fast),
+            subsequent batches = 50 (catches up the rest)
+  Daily cap per target: 100 automatic, rest on-demand
+  Input: target + user_profile + (title, JD snippet)
+  Output: {job_id: {score: 0-100, axes: {title_fit, skills_fit, seniority_fit, domain_fit}, reasoning}}
+  Reuses derive_fit_score scaffold — same scorecard, same scale, same model
+  Persist: scores.score, scores.score_breakdown (axis_scores), scores.fit_reasoning
+  Cost: ~$2.25 per full backfill per target; ~$0.10 per poll cycle per target
+  Fallback when LLM unavailable: leave scores.promising=true, scores.score=NULL — UI shows "Pending"
+
+PHASE 2 RE-GRADING CONTRACT
+  - Activate/deactivate flicker: do NOT re-grade jobs where
+    scores.scored_profile_version >= target.profile_version. The
+    existing bulk_score_for_target already does this check (#502 lazy
+    re-scoring). Phase 2 inherits the contract.
+  - Feedback-learner-triggered rescore: when the learner bumps
+    profile_version, the rescore uses the same progressive batching
+    (20 → 50). No single user action triggers an 8k-job LLM blast.
+  - Newly-activated target with prior scores at version N, profile now
+    at version N: nothing to do, scores already current. New scores
+    get added for jobs that were ingested while the target was
+    inactive (those have no scores row for this target yet).
+
+POST-PHASE-2: Apply recency decay at read time
+  final_score = phase2_score * max(0.3, 1.0 - max(0, age_days - 7) * 0.015)
+  Fresh window: 7 days at full score
+  Loses 1.5 points/day after grace
+  Floors at 30% after ~50 days
+  Computed in /jobs endpoint, NOT persisted — always reflects current date
+
+PHASE 3 (USER-TRIGGERED DEEP DIVE): Opus 4.7 per request
+  Same scorecard shape as Phase 2 + full JD analysis + match/gap explanation
+  Expected variance from Phase 2: ±20 points
+  Cost: ~$0.05/call
+  Cap: 50/user/day soft limit
+```
+
+### Why this works
+
+- **One scoring rubric end-to-end.** Phase 2 and Phase 3 emit the same `FitResult` shape on the same 0-100 scale. UI shows consistent axis breakdowns. Daniel's "±20 variance" expectation falls out naturally.
+- **Per-target prompts, no global taxonomy.** Works for any profession the tool supports. Daniel's "Staff Frontend Engineer" target and Melissa's "Director of CX Operations" target both work without us defining role enums.
+- **Cheap-then-expensive.** Phase 1 culls ~80% of noise at Haiku prices. Phase 2 only pays Sonnet costs on the survivors. Phase 3 only pays Opus on user-clicked items.
+- **Examples evolve.** Auto-generated at target creation, then drift toward user-confirmed examples after ≥5 thumbs-up/down per side.
+- **Recency baked in.** Stale postings naturally fall off without manual archiving — score multiplier does the work.
+
+## Build order
+
+### Foundation (overnight)
+
+| #   | PR                        | Description                                                                                | Worktree      | Status |
+| --- | ------------------------- | ------------------------------------------------------------------------------------------ | ------------- | ------ |
+| 1   | foundation-fit-module     | Refactor `derive_fit_score` into `app/services/fit/` with shared scaffold                  | fit-module    | TODO   |
+| 2   | fix/skip-inactive-targets | Skip scoring for inactive targets across all paths                                         | skip-inactive | TODO   |
+| 3   | feat/target-example-pools | Auto-generate `example_promising_titles` + `example_unpromising_titles` at target creation | example-pools | TODO   |
+
+### Core redesign (next sessions)
+
+| #   | PR                         | Description                                                              | Notes                                                                        |
+| --- | -------------------------- | ------------------------------------------------------------------------ | ---------------------------------------------------------------------------- |
+| 4   | feat/phase1-title-triage   | Replace cosine prefilter with LLM binary classifier                      | Adds `scores.promising` column; cosine columns kept (unused) for one release |
+| 5   | feat/recency-decay         | Final score multiplier at read time                                      | Tiny PR, big UX win                                                          |
+| 6   | feat/phase2-job-fit        | Replace keyword pipeline with `derive_job_fit`                           | Biggest piece; ships with backfill script                                    |
+| 7   | feat/feedback-example-pool | 👍/👎 wired to per-target example pools, swap in once ≥5 labels per side | Requires UI affordance + persistence                                         |
+| 8   | feat/phase3-deep-dive      | Refit user-triggered deep dive onto new schema                           | Stronger model + full JD context                                             |
+
+### UX wins (parallel, can ship anytime)
+
+| #   | PR                                       | Description                              |
+| --- | ---------------------------------------- | ---------------------------------------- |
+| U1  | ux/default-all-jobs-tab + enter-debounce | Two small wins in one PR                 |
+| U2  | ux/persist-filters-localstorage          | Per-(user, target) filter state          |
+| U3  | feat/active-target-limit                 | 5-active cap                             |
+| U4  | ux/target-tab-pills                      | `[fit_score] [name] [⚙ gear]` tab format |
+
+### Migration risks
+
+- **Score column repurposed.** Existing keyword-derived scores aren't comparable to new LLM-derived scores. One-time re-grade required on Phase 2 ship. Cost: ~$5-10 across the system.
+- **Cosine columns stay in DB.** Drop in a cleanup PR one release after Phase 1 ships, after we've confirmed nothing reads them.
+- **Backfill needed at Phase 2 ship.** Reuse the `scripts/backfill_relevance_prefilter.py` pattern — paginated, idempotent, `--dry-run` flag.
+
+### Cost ceilings (per active target, per month)
+
+| Phase   | Tokens per job    | Model      | $ per job | Jobs/month estimate                                                               | Monthly $ |
+| ------- | ----------------- | ---------- | --------- | --------------------------------------------------------------------------------- | --------- |
+| Phase 1 | ~50 in, ~10 out   | Haiku 4.5  | $0.0001   | 100k (12 polls/day × ~8k titles seen across all sources / divided across targets) | $1-3      |
+| Phase 2 | ~500 in, ~100 out | Sonnet 4.6 | $0.0035   | 15k (only promising × 100/day cap)                                                | $5-15     |
+| Phase 3 | ~2k in, ~500 out  | Opus 4.7   | $0.05     | 200 (user-triggered, 50/day cap × 4 users)                                        | $10       |
+
+Total per active user per month: ~$15-30. Per 5-target user: ~$80-150/month worst case. Sustainable for now.
+
+## Activate/deactivate flicker protection
+
+Beyond the progressive batching above, a user can toggle a target on and off freely (intentional or not). The contract:
+
+- **Off → On (no metadata change since last on):** zero LLM work. Existing scores at `scored_profile_version == target.profile_version` stay valid.
+- **Off → On (target's `profile_version` bumped while off):** rescore stale rows progressively (20, then 50 chunks).
+- **Off → On (new jobs ingested while off):** Phase 1 grades the new arrivals only. Existing scored rows untouched.
+- **On → Off:** trigger flips `targets.is_active` via the user_targets OR. Foundation PR #784 already short-circuits all per-target scoring entry points. Zero work.
+
+This keeps a careless flicker session at $0.00 in LLM cost.
+
+## Limits roadmap (parallel runaway-protection)
+
+Beyond the 5-active-target cap, these guards need to land alongside the redesign or shortly after:
+
+1. **Skip inactive targets in all scoring code paths** ← Foundation PR #2
+2. **Phase 2 daily cap per target**: top 100 promising jobs/day automatic; rest on-demand. Prevents a bursty source from blowing the budget.
+3. **Phase 3 daily cap per user**: 50/day soft. Surfaced as "you've hit the deep-dive limit for today — try again tomorrow" if exceeded.
+4. **Reference JDs per target**: 5 max. Each one re-derives the profile, expensive.
+5. **Resume tailor/regenerate per user per day**: 30/day soft.
+6. **Manual job submission per user per hour**: 20/hour.
+7. **Saved/applied jobs per user**: 500 hard cap.
+8. **Document storage**: 20 docs/user, 2MB each.
+9. **Magic-link request rate**: 3/email/15min. (Verify existing.)
+
+I'll add an ADR for the limits framework once 2-3 of these ship as a pattern.
+
+## Open questions for Daniel's review
+
+1. **Phase 2 deferred grading UX.** When a job is promising but not in the top-100/day for Phase 2, what does the user see? Options:
+   - "Pending score" badge — shows in the list, sorted at the bottom
+   - Hidden until graded — list view only shows graded rows
+   - Sorted by Phase 1 confidence (if we capture it) — partial signal until Phase 2 lands
+     My lean: pending badge + sort to bottom. Surfaces breadth, doesn't lose them.
+
+2. **Cosine deprecation timing.** Two options:
+   - Drop the columns + code path in the Phase 1 PR.
+   - Keep columns for one release in case we need to roll back. Drop in a cleanup PR.
+     My lean: keep one release. Cheap insurance.
+
+3. **Per-target Phase 2 spend visibility.** Should we surface "$X spent grading jobs for this target this month" in target settings? Helps Daniel feel agency over costs as we scale.
+
+4. **Phase 1 confidence signal.** Bool is the contract, but we could log confidence (0-100) for analytics — "Phase 1 was 53% sure on this one, Phase 2 graded it 81". Useful for tuning the bias.
+
+## Rollback plan
+
+Each PR is independently reversible:
+
+- **Foundation #1 (refactor)**: zero behavior change — revert PR if anything regresses.
+- **Foundation #2 (skip inactive)**: if it breaks anything, set the guard to no-op via env var (e.g., `SKIP_INACTIVE_TARGETS=false`).
+- **Foundation #3 (example pools)**: columns are nullable — if generation fails, target works as before.
+- **Phase 1**: feature flag (`PHASE1_TRIAGE_ENABLED`) defaults off until we verify Daniel's targets behave; flip on after one good poll cycle.
+- **Phase 2**: same flag pattern. Falls back to keyword scorer if flag off.
+- **Recency decay**: single multiplier, can be flagged to 1.0 (no-op).
+
+## What I'm doing tonight
+
+In order, until I run out of time or hit something ambiguous:
+
+1. Foundation #1 → PR
+2. Foundation #2 → PR
+3. Foundation #3 → PR (if API stable enough)
+4. UX U1 (default tab + enter short-circuit) → PR
+5. UX U2 (filter localStorage) → PR
+6. UX U3 (active-target limit) → PR
+
+If I hit something I can't decide without you, I'll stop and document the decision point in this plan rather than guess.
+
+## Decisions log
+
+### 2026-06-03 — Overnight delivery
+
+Five PRs opened, all small and independently revertable. None merged — left for Daniel's morning review.
+
+| PR   | Branch                                       | Purpose                                                                                |
+| ---- | -------------------------------------------- | -------------------------------------------------------------------------------------- |
+| #784 | feat/wyrdfold-skip-inactive-targets          | Skip scoring + polling for inactive targets (foundation guard for LLM cost protection) |
+| #785 | feat/wyrdfold-default-all-tab-enter-debounce | Default Jobs page tab = All Jobs; Enter short-circuits search debounce                 |
+| #786 | feat/wyrdfold-persist-filters-localstorage   | Per-target filter persistence (localStorage)                                           |
+| #787 | feat/wyrdfold-active-target-limit            | 5-active-target cap with 409 ACTIVE_LIMIT response                                     |
+| #788 | feat/wyrdfold-target-example-pools           | Auto-generate example_promising_titles + example_unpromising_titles at target creation |
+
+Test count: 988 → 993 (api) + new Jest hook tests (frontend).
+
+### 2026-06-03 — Reference JD merge of example pools
+
+Adding a new reference JD to a target updates the example pools to reflect the LATEST JD only — not merged across all JDs. Concrete title examples don't aggregate the way weighted keywords do; merging would dilute the few-shot signal. Acceptable behavior: pools shift toward the most recent JD's worldview, but stay coherent for whichever JD was last added. If this becomes a problem (e.g., a user wants pools to span multiple JDs), the fix is a separate "pool aggregation" pass — out of scope for now.
+
+### 2026-06-03 — Recency decay deferred
+
+Started building, hit a design fork that needs Daniel's call:
+
+- **Display-only decay** (apply multiplier in Python after fetch) breaks the list sort order: a 30-day-old job at raw 90 decays to 59 but the DB still sorts it above a 1-day-old job at raw 85. User sees top of list with lower visible scores than rows below.
+- **Sort-respecting decay** requires either (a) recomputing+storing a `recency_decayed_score` column nightly via cron, (b) a Postgres expression/view that computes decay at query time (forces a full table scan unless indexed), or (c) loading all matching rows into Python and sorting after decay (kills pagination).
+
+Defer to a proper design session — none of these are right to commit to autonomously overnight. The math helper (`compute_recency_multiplier`) is uncontroversial; the storage/sort architecture is the question.
+
+### 2026-06-03 — Fit-module refactor folded into Phase 2
+
+Originally planned as a setup PR (move `derive_fit_score` to `app/services/fit/`). On reflection, no value to ship in isolation — Phase 2 will create the shared `app/services/fit/` package itself when adding `derive_job_fit`, and at that point both functions get the unified schema. Skipping the standalone refactor.

--- a/apps/wyrdfold-api/app/config.py
+++ b/apps/wyrdfold-api/app/config.py
@@ -65,6 +65,15 @@ class Settings(BaseSettings):
     # flag is a pure sort change, safe to flip per-deploy.
     recency_decay_enabled: bool = False
 
+    # Phase 2 LLM job-fit grading (#6). When True the poller runs the
+    # Sonnet-backed ``score_with_phase2_and_persist`` over promising
+    # (Phase 1) jobs in place of the legacy Stage 3 keyword+LLM blend,
+    # progressively batched and bounded by the per-target daily cap. When
+    # False the poller runs the legacy Stage 3 path unchanged. Phase 2
+    # only grades rows Phase 1 marked ``promising``, so it requires
+    # ``phase1_triage_enabled`` to surface any work.
+    phase2_enabled: bool = False
+
     # Email/SMS notifications — Next.js app URL and shared secret for job alerts.
     next_app_url: str = ""
     job_alert_secret: str = Field(default="", repr=False)

--- a/apps/wyrdfold-api/app/config.py
+++ b/apps/wyrdfold-api/app/config.py
@@ -57,6 +57,14 @@ class Settings(BaseSettings):
     # downstream keyword scoring.
     phase1_triage_enabled: bool = False
 
+    # Recency decay (#5). When True the /jobs list sorts/paginates by
+    # ``scores.recency_score`` (the fit score decayed by posting age via
+    # ``app/services/recency.py``) and the poller refreshes that column
+    # each cycle. When False the multiplier is 1.0 (recency_score ==
+    # score) and the list sorts by raw fit score exactly as before — the
+    # flag is a pure sort change, safe to flip per-deploy.
+    recency_decay_enabled: bool = False
+
     # Email/SMS notifications — Next.js app URL and shared secret for job alerts.
     next_app_url: str = ""
     job_alert_secret: str = Field(default="", repr=False)

--- a/apps/wyrdfold-api/app/routers/jobs.py
+++ b/apps/wyrdfold-api/app/routers/jobs.py
@@ -11,6 +11,7 @@ from postgrest.types import CountMethod
 from supabase import Client
 
 from app.cache import job_list_cache, jobs_cache_prefix, make_cache_key
+from app.config import settings
 from app.dependencies import (
     get_current_user_id,
     get_current_user_id_optional,
@@ -228,6 +229,11 @@ def _list_jobs_for_target_rpc(
     # whenever the user typed more than one word.
     if search and len(_tokenize_search(search)) > 1:
         raise RuntimeError("RPC path skipped: multi-word search uses OR semantics")
+    # Recency decay sorts by ``scores.recency_score``, which the deployed
+    # RPC doesn't return or order by. The two-query fallback handles that
+    # column directly, so force it when the flag is on.
+    if settings.recency_decay_enabled and sort == "score":
+        raise RuntimeError("RPC path skipped: recency-decay sort handled in two-query path")
     """List jobs via server-side join RPC (single round-trip)."""
     resp = supabase.rpc(
         "get_target_jobs",
@@ -270,10 +276,22 @@ def _list_jobs_for_target_two_query(
 ) -> dict[str, Any]:
     """Fallback: two-query pattern with pagination pushed to the scores layer."""
     sort_col = "score" if sort == "score" else sort
+    # When recency decay is on, the logical "score" sort orders by the
+    # decayed ``recency_score`` column instead of the raw fit score.
+    # min_score still filters on the raw ``score`` (the user's fit floor
+    # is a quality bar, not a recency bar); only the ORDER BY changes.
+    order_col = (
+        "recency_score"
+        if sort_col == "score" and settings.recency_decay_enabled
+        else "score"
+    )
     has_location_filter = bool(exclude_terms or only_terms)
     ts_query = (
         supabase.table("scores")
-        .select("job_posting_id, score, score_breakdown, scoring_status", count=CountMethod.exact)
+        .select(
+            "job_posting_id, score, recency_score, score_breakdown, scoring_status",
+            count=CountMethod.exact,
+        )
         .eq("target_id", target_id)
         .eq("excluded", False)
     )
@@ -286,7 +304,7 @@ def _list_jobs_for_target_two_query(
     # stable position — without this, the last row of page N could
     # reappear as the first row of page N+1.
     if sort_col == "score":
-        ts_query = ts_query.order("score", desc=not ascending).order(
+        ts_query = ts_query.order(order_col, desc=not ascending).order(
             "job_posting_id"
         )
     # For non-score sorts we still need all qualifying IDs (sorted in Python after join)
@@ -340,9 +358,15 @@ def _list_jobs_for_target_two_query(
             )
 
         def _sort_key(p: dict[str, Any]) -> Any:
+            if sort == "score":
+                # Order by recency_score (or raw score when decay is off);
+                # read from the scores lookup so we don't leak an internal
+                # column into the postings response.
+                ts = score_lookup.get(p["id"]) or {}
+                return ts.get(order_col) or 0
             val = p.get(sort)
             if val is None:
-                return 0 if sort == "score" else ""
+                return ""
             return val
 
         postings.sort(key=_sort_key, reverse=not ascending)
@@ -433,10 +457,21 @@ def _list_jobs_across_user_targets(
     filter rejected every row.
     """
     sort_col = "score" if sort == "score" else sort
+    # See ``_list_jobs_for_target_two_query``: the "score" sort orders by
+    # the decayed ``recency_score`` when the flag is on; min_score still
+    # filters on the raw fit score.
+    order_col = (
+        "recency_score"
+        if sort_col == "score" and settings.recency_decay_enabled
+        else "score"
+    )
 
     score_query = (
         supabase.table("scores")
-        .select("job_posting_id, target_id, score, score_breakdown, scoring_status")
+        .select(
+            "job_posting_id, target_id, score, recency_score, "
+            "score_breakdown, scoring_status"
+        )
         .in_("target_id", list(user_target_ids))
         .eq("excluded", False)
     )
@@ -475,7 +510,7 @@ def _list_jobs_across_user_targets(
         # iterates a dict).
         ranked_ids = sorted(
             best.keys(),
-            key=lambda jid: (best[jid]["score"], jid),
+            key=lambda jid: (best[jid].get(order_col) or 0, jid),
             reverse=not ascending,
         )
         page_ids = ranked_ids[offset : offset + page_size]
@@ -507,9 +542,15 @@ def _list_jobs_across_user_targets(
             )
 
         def _sort_key(p: dict[str, Any]) -> Any:
+            if sort == "score":
+                # Order by recency_score (or raw score when decay is off);
+                # read from the per-job best-score lookup so we don't leak
+                # an internal column into the postings response.
+                ts = best.get(p["id"]) or {}
+                return ts.get(order_col) or 0
             val = p.get(sort)
             if val is None:
-                return 0 if sort == "score" else ""
+                return ""
             return val
 
         postings.sort(key=_sort_key, reverse=not ascending)

--- a/apps/wyrdfold-api/app/services/fit/__init__.py
+++ b/apps/wyrdfold-api/app/services/fit/__init__.py
@@ -25,14 +25,22 @@ from app.services.fit.job_fit import (
     JobFitResult,
     derive_job_fit,
 )
+from app.services.fit.phase2_runner import (
+    PHASE2_BATCH_SIZE,
+    PHASE2_FIRST_BATCH,
+    run_phase2_for_jobs,
+)
 from app.services.fit.score_persistence import score_with_phase2_and_persist
 
 __all__ = [
     "DEFAULT_DAILY_CAP",
     "JOB_FIT_PURPOSE",
+    "PHASE2_BATCH_SIZE",
+    "PHASE2_FIRST_BATCH",
     "AxisScores",
     "JobFitResult",
     "derive_job_fit",
     "phase2_quota_remaining",
+    "run_phase2_for_jobs",
     "score_with_phase2_and_persist",
 ]

--- a/apps/wyrdfold-api/app/services/fit/phase2_runner.py
+++ b/apps/wyrdfold-api/app/services/fit/phase2_runner.py
@@ -1,0 +1,221 @@
+"""Phase 2 orchestration: which promising jobs to grade, and how (#6).
+
+``score_with_phase2_and_persist`` grades one (user, target, job) tuple.
+This module decides which tuples to spend Sonnet on in a given run and
+in what order:
+
+- **Gate on Phase 1.** Only jobs whose scores row is ``promising=true``
+  reach the grader. ``promising IS NULL`` (Phase 1 disabled / legacy)
+  and ``promising=false`` are skipped — Phase 2 inherits Phase 1's
+  precision filter rather than re-deriving it.
+- **Re-grade contract.** Skip a job already finished at the current
+  profile version (``scoring_status == 'complete'`` AND
+  ``scored_profile_version >= target.profile_version``). A profile bump
+  resets the row to ``stage2`` (via ``bulk_score_for_target``), which
+  re-admits it. This is the same lazy-rescore contract #502 established
+  and the activate/deactivate-flicker protection depends on.
+- **Daily cap.** Each target gets ``DEFAULT_DAILY_CAP`` automatic grades
+  per UTC day (see ``daily_cap``). Candidates beyond the remaining quota
+  stay ``promising=true`` with their keyword score — surfaced as
+  "pending" and picked up on the next day's quota or on user click.
+- **Progressive batching.** The first ``PHASE2_FIRST_BATCH`` candidates
+  grade in one eager fan-out so the first list page fills fast; the rest
+  catch up in ``PHASE2_BATCH_SIZE`` chunks. Concurrency inside a batch is
+  bounded so we never open 50 Sonnet sockets at once.
+
+This is the single entry point both the poller and the backfill script
+call, so the gate / cap / batching policy lives in exactly one place.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, cast
+
+from supabase import Client
+
+from app.models.experience import OptimizedPayload
+from app.models.targets import JobTarget
+from app.services.fit.daily_cap import DEFAULT_DAILY_CAP, phase2_quota_remaining
+from app.services.fit.score_persistence import score_with_phase2_and_persist
+from app.services.llm.client import LLMClient
+from app.services.scoring import strip_html
+
+logger = logging.getLogger(__name__)
+
+# First batch is small so the first /jobs page renders with fresh Phase 2
+# grades quickly; the remainder catches up in larger chunks. Matches the
+# "FIRST batch = 20, subsequent = 50" policy in the migration plan.
+PHASE2_FIRST_BATCH = 20
+PHASE2_BATCH_SIZE = 50
+
+# Cap concurrent Sonnet calls within a batch. A batch of 50 must not open
+# 50 sockets at once — mirrors the poller's LLM_CONCURRENCY for Stage 3.
+PHASE2_CONCURRENCY = 3
+
+# Chunk size for the scores-state lookup IN-query (mirrors the sizing in
+# target_scoring / recency so the request stays under PostgREST limits).
+_STATE_CHUNK_SIZE = 500
+
+
+def _needs_phase2(
+    promising: bool | None,
+    scoring_status: str | None,
+    scored_profile_version: int | None,
+    target_profile_version: int,
+) -> bool:
+    """Phase 2 candidacy for one (job, target) scores row.
+
+    True iff the row is promising AND has not already been finished at the
+    current-or-newer profile version. ``promising`` must be exactly
+    ``True`` — ``None`` (Phase 1 off / legacy) and ``False`` are excluded.
+    """
+    if promising is not True:
+        return False
+    already_current = (
+        scoring_status == "complete"
+        and (scored_profile_version or 0) >= target_profile_version
+    )
+    return not already_current
+
+
+def _fetch_phase2_state(
+    supabase: Client, target_id: str, job_ids: list[str]
+) -> dict[str, tuple[bool | None, str | None, int | None]]:
+    """Read (promising, scoring_status, scored_profile_version) per job.
+
+    Keyed by ``job_posting_id`` for this one target. Jobs with no scores
+    row (Phase 1 dropped them under this target) are simply absent from
+    the result and never become candidates.
+    """
+    state: dict[str, tuple[bool | None, str | None, int | None]] = {}
+    for i in range(0, len(job_ids), _STATE_CHUNK_SIZE):
+        chunk = job_ids[i : i + _STATE_CHUNK_SIZE]
+        resp = (
+            supabase.table("scores")
+            .select(
+                "job_posting_id, promising, scoring_status, scored_profile_version"
+            )
+            .eq("target_id", target_id)
+            .in_("job_posting_id", chunk)
+            .execute()
+        )
+        for row in cast(list[dict[str, Any]], resp.data or []):
+            state[row["job_posting_id"]] = (
+                row.get("promising"),
+                row.get("scoring_status"),
+                row.get("scored_profile_version"),
+            )
+    return state
+
+
+def _progressive_batches(
+    items: list[str], first: int, rest: int
+) -> list[list[str]]:
+    """Split ``items`` into a small first batch then larger chunks."""
+    if not items:
+        return []
+    batches = [items[:first]]
+    i = first
+    while i < len(items):
+        batches.append(items[i : i + rest])
+        i += rest
+    return batches
+
+
+async def run_phase2_for_jobs(
+    supabase: Client,
+    llm: LLMClient,
+    *,
+    target: JobTarget,
+    payload: OptimizedPayload,
+    jobs: list[dict[str, Any]],
+    user_id: str | None = None,
+    cap: int = DEFAULT_DAILY_CAP,
+    first_batch_size: int = PHASE2_FIRST_BATCH,
+    batch_size: int = PHASE2_BATCH_SIZE,
+    concurrency: int = PHASE2_CONCURRENCY,
+) -> int:
+    """Grade the promising, not-yet-current jobs in ``jobs`` for ``target``.
+
+    ``jobs`` are job dicts carrying at least ``id`` and ``title`` (and
+    ``description_html`` for the JD context; ``first_seen_at`` is used for
+    ordering when present). Returns the number of jobs actually graded.
+
+    Order of operations: gate + re-grade filter → order newest-first →
+    trim to the remaining daily quota → progressive batches with bounded
+    concurrency. Per-job failures inside ``score_with_phase2_and_persist``
+    are swallowed there (return ``None``), so one bad grade never sinks
+    the batch.
+    """
+    if not jobs:
+        return 0
+
+    job_by_id = {j["id"]: j for j in jobs if j.get("id")}
+    job_ids = list(job_by_id)
+    if not job_ids:
+        return 0
+
+    state = _fetch_phase2_state(supabase, target.id, job_ids)
+    candidates = [
+        jid
+        for jid in job_ids
+        if jid in state
+        and _needs_phase2(*state[jid], target.profile_version)
+    ]
+    if not candidates:
+        return 0
+
+    # Newest-first so the freshest promising postings claim the quota
+    # before older ones. ``first_seen_at`` is an ISO-8601 string, sortable
+    # lexically; missing values sort last.
+    candidates.sort(
+        key=lambda jid: job_by_id[jid].get("first_seen_at") or "", reverse=True
+    )
+
+    # Daily cap: don't grade more than the target's remaining quota. This
+    # is a soft, best-effort budget — concurrent poll cycles for the same
+    # target can each read the same remaining count and slightly overshoot;
+    # the cap exists to bound runaway spend, not to be exact.
+    quota = phase2_quota_remaining(supabase, target.id, cap)
+    if quota <= 0:
+        logger.info(
+            "Phase 2: target %s at daily cap; deferring %d promising job(s)",
+            target.id,
+            len(candidates),
+        )
+        return 0
+    if len(candidates) > quota:
+        logger.info(
+            "Phase 2: target %s quota %d < %d candidates; deferring the rest",
+            target.id,
+            quota,
+            len(candidates),
+        )
+        candidates = candidates[:quota]
+
+    sem = asyncio.Semaphore(concurrency)
+
+    async def _grade_one(job_id: str) -> bool:
+        job = job_by_id[job_id]
+        async with sem:
+            fit = await score_with_phase2_and_persist(
+                supabase,
+                llm,
+                payload=payload,
+                target=target,
+                job_posting_id=job_id,
+                title=job.get("title", ""),
+                jd_text=strip_html(job.get("description_html", "")),
+                user_id=user_id,
+            )
+        return fit is not None
+
+    graded = 0
+    for batch in _progressive_batches(candidates, first_batch_size, batch_size):
+        results = await asyncio.gather(
+            *(_grade_one(jid) for jid in batch), return_exceptions=True
+        )
+        graded += sum(1 for r in results if r is True)
+    return graded

--- a/apps/wyrdfold-api/app/services/fit/score_persistence.py
+++ b/apps/wyrdfold-api/app/services/fit/score_persistence.py
@@ -103,6 +103,18 @@ async def score_with_phase2_and_persist(
                 "axis_scores": fit.axes.model_dump(),
                 "fit_reasoning": fit.reasoning,
                 "scoring_status": "complete",
+                # Stamp the version this grade was computed at so the
+                # re-grade contract holds: a row that's ``complete`` at
+                # ``scored_profile_version >= target.profile_version`` is
+                # skipped on the next poll / backfill. A profile bump (via
+                # bulk_score_for_target) resets status to ``stage2``, which
+                # re-admits the row for grading.
+                "scored_profile_version": target.profile_version,
+                # Keep the recency invariant (recency_score == score when
+                # decay is off). When decay is on the poller's
+                # refresh_recency_scores pass overwrites this with the
+                # age-decayed value later in the same cycle.
+                "recency_score": fit.fit_score,
                 "updated_at": datetime.now(UTC).isoformat(),
             }
         ).eq("job_posting_id", job_posting_id).eq(

--- a/apps/wyrdfold-api/app/services/poller.py
+++ b/apps/wyrdfold-api/app/services/poller.py
@@ -26,6 +26,7 @@ from app.services.ashby import fetch_ashby_jobs
 from app.services.experience.optimized import get_latest as get_latest_optimized
 from app.services.extract import extract_salary_from_text
 from app.services.firecrawl import fetch_firecrawl_jobs
+from app.services.fit import run_phase2_for_jobs
 from app.services.greenhouse import fetch_board_jobs
 from app.services.jd_parser import parse_jd
 from app.services.jsonld import fetch_jsonld_jobs
@@ -793,7 +794,46 @@ async def _poll_one_source(
                 supabase, active_targets, company_name
             )
 
-            if primary_by_user:
+            if settings.phase2_enabled and primary_by_user:
+                # ---- Phase 2: LLM job-fit grading (#6) ----
+                # Replaces the legacy Stage 3 keyword+LLM blend with the
+                # Sonnet scorecard. ``run_phase2_for_jobs`` gates on the
+                # Phase 1 ``promising`` verdict, honours the re-grade
+                # contract, enforces the per-target daily cap, and applies
+                # progressive batching. We re-aggregate the global
+                # ``jobs.score`` afterwards because Phase 2 rewrites
+                # ``scores.score`` (Stage 2's keyword value was a
+                # placeholder until graded).
+                llm = get_default_llm_client()
+                cycle_rows = [
+                    cast(dict[str, Any], r) for r in upsert_resp.data or []
+                ]
+                for uid, p2_target in primary_by_user.items():
+                    try:
+                        await run_phase2_for_jobs(
+                            supabase,
+                            llm,
+                            target=p2_target,
+                            payload=user_optimized[uid].payload,
+                            jobs=cycle_rows,
+                            user_id=uid,
+                        )
+                    except Exception:
+                        logger.exception(
+                            "Phase 2 grading failed for user %s / target %s",
+                            uid,
+                            p2_target.id,
+                        )
+                if stage2_ids:
+                    try:
+                        await asyncio.to_thread(
+                            batch_update_global_scores, supabase, stage2_ids
+                        )
+                    except Exception:
+                        logger.exception(
+                            "Global score update failed after Phase 2"
+                        )
+            elif primary_by_user:
                 llm = get_default_llm_client()
                 llm_sem = asyncio.Semaphore(LLM_CONCURRENCY)
 

--- a/apps/wyrdfold-api/app/services/poller.py
+++ b/apps/wyrdfold-api/app/services/poller.py
@@ -34,6 +34,7 @@ from app.services.llm import get_default_client as get_default_llm_client
 from app.services.llm.client import LLMClient
 from app.services.llm.cost_log import enqueue as enqueue_llm_cost
 from app.services.llm.cost_log import record as record_llm_cost
+from app.services.recency import refresh_recency_scores
 from app.services.relevance.title_triage import (
     PHASE1_BATCH_SIZE,
     PHASE1_PURPOSE,
@@ -817,6 +818,22 @@ async def _poll_one_source(
                         for uid in primary_by_user
                     )
                 )
+
+            # ---- Recency decay refresh (#5) ----
+            # Re-derive ``scores.recency_score`` for every row touched
+            # this cycle from the job's age, now that the fit scores are
+            # settled. Gated on the flag so a disabled rollout skips the
+            # extra writes — recency_score already mirrors score from the
+            # upsert in that case, so the list sort is unaffected.
+            if settings.recency_decay_enabled and stage2_ids:
+                try:
+                    await asyncio.to_thread(
+                        refresh_recency_scores, supabase, stage2_ids
+                    )
+                except Exception:
+                    logger.exception(
+                        "Recency refresh failed for %s", company_name
+                    )
         else:
             existing_resp = await asyncio.to_thread(existing_query.execute)
 

--- a/apps/wyrdfold-api/app/services/recency.py
+++ b/apps/wyrdfold-api/app/services/recency.py
@@ -1,0 +1,172 @@
+"""Recency decay for job list ordering (#5).
+
+The fit score (``scores.score``) measures match quality; it says nothing
+about whether a posting is still live. ``recency_score`` is the value the
+/jobs list sorts and paginates by — the fit score multiplied by an age
+decay so stale postings drift down without being archived.
+
+    final = score * max(0.3, 1 - max(0, age_days - 7) * 0.015)
+
+- 7-day grace window at full score.
+- Loses 1.5% of the multiplier per day after the grace window.
+- Floors at 30% of the fit score around ~54 days old.
+
+Daniel's call (see plan-llm-scoring-migration.md, "Recency decay
+deferred"): STORE the decayed score in a column and refresh it in the
+poller, rather than computing it at read time. Read-time decay breaks
+the list sort (a high-fit old job sorts above a fresh one by raw score
+even though its visible decayed score is lower) and a query-time
+expression forces a full-table scan. A stored, indexed column lets the
+list page server-side.
+
+Feature flag ``RECENCY_DECAY_ENABLED`` (default off): when off the
+multiplier is 1.0, so ``recency_score == score`` and ordering is
+unchanged. The column is always written (never NULL for live rows) so
+flipping the flag on is a pure sort change with no backfill gap.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from typing import Any, cast
+
+from supabase import Client
+
+from app.config import settings
+
+logger = logging.getLogger(__name__)
+
+# Decay parameters. Kept as module constants so the migration comment,
+# the helper, and the tests all point at one source of truth.
+RECENCY_GRACE_DAYS = 7
+RECENCY_DAILY_DECAY = 0.015
+RECENCY_FLOOR = 0.3
+
+# Chunk size for the bulk recency RPC payload. Matches the IN-chunk
+# sizing used elsewhere (target_scoring, jobs router) — keeps the JSONB
+# argument well under PostgREST's request limits.
+_RECENCY_CHUNK_SIZE = 500
+
+
+def compute_recency_multiplier(age_days: float) -> float:
+    """Return the age-decay multiplier in ``[RECENCY_FLOOR, 1.0]``.
+
+    ``age_days`` is the posting's age (now - first_seen_at) in days.
+    Negative ages (clock skew on a just-ingested row) clamp to the full
+    multiplier. The floor means a very old posting never drops to zero —
+    a strong match stays findable, just demoted.
+    """
+    decay_days = max(0.0, age_days - RECENCY_GRACE_DAYS)
+    return max(RECENCY_FLOOR, 1.0 - decay_days * RECENCY_DAILY_DECAY)
+
+
+def compute_recency_score(
+    score: int, age_days: float, *, enabled: bool
+) -> int:
+    """Decay ``score`` by posting age. ``enabled=False`` is an identity
+    (multiplier 1.0) so the column mirrors ``score`` when the flag is
+    off."""
+    if not enabled:
+        return score
+    return round(score * compute_recency_multiplier(age_days))
+
+
+def _age_days(first_seen_at: Any, now: datetime) -> float:
+    """Days between ``first_seen_at`` and ``now``. Unparseable / missing
+    timestamps return 0.0 (treat as fresh — no decay) so a bad row never
+    crashes the refresh pass."""
+    if not first_seen_at:
+        return 0.0
+    try:
+        if isinstance(first_seen_at, str):
+            seen = datetime.fromisoformat(first_seen_at.replace("Z", "+00:00"))
+        else:
+            seen = first_seen_at
+        if seen.tzinfo is None:
+            seen = seen.replace(tzinfo=UTC)
+    except (TypeError, ValueError):
+        return 0.0
+    return max(0.0, (now - seen).total_seconds() / 86400.0)
+
+
+def refresh_recency_scores(
+    supabase: Client, job_posting_ids: list[str]
+) -> int:
+    """Recompute ``recency_score`` for every scores row of the given jobs.
+
+    Reads each job's ``first_seen_at`` to derive its age, then writes
+    ``score * decay`` back to each (job, target) scores row via the
+    ``bulk_update_recency_scores`` RPC. Called by the poller after the
+    cycle's fit scores are settled (keyword and/or Phase 2), so the
+    stored value tracks both the latest fit score and the current date.
+
+    Idempotent and side-effect-light: a no-op when the recency flag is
+    off would still be correct (recency_score == score), but the poller
+    only calls this when the flag is on to avoid the extra writes. Errors
+    are logged and swallowed — a failed recency refresh must never fail a
+    poll cycle. Returns the number of rows written.
+    """
+    if not job_posting_ids:
+        return 0
+
+    unique_ids = list(set(job_posting_ids))
+    enabled = settings.recency_decay_enabled
+    now = datetime.now(UTC)
+
+    # 1. Job ages (one property per posting, shared across its targets).
+    age_by_job: dict[str, float] = {}
+    for i in range(0, len(unique_ids), _RECENCY_CHUNK_SIZE):
+        chunk = unique_ids[i : i + _RECENCY_CHUNK_SIZE]
+        try:
+            resp = (
+                supabase.table("jobs")
+                .select("id, first_seen_at")
+                .in_("id", chunk)
+                .execute()
+            )
+        except Exception:
+            logger.exception("refresh_recency_scores: jobs fetch failed")
+            return 0
+        for row in cast(list[dict[str, Any]], resp.data or []):
+            age_by_job[row["id"]] = _age_days(row.get("first_seen_at"), now)
+
+    # 2. Per-(job, target) score rows → recency_score updates.
+    updates: list[dict[str, Any]] = []
+    for i in range(0, len(unique_ids), _RECENCY_CHUNK_SIZE):
+        chunk = unique_ids[i : i + _RECENCY_CHUNK_SIZE]
+        try:
+            resp = (
+                supabase.table("scores")
+                .select("id, job_posting_id, score")
+                .in_("job_posting_id", chunk)
+                .execute()
+            )
+        except Exception:
+            logger.exception("refresh_recency_scores: scores fetch failed")
+            return 0
+        for row in cast(list[dict[str, Any]], resp.data or []):
+            age = age_by_job.get(row["job_posting_id"], 0.0)
+            updates.append(
+                {
+                    "id": row["id"],
+                    "recency_score": compute_recency_score(
+                        row.get("score") or 0, age, enabled=enabled
+                    ),
+                }
+            )
+
+    if not updates:
+        return 0
+
+    written = 0
+    for i in range(0, len(updates), _RECENCY_CHUNK_SIZE):
+        chunk_updates = updates[i : i + _RECENCY_CHUNK_SIZE]
+        try:
+            supabase.rpc(
+                "bulk_update_recency_scores", {"p_updates": chunk_updates}
+            ).execute()
+            written += len(chunk_updates)
+        except Exception:
+            logger.exception("refresh_recency_scores: bulk update failed")
+    return written

--- a/apps/wyrdfold-api/app/services/target_scoring.py
+++ b/apps/wyrdfold-api/app/services/target_scoring.py
@@ -84,6 +84,12 @@ def _upsert_score(
         "excluded": excluded,
         "scoring_status": scoring_status,
         "scored_profile_version": scored_profile_version,
+        # Initialise recency_score to the raw fit score (fresh-posting,
+        # decay multiplier 1.0). Correct as-is when RECENCY_DECAY_ENABLED
+        # is off; when on, the poller's ``refresh_recency_scores`` pass
+        # overwrites it with the age-decayed value later in the cycle.
+        # Keeping it non-NULL means a flag flip is a pure sort change.
+        "recency_score": score,
         "updated_at": datetime.now(UTC).isoformat(),
     }
     if promising is not None:
@@ -298,6 +304,10 @@ def bulk_score_for_target(supabase: Client, target: JobTarget) -> int:
                 "excluded": result.excluded or excluded_by_prefilter,
                 "scoring_status": "stage2",
                 "scored_profile_version": target.profile_version,
+                # Reset recency_score to the new raw score; the next poll
+                # cycle's refresh pass re-applies age decay (see
+                # ``_upsert_score`` and ``app/services/recency.py``).
+                "recency_score": result.score,
                 "updated_at": now,
             }
             # Pass-through ``promising`` only when it's set on the

--- a/apps/wyrdfold-api/scripts/backfill_phase2_fit.py
+++ b/apps/wyrdfold-api/scripts/backfill_phase2_fit.py
@@ -1,0 +1,203 @@
+"""One-time Phase 2 re-grade for promising jobs (#6 ship migration).
+
+When Phase 2 ships, every existing ``scores`` row carries a keyword-
+derived score that isn't comparable to the new Sonnet fit scale (see
+plan-llm-scoring-migration.md, "Migration risks"). This script re-grades
+the promising backlog through ``run_phase2_for_jobs`` so the list shows
+LLM scores from day one instead of trickling in over many poll cycles.
+
+For each ACTIVE target it:
+  1. resolves the target's owning user + their optimized profile,
+  2. collects the target's ``promising=true`` jobs,
+  3. hands them to ``run_phase2_for_jobs``, which applies the same gate /
+     re-grade contract / progressive batching as the poller.
+
+Idempotent: the re-grade contract skips rows already ``complete`` at the
+current ``profile_version``, so a re-run only grades what's still
+pending. ``--cap`` defaults high (the daily cap is a poll-cycle guard,
+not a backfill one); ``--dry-run`` reports candidate counts without
+spending a token.
+
+Usage:
+    cd apps/wyrdfold-api && uv run python scripts/backfill_phase2_fit.py --dry-run
+    cd apps/wyrdfold-api && uv run python scripts/backfill_phase2_fit.py
+    cd apps/wyrdfold-api && uv run python scripts/backfill_phase2_fit.py --target <id> --cap 500
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+from typing import Any, cast
+
+from app.models.targets import JobTarget
+from app.services.experience.optimized import get_latest as get_latest_optimized
+from app.services.fit import run_phase2_for_jobs
+from app.services.fit.phase2_runner import _fetch_phase2_state, _needs_phase2
+from app.services.llm import get_default_client as get_llm_client
+from app.services.targets.crud import get_active as get_active_targets
+from app.supabase_pool import get_supabase_pool, init_supabase
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+logger = logging.getLogger("backfill_phase2")
+
+# Effectively-unbounded default cap: a backfill should grade the whole
+# promising backlog, not stop at the per-target daily poll budget.
+_BACKFILL_CAP = 100_000
+_PAGE = 500
+
+
+def _promising_job_ids(supabase: Any, target_id: str) -> list[str]:
+    """All ``promising=true`` job ids for a target (paginated)."""
+    job_ids: list[str] = []
+    offset = 0
+    while True:
+        resp = (
+            supabase.table("scores")
+            .select("job_posting_id")
+            .eq("target_id", target_id)
+            .eq("promising", True)
+            .range(offset, offset + _PAGE - 1)
+            .execute()
+        )
+        rows = cast(list[dict[str, Any]], resp.data or [])
+        if not rows:
+            break
+        job_ids.extend(r["job_posting_id"] for r in rows)
+        if len(rows) < _PAGE:
+            break
+        offset += _PAGE
+    return job_ids
+
+
+def _fetch_jobs(supabase: Any, job_ids: list[str]) -> list[dict[str, Any]]:
+    """Fetch the job rows Phase 2 needs (id, title, JD, first_seen_at)."""
+    jobs: list[dict[str, Any]] = []
+    for i in range(0, len(job_ids), _PAGE):
+        chunk = job_ids[i : i + _PAGE]
+        resp = (
+            supabase.table("jobs")
+            .select("id, title, description_html, first_seen_at")
+            .in_("id", chunk)
+            .execute()
+        )
+        jobs.extend(cast(list[dict[str, Any]], resp.data or []))
+    return jobs
+
+
+def _resolve_target_user(
+    supabase: Any, target: JobTarget
+) -> tuple[str, Any] | None:
+    """Return ``(user_id, optimized_payload)`` for an active target.
+
+    Picks the first active owner with a generated optimized profile —
+    Phase 2 scores a job against that user's profile, so a target with no
+    profiled owner is skipped (nothing to grade against).
+    """
+    resp = (
+        supabase.table("user_targets")
+        .select("user_id")
+        .eq("target_id", target.id)
+        .eq("is_active", True)
+        .execute()
+    )
+    for row in cast(list[dict[str, Any]], resp.data or []):
+        doc = get_latest_optimized(supabase, row["user_id"])
+        if doc is not None:
+            return row["user_id"], doc.payload
+    return None
+
+
+async def backfill(
+    *, dry_run: bool, cap: int, target_id: str | None
+) -> int:
+    init_supabase()
+    supabase = get_supabase_pool()
+    if supabase is None:
+        raise RuntimeError("Supabase not configured — check .env")
+
+    targets = get_active_targets(supabase)
+    if target_id:
+        targets = [t for t in targets if t.id == target_id]
+    logger.info("Re-grading Phase 2 for %d active target(s)", len(targets))
+
+    total = 0
+    for target in targets:
+        resolved = _resolve_target_user(supabase, target)
+        if resolved is None:
+            logger.warning(
+                "Skipping target %s (%s) — no active owner with a profile",
+                target.id,
+                target.label,
+            )
+            continue
+        user_id, payload = resolved
+
+        job_ids = _promising_job_ids(supabase, target.id)
+        if not job_ids:
+            logger.info("%s — no promising jobs", target.label)
+            continue
+        jobs = _fetch_jobs(supabase, job_ids)
+
+        if dry_run:
+            state = _fetch_phase2_state(supabase, target.id, [j["id"] for j in jobs])
+            pending = sum(
+                1
+                for j in jobs
+                if j["id"] in state
+                and _needs_phase2(*state[j["id"]], target.profile_version)
+            )
+            logger.info(
+                "%s — %d promising, %d need Phase 2 (dry-run)",
+                target.label,
+                len(jobs),
+                pending,
+            )
+            total += pending
+            continue
+
+        graded = await run_phase2_for_jobs(
+            supabase,
+            get_llm_client(),
+            target=target,
+            payload=payload,
+            jobs=jobs,
+            user_id=user_id,
+            cap=cap,
+        )
+        logger.info("✓ %s — graded %d job(s)", target.label, graded)
+        total += graded
+
+    verb = "would grade" if dry_run else "graded"
+    logger.info("Done — %s %d job(s) total", verb, total)
+    return total
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="One-time Phase 2 fit re-grade")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report candidate counts without calling the LLM.",
+    )
+    parser.add_argument(
+        "--cap",
+        type=int,
+        default=_BACKFILL_CAP,
+        help="Per-target grade ceiling (default: effectively unbounded).",
+    )
+    parser.add_argument(
+        "--target",
+        type=str,
+        default=None,
+        help="Restrict to a single target id.",
+    )
+    args = parser.parse_args()
+    asyncio.run(
+        backfill(dry_run=args.dry_run, cap=args.cap, target_id=args.target)
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/wyrdfold-api/tests/test_phase2_runner.py
+++ b/apps/wyrdfold-api/tests/test_phase2_runner.py
@@ -1,0 +1,244 @@
+"""Tests for Phase 2 orchestration (#6).
+
+Covers the gate / re-grade predicate, progressive batching, and
+``run_phase2_for_jobs``: promising-only selection, the daily cap trim,
+newest-first ordering, and the graded count. The actual grader
+(``score_with_phase2_and_persist``) and the quota counter are stubbed —
+this exercises the policy, not the LLM or DB.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.models.experience import OptimizedPayload
+from app.models.targets import (
+    CategoryProfile,
+    JobTarget,
+    ScoringProfile,
+    SeniorityProfile,
+)
+from app.services.fit.job_fit import AxisScores, JobFitResult
+from app.services.fit.phase2_runner import (
+    PHASE2_BATCH_SIZE,
+    PHASE2_FIRST_BATCH,
+    _needs_phase2,
+    _progressive_batches,
+    run_phase2_for_jobs,
+)
+
+_RUNNER = "app.services.fit.phase2_runner"
+
+
+def _target(profile_version: int = 1) -> JobTarget:
+    return JobTarget(
+        id="t-1",
+        label="Staff Frontend Engineer",
+        scoring_profile=ScoringProfile(
+            categories={"core": CategoryProfile(keywords={"x": 1}, weight=2.0)},
+            seniority=SeniorityProfile(signals=["staff"]),
+        ),
+        profile_version=profile_version,
+        is_active=True,
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
+    )
+
+
+def _payload() -> OptimizedPayload:
+    return OptimizedPayload(summary="...", roles=[], skills=[], outcomes=[])
+
+
+def _fit() -> JobFitResult:
+    return JobFitResult(
+        fit_score=82,
+        axes=AxisScores(title_fit=90, skills_fit=80, seniority_fit=85, domain_fit=70),
+        reasoning="ok",
+    )
+
+
+# ---- _needs_phase2 ---------------------------------------------------------
+
+
+def test_needs_phase2_requires_promising_true() -> None:
+    # Not promising / unknown → never a candidate.
+    assert _needs_phase2(None, "stage2", 1, 1) is False
+    assert _needs_phase2(False, "stage2", 1, 1) is False
+    # Promising + not yet finished → candidate.
+    assert _needs_phase2(True, "stage2", 1, 1) is True
+
+
+def test_needs_phase2_skips_already_current() -> None:
+    # Complete at the current version → skip (re-grade contract).
+    assert _needs_phase2(True, "complete", 2, 2) is False
+    assert _needs_phase2(True, "complete", 3, 2) is False
+
+
+def test_needs_phase2_regrades_stale_complete() -> None:
+    # Complete but at an older profile version → re-grade.
+    assert _needs_phase2(True, "complete", 1, 2) is True
+
+
+# ---- _progressive_batches --------------------------------------------------
+
+
+def test_progressive_batches_small_set_single_batch() -> None:
+    assert _progressive_batches(["a", "b"], PHASE2_FIRST_BATCH, PHASE2_BATCH_SIZE) == [
+        ["a", "b"]
+    ]
+
+
+def test_progressive_batches_first_small_then_large() -> None:
+    items = [str(i) for i in range(75)]
+    batches = _progressive_batches(items, PHASE2_FIRST_BATCH, PHASE2_BATCH_SIZE)
+    # 75 = 20 (first) + 50 + 5.
+    assert [len(b) for b in batches] == [20, 50, 5]
+    # Order preserved, no drops.
+    assert [x for b in batches for x in b] == items
+
+
+def test_progressive_batches_empty() -> None:
+    assert _progressive_batches([], PHASE2_FIRST_BATCH, PHASE2_BATCH_SIZE) == []
+
+
+# ---- run_phase2_for_jobs ---------------------------------------------------
+
+
+class _StateChain:
+    def __init__(self, rows: list[dict[str, Any]]) -> None:
+        self._rows = rows
+
+    def select(self, *_a: Any, **_kw: Any) -> _StateChain:
+        return self
+
+    def eq(self, *_a: Any, **_kw: Any) -> _StateChain:
+        return self
+
+    def in_(self, *_a: Any, **_kw: Any) -> _StateChain:
+        return self
+
+    def execute(self) -> Any:
+        return MagicMock(data=self._rows)
+
+
+def _supabase(state_rows: list[dict[str, Any]]) -> MagicMock:
+    sb = MagicMock()
+    sb.table.side_effect = lambda name: _StateChain(state_rows)
+    return sb
+
+
+def _patch_grader(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    graded: list[str] = []
+
+    async def fake_score(
+        _sb: Any, _llm: Any, *, job_posting_id: str, **_kw: Any
+    ) -> JobFitResult:
+        graded.append(job_posting_id)
+        return _fit()
+
+    monkeypatch.setattr(f"{_RUNNER}.score_with_phase2_and_persist", fake_score)
+    return graded
+
+
+def _patch_quota(monkeypatch: pytest.MonkeyPatch, quota: int) -> None:
+    monkeypatch.setattr(
+        f"{_RUNNER}.phase2_quota_remaining", lambda *_a, **_kw: quota
+    )
+
+
+@pytest.mark.asyncio
+async def test_grades_only_promising_pending(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    graded = _patch_grader(monkeypatch)
+    _patch_quota(monkeypatch, 100)
+    rows = [
+        {"job_posting_id": "j-yes", "promising": True, "scoring_status": "stage2",
+         "scored_profile_version": 1},
+        {"job_posting_id": "j-no-prom", "promising": False, "scoring_status": "stage2",
+         "scored_profile_version": 1},
+        {"job_posting_id": "j-done", "promising": True, "scoring_status": "complete",
+         "scored_profile_version": 1},
+        # No scores row at all for j-missing (Phase 1 dropped it).
+    ]
+    jobs = [
+        {"id": "j-yes", "title": "FE", "description_html": "<p>x</p>"},
+        {"id": "j-no-prom", "title": "PM", "description_html": ""},
+        {"id": "j-done", "title": "FE2", "description_html": ""},
+        {"id": "j-missing", "title": "??", "description_html": ""},
+    ]
+
+    n = await run_phase2_for_jobs(
+        _supabase(rows), MagicMock(), target=_target(1), payload=_payload(), jobs=jobs
+    )
+
+    assert n == 1
+    assert graded == ["j-yes"]
+
+
+@pytest.mark.asyncio
+async def test_daily_cap_trims_to_quota_newest_first(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    graded = _patch_grader(monkeypatch)
+    _patch_quota(monkeypatch, 2)  # only two grades left today
+    rows = [
+        {"job_posting_id": f"j{i}", "promising": True, "scoring_status": "stage2",
+         "scored_profile_version": 1}
+        for i in range(4)
+    ]
+    # j3 newest, j0 oldest — cap should pick the two freshest.
+    jobs = [
+        {"id": "j0", "title": "a", "description_html": "", "first_seen_at": "2026-01-01T00:00:00+00:00"},
+        {"id": "j1", "title": "b", "description_html": "", "first_seen_at": "2026-02-01T00:00:00+00:00"},
+        {"id": "j2", "title": "c", "description_html": "", "first_seen_at": "2026-03-01T00:00:00+00:00"},
+        {"id": "j3", "title": "d", "description_html": "", "first_seen_at": "2026-04-01T00:00:00+00:00"},
+    ]
+
+    n = await run_phase2_for_jobs(
+        _supabase(rows), MagicMock(), target=_target(1), payload=_payload(), jobs=jobs
+    )
+
+    assert n == 2
+    assert set(graded) == {"j3", "j2"}
+
+
+@pytest.mark.asyncio
+async def test_zero_quota_grades_nothing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    graded = _patch_grader(monkeypatch)
+    _patch_quota(monkeypatch, 0)
+    rows = [
+        {"job_posting_id": "j0", "promising": True, "scoring_status": "stage2",
+         "scored_profile_version": 1}
+    ]
+    jobs = [{"id": "j0", "title": "a", "description_html": ""}]
+
+    n = await run_phase2_for_jobs(
+        _supabase(rows), MagicMock(), target=_target(1), payload=_payload(), jobs=jobs
+    )
+
+    assert n == 0
+    assert graded == []
+
+
+@pytest.mark.asyncio
+async def test_empty_jobs_short_circuits(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    graded = _patch_grader(monkeypatch)
+    # Quota counter must not even be consulted on empty input.
+    monkeypatch.setattr(
+        f"{_RUNNER}.phase2_quota_remaining",
+        lambda *_a, **_kw: (_ for _ in ()).throw(AssertionError("called")),
+    )
+    n = await run_phase2_for_jobs(
+        MagicMock(), MagicMock(), target=_target(1), payload=_payload(), jobs=[]
+    )
+    assert n == 0
+    assert graded == []

--- a/apps/wyrdfold-api/tests/test_recency.py
+++ b/apps/wyrdfold-api/tests/test_recency.py
@@ -77,10 +77,10 @@ class _TableChain:
     def __init__(self, resp: _Resp) -> None:
         self._resp = resp
 
-    def select(self, *_a: Any, **_kw: Any) -> "_TableChain":
+    def select(self, *_a: Any, **_kw: Any) -> _TableChain:
         return self
 
-    def in_(self, *_a: Any, **_kw: Any) -> "_TableChain":
+    def in_(self, *_a: Any, **_kw: Any) -> _TableChain:
         return self
 
     def execute(self) -> _Resp:
@@ -179,25 +179,25 @@ class _ListChain:
     def __init__(self, resp: _ListResp) -> None:
         self._resp = resp
 
-    def select(self, *_a: Any, **_kw: Any) -> "_ListChain":
+    def select(self, *_a: Any, **_kw: Any) -> _ListChain:
         return self
 
-    def eq(self, *_a: Any, **_kw: Any) -> "_ListChain":
+    def eq(self, *_a: Any, **_kw: Any) -> _ListChain:
         return self
 
-    def in_(self, *_a: Any, **_kw: Any) -> "_ListChain":
+    def in_(self, *_a: Any, **_kw: Any) -> _ListChain:
         return self
 
-    def gte(self, *_a: Any, **_kw: Any) -> "_ListChain":
+    def gte(self, *_a: Any, **_kw: Any) -> _ListChain:
         return self
 
-    def ilike(self, *_a: Any, **_kw: Any) -> "_ListChain":
+    def ilike(self, *_a: Any, **_kw: Any) -> _ListChain:
         return self
 
-    def order(self, *_a: Any, **_kw: Any) -> "_ListChain":
+    def order(self, *_a: Any, **_kw: Any) -> _ListChain:
         return self
 
-    def range(self, *_a: Any, **_kw: Any) -> "_ListChain":
+    def range(self, *_a: Any, **_kw: Any) -> _ListChain:
         return self
 
     def execute(self) -> _ListResp:

--- a/apps/wyrdfold-api/tests/test_recency.py
+++ b/apps/wyrdfold-api/tests/test_recency.py
@@ -1,0 +1,296 @@
+"""Tests for recency decay (#5).
+
+Covers the pure decay math (``compute_recency_multiplier`` /
+``compute_recency_score``), the poller-side refresh pass
+(``refresh_recency_scores``), and the /jobs two-query ordering when the
+``RECENCY_DECAY_ENABLED`` flag is on.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.config import settings
+from app.routers.jobs import (
+    _list_jobs_across_user_targets,
+    _list_jobs_for_target_two_query,
+)
+from app.services.recency import (
+    RECENCY_FLOOR,
+    compute_recency_multiplier,
+    compute_recency_score,
+    refresh_recency_scores,
+)
+
+# ---- Pure decay math -------------------------------------------------------
+
+
+def test_multiplier_full_inside_grace_window() -> None:
+    assert compute_recency_multiplier(0) == 1.0
+    assert compute_recency_multiplier(7) == 1.0
+
+
+def test_multiplier_decays_after_grace() -> None:
+    # Day 8: one day past the 7-day grace → lose 1.5%.
+    assert compute_recency_multiplier(8) == pytest.approx(0.985)
+    # Day 27: 20 days past grace → lose 30%.
+    assert compute_recency_multiplier(27) == pytest.approx(0.70)
+
+
+def test_multiplier_floors_at_30_percent() -> None:
+    # 1 - (age-7)*0.015 = 0.3 → age ≈ 53.7; anything older clamps to the floor.
+    assert compute_recency_multiplier(54) == RECENCY_FLOOR
+    assert compute_recency_multiplier(365) == RECENCY_FLOOR
+
+
+def test_multiplier_clamps_negative_age() -> None:
+    """Clock skew on a just-ingested row must not exceed full score."""
+    assert compute_recency_multiplier(-3) == 1.0
+
+
+def test_compute_recency_score_disabled_is_identity() -> None:
+    # Even a very old posting keeps its raw score when the flag is off.
+    assert compute_recency_score(90, age_days=200, enabled=False) == 90
+
+
+def test_compute_recency_score_enabled_applies_decay() -> None:
+    assert compute_recency_score(90, age_days=0, enabled=True) == 90
+    # 20 days past grace → 0.70 → round(90 * 0.70) = 63.
+    assert compute_recency_score(90, age_days=27, enabled=True) == 63
+    # Past the floor → round(90 * 0.30) = 27.
+    assert compute_recency_score(90, age_days=400, enabled=True) == 27
+
+
+# ---- refresh_recency_scores ------------------------------------------------
+
+
+class _Resp:
+    def __init__(self, data: list[dict[str, Any]]) -> None:
+        self.data = data
+
+
+class _TableChain:
+    def __init__(self, resp: _Resp) -> None:
+        self._resp = resp
+
+    def select(self, *_a: Any, **_kw: Any) -> "_TableChain":
+        return self
+
+    def in_(self, *_a: Any, **_kw: Any) -> "_TableChain":
+        return self
+
+    def execute(self) -> _Resp:
+        return self._resp
+
+
+class _RpcChain:
+    def __init__(self, sink: list[dict[str, Any]]) -> None:
+        self._sink = sink
+
+    def execute(self) -> _Resp:
+        return _Resp([])
+
+
+def _refresh_supabase(
+    jobs: list[dict[str, Any]],
+    scores: list[dict[str, Any]],
+    rpc_calls: list[tuple[str, dict[str, Any]]],
+) -> MagicMock:
+    sb = MagicMock()
+    sb.table.side_effect = lambda name: _TableChain(
+        _Resp(jobs if name == "jobs" else scores)
+    )
+
+    def _rpc(name: str, params: dict[str, Any]) -> _RpcChain:
+        rpc_calls.append((name, params))
+        return _RpcChain([])
+
+    sb.rpc.side_effect = _rpc
+    return sb
+
+
+def test_refresh_applies_decay_per_row_when_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "recency_decay_enabled", True)
+    fresh = datetime.now(UTC).isoformat()
+    old = (datetime.now(UTC) - timedelta(days=27)).isoformat()
+    jobs = [
+        {"id": "j-fresh", "first_seen_at": fresh},
+        {"id": "j-old", "first_seen_at": old},
+    ]
+    # Two targets for the old job → two rows, different scores, same age.
+    scores = [
+        {"id": "s1", "job_posting_id": "j-fresh", "score": 80},
+        {"id": "s2", "job_posting_id": "j-old", "score": 90},
+        {"id": "s3", "job_posting_id": "j-old", "score": 40},
+    ]
+    rpc_calls: list[tuple[str, dict[str, Any]]] = []
+    sb = _refresh_supabase(jobs, scores, rpc_calls)
+
+    written = refresh_recency_scores(sb, ["j-fresh", "j-old"])
+
+    assert written == 3
+    assert len(rpc_calls) == 1
+    name, params = rpc_calls[0]
+    assert name == "bulk_update_recency_scores"
+    by_id = {u["id"]: u["recency_score"] for u in params["p_updates"]}
+    assert by_id["s1"] == 80  # fresh → no decay
+    assert by_id["s2"] == 63  # round(90 * 0.70)
+    assert by_id["s3"] == 28  # round(40 * 0.70)
+
+
+def test_refresh_mirrors_score_when_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "recency_decay_enabled", False)
+    old = (datetime.now(UTC) - timedelta(days=100)).isoformat()
+    jobs = [{"id": "j-old", "first_seen_at": old}]
+    scores = [{"id": "s1", "job_posting_id": "j-old", "score": 90}]
+    rpc_calls: list[tuple[str, dict[str, Any]]] = []
+    sb = _refresh_supabase(jobs, scores, rpc_calls)
+
+    refresh_recency_scores(sb, ["j-old"])
+
+    by_id = {u["id"]: u["recency_score"] for u in rpc_calls[0][1]["p_updates"]}
+    assert by_id["s1"] == 90  # flag off → recency mirrors raw score
+
+
+def test_refresh_noop_on_empty_input() -> None:
+    sb = MagicMock()
+    assert refresh_recency_scores(sb, []) == 0
+    sb.rpc.assert_not_called()
+
+
+# ---- /jobs ordering by recency_score ---------------------------------------
+
+
+class _ListResp:
+    def __init__(self, data: list[dict[str, Any]], count: int | None = None) -> None:
+        self.data = data
+        self.count = count
+
+
+class _ListChain:
+    def __init__(self, resp: _ListResp) -> None:
+        self._resp = resp
+
+    def select(self, *_a: Any, **_kw: Any) -> "_ListChain":
+        return self
+
+    def eq(self, *_a: Any, **_kw: Any) -> "_ListChain":
+        return self
+
+    def in_(self, *_a: Any, **_kw: Any) -> "_ListChain":
+        return self
+
+    def gte(self, *_a: Any, **_kw: Any) -> "_ListChain":
+        return self
+
+    def ilike(self, *_a: Any, **_kw: Any) -> "_ListChain":
+        return self
+
+    def order(self, *_a: Any, **_kw: Any) -> "_ListChain":
+        return self
+
+    def range(self, *_a: Any, **_kw: Any) -> "_ListChain":
+        return self
+
+    def execute(self) -> _ListResp:
+        return self._resp
+
+
+def _list_supabase(table_resps: dict[str, _ListResp]) -> MagicMock:
+    sb = MagicMock()
+    sb.table.side_effect = lambda name: _ListChain(table_resps[name])
+    return sb
+
+
+def test_target_two_query_orders_by_recency_when_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A high-fit but stale job sorts BELOW a fresher, lower-fit job once
+    decay is on — the visible (raw) score still rides along."""
+    monkeypatch.setattr(settings, "recency_decay_enabled", True)
+    # Rows arrive pre-ordered by recency_score desc (what the .order() on
+    # recency_score produces server-side): fresh-70 ranks above stale-95.
+    ts_rows = [
+        {"job_posting_id": "j-fresh", "score": 70, "recency_score": 70,
+         "score_breakdown": {}, "scoring_status": "complete"},
+        {"job_posting_id": "j-stale", "score": 95, "recency_score": 48,
+         "score_breakdown": {}, "scoring_status": "complete"},
+    ]
+    postings_storage_order = [
+        {"id": "j-stale", "title": "stale high-fit"},
+        {"id": "j-fresh", "title": "fresh"},
+    ]
+    sb = _list_supabase(
+        {
+            "scores": _ListResp(ts_rows, count=2),
+            "jobs": _ListResp(postings_storage_order),
+        }
+    )
+
+    result = _list_jobs_for_target_two_query(
+        sb,
+        target_id="t-1",
+        offset=0,
+        page=1,
+        page_size=10,
+        sort="score",
+        ascending=False,
+        min_score=None,
+        status=None,
+        company=None,
+        search=None,
+        exclude_terms=[],
+        only_terms=[],
+    )
+
+    assert [p["id"] for p in result["postings"]] == ["j-fresh", "j-stale"]
+    # Displayed score is the raw fit score, not the decayed value.
+    assert [p["score"] for p in result["postings"]] == [70, 95]
+
+
+def test_across_targets_orders_by_recency_when_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "recency_decay_enabled", True)
+    # Location filter active → forces the Python sort path (not the
+    # scores-layer slice), exercising the _sort_key recency branch.
+    score_rows = [
+        {"job_posting_id": "j-fresh", "target_id": "t-1", "score": 70,
+         "recency_score": 70, "score_breakdown": {}, "scoring_status": "complete"},
+        {"job_posting_id": "j-stale", "target_id": "t-2", "score": 95,
+         "recency_score": 48, "score_breakdown": {}, "scoring_status": "complete"},
+    ]
+    postings = [
+        {"id": "j-stale", "title": "stale", "location": "Remote · US"},
+        {"id": "j-fresh", "title": "fresh", "location": "Remote · US"},
+    ]
+    sb = _list_supabase(
+        {"scores": _ListResp(score_rows), "jobs": _ListResp(postings)}
+    )
+
+    result = _list_jobs_across_user_targets(
+        sb,
+        user_target_ids={"t-1", "t-2"},
+        offset=0,
+        page=1,
+        page_size=10,
+        sort="score",
+        ascending=False,
+        min_score=None,
+        status=None,
+        company=None,
+        search=None,
+        exclude_terms=[],
+        only_terms=["remote"],
+    )
+
+    assert [p["id"] for p in result["postings"]] == ["j-fresh", "j-stale"]
+    assert [p["score"] for p in result["postings"]] == [70, 95]

--- a/supabase/migrations/20260603050000_scores_recency_score.sql
+++ b/supabase/migrations/20260603050000_scores_recency_score.sql
@@ -1,0 +1,82 @@
+-- Recency-decayed sort score (Phase 5 of the LLM scoring migration).
+--
+-- The fit signal (``scores.score``) answers "how well does this job
+-- match the target?". It says nothing about whether the posting is
+-- still worth surfacing — a 90-fit role that's been open for two months
+-- is usually gone. ``recency_score`` is the value the /jobs list sorts
+-- and paginates by: the fit score multiplied by an age decay so stale
+-- postings drift down the list without being archived.
+--
+--   recency_score = round(score * max(0.3, 1 - max(0, age_days - 7) * 0.015))
+--
+-- - 7-day grace window at full score.
+-- - Loses 1.5% of the multiplier per day after the grace window.
+-- - Floors at 30% of the fit score around ~54 days old.
+--
+-- See ``app/services/recency.py`` for the canonical helper. The decay
+-- is computed and STORED (Daniel's call) rather than applied at read
+-- time, so the list can sort + paginate by it server-side without a
+-- full-table scan. The poller refreshes the column every cycle from
+-- the job's ``first_seen_at`` (see ``refresh_recency_scores``).
+--
+-- Feature flag: ``RECENCY_DECAY_ENABLED`` (default off). When off the
+-- multiplier is 1.0, so ``recency_score == score`` and list ordering is
+-- unchanged. The column is always populated (never NULL for new rows)
+-- so flipping the flag on is a pure sort change — no backfill gap.
+
+alter table public.scores
+  add column if not exists recency_score integer;
+
+comment on column public.scores.recency_score is
+  'Fit score (scores.score) decayed by posting age — the value the '
+  '/jobs list sorts/paginates by. recency_score == score when '
+  'RECENCY_DECAY_ENABLED is off. Refreshed by the poller each cycle '
+  'from jobs.first_seen_at. See app/services/recency.py.';
+
+-- Backfill existing rows so the column is never NULL when the flag
+-- flips on (NULLS would sort last and hide live jobs until re-polled).
+-- Fresh value == score; the poller applies real decay on next cycle.
+update public.scores
+  set recency_score = score
+  where recency_score is null;
+
+-- Index the list's default sort key. ``score`` already had no dedicated
+-- index for this; recency_score replaces it as the ORDER BY column when
+-- decay is on, so give it the (target_id, recency_score DESC) shape the
+-- two-query list path and the get_target_jobs RPC both page against.
+create index if not exists scores_target_recency_idx
+  on public.scores (target_id, recency_score desc);
+
+-- Bulk-write helper so the poller can refresh many rows' recency_score
+-- in a single round-trip (mirrors ``bulk_update_scores``, which writes
+-- jobs.score). Each element is ``{"id": <scores.id>, "recency_score":
+-- <int>}``. recency_score is per-row (depends on that row's fit score),
+-- so we can't collapse it to one UPDATE value — this keeps it to one
+-- statement instead of one round-trip per row.
+create or replace function public.bulk_update_recency_scores(p_updates jsonb)
+returns integer
+language plpgsql
+security definer
+set search_path = public, pg_catalog
+as $$
+declare
+  cnt integer;
+begin
+  if p_updates is null or jsonb_array_length(p_updates) = 0 then
+    return 0;
+  end if;
+
+  with u as (
+    select (elem->>'id')::uuid            as id,
+           (elem->>'recency_score')::int  as recency_score
+    from   jsonb_array_elements(p_updates) elem
+  )
+  update public.scores s
+  set    recency_score = u.recency_score
+  from   u
+  where  s.id = u.id;
+
+  get diagnostics cnt = row_count;
+  return cnt;
+end;
+$$;


### PR DESCRIPTION
## Summary

Two flag-gated additions that complete the code path for the new LLM scoring pipeline. Both default OFF — landing this PR is safe; turning the pipeline on is a separate flag flip + one-time backfill.

### #5 — Recency decay sort score

- New `scores.recency_score` column: `round(score * max(0.3, 1 - max(0, age_days - 7) * 0.015))`
  - 7-day grace, 1.5%/day decay, floors at 30% (~54 days).
- Computed and **stored** (not read-time) so the list pages server-side without a full-table scan. Refreshed each poll cycle from `jobs.first_seen_at` via the new `bulk_update_recency_scores` RPC.
- Wired into both `/jobs` read paths (per-target two-query + across-targets) when `RECENCY_DECAY_ENABLED` is on.
- Migration backfills existing rows and adds `(target_id, recency_score desc)` index. Column is always non-NULL (seeded from raw score on every scores upsert), so flipping the flag on is a pure sort change with no backfill gap.

### #6 — Phase 2 LLM job-fit grading wired into the poller

Connects the existing `score_with_phase2_and_persist` scaffold (merged in #793) to the live poll cycle behind `PHASE2_ENABLED`.

- **New `app/services/fit/phase2_runner.py`** owns the grading policy in one place (shared by the poller and the backfill script):
  - Gates on Phase 1 `promising=true` — `NULL` / `false` rows skipped.
  - Honours the re-grade contract: skip rows already `complete` at `scored_profile_version >= target.profile_version`; a profile bump resets status to `stage2` and re-admits them (#502 lazy-rescore contract).
  - Per-target daily cap (soft budget via `phase2_quota_remaining`).
  - Progressive batching: first 20 eager, rest in 50-chunks, bounded concurrency, newest-first ordering.
- `score_persistence` now stamps `scored_profile_version` + `recency_score` so the re-grade contract and recency invariant hold across grading.
- **Poller**: when `PHASE2_ENABLED`, Phase 2 replaces the legacy Stage 3 keyword+LLM blend and re-aggregates `jobs.score` afterwards; otherwise Stage 3 runs unchanged.
- **`scripts/backfill_phase2_fit.py`**: one-time idempotent re-grade of the promising backlog at ship — `--dry-run`, `--cap`, `--target` flags.

## Tests

Full wyrdfold-api suite green (1028 passing) in the previous session, including new files:
- `tests/test_recency.py` (11 tests): decay math, refresh pass, two-query + across-targets list ordering.
- `tests/test_phase2_runner.py` (9 tests): gate/re-grade predicate, batch sizing, promising-only selection, cap trim (newest-first), zero-quota and empty-input short-circuits.

Ruff + mypy clean across all touched files.

## Test plan

- [ ] CI green
- [ ] Apply `supabase/migrations/20260603050000_scores_recency_score.sql` in preview
- [ ] Verify `recency_score` defaults to raw `score` (no NULLs) post-migration
- [ ] Flip `RECENCY_DECAY_ENABLED=true` in preview; spot-check that stale jobs drift down the list, raw score badge unchanged
- [ ] Flip `PHASE2_ENABLED=true` in preview alongside `PHASE1_TRIAGE_ENABLED=true`; spot-check that promising jobs get Sonnet scorecards + axis breakdowns
- [ ] Run `scripts/backfill_phase2_fit.py --dry-run` to size the one-time re-grade
- [ ] Run backfill against the promising backlog (idempotent; safe to re-run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)