### PR TITLE
fix(wyrdfold-e2e): point identity test at /profile + flag stale audit-scan snapshots

### DIFF
--- a/apps/wyrdfold-e2e/src/authed-profile-identity.spec.ts
+++ b/apps/wyrdfold-e2e/src/authed-profile-identity.spec.ts
@@ -1,9 +1,11 @@
 import { test, expect } from '@playwright/test';
 
 /**
- * Authenticated round-trip for the Settings → Profile identity card
- * (added in #703 / extended in F3-A). Verifies the full FE → API →
- * DB → API → FE loop without burning LLM credits:
+ * Authenticated round-trip for the Profile identity card (added in
+ * #703 / extended in F3-A; moved from /settings to /profile in the
+ * settings refactor — see ``SettingsPage.tsx:444`` "Identity ...
+ * lives on /profile now"). Verifies the full FE → API → DB → API → FE
+ * loop without burning LLM credits:
  *
  *   1. ``GET /api/profile/identity`` populates the Name input on
  *      mount.
@@ -23,19 +25,19 @@ import { test, expect } from '@playwright/test';
  *     ``_get_or_create_profile``).
  *   - PATCH /identity regression (Pydantic shape drift, empty-string
  *     clear-to-NULL behavior, autosave debouncer never firing).
- *   - The Settings page never re-syncing from the server response
+ *   - The Profile page never re-syncing from the server response
  *     (the page does a setState from the PATCH response in the
  *     handleSaveProfile path — this catches a regression where it
  *     drops that re-sync).
  */
-test.describe('settings identity round-trip', () => {
+test.describe('profile identity round-trip', () => {
   test('Name edits persist across reload', async ({ page }) => {
     const TEST_NAME = `E2E Test User ${Date.now()}`;
 
-    await page.goto('/settings');
+    await page.goto('/profile');
 
-    // Wait for the Settings page to mount. The Name input lives in
-    // the Profile card; the Skeleton is replaced once GET /identity
+    // Wait for the Profile page to mount. The Name input lives in
+    // ProfileIdentityCard; the Skeleton is replaced once GET /identity
     // resolves.
     const nameInput = page.getByLabel('Name', { exact: true });
     await expect(nameInput).toBeVisible();


### PR DESCRIPTION
## Summary

Investigates and partially fixes the two E2E tests that have been failing on \`develop\` since the settings/audit refactors.

| Test | Cause | Fix |
|---|---|---|
| \`wyrdfold-e2e/authed-settings-identity.spec.ts:41\` element-not-visible on "Name" | Identity card was moved \`/settings\` → \`/profile\` (see \`SettingsPage.tsx:444\` "Identity ... lives on /profile now"); test still navigated to \`/settings\` | ✅ Fixed in this PR — \`page.goto('/profile')\` + rename file + update comments |
| \`root-e2e/visual-regression.spec.ts:167\` audit-scan screenshot mismatch | Multiple recent commits to \`apps/root/src/app/audit/*\` changed the rendered UI; baseline PNGs stale | ⚠️ **Needs snapshot regeneration** — must be done by you via \`workflow_dispatch\` with \`update-snapshots: true\` per \`CLAUDE.md\` (I can't dispatch workflows) |

## What's fixed

### wyrdfold-e2e

\`apps/wyrdfold-e2e/src/authed-settings-identity.spec.ts\` → \`authed-profile-identity.spec.ts\`

- \`page.goto('/settings')\` → \`'/profile'\`
- describe block + comments updated to reflect the new home
- File renamed for clarity; round-trip semantics unchanged

The complementary unit test \`SettingsPage.spec.tsx::no longer renders the Identity card — moved to /profile\` documents the move from the SETTINGS side and has been green all along. This PR brings the e2e in line.

### root-e2e visual-regression — still pending you

Recent commits touching \`apps/root/src/app/audit/*\`:

\`\`\`
9ed866e9 fix(audit): render step titles as h3 headings for e2e accessibility test
934a971e refactor: extract Step kit component from services and audit pages
141aead9 content: fix remaining passive voice in thank-you, error, and audit copy
d16f31f8 content: apply style review to app pages and data files
\`\`\`

These are legitimate UI/copy changes — the baseline screenshots just haven't been refreshed to match. Per \`CLAUDE.md\`:

> Snapshot updates via \`workflow_dispatch\` with \`update-snapshots: true\`

To unblock: trigger the snapshot-update workflow on \`develop\`. Once those refreshed PNGs land, the next CI run on this PR (or any PR) will go green on \`visual-regression.spec.ts\`.

If for some reason the audit page LOOKS WRONG visually (i.e. it's a regression, not an intended update), the snapshot regeneration would lock in the regression. Worth eyeballing the audit page in preview before dispatching. I couldn't visually verify from CI artifacts.

## Test plan

- [ ] CI green on \`fast / checks\` + \`ci-python\` + \`size\` + \`preflight\`
- [ ] \`full / full\` still fails on \`visual-regression.spec.ts:167\` (audit-scan) — expected; needs separate snapshot dispatch
- [ ] \`full / full\` should now PASS on \`authed-profile-identity.spec.ts\` (the test this PR moved)
- [ ] After this lands AND snapshots are regenerated, develop CI should be fully green for the first time in many days

🤖 Generated with [Claude Code](https://claude.com/claude-code)