### PR TITLE
feat(wyrdfold-api): ship V3 evidence-first Phase 2 prompt + adjacent config

### DIFF
--- a/apps/wyrdfold-api/app/config.py
+++ b/apps/wyrdfold-api/app/config.py
@@ -33,7 +33,12 @@ class Settings(BaseSettings):
     llm_provider: Literal["mock", "anthropic"] = "mock"
     anthropic_api_key: str = Field(default="", repr=False)
     anthropic_timeout_seconds: float = Field(default=600.0, ge=1.0, le=3600.0)
-    anthropic_max_retries: int = Field(default=2, ge=0, le=10)
+    # Bumped from 2 → 5 alongside the V3 prompt rollout. The default-2 budget
+    # exhausts on a small fraction of cases during burst load (e.g. Phase 2
+    # backfill grading dozens of jobs in under a minute); 5 gives Anthropic
+    # rate-limit retries enough headroom to recover without sacrificing
+    # responsiveness. Each retry uses exponential backoff inside the SDK.
+    anthropic_max_retries: int = Field(default=5, ge=0, le=10)
 
     # URL validation — enable to validate job URLs during polling.
     validate_poll_urls: bool = True

--- a/apps/wyrdfold-api/app/services/fit/job_fit.py
+++ b/apps/wyrdfold-api/app/services/fit/job_fit.py
@@ -98,7 +98,7 @@ user has done before? Greater weight for targets where domain is part \
 of the user's intent (e.g., "Director of CX Operations" in a SaaS \
 context); lighter weight when the target is domain-agnostic.
 
-Overall fit_score guidance
+Overall fit_score guidance (same bands as baseline)
 - 85-100: excellent across the board; title squarely matches, skills \
 overlap is strong, seniority lines up. Strong recommend.
 - 70-84: solid match with one minor gap (e.g., right title + skills, \
@@ -111,12 +111,24 @@ weak skills overlap, off seniority).
 - 0-29: wrong role function or domain entirely. Should not have \
 reached you if Phase 1 was working — flag it loudly.
 
-Reasoning rules
-- 1-2 sentences. Lead with the strongest match dimension; close with \
-the biggest gap. Mention specific skills / titles / seniority cues — \
-no generic phrases like "good cultural fit".
-- Anchor in evidence from the JD and the user profile. Don't speculate \
-about the company or invent skills the user didn't list.
+Reasoning rules — STRICT (evidence-first):
+- The reasoning string MUST cite at least one specific JD phrase in \
+quotes (e.g., 'the JD asks for "5+ years of React"').
+- The reasoning string MUST cite at least one specific item from the \
+user profile (specific skill, prior company, named outcome) — not a \
+category label.
+- Lead with the STRONGEST matched dimension and name it explicitly: \
+"Title:", "Skills:", "Seniority:", or "Domain:".
+- Close with the BIGGEST GAP, also named explicitly.
+- Hard ban: words like "strong", "great", "well", "alignment", \
+"synergy", "cultural fit" — these are confidence words without \
+evidence. Replace with the underlying fact.
+- 2-3 sentences. Longer if you must, but every sentence must carry a \
+specific fact.
+
+The discipline of forcing concrete evidence in the reasoning should \
+naturally calibrate the score — a score of 80+ that you cannot back up \
+with quoted evidence is a wrong score.
 
 Return JSON matching this exact schema:
 
@@ -128,9 +140,11 @@ Return JSON matching this exact schema:
     "seniority_fit": 85,
     "domain_fit": 70
   },
-  "reasoning": "Title and seniority squarely match a Staff Frontend role; \
-React/TypeScript/Storybook all present in your profile. Missing the \
-e-commerce domain experience the JD emphasises."
+  "reasoning": "Title: 'Staff Frontend Engineer' matches the target \
+exactly. Skills: the JD asks for 'React, TypeScript, accessibility' \
+which appear as headline strengths in your FightCamp work (Lighthouse \
++40, WCAG audit). Gap — Domain: the JD names 'AI safety surfaces' \
+which is absent from your e-commerce/healthtech profile."
 }
 
 Return ONLY the JSON object. No prose, no markdown, no code fences."""
@@ -220,6 +234,12 @@ async def derive_job_fit(
         messages=[Message(role="user", content=user_message)],
         schema=JobFitResult,
         purpose=purpose,
-        max_tokens=512,
+        # 1024 (was 512) to give Sonnet headroom for the evidence-first
+        # reasoning. Sonnet only emits as many tokens as it needs, so the
+        # cost impact is minimal — the prior 512 cap occasionally truncated
+        # mid-JSON on softer / vaguer CX-style JDs where the model tried
+        # harder to find quotable evidence. See plan-wyrdfold-relevance-
+        # findings.md "Experiment 3" for the diagnostic chain.
+        max_tokens=1024,
         cache_system=True,
     )


### PR DESCRIPTION
## Summary

Ships the **V3 evidence-first prompt** for Phase 2 grading, validated against the baseline via a four-way A/B + Sonnet-as-judge across two target types (technical IC + soft leadership). Plus two adjacent config bumps to make V3 robust under burst load.

## Validation receipts

| Target | n | V3 head-to-head wins | Reasoning Δ | Calibration Δ | Approp Δ |
|---|---:|---:|---:|---:|---:|
| Staff Frontend Engineer (technical IC) | 30 | **80%** | +2.10 | -0.03 | +0.03 |
| Director of CX Operations (soft, leadership) | 26 | **96.2%** | +2.65 | +0.16 | +0.23 |

Compared against three other variants in the four-way A/B (see `scripts/.audit-logs/experiments/experiment-log.md` locally for full data):

- **Baseline** (current prompt): second place
- **V1 light band-expansion**: regressed appropriateness
- **V2 aggressive band-expansion**: regressed appropriateness AND calibration
- **V3 evidence-first** (this PR): won head-to-head 80% / 96.2% on the two targets

The win is on reasoning quality. V3 forces concrete JD-phrase citations + specific profile facts, lead with strongest dimension named, close with biggest gap named, bans abstract words. The discipline of "back up scores with quoted evidence" appears to naturally calibrate the score — appropriateness + calibration match-or-exceed baseline while reasoning quality jumps 2+ points.

## What changes

### `app/services/fit/job_fit.py`

1. `_SYSTEM_PROMPT` rewritten with the V3 evidence-first rules. Same score-band definitions as before (NO ceiling expansion — V1/V2 proved that hurts quality). Only the reasoning rules change.
2. `derive_job_fit` `max_tokens=512 → 1024`. Belt-and-suspenders headroom for V3's slightly longer reasoning. Sonnet only emits what it needs, so cost impact is minimal.

### `app/config.py`

3. `anthropic_max_retries` default `2 → 5`. During Phase 2 backfill burst load (~30 calls in <60s), the default-2 budget exhausted on ~3-7% of cases. 5 absorbs typical rate-limit recovery windows.

## Validation methodology

Per the harness in PR #799 (`scripts/eval_grading_prompts.py` + `scripts/judge_grading_variants.py`):

1. Snapshot a balanced eval set per target (top 10 + bottom 10 + middle 10).
2. Re-grade with baseline + V3, save per-row JSON.
3. Sonnet-as-judge rates each variant per case on `score_appropriateness`, `reasoning_quality`, `calibration` (0-10 each).
4. Aggregate + head-to-head.

Noise floor for the harness: Spearman ρ=0.98 for same-prompt-same-model re-grade. V3 stays at-or-above this on both targets — ranking preserved while reasoning quality improves.

## Production sequencing

1. Merge this PR.
2. Confirm Railway env has `ANTHROPIC_MAX_RETRIES` unset (so default takes) OR explicitly bumped to 5.
3. **Optional: trigger a full system re-grade** (~$1.50) to apply V3's reasoning style to existing rows. The migration plan's lazy-rescore contract handles this automatically as `scored_profile_version` bumps; or run `scripts/backfill_phase2_fit.py` explicitly.

Skipping the re-grade is fine — existing scores stay valid (V3's calibration is at-baseline), and the new poll cycle starts producing V3 reasoning on new jobs immediately.

## Test plan

- [ ] CI green
- [ ] Spot-check 5 newly-graded jobs after deploy — verify reasoning is concrete (quotes JD + specific profile facts; named dimensions; no "strong"/"well"/"alignment")
- [ ] Monitor Phase 2 failure rate via Sentry / logs for first 24h — expect drop from the ~5% rate-limit-exhaustion baseline to <2%
- [ ] (Optional) Run `scripts/backfill_phase2_fit.py --dry-run` to size a full re-grade; decide whether worth the ~\$1.50

## Cost summary (this PR's validation)

| Step | Cost |
|---|---:|
| 4-way A/B on Staff FE | $1.20 |
| Judge across 4 variants | $0.30 |
| Cross-target validation on Melissa | $0.85 |
| Retry / max-token diagnostic runs | $0.35 |
| **Total to validate V3** | **~\$2.70** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)