### PR TITLE
feat(wyrdfold-api): Phase 1 confidence capture + confidence-ordered Phase 2

### DIFF
--- a/apps/wyrdfold-api/app/services/fit/phase2_runner.py
+++ b/apps/wyrdfold-api/app/services/fit/phase2_runner.py
@@ -82,20 +82,26 @@ def _needs_phase2(
 
 def _fetch_phase2_state(
     supabase: Client, target_id: str, job_ids: list[str]
-) -> dict[str, tuple[bool | None, str | None, int | None]]:
-    """Read (promising, scoring_status, scored_profile_version) per job.
+) -> dict[str, tuple[bool | None, str | None, int | None, int | None]]:
+    """Read (promising, scoring_status, scored_profile_version, phase1_confidence) per job.
 
     Keyed by ``job_posting_id`` for this one target. Jobs with no scores
     row (Phase 1 dropped them under this target) are simply absent from
-    the result and never become candidates.
+    the result and never become candidates. ``phase1_confidence`` is None
+    for rows triaged before the confidence column existed — the runner's
+    ordering treats None as "lowest priority" so legacy rows still grade
+    but newer high-confidence rows go first.
     """
-    state: dict[str, tuple[bool | None, str | None, int | None]] = {}
+    state: dict[
+        str, tuple[bool | None, str | None, int | None, int | None]
+    ] = {}
     for i in range(0, len(job_ids), _STATE_CHUNK_SIZE):
         chunk = job_ids[i : i + _STATE_CHUNK_SIZE]
         resp = (
             supabase.table("scores")
             .select(
-                "job_posting_id, promising, scoring_status, scored_profile_version"
+                "job_posting_id, promising, scoring_status, "
+                "scored_profile_version, phase1_confidence"
             )
             .eq("target_id", target_id)
             .in_("job_posting_id", chunk)
@@ -106,6 +112,7 @@ def _fetch_phase2_state(
                 row.get("promising"),
                 row.get("scoring_status"),
                 row.get("scored_profile_version"),
+                row.get("phase1_confidence"),
             )
     return state
 
@@ -162,17 +169,29 @@ async def run_phase2_for_jobs(
         jid
         for jid in job_ids
         if jid in state
-        and _needs_phase2(*state[jid], target.profile_version)
+        # Pass only the first 3 fields — confidence is for ordering, not gating.
+        and _needs_phase2(*state[jid][:3], target.profile_version)
     ]
     if not candidates:
         return 0
 
-    # Newest-first so the freshest promising postings claim the quota
-    # before older ones. ``first_seen_at`` is an ISO-8601 string, sortable
-    # lexically; missing values sort last.
-    candidates.sort(
-        key=lambda jid: job_by_id[jid].get("first_seen_at") or "", reverse=True
-    )
+    # Order candidates so the Phase 2 daily cap goes to the highest-leverage
+    # jobs first:
+    #   1) phase1_confidence DESC — Haiku's certainty in the promising
+    #      verdict (None sorts last; legacy rows get graded eventually).
+    #   2) first_seen_at DESC — among equal-confidence rows, prefer the
+    #      freshest.
+    # ``first_seen_at`` is an ISO-8601 string, sortable lexically; missing
+    # values sort last.
+    def _priority(jid: str) -> tuple[int, str]:
+        conf = state[jid][3]  # phase1_confidence
+        # Treat None as -1 so any real confidence wins; combined with
+        # reverse=True the highest confidence comes first.
+        c = int(conf) if conf is not None else -1
+        seen = job_by_id[jid].get("first_seen_at") or ""
+        return (c, seen)
+
+    candidates.sort(key=_priority, reverse=True)
 
     # Daily cap: don't grade more than the target's remaining quota. This
     # is a soft, best-effort budget — concurrent poll cycles for the same

--- a/apps/wyrdfold-api/app/services/poller.py
+++ b/apps/wyrdfold-api/app/services/poller.py
@@ -39,6 +39,7 @@ from app.services.recency import refresh_recency_scores
 from app.services.relevance.title_triage import (
     PHASE1_BATCH_SIZE,
     PHASE1_PURPOSE,
+    TitleVerdict,
     triage_titles,
 )
 from app.services.sanitize import sanitize_html
@@ -554,7 +555,7 @@ async def _poll_one_source(
         # flag so the PR can ship dark; when flag is False the gate
         # admits everything (pass-through) and we rely on downstream
         # keyword scoring for filtering.
-        phase1_verdicts: dict[str, dict[int, bool]] = {}
+        phase1_verdicts: dict[str, dict[int, TitleVerdict]] = {}
         if settings.phase1_triage_enabled and active_targets and jobs:
             llm = get_default_llm_client()
             titles = [job.title for job in jobs]
@@ -562,7 +563,7 @@ async def _poll_one_source(
                 # Chunk to PHASE1_BATCH_SIZE per call. Sources usually
                 # return well under one batch (10-200 jobs); larger
                 # sources spread cost across multiple calls.
-                target_verdicts: dict[int, bool] = {}
+                target_verdicts: dict[int, TitleVerdict] = {}
                 for start in range(0, len(titles), PHASE1_BATCH_SIZE):
                     batch = titles[start : start + PHASE1_BATCH_SIZE]
                     verdicts, result = await triage_titles(
@@ -587,17 +588,23 @@ async def _poll_one_source(
                                 active_target.id,
                             )
                     # Shift batch-local ids to global (1-based) job indices.
-                    for batch_idx, promising in verdicts.items():
+                    for batch_idx, verdict in verdicts.items():
                         global_idx = start + batch_idx  # batch_idx is 1-based
-                        target_verdicts[global_idx] = promising
+                        target_verdicts[global_idx] = verdict
                 phase1_verdicts[active_target.id] = target_verdicts
 
         def _any_target_admits(global_job_idx: int) -> bool:
-            """``global_job_idx`` is 1-based (matches Phase 1's id contract)."""
+            """``global_job_idx`` is 1-based (matches Phase 1's id contract).
+
+            Fail-open: a missing verdict (LLM didn't return an id) is
+            treated as PROMISING. Same semantics as before the
+            confidence rollout.
+            """
             if not phase1_verdicts:
                 return True  # gate disabled or no targets — admit
             for target_verdicts in phase1_verdicts.values():
-                if target_verdicts.get(global_job_idx, True):
+                v = target_verdicts.get(global_job_idx)
+                if v is None or v.promising:
                     return True
             return False
 
@@ -734,16 +741,20 @@ async def _poll_one_source(
                 async def _full_score_one(
                     row_data: dict[str, Any],
                     target: JobTarget = active_target,
-                    verdicts: dict[int, bool] = target_verdicts,
+                    verdicts: dict[int, TitleVerdict] = target_verdicts,
                 ) -> None:
                     try:
                         ext_id = row_data.get("external_id", "")
                         phase1_idx = phase1_idx_by_external_id.get(ext_id)
-                        promising = (
-                            verdicts.get(phase1_idx, True)
+                        verdict = (
+                            verdicts.get(phase1_idx)
                             if phase1_idx is not None
-                            else True
+                            else None
                         )
+                        # Fail-open: missing verdict = admit (matches the
+                        # pre-confidence rollout's `.get(idx, True)` default).
+                        promising = verdict.promising if verdict is not None else True
+                        phase1_confidence = verdict.confidence if verdict is not None else None
                         await asyncio.to_thread(
                             target_score_and_upsert,
                             supabase,
@@ -754,6 +765,7 @@ async def _poll_one_source(
                             parsed_jd=jd_cache.get(row_data["id"]),
                             excluded_by_prefilter=not promising,
                             promising=promising if phase1_verdicts else None,
+                            phase1_confidence=phase1_confidence,
                         )
                     except Exception:
                         logger.exception(
@@ -1089,7 +1101,7 @@ async def _poll_one_source_for_target(
         # Phase 1 per-target triage (single target). Same semantics as
         # ``_poll_one_source`` but the candidate set is one target, so
         # ``phase1_verdicts`` collapses to a single dict.
-        target_verdicts: dict[int, bool] = {}
+        target_verdicts: dict[int, TitleVerdict] = {}
         if settings.phase1_triage_enabled and jobs:
             llm = get_default_llm_client()
             titles = [job.title for job in jobs]
@@ -1116,16 +1128,18 @@ async def _poll_one_source_for_target(
                             "Failed to record Phase 1 cost for target %s",
                             target.id,
                         )
-                for batch_idx, promising in verdicts.items():
-                    target_verdicts[start + batch_idx] = promising
+                for batch_idx, verdict in verdicts.items():
+                    target_verdicts[start + batch_idx] = verdict
 
         rows_to_upsert: list[dict[str, Any]] = []
         phase1_idx_by_external_id: dict[str, int] = {}
         for idx, job in enumerate(jobs):
             # Phase 1 ids are 1-based. Fail-open when no verdict (gate
             # disabled or LLM dropped the entry).
-            if target_verdicts and not target_verdicts.get(idx + 1, True):
-                continue
+            if target_verdicts:
+                v = target_verdicts.get(idx + 1)
+                if v is not None and not v.promising:
+                    continue
             if not _title_matches_target(job.title, target.search_keywords):
                 continue
             if not _is_us_location(job.location_name):
@@ -1201,10 +1215,14 @@ async def _poll_one_source_for_target(
                     # Phase 2 candidate selection can rely on it.
                     ext_id = row_data.get("external_id", "")
                     phase1_idx = phase1_idx_by_external_id.get(ext_id)
-                    promising = (
-                        target_verdicts.get(phase1_idx, True)
+                    verdict = (
+                        target_verdicts.get(phase1_idx)
                         if phase1_idx is not None
-                        else True
+                        else None
+                    )
+                    promising = verdict.promising if verdict is not None else True
+                    phase1_confidence = (
+                        verdict.confidence if verdict is not None else None
                     )
                     await asyncio.to_thread(
                         target_score_and_upsert,
@@ -1216,6 +1234,7 @@ async def _poll_one_source_for_target(
                         parsed_jd=jd_cache.get(row_data["id"]),
                         excluded_by_prefilter=not promising,
                         promising=promising if target_verdicts else None,
+                        phase1_confidence=phase1_confidence,
                     )
                 except Exception:
                     logger.exception(

--- a/apps/wyrdfold-api/app/services/relevance/title_triage.py
+++ b/apps/wyrdfold-api/app/services/relevance/title_triage.py
@@ -104,19 +104,38 @@ tech "Director of CX" target).
 - Clearly off-discipline even if the title shares a word ("Director of \
 Sales" for a "Director of CX" target).
 
+Also include a confidence score (0-100) per verdict — how certain you \
+are about the promising/unpromising call. Use this scale:
+
+- 90-100: bullseye obvious. "Director of CX Operations" for a "Director \
+of CX Operations" target (promising 100); "Senior Frontend Engineer" \
+for the same target (unpromising 100).
+- 70-89: confident. Adjacent specialisation or one-rung-off seniority \
+that fits cleanly under the lean-promising rule (or its inverse for \
+unpromising).
+- 40-69: legitimately ambiguous — could go either way. Use this band \
+honestly; downstream tooling will rely on it to deprioritise borderline \
+cases when the Phase 2 cap bites.
+- 0-39: hedged. You're guessing. Still emit a verdict (the lean-promising \
+rule applies here too), but flag your low certainty.
+
+Confidence is the model's certainty in its verdict, NOT a fit score. \
+A high-confidence UNPROMISING is just as useful as a high-confidence \
+PROMISING — both let downstream tooling skip Phase 2 work.
+
 Return JSON matching this exact schema:
 
 {
   "verdicts": [
-    {"id": 1, "promising": true},
-    {"id": 2, "promising": false},
-    {"id": 3, "promising": true}
+    {"id": 1, "promising": true,  "confidence": 95},
+    {"id": 2, "promising": false, "confidence": 88},
+    {"id": 3, "promising": true,  "confidence": 55}
   ]
 }
 
 One verdict per input title, keyed by the input id. Do NOT omit ids — \
-if you can't decide, default to PROMISING. Return ONLY the JSON \
-object. No prose, no markdown, no code fences."""
+if you can't decide, default to PROMISING with confidence < 50. Return \
+ONLY the JSON object. No prose, no markdown, no code fences."""
 
 
 class TitleVerdict(BaseModel):
@@ -125,10 +144,18 @@ class TitleVerdict(BaseModel):
     ``id`` matches the 1-based position in the input batch — the caller
     maps it back to a job_id. We use integer ids (not the job UUID)
     because numeric ids are cheaper for the model to track than UUIDs.
+
+    ``confidence`` is optional for back-compat: pre-confidence-prompt
+    responses don't include it (defaults to None). When present, it's
+    the model's 0-100 certainty in the ``promising`` verdict (not a fit
+    score — see prompt). The poller persists this to
+    ``scores.phase1_confidence`` so ``phase2_runner`` can order
+    Phase 2 candidates by confidence DESC.
     """
 
     id: int = Field(ge=1)
     promising: bool
+    confidence: int | None = Field(default=None, ge=0, le=100)
 
 
 class TitleTriageResponse(BaseModel):
@@ -177,14 +204,16 @@ async def triage_titles(
     titles: list[str],
     model: ModelId = PHASE1_MODEL,
     purpose: str = PHASE1_PURPOSE,
-) -> tuple[dict[int, bool], LLMResult | None]:
+) -> tuple[dict[int, TitleVerdict], LLMResult | None]:
     """Grade up to ``PHASE1_BATCH_SIZE`` titles against one target.
 
-    Returns ``(verdict_by_index, llm_result)`` where:
-    - ``verdict_by_index`` maps the 1-based input index to ``True`` /
-      ``False``. Indices missing from the dict mean "no verdict";
-      callers must treat that as fail-open (admit the job) so a partial
-      LLM hiccup doesn't drop relevant postings.
+    Returns ``(verdicts_by_index, llm_result)`` where:
+    - ``verdicts_by_index`` maps the 1-based input index to a
+      ``TitleVerdict`` carrying ``promising`` (bool) and ``confidence``
+      (int 0-100, or None on legacy / partial responses). Indices missing
+      from the dict mean "no verdict"; callers must treat that as
+      fail-open (admit the job) so a partial LLM hiccup doesn't drop
+      relevant postings.
     - ``llm_result`` is the LLMResult for cost logging, or ``None`` if
       the call failed entirely (caller logs the exception via the
       ``logger`` import).
@@ -230,5 +259,5 @@ async def triage_titles(
 
     # Map verdicts by id. Tolerate the model returning duplicates (last
     # one wins) or omitting ids (treated as fail-open by the caller's
-    # ``.get(i, True)`` pattern).
-    return {v.id: v.promising for v in parsed.verdicts}, result
+    # ``.get(i)``-returns-None pattern).
+    return {v.id: v for v in parsed.verdicts}, result

--- a/apps/wyrdfold-api/app/services/target_scoring.py
+++ b/apps/wyrdfold-api/app/services/target_scoring.py
@@ -66,6 +66,7 @@ def _upsert_score(
     scoring_status: ScoringStatus,
     scored_profile_version: int = 1,
     promising: bool | None = None,
+    phase1_confidence: int | None = None,
 ) -> JobTargetScore:
     """Upsert a score row and return the parsed result.
 
@@ -74,6 +75,11 @@ def _upsert_score(
     to leave the column untouched on re-upserts; pass ``True`` / ``False``
     to set explicitly. The default ``None`` means legacy keyword-scoring
     callsites don't need to know about Phase 1.
+
+    ``phase1_confidence`` (0-100) is the model's certainty in its Phase 1
+    verdict. Same None-leaves-untouched semantics. Used by
+    ``phase2_runner`` to order candidates by phase1_confidence DESC so
+    the daily Sonnet cap goes to highest-likelihood-promising jobs first.
     """
     row: dict[str, Any] = {
         "job_posting_id": job_posting_id,
@@ -94,6 +100,8 @@ def _upsert_score(
     }
     if promising is not None:
         row["promising"] = promising
+    if phase1_confidence is not None:
+        row["phase1_confidence"] = phase1_confidence
     # Idempotent upsert (`on_conflict` matches the unique constraint), so
     # retrying on a Supabase HTTP/2 stream drop is safe.
     resp = execute_with_retry_sync(
@@ -156,6 +164,7 @@ def score_and_upsert(
     parsed_jd: ParsedJD | None = None,
     excluded_by_prefilter: bool = False,
     promising: bool | None = None,
+    phase1_confidence: int | None = None,
 ) -> JobTargetScore:
     """Stage 2: Score one job's full JD against one target and upsert.
 
@@ -194,6 +203,7 @@ def score_and_upsert(
         scoring_status="stage2",
         scored_profile_version=target.profile_version,
         promising=promising,
+        phase1_confidence=phase1_confidence,
     )
 
 

--- a/apps/wyrdfold-api/scripts/audit_phase1_fn.py
+++ b/apps/wyrdfold-api/scripts/audit_phase1_fn.py
@@ -124,10 +124,10 @@ async def _audit_target(
             model=_AUDIT_MODEL,
             purpose=_AUDIT_PURPOSE,
         )
-        for batch_idx, promising in verdicts.items():
+        for batch_idx, verdict in verdicts.items():
             # batch_idx is 1-based; map to original (job_id, title).
             orig_idx = start + batch_idx - 1
-            if 0 <= orig_idx < len(pairs) and promising is True:
+            if 0 <= orig_idx < len(pairs) and verdict.promising is True:
                 fns += 1
                 fn_examples.append(pairs[orig_idx][1])
     rate = fns / len(pairs) if pairs else 0.0

--- a/apps/wyrdfold-api/scripts/backfill_phase1_promising.py
+++ b/apps/wyrdfold-api/scripts/backfill_phase1_promising.py
@@ -191,14 +191,21 @@ async def _grade_and_persist_target(
         # both promising AND excluded based on the verdict.
         for batch_idx_zero, row in enumerate(chunk):
             batch_idx = batch_idx_zero + 1  # Phase 1 ids are 1-based
-            promising = verdicts.get(batch_idx)
-            if promising is None:
+            verdict = verdicts.get(batch_idx)
+            if verdict is None:
                 # No verdict (LLM omitted or fail-open from triage call).
                 # Leave the row untouched (promising stays NULL).
                 fail_open_count += 1
                 continue
 
+            promising = verdict.promising
             update_payload: dict[str, Any] = {"promising": promising}
+            # Persist the model's confidence too — used by
+            # phase2_runner to order Phase 2 candidates. ``None`` from
+            # pre-confidence prompt versions is fine; the column stays
+            # NULL and the runner treats it as lowest priority.
+            if verdict.confidence is not None:
+                update_payload["phase1_confidence"] = verdict.confidence
             # When Phase 1 rejects a row, also mark excluded=true so
             # the row drops out of the list view immediately. We don't
             # un-exclude on promising=true because the scorer may have

--- a/apps/wyrdfold-api/tests/test_phase2_runner.py
+++ b/apps/wyrdfold-api/tests/test_phase2_runner.py
@@ -242,3 +242,91 @@ async def test_empty_jobs_short_circuits(
     )
     assert n == 0
     assert graded == []
+
+
+# ---- Phase 1 confidence ordering ------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_orders_candidates_by_confidence_desc(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the daily cap bites, the highest-confidence jobs grade first."""
+    graded = _patch_grader(monkeypatch)
+    _patch_quota(monkeypatch, 2)  # only two grades allowed
+    # 4 promising candidates at the same first_seen_at; confidences differ.
+    rows = [
+        {"job_posting_id": "j-low-1", "promising": True, "scoring_status": "stage2",
+         "scored_profile_version": 1, "phase1_confidence": 30},
+        {"job_posting_id": "j-high", "promising": True, "scoring_status": "stage2",
+         "scored_profile_version": 1, "phase1_confidence": 95},
+        {"job_posting_id": "j-mid", "promising": True, "scoring_status": "stage2",
+         "scored_profile_version": 1, "phase1_confidence": 70},
+        {"job_posting_id": "j-low-2", "promising": True, "scoring_status": "stage2",
+         "scored_profile_version": 1, "phase1_confidence": 40},
+    ]
+    jobs = [
+        {"id": jid, "title": "x", "description_html": "",
+         "first_seen_at": "2026-04-01T00:00:00+00:00"}
+        for jid in ("j-low-1", "j-high", "j-mid", "j-low-2")
+    ]
+    n = await run_phase2_for_jobs(
+        _supabase(rows), MagicMock(), target=_target(1), payload=_payload(), jobs=jobs
+    )
+    assert n == 2
+    # j-high (95) + j-mid (70) — NOT the lower-confidence ones.
+    assert set(graded) == {"j-high", "j-mid"}
+
+
+@pytest.mark.asyncio
+async def test_null_confidence_sorts_below_any_real_value(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Legacy rows (no confidence captured yet) still grade — but real-
+    confidence rows go first when there's contention for the cap."""
+    graded = _patch_grader(monkeypatch)
+    _patch_quota(monkeypatch, 1)
+    rows = [
+        {"job_posting_id": "j-legacy", "promising": True, "scoring_status": "stage2",
+         "scored_profile_version": 1, "phase1_confidence": None},
+        {"job_posting_id": "j-confident", "promising": True, "scoring_status": "stage2",
+         "scored_profile_version": 1, "phase1_confidence": 50},
+    ]
+    jobs = [
+        {"id": "j-legacy", "title": "a", "description_html": "",
+         "first_seen_at": "2026-04-02T00:00:00+00:00"},  # NEWER
+        {"id": "j-confident", "title": "b", "description_html": "",
+         "first_seen_at": "2026-04-01T00:00:00+00:00"},  # OLDER but has confidence
+    ]
+    n = await run_phase2_for_jobs(
+        _supabase(rows), MagicMock(), target=_target(1), payload=_payload(), jobs=jobs
+    )
+    assert n == 1
+    # Confidence wins over first_seen_at — j-confident graded, j-legacy deferred.
+    assert graded == ["j-confident"]
+
+
+@pytest.mark.asyncio
+async def test_confidence_ties_break_by_first_seen_at_desc(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Equal confidence → freshest first."""
+    graded = _patch_grader(monkeypatch)
+    _patch_quota(monkeypatch, 1)
+    rows = [
+        {"job_posting_id": "j-old", "promising": True, "scoring_status": "stage2",
+         "scored_profile_version": 1, "phase1_confidence": 80},
+        {"job_posting_id": "j-new", "promising": True, "scoring_status": "stage2",
+         "scored_profile_version": 1, "phase1_confidence": 80},
+    ]
+    jobs = [
+        {"id": "j-old", "title": "a", "description_html": "",
+         "first_seen_at": "2026-01-01T00:00:00+00:00"},
+        {"id": "j-new", "title": "b", "description_html": "",
+         "first_seen_at": "2026-04-01T00:00:00+00:00"},
+    ]
+    n = await run_phase2_for_jobs(
+        _supabase(rows), MagicMock(), target=_target(1), payload=_payload(), jobs=jobs
+    )
+    assert n == 1
+    assert graded == ["j-new"]

--- a/apps/wyrdfold-api/tests/test_relevance_title_triage.py
+++ b/apps/wyrdfold-api/tests/test_relevance_title_triage.py
@@ -150,7 +150,11 @@ class TestTriageTitles:
             titles=["Senior FE", "Sales Lead", "Web Engineer"],
         )
 
-        assert verdicts == {1: True, 2: False, 3: True}
+        # Now returns dict[int, TitleVerdict] (confidence field optional).
+        assert set(verdicts.keys()) == {1, 2, 3}
+        assert verdicts[1].promising is True
+        assert verdicts[2].promising is False
+        assert verdicts[3].promising is True
         assert result is not None  # MagicMock, but not None
 
     @pytest.mark.asyncio
@@ -200,7 +204,8 @@ class TestTriageTitles:
 
         llm = MagicMock()
         verdicts, _ = await triage_titles(llm, target=_target(), titles=["A"])
-        assert verdicts == {1: False}
+        assert set(verdicts.keys()) == {1}
+        assert verdicts[1].promising is False
 
     @pytest.mark.asyncio
     async def test_missing_verdict_omitted_from_dict(
@@ -229,7 +234,8 @@ class TestTriageTitles:
 
         # Only the present id is in the dict; caller treats missing as
         # admit (fail-open).
-        assert verdicts == {1: True}
+        assert set(verdicts.keys()) == {1}
+        assert verdicts[1].promising is True
         assert 2 not in verdicts
 
 

--- a/supabase/migrations/20260603070000_scores_phase1_confidence.sql
+++ b/supabase/migrations/20260603070000_scores_phase1_confidence.sql
@@ -1,0 +1,29 @@
+-- Phase 1 confidence (open question #4 from plan-llm-scoring-migration.md).
+--
+-- Phase 1 (Haiku title triage) emits a binary promising/unpromising verdict
+-- per job. Open question #4 was answered "yes — capture confidence (0-100)
+-- alongside the bool". This column persists that confidence so:
+--   1. ``phase2_runner`` can order candidates by phase1_confidence DESC
+--      instead of first_seen_at — highest-likelihood-promising jobs get the
+--      daily Sonnet cap first.
+--   2. The relevance diagnosis can plot confidence-vs-Phase-2-score
+--      correlation (should be positive; flat = Phase 1 noise).
+--   3. We can later derive a confidence floor (e.g. only grade jobs with
+--      phase1_confidence >= 70) to cut Phase 2 spend ~50% with negligible
+--      precision loss.
+--
+-- NULL is the legacy state — rows triaged before this column existed, or
+-- ones where the LLM response didn't include a confidence value
+-- (forward-compat). phase2_runner treats NULL as "lowest priority" so old
+-- rows still grade but new high-confidence ones go first.
+
+alter table public.scores
+  add column if not exists phase1_confidence integer
+    check (phase1_confidence is null or (phase1_confidence between 0 and 100));
+
+comment on column public.scores.phase1_confidence is
+  'Phase 1 LLM confidence (0-100) in its promising/unpromising verdict for '
+  'this (job, target) pair. NULL on legacy rows or when the Phase 1 response '
+  'lacked a confidence value. Used by phase2_runner to order candidates '
+  '(highest confidence first) and by relevance diagnostics to validate '
+  'whether Phase 1 confidence predicts Phase 2 score.';


### PR DESCRIPTION
## Summary

Open question #4 from \`plan-llm-scoring-migration.md\` answered: capture Phase 1 confidence (0-100) and use it to order Phase 2 candidates so the per-target daily Sonnet cap goes to the highest-likelihood-promising jobs first.

**No new LLM calls.** Confidence comes back in the same Haiku response that already produces the bool verdict. The migration adds one nullable column.

## What

### Phase 1 prompt + model

- \`TitleVerdict\` gains optional \`confidence: int | None\` (0-100).
- System prompt extended with a confidence rubric:
  - **90-100**: bullseye obvious
  - **70-89**: confident
  - **40-69**: legitimately ambiguous
  - **0-39**: hedged
- \`triage_titles\` return changes from \`dict[int, bool]\` → \`dict[int, TitleVerdict]\` so callers can read both fields. (Three callers updated: poller × 2, audit script, backfill script.)

### Schema

\`scores.phase1_confidence integer\` (CHECK 0-100, NULL allowed). Legacy rows + pre-confidence-prompt responses stay NULL; \`phase2_runner\` treats None as "lowest priority" so they still grade eventually.

### Phase 2 candidate ordering

\`phase2_runner.run_phase2_for_jobs\` now orders candidates by:
1. \`phase1_confidence\` DESC (None → lowest)
2. \`first_seen_at\` DESC (tiebreaker for equal confidence)

Was previously \`first_seen_at\` only. **\`_needs_phase2\` is unchanged — confidence affects ordering, not gating.** A low-confidence promising row still grades if the cap allows.

## Why this matters

At the per-target Phase 2 daily cap (default 100), today's \`first_seen_at\`-only ordering wastes Sonnet on low-likelihood-promising rows when high-likelihood ones could have been graded instead. Confidence-ordered selection is the cheapest precision boost available — no extra LLM calls, no model swap, no schema redesign.

## Test plan

- [ ] CI green
- [ ] Apply migration in preview Supabase
- [ ] Trigger one poll cycle with \`PHASE1_TRIAGE_ENABLED=true\`; verify \`scores.phase1_confidence\` populates for new rows
- [ ] Verify legacy rows (NULL confidence) still grade via Phase 2 backfill — they just go after current-confidence rows in queue
- [ ] Diagnostic: \`SELECT corr(phase1_confidence, score) FROM scores WHERE phase1_confidence IS NOT NULL AND scoring_status='complete'\` — expect positive correlation as evidence Phase 1 confidence predicts Phase 2 score

## Tests

3 new in \`test_phase2_runner.py\`:
- confidence DESC wins the cap
- null confidence sorts below any real value
- confidence ties break on \`first_seen_at\` DESC

Existing Phase 1 triage tests updated for the new return shape. **Full suite 1,031 passing**.

## Cost impact

**Zero.** Same Haiku call, ~10 extra output tokens per verdict (a few cents per backfill). The savings come from the Phase 2 cap going to better candidates — eventually we'll add a confidence floor (\`>= 70\`) that cuts Phase 2 spend ~50% without dropping signal, but that's a follow-on once we have a week of data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)