### PR TITLE
feat(wyrdfold-api): wire axis weights into /targets and /jobs (PR E follow-up)

### DIFF
--- a/apps/wyrdfold-api/app/routers/jobs.py
+++ b/apps/wyrdfold-api/app/routers/jobs.py
@@ -29,6 +29,7 @@ from app.models.schemas import (
     UrlValidateRequest,
     UrlValidateResponse,
 )
+from app.models.targets import AxisWeights
 from app.services.extract import (
     MANUAL_SOURCE_ID,
     ExtractionResult,
@@ -36,6 +37,7 @@ from app.services.extract import (
     extract_job_from_html,
     extract_salary_from_text,
 )
+from app.services.fit.axis_weights import display_score_or_passthrough
 from app.services.jd_parser import parse_jd
 from app.services.sanitize import sanitize_html
 from app.services.scoring import strip_html
@@ -48,7 +50,11 @@ from app.services.target_scoring import (
 )
 from app.services.targets.crud import get as get_target
 from app.services.targets.crud import get_active as get_active_target
-from app.services.targets.crud import get_user_target_ids
+from app.services.targets.crud import (
+    get_user_target,
+    get_user_target_ids,
+    list_user_targets,
+)
 from app.services.validate import (
     assert_safe_host,
     is_banned_domain,
@@ -273,8 +279,20 @@ def _list_jobs_for_target_two_query(
     search: str | None,
     exclude_terms: list[str],
     only_terms: list[str],
+    axis_weights: AxisWeights | None = None,
 ) -> dict[str, Any]:
-    """Fallback: two-query pattern with pagination pushed to the scores layer."""
+    """Fallback: two-query pattern with pagination pushed to the scores layer.
+
+    ``axis_weights`` is the per-(user, target) read-time multiplier on
+    Phase 2's axis scores. When non-None, the response's per-row ``score``
+    field is replaced with the weighted display score computed from
+    ``axis_scores``. Sort order is unchanged in this iteration —
+    server-side ORDER BY still keys on ``recency_score`` (when decay is
+    on) or ``score`` so pagination stays cheap. A future iteration will
+    push the weighted sort into Python when weights diverge from
+    defaults. See plan-wyrdfold-streamlined-target.md "User-tunable axis
+    weights".
+    """
     sort_col = "score" if sort == "score" else sort
     # When recency decay is on, the logical "score" sort orders by the
     # decayed ``recency_score`` column instead of the raw fit score.
@@ -289,7 +307,8 @@ def _list_jobs_for_target_two_query(
     ts_query = (
         supabase.table("scores")
         .select(
-            "job_posting_id, score, recency_score, score_breakdown, scoring_status",
+            "job_posting_id, score, recency_score, score_breakdown, "
+            "scoring_status, axis_scores",
             count=CountMethod.exact,
         )
         .eq("target_id", target_id)
@@ -340,11 +359,19 @@ def _list_jobs_for_target_two_query(
         supabase, page_ids, status=status, company=company, search=search
     )
 
-    # Overlay target scores
+    # Overlay target scores. When axis_weights are set for this
+    # (user, target) pairing, the displayed ``score`` is the weighted
+    # combination of axis_scores; otherwise it's the raw Sonnet score.
+    # The original is preserved alongside as ``raw_score`` so the
+    # frontend can show both (and so debugging is easy).
     for p in postings:
         ts = score_lookup.get(p["id"])
         if ts:
-            p["score"] = ts["score"]
+            raw_score = int(ts["score"])
+            p["score"] = display_score_or_passthrough(
+                ts.get("axis_scores"), raw_score, axis_weights
+            )
+            p["raw_score"] = raw_score
             p["score_breakdown"] = ts.get("score_breakdown")
             p["scoring_status"] = ts.get("scoring_status", "stage1")
 
@@ -402,6 +429,7 @@ def _list_jobs_for_target(
     search: str | None,
     exclude_terms: list[str],
     only_terms: list[str],
+    axis_weights: AxisWeights | None = None,
 ) -> dict[str, Any]:
     """List jobs for a target view, sorted/paginated by target-specific scores.
 
@@ -409,6 +437,11 @@ def _list_jobs_for_target(
     optimized two-query pattern if the RPC function hasn't been deployed yet.
     The two-query path also takes over when location filters are active, since
     the RPC paginates server-side with no knowledge of the location filter.
+
+    When ``axis_weights`` is set we skip the RPC and use the two-query path —
+    the RPC doesn't return ``axis_scores`` so it can't apply the overlay. This
+    keeps the v1 behaviour: the displayed ``score`` is the weighted blend,
+    sort order is unchanged (still raw / recency).
     """
     kwargs: dict[str, Any] = {
         "target_id": target_id,
@@ -424,6 +457,10 @@ def _list_jobs_for_target(
         "exclude_terms": exclude_terms,
         "only_terms": only_terms,
     }
+    if axis_weights is not None:
+        return _list_jobs_for_target_two_query(
+            supabase, axis_weights=axis_weights, **kwargs
+        )
     try:
         return _list_jobs_for_target_rpc(supabase, **kwargs)
     except Exception:
@@ -446,15 +483,21 @@ def _list_jobs_across_user_targets(
     search: str | None,
     exclude_terms: list[str],
     only_terms: list[str],
+    weights_by_target: dict[str, AxisWeights] | None = None,
 ) -> dict[str, Any]:
     """Untargeted list — returns the union of jobs scored against any of the
     user's active targets, deduplicated by job id.
 
     Two-query pattern, mirroring ``_list_jobs_for_target_two_query`` but
     aggregating by ``max(score)`` across the user's targets so each job
-    appears once. Replaces the previous "global view" path which filtered
-    by ``jobs.target_id`` — a column the poller never populates, so that
-    filter rejected every row.
+    appears once.
+
+    ``weights_by_target`` maps target_id → AxisWeights for any user-target
+    pairing with custom weights set; absent / None means use raw score.
+    The displayed ``score`` per row applies the weights for that row's
+    target. The deduplication still keys on raw ``max(score)`` so the
+    "best representative target" picked per job is stable across users
+    with different weights (only the displayed number differs).
     """
     sort_col = "score" if sort == "score" else sort
     # See ``_list_jobs_for_target_two_query``: the "score" sort orders by
@@ -470,7 +513,7 @@ def _list_jobs_across_user_targets(
         supabase.table("scores")
         .select(
             "job_posting_id, target_id, score, recency_score, "
-            "score_breakdown, scoring_status"
+            "axis_scores, score_breakdown, scoring_status"
         )
         .in_("target_id", list(user_target_ids))
         .eq("excluded", False)
@@ -526,10 +569,17 @@ def _list_jobs_across_user_targets(
         supabase, page_ids, status=status, company=company, search=search
     )
 
+    weights_by_target = weights_by_target or {}
     for p in postings:
         ts = best.get(p["id"])
         if ts:
-            p["score"] = ts["score"]
+            raw_score = int(ts["score"])
+            tid = cast(str | None, ts.get("target_id"))
+            w = weights_by_target.get(tid) if tid else None
+            p["score"] = display_score_or_passthrough(
+                ts.get("axis_scores"), raw_score, w
+            )
+            p["raw_score"] = raw_score
             p["score_breakdown"] = ts.get("score_breakdown")
             p["scoring_status"] = ts.get("scoring_status", "stage1")
 
@@ -717,6 +767,14 @@ def list_jobs(
 
     # Target view: sort/paginate by target-specific scores
     if target_id:
+        # Per-pairing axis weights override the displayed score for this
+        # user's target view. JWT-only — api-key callers get raw scores
+        # (no user identity to scope weights by).
+        axis_weights: AxisWeights | None = None
+        if user_id is not None:
+            ut = get_user_target(supabase, user_id, target_id)
+            if ut is not None:
+                axis_weights = ut.axis_weights
         result = _list_jobs_for_target(
             supabase,
             target_id=target_id,
@@ -731,6 +789,7 @@ def list_jobs(
             search=search,
             exclude_terms=exclude_terms,
             only_terms=only_terms,
+            axis_weights=axis_weights,
         )
         result["applied_min_score"] = min_score
         job_list_cache.set(cache_key, result)
@@ -741,6 +800,12 @@ def list_jobs(
     # callers (cron/poller) we keep the old "table scan" path: they need
     # to operate on the whole table by design (rescore-all, backfill).
     if user_target_ids is not None:
+        # Build target_id -> AxisWeights map for any pairings that have
+        # custom weights set. Missing entries fall through to raw score.
+        weights_by_target: dict[str, AxisWeights] = {}
+        for ut in list_user_targets(supabase, user_id):  # type: ignore[arg-type]
+            if ut.axis_weights is not None:
+                weights_by_target[ut.target_id] = ut.axis_weights
         result = _list_jobs_across_user_targets(
             supabase,
             user_target_ids=user_target_ids,
@@ -755,6 +820,7 @@ def list_jobs(
             search=search,
             exclude_terms=exclude_terms,
             only_terms=only_terms,
+            weights_by_target=weights_by_target or None,
         )
         result["applied_min_score"] = min_score
         job_list_cache.set(cache_key, result)

--- a/apps/wyrdfold-api/app/routers/targets.py
+++ b/apps/wyrdfold-api/app/routers/targets.py
@@ -14,6 +14,7 @@ from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
 from postgrest.types import CountMethod
 from supabase import Client
 
+from app.cache import job_list_cache, jobs_cache_prefix
 from app.dependencies import (
     enforce_llm_budget,
     get_current_user_id,
@@ -26,6 +27,7 @@ from app.dependencies import (
 from app.http_client import ResponseTooLargeError, get_with_size_cap
 from app.models.schemas import PollResult
 from app.models.targets import (
+    AxisWeights,
     CreateOrLinkResult,
     DeleteResponse,
     JobTarget,
@@ -555,6 +557,108 @@ async def deactivate_target(
         supabase, user_id=user_id, target_id=target_id
     )
     return crud.get(supabase, target_id) or target
+
+
+# ---- Axis weights (PR E follow-up) ----------------------------------------
+#
+# Per-(user, target) read-time multipliers for the four Phase 2 axes.
+# See plan-wyrdfold-streamlined-target.md "User-tunable axis weights".
+#
+# - PATCH /targets/{id}/axis-weights — set new weights; snapshots prior
+#   into axis_weights_previous so /undo can revert in one click.
+# - POST  /targets/{id}/axis-weights/undo — swap current ↔ previous.
+# - DELETE /targets/{id}/axis-weights — reset to defaults (NULL); also
+#   snapshots, so undo recovers the prior custom weights.
+
+
+@router.patch("/{target_id}/axis-weights", response_model=UserTarget)
+async def set_axis_weights(
+    target_id: str,
+    weights: AxisWeights,
+    supabase: Client = Depends(get_supabase),
+    user_id: str = Depends(get_current_user_id),
+) -> UserTarget:
+    """Set the user's per-target axis weights.
+
+    Snapshots the prior value into ``axis_weights_previous`` so the
+    /undo endpoint can revert. Pure read-time math — does NOT trigger
+    any re-grade; existing scores rows are unchanged.
+    """
+    updated = crud.set_user_target_axis_weights(
+        supabase,
+        user_id=user_id,
+        target_id=target_id,
+        weights=weights,
+    )
+    if updated is None:
+        raise HTTPException(
+            status_code=404,
+            detail="No user_targets row for (user, target). Link the target first.",
+        )
+    _invalidate_jobs_cache_for_target(target_id)
+    return updated
+
+
+@router.delete("/{target_id}/axis-weights", response_model=UserTarget)
+async def reset_axis_weights(
+    target_id: str,
+    supabase: Client = Depends(get_supabase),
+    user_id: str = Depends(get_current_user_id),
+) -> UserTarget:
+    """Reset axis_weights to defaults (NULL — equal quartile).
+
+    Same snapshot behaviour as PATCH: the prior custom weights move to
+    ``axis_weights_previous`` so /undo can put them back. "Reset" and
+    "undo" cancel each other out in one round-trip.
+    """
+    updated = crud.set_user_target_axis_weights(
+        supabase,
+        user_id=user_id,
+        target_id=target_id,
+        weights=None,
+    )
+    if updated is None:
+        raise HTTPException(
+            status_code=404,
+            detail="No user_targets row for (user, target). Link the target first.",
+        )
+    _invalidate_jobs_cache_for_target(target_id)
+    return updated
+
+
+@router.post("/{target_id}/axis-weights/undo", response_model=UserTarget)
+async def undo_axis_weights(
+    target_id: str,
+    supabase: Client = Depends(get_supabase),
+    user_id: str = Depends(get_current_user_id),
+) -> UserTarget:
+    """Swap ``axis_weights`` and ``axis_weights_previous``.
+
+    The button-press behind the safety-design's "Undo last change". Two
+    consecutive undos toggle back and forth — that's the intended
+    contract (undo, then change-my-mind-and-redo).
+    """
+    updated = crud.undo_user_target_axis_weights(
+        supabase, user_id=user_id, target_id=target_id
+    )
+    if updated is None:
+        raise HTTPException(
+            status_code=404,
+            detail="No user_targets row for (user, target).",
+        )
+    _invalidate_jobs_cache_for_target(target_id)
+    return updated
+
+
+def _invalidate_jobs_cache_for_target(target_id: str) -> None:
+    """Bust the jobs list cache for this target plus the untargeted view.
+
+    The untargeted view ("global") merges scores across the user's targets,
+    so a weight change on any one target can shift its displayed scores.
+    Sibling targets are untouched.
+    """
+    job_list_cache.invalidate(prefix=jobs_cache_prefix(target_id=target_id))
+    job_list_cache.invalidate(prefix=jobs_cache_prefix(target_id=None))
 
 
 @router.post(

--- a/apps/wyrdfold-api/app/services/targets/crud.py
+++ b/apps/wyrdfold-api/app/services/targets/crud.py
@@ -485,6 +485,88 @@ def set_user_target_inactive(
     return _parse_user_target(rows[0]) if rows else None
 
 
+def set_user_target_axis_weights(
+    supabase: Client,
+    *,
+    user_id: str,
+    target_id: str,
+    weights: AxisWeights | None,
+) -> UserTarget | None:
+    """Set (or clear) the user-tunable axis weights for this user-target pair.
+
+    Snapshots the prior ``axis_weights`` value into ``axis_weights_previous``
+    so the UI's "undo last change" button can revert in one click. Only
+    the most recent prior state is kept — full history is YAGNI for v1
+    (see plan-wyrdfold-streamlined-target.md "User-tunable axis weights").
+
+    Passing ``weights=None`` resets to defaults (DB column becomes NULL).
+    The previous value is still snapshotted so the user can undo "reset
+    to default" too.
+
+    Returns the updated ``UserTarget`` or ``None`` if no row exists for
+    this (user, target) pairing.
+    """
+    current = get_user_target(supabase, user_id, target_id)
+    if current is None:
+        return None
+    updates: dict[str, Any] = {
+        "axis_weights": weights.model_dump() if weights is not None else None,
+        "axis_weights_previous": (
+            current.axis_weights.model_dump()
+            if current.axis_weights is not None
+            else None
+        ),
+        "updated_at": datetime.now(UTC).isoformat(),
+    }
+    resp = (
+        supabase.table(USER_TARGETS_TABLE)
+        .update(updates)
+        .eq("user_id", user_id)
+        .eq("target_id", target_id)
+        .execute()
+    )
+    rows = cast(list[dict[str, Any]], resp.data or [])
+    return _parse_user_target(rows[0]) if rows else None
+
+
+def undo_user_target_axis_weights(
+    supabase: Client, *, user_id: str, target_id: str
+) -> UserTarget | None:
+    """Revert ``axis_weights`` to ``axis_weights_previous``.
+
+    Swaps the two columns (previous → current, current → previous).
+    Idempotent in the sense that calling twice toggles back and forth —
+    that's actually the intended behaviour: "Undo" then "Undo" returns
+    to where you started.
+
+    Returns ``None`` if the (user, target) row doesn't exist OR if
+    there's no previous state to revert to (caller should 422).
+    """
+    current = get_user_target(supabase, user_id, target_id)
+    if current is None:
+        return None
+    new_current = current.axis_weights_previous
+    new_previous = current.axis_weights
+    updates: dict[str, Any] = {
+        "axis_weights": (
+            new_current.model_dump() if new_current is not None else None
+        ),
+        "axis_weights_previous": (
+            new_previous.model_dump() if new_previous is not None else None
+        ),
+        "updated_at": datetime.now(UTC).isoformat(),
+    }
+    resp = (
+        supabase.table(USER_TARGETS_TABLE)
+        .update(updates)
+        .eq("user_id", user_id)
+        .eq("target_id", target_id)
+        .execute()
+    )
+    rows = cast(list[dict[str, Any]], resp.data or [])
+    return _parse_user_target(rows[0]) if rows else None
+
+
 # ---- Reference JD CRUD -----------------------------------------------------
 
 

--- a/apps/wyrdfold-api/tests/test_axis_weights_crud.py
+++ b/apps/wyrdfold-api/tests/test_axis_weights_crud.py
@@ -1,0 +1,212 @@
+"""Tests for the axis-weights CRUD helpers (PR E follow-up).
+
+Covers ``set_user_target_axis_weights`` and ``undo_user_target_axis_weights``
+in app.services.targets.crud — the snapshot-then-update + swap semantics
+that back the PATCH / DELETE / POST-undo endpoints.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import MagicMock
+
+from app.models.targets import AxisWeights
+from app.services.targets import crud
+
+
+def _row(
+    *,
+    axis_weights: dict[str, float] | None = None,
+    axis_weights_previous: dict[str, float] | None = None,
+) -> dict[str, Any]:
+    now = datetime.now(UTC).isoformat()
+    return {
+        "id": "ut-1",
+        "user_id": "user-1",
+        "target_id": "target-1",
+        "is_active": True,
+        "fit_score": None,
+        "fit_score_reasoning": None,
+        "axis_weights": axis_weights,
+        "axis_weights_previous": axis_weights_previous,
+        "created_at": now,
+        "updated_at": now,
+    }
+
+
+def _wire_select(supabase: MagicMock, rows: list[dict[str, Any]]) -> None:
+    """Mock the 3-eq chain used by ``get_user_target`` (table-select-eq-eq)."""
+    chain = (
+        supabase.table.return_value.select.return_value.eq.return_value.eq.return_value.execute
+    )
+    chain.return_value.data = rows
+
+
+def _wire_update(supabase: MagicMock, rows: list[dict[str, Any]]) -> None:
+    chain = (
+        supabase.table.return_value.update.return_value.eq.return_value.eq.return_value.execute
+    )
+    chain.return_value.data = rows
+
+
+# ---- set_user_target_axis_weights ----------------------------------------
+
+
+def test_set_axis_weights_snapshots_prior_into_previous() -> None:
+    """The PATCH semantics: snapshot the *current* axis_weights into
+    axis_weights_previous before overwriting. This is what makes the UI's
+    "Undo last change" button a one-click revert."""
+    prior = {
+        "title_fit": 0.4,
+        "skills_fit": 0.2,
+        "seniority_fit": 0.2,
+        "domain_fit": 0.2,
+    }
+    new = AxisWeights(
+        title_fit=0.1, skills_fit=0.4, seniority_fit=0.4, domain_fit=0.1
+    )
+
+    supabase = MagicMock()
+    _wire_select(supabase, [_row(axis_weights=prior)])
+    _wire_update(
+        supabase,
+        [_row(axis_weights=new.model_dump(), axis_weights_previous=prior)],
+    )
+
+    result = crud.set_user_target_axis_weights(
+        supabase, user_id="user-1", target_id="target-1", weights=new
+    )
+
+    payload = supabase.table.return_value.update.call_args.args[0]
+    assert payload["axis_weights"] == new.model_dump()
+    assert payload["axis_weights_previous"] == prior
+    assert result is not None
+    assert result.axis_weights == new
+
+
+def test_set_axis_weights_to_none_resets_and_still_snapshots() -> None:
+    """DELETE semantics: weights=None resets to default (NULL), but the
+    snapshot still happens so the user can undo the reset."""
+    prior = {
+        "title_fit": 0.4,
+        "skills_fit": 0.2,
+        "seniority_fit": 0.2,
+        "domain_fit": 0.2,
+    }
+
+    supabase = MagicMock()
+    _wire_select(supabase, [_row(axis_weights=prior)])
+    _wire_update(
+        supabase,
+        [_row(axis_weights=None, axis_weights_previous=prior)],
+    )
+
+    result = crud.set_user_target_axis_weights(
+        supabase, user_id="user-1", target_id="target-1", weights=None
+    )
+
+    payload = supabase.table.return_value.update.call_args.args[0]
+    assert payload["axis_weights"] is None
+    assert payload["axis_weights_previous"] == prior
+    assert result is not None
+    assert result.axis_weights is None
+
+
+def test_set_axis_weights_returns_none_when_row_missing() -> None:
+    """No (user, target) pairing → return None so the router can 404."""
+    supabase = MagicMock()
+    _wire_select(supabase, [])
+
+    result = crud.set_user_target_axis_weights(
+        supabase,
+        user_id="user-1",
+        target_id="missing",
+        weights=AxisWeights(),
+    )
+
+    assert result is None
+    supabase.table.return_value.update.assert_not_called()
+
+
+# ---- undo_user_target_axis_weights ---------------------------------------
+
+
+def test_undo_swaps_current_and_previous() -> None:
+    """The two columns get swapped: previous becomes current, current
+    becomes previous. Two consecutive undos return to the starting state."""
+    current = {
+        "title_fit": 0.1,
+        "skills_fit": 0.4,
+        "seniority_fit": 0.4,
+        "domain_fit": 0.1,
+    }
+    previous = {
+        "title_fit": 0.25,
+        "skills_fit": 0.25,
+        "seniority_fit": 0.25,
+        "domain_fit": 0.25,
+    }
+
+    supabase = MagicMock()
+    _wire_select(
+        supabase,
+        [_row(axis_weights=current, axis_weights_previous=previous)],
+    )
+    _wire_update(
+        supabase,
+        [_row(axis_weights=previous, axis_weights_previous=current)],
+    )
+
+    result = crud.undo_user_target_axis_weights(
+        supabase, user_id="user-1", target_id="target-1"
+    )
+
+    payload = supabase.table.return_value.update.call_args.args[0]
+    assert payload["axis_weights"] == previous
+    assert payload["axis_weights_previous"] == current
+    assert result is not None
+
+
+def test_undo_with_no_previous_clears_current() -> None:
+    """If there's no previous state, "undo" effectively reverts to
+    defaults (current → previous, previous → None). Idempotent re-call
+    swaps back. Caller treats this as "nothing useful to undo".
+    """
+    current = {
+        "title_fit": 0.4,
+        "skills_fit": 0.2,
+        "seniority_fit": 0.2,
+        "domain_fit": 0.2,
+    }
+
+    supabase = MagicMock()
+    _wire_select(
+        supabase, [_row(axis_weights=current, axis_weights_previous=None)]
+    )
+    _wire_update(
+        supabase,
+        [_row(axis_weights=None, axis_weights_previous=current)],
+    )
+
+    result = crud.undo_user_target_axis_weights(
+        supabase, user_id="user-1", target_id="target-1"
+    )
+
+    payload = supabase.table.return_value.update.call_args.args[0]
+    assert payload["axis_weights"] is None
+    assert payload["axis_weights_previous"] == current
+    assert result is not None
+    assert result.axis_weights is None
+
+
+def test_undo_returns_none_when_row_missing() -> None:
+    supabase = MagicMock()
+    _wire_select(supabase, [])
+
+    result = crud.undo_user_target_axis_weights(
+        supabase, user_id="user-1", target_id="missing"
+    )
+
+    assert result is None
+    supabase.table.return_value.update.assert_not_called()


### PR DESCRIPTION
## Summary

Follow-up to #807 (axis-weights groundwork). Adds the endpoints + /jobs
integration so the new schema actually does something.

- **PATCH /targets/{id}/axis-weights** — set weights; snapshots prior into ``axis_weights_previous`` so the FE's "Undo last change" button is one click.
- **DELETE /targets/{id}/axis-weights** — reset to defaults (NULL); also snapshots so undo recovers prior custom weights.
- **POST /targets/{id}/axis-weights/undo** — swap current ↔ previous. Two consecutive undos return to start (intended).
- **/jobs overlay (v1)** — when a user has weights set for a (user, target) pairing, ``score`` in the response is the weighted blend of ``axis_scores``; the raw value is preserved as ``raw_score``. **Sort order is unchanged** (still raw score / ``recency_score``). Sort-by-weights is deferred to v2, paired with the FE sliders so the user sees previews before re-ranking.

## Implementation notes

- Single-target path bypasses the RPC when weights are set: the RPC doesn't ``SELECT axis_scores`` so it can't apply the overlay. Falls through to the two-query path.
- Untargeted ("global") path now fetches the user's full ``user_targets`` list and builds a ``target_id -> AxisWeights`` map so each row's display number reflects *its own* pairing's weights.
- Any weight mutation invalidates the jobs list cache for both the per-target prefix and the global prefix (untargeted view aggregates across all of a user's targets).
- ``get_user_target`` already existed with positional args; reused that one and dropped the duplicate keyword-arg helper I'd added by mistake.

## Test plan

- [x] ``ruff check`` clean
- [x] ``mypy app/`` clean (134 files)
- [x] ``pytest`` clean (1078 passed; 6 new tests in ``test_axis_weights_crud.py`` cover snapshot/reset/undo semantics)
- [x] ``pnpm tsc --noEmit`` clean
- [ ] Manually exercise on preview deploy: PATCH weights → /jobs view shows blended score, raw_score preserved, undo round-trips

## Out of scope

- FE sliders / undo button (separate PR; this is the API contract only)
- Sort-by-weights (v2)
- Logistics chips (separate plan item)