### PR TITLE
fix(wyrdfold): switch invite + magic-link templates to token_hash flow

### DIFF
--- a/supabase/templates/invite.html
+++ b/supabase/templates/invite.html
@@ -116,7 +116,7 @@
                   <tr>
                     <td bgcolor="#8FC900" style="border-radius: 8px">
                       <a
-                        href="{{ .ConfirmationURL }}"
+                        href="{{ .SiteURL }}/auth/callback?token_hash={{ .TokenHash }}&type=invite"
                         style="
                           display: inline-block;
                           padding: 14px 28px;
@@ -144,9 +144,9 @@
                   If the button doesn't work, paste this link into your
                   browser:<br />
                   <a
-                    href="{{ .ConfirmationURL }}"
+                    href="{{ .SiteURL }}/auth/callback?token_hash={{ .TokenHash }}&type=invite"
                     style="color: #bef264; word-break: break-all"
-                    >{{ .ConfirmationURL }}</a
+                    >{{ .SiteURL }}/auth/callback?token_hash={{ .TokenHash }}&type=invite</a
                   >
                 </p>
               </td>

--- a/supabase/templates/magic-link.html
+++ b/supabase/templates/magic-link.html
@@ -104,7 +104,7 @@
                   <tr>
                     <td bgcolor="#8FC900" style="border-radius: 8px">
                       <a
-                        href="{{ .ConfirmationURL }}"
+                        href="{{ .SiteURL }}/auth/callback?token_hash={{ .TokenHash }}&type=magiclink"
                         style="
                           display: inline-block;
                           padding: 14px 28px;
@@ -132,9 +132,9 @@
                   The link works once and expires in an hour. If it doesn't
                   work, paste this into your browser:<br />
                   <a
-                    href="{{ .ConfirmationURL }}"
+                    href="{{ .SiteURL }}/auth/callback?token_hash={{ .TokenHash }}&type=magiclink"
                     style="color: #bef264; word-break: break-all"
-                    >{{ .ConfirmationURL }}</a
+                    >{{ .SiteURL }}/auth/callback?token_hash={{ .TokenHash }}&type=magiclink</a
                   >
                 </p>
               </td>


### PR DESCRIPTION
## Summary

Companion to #796. The auth callback now handles `?token_hash=` PKCE-free, but the templates were still sending `{{ .ConfirmationURL }}` — which goes through `/auth/v1/verify` and on a PKCE project always redirects back with `?code=`, re-triggering the original bug.

Both templates now send the token-hash form directly:

- `invite.html` → `{{ .SiteURL }}/auth/callback?token_hash={{ .TokenHash }}&type=invite`
- `magic-link.html` → `{{ .SiteURL }}/auth/callback?token_hash={{ .TokenHash }}&type=magiclink`

`verifyOtp` doesn't need a code_verifier cookie, so both flows now work cross-browser. The callback's PKCE branch (still in #796) is preserved as a fallback for `?code=` links already in transit when this ships.

## Why magic-link too, not just invite

Same PKCE pathology fires any time the recipient opens the email in a different browser/device than they requested on — a phone click on a desktop-requested link, for instance. token_hash is robust to all of these.

## Test plan

- [ ] CI green (no code changes; templates only)
- [ ] Deploy templates to Supabase (per `supabase/config.toml:248,253` they're loaded from these paths)
- [ ] Re-invite `hello@piotr-kuczynski.com`; confirm the email link lands at `/auth/callback?token_hash=...&type=invite` and signs him in
- [ ] Request a magic link on desktop, click on phone — should sign in cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)