### PR TITLE
feat(wyrdfold): use new /user-target endpoint in target detail

### DIFF
--- a/apps/wyrdfold/src/app/(app)/targets/[id]/TargetDetail.tsx
+++ b/apps/wyrdfold/src/app/(app)/targets/[id]/TargetDetail.tsx
@@ -46,21 +46,17 @@ export default function TargetDetail({ id }: TargetDetailProps) {
   }, [id, toast]);
 
   /**
-   * Pull this user's `user_target` row out of `/targets/mine`. We need
-   * it for the axis-weights editor (which lives on this page, but reads
-   * from `user_targets`, not the shared `targets` row). The list is
-   * small (per-user, dozens of rows at most) — one round-trip is fine
-   * for v1. Future optimization: a per-target `/user-target` endpoint.
+   * Fetch this user's `user_target` row for the current target. Powers
+   * the axis-weights editor (which reads from `user_targets`, not the
+   * shared `targets` row). One round-trip via the per-target endpoint —
+   * supersedes the old fetch-all-/mine pattern.
    */
   const fetchUserTarget = useCallback(async () => {
     try {
-      const res = await fetch(`/api/targets/mine`);
+      const res = await fetch(`/api/targets/${id}/user-target`);
       if (!res.ok) throw new Error('Failed to fetch user target');
-      const payload = (await res.json()) as {
-        targets: UserTargetWithTarget[];
-      };
-      const match = payload.targets.find(t => t.target.id === id);
-      setUserTarget(match?.user_target ?? null);
+      const payload = (await res.json()) as UserTargetWithTarget;
+      setUserTarget(payload.user_target);
     } catch {
       // Non-fatal — the axis weights editor will just not render.
       // The rest of the page still works.

--- a/apps/wyrdfold/src/app/api/targets/[id]/user-target/route.ts
+++ b/apps/wyrdfold/src/app/api/targets/[id]/user-target/route.ts
@@ -1,0 +1,20 @@
+import type { NextRequest } from 'next/server';
+
+import { proxyToWyrdfoldAPI } from '@/lib/api/proxy';
+
+type Params = { params: Promise<{ id: string }> };
+
+/**
+ * GET /api/targets/{id}/user-target — return the current user's
+ * user_targets row for this target, paired with the shared target data.
+ *
+ * Replaces the previous "fetch all /targets/mine and find the matching
+ * row" pattern used by the axis-weights editor. One round-trip, no
+ * over-fetch as a user accumulates targets.
+ */
+export async function GET(_request: NextRequest, { params }: Params) {
+  const { id } = await params;
+  return proxyToWyrdfoldAPI(`/targets/${id}/user-target`, {
+    method: 'GET',
+  });
+}


### PR DESCRIPTION
## Summary

Closes the API-gap loop opened by #810 / #812.

- Switch the axis-weights editor's user-target fetch from \`/api/targets/mine\` (fetches all rows, then \`find()\`) to the new single-row endpoint \`/api/targets/{id}/user-target\` (shipped in #812).
- Add the Next.js proxy route forwarding the JWT.

## Depends on

- [#812](https://github.com/danieljoffe/danieljoffe.com/pull/812) — must merge first. This FE PR calls the new BE endpoint; it'll 404 in preview deploys until #812 is in develop.

## Test plan

- [x] tsc, lint, test all green
- [ ] Manually load \`/targets/[id]\` after both PRs merge; confirm Network panel shows one request to \`/api/targets/[id]/user-target\` instead of the full list