### PR TITLE
feat(wyrdfold-api): logistics_filters schema + model groundwork

### DIFF
--- a/apps/wyrdfold-api/app/models/logistics.py
+++ b/apps/wyrdfold-api/app/models/logistics.py
@@ -1,0 +1,71 @@
+"""Logistics filters extracted by the Phase 2 grader.
+
+Groundwork for plan-wyrdfold-logistics-chips.md. The Phase 2 prompt
+change that actually emits these fields lands in a follow-up PR; this
+module is the schema half — defines the shape and validates anything
+that does write to the column today (e.g. backfill scripts).
+
+Filter-only: the values inform the /jobs chips and filter query
+params (?remote_only=true, ?min_salary=150000, ?country=US). They
+never affect ``score``, ``recency_score``, or sort order.
+
+See the "Concepts" block in plan-wyrdfold-streamlined-target.md for
+the distinction between **axis weights** (score-tuning, lives on
+user_targets) and **logistics filters** (list-filtering, lives on
+scores). They are independent mechanisms and never collide in the
+data path.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+RemoteStatus = Literal["remote", "hybrid", "onsite", "unspecified"]
+SalaryUnit = Literal["year", "hour"]
+
+
+class LogisticsFilters(BaseModel):
+    """Structured logistics observed in the JD by the Phase 2 grader.
+
+    Every field is optional / has a sentinel ``unspecified`` value;
+    the grader is instructed to lean conservative and say "I don't
+    know" rather than guess. False positives on filter pills are worse
+    than misses — a "Remote only" filter that surfaces hybrid roles
+    looks broken; a slightly under-populated chip list does not.
+
+    Salary fields are intended to capture the explicit disclosed range
+    only. "Competitive salary" / "DOE" / equity-only postings stay
+    NULL across all four salary fields.
+
+    Location fields capture the primary office anchor when one is
+    named. A remote-only role with no anchor city / country leaves
+    both NULL — the ``remote_status`` field carries the signal in
+    that case.
+    """
+
+    remote_status: RemoteStatus = "unspecified"
+
+    salary_min: int | None = Field(default=None, ge=0)
+    salary_max: int | None = Field(default=None, ge=0)
+    salary_currency: str | None = Field(default=None, max_length=8)
+    salary_unit: SalaryUnit | None = None
+
+    location_city: str | None = Field(default=None, max_length=120)
+    location_country: str | None = Field(default=None, max_length=4)
+
+    def has_any_signal(self) -> bool:
+        """Whether this row carries any non-default information.
+
+        Useful for the FE chip renderer: when this returns False the
+        chip row can be skipped entirely rather than rendering an
+        empty container.
+        """
+        return (
+            self.remote_status != "unspecified"
+            or self.salary_min is not None
+            or self.salary_max is not None
+            or self.location_city is not None
+            or self.location_country is not None
+        )

--- a/apps/wyrdfold-api/tests/test_logistics_filters_model.py
+++ b/apps/wyrdfold-api/tests/test_logistics_filters_model.py
@@ -1,0 +1,86 @@
+"""Tests for the LogisticsFilters model (groundwork for logistics chips).
+
+Schema-only at this stage. The Phase 2 grader doesn't emit these
+fields yet; this test suite locks the shape so the follow-up prompt
+PR has a clear contract to target.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from app.models.logistics import LogisticsFilters
+
+
+def test_defaults_are_unspecified() -> None:
+    """The grader should produce a defaulted row even when the JD says
+    nothing useful — never a missing column. ``unspecified`` is the
+    sentinel for "no signal" so consumers can distinguish from null."""
+    f = LogisticsFilters()
+    assert f.remote_status == "unspecified"
+    assert f.salary_min is None
+    assert f.salary_max is None
+    assert f.salary_currency is None
+    assert f.salary_unit is None
+    assert f.location_city is None
+    assert f.location_country is None
+    assert f.has_any_signal() is False
+
+
+def test_rejects_unknown_remote_status() -> None:
+    """Enum is closed: extending it is intentional, not silent."""
+    with pytest.raises(ValidationError):
+        LogisticsFilters(remote_status="maybe")  # type: ignore[arg-type]
+
+
+def test_rejects_negative_salary() -> None:
+    """A negative salary is always a parse bug, not a legitimate value."""
+    with pytest.raises(ValidationError):
+        LogisticsFilters(salary_min=-1)
+
+
+def test_rejects_unknown_salary_unit() -> None:
+    with pytest.raises(ValidationError):
+        LogisticsFilters(salary_unit="month")  # type: ignore[arg-type]
+
+
+def test_has_any_signal_true_when_remote_known() -> None:
+    f = LogisticsFilters(remote_status="remote")
+    assert f.has_any_signal() is True
+
+
+def test_has_any_signal_true_when_salary_floor_known() -> None:
+    f = LogisticsFilters(salary_min=150000)
+    assert f.has_any_signal() is True
+
+
+def test_has_any_signal_true_when_location_known() -> None:
+    f = LogisticsFilters(location_country="US")
+    assert f.has_any_signal() is True
+
+
+def test_full_shape_round_trips_through_dict() -> None:
+    """Important for the jsonb write/read path: a fully-populated row
+    should serialize to a dict the DB can store and parse back into an
+    identical model."""
+    f = LogisticsFilters(
+        remote_status="hybrid",
+        salary_min=150_000,
+        salary_max=180_000,
+        salary_currency="USD",
+        salary_unit="year",
+        location_city="San Francisco",
+        location_country="US",
+    )
+    roundtripped = LogisticsFilters.model_validate(f.model_dump())
+    assert roundtripped == f
+
+
+def test_country_field_caps_short_codes() -> None:
+    """ISO country codes are 2 or 3 chars; the field allows up to 4 for
+    legacy /  special-case codes but should reject sprawling free-text."""
+    LogisticsFilters(location_country="US")
+    LogisticsFilters(location_country="USA")
+    with pytest.raises(ValidationError):
+        LogisticsFilters(location_country="United States of America")

--- a/supabase/migrations/20260603100000_scores_logistics_filters.sql
+++ b/supabase/migrations/20260603100000_scores_logistics_filters.sql
@@ -1,0 +1,45 @@
+-- Logistics filters extracted by the Phase 2 grader (groundwork for
+-- plan-wyrdfold-logistics-chips.md).
+--
+-- Phase 2 (Sonnet) already reads the full JD to produce axis_scores.
+-- A follow-up PR will extend the same prompt to emit a structured
+-- logistics JSON section per (job, target) at near-zero token cost.
+-- This migration is the schema half: ships now so the column is in
+-- place when the prompt change lands.
+--
+-- Shape (v1):
+--   {
+--     "remote_status": "remote" | "hybrid" | "onsite" | "unspecified",
+--     "salary_min": int | null,
+--     "salary_max": int | null,
+--     "salary_currency": "USD" | ...  | null,
+--     "salary_unit": "year" | "hour" | null,
+--     "location_city": "San Francisco" | null,
+--     "location_country": "US" | null
+--   }
+--
+-- Powers the /jobs chips and filter pills (?remote_only=true,
+-- ?min_salary=150000, ?country=US). Informational / filter-only —
+-- NEVER folded into score or sort order. The axis weights mechanism
+-- on user_targets is the score-tuning surface; this is the list-
+-- filtering surface. See "Concepts" in
+-- plan-wyrdfold-streamlined-target.md for the canonical vocabulary.
+--
+-- Behaviorally neutral on its own: until the Phase 2 prompt change
+-- lands, the column stays NULL on every new row and no consumer
+-- reads it. The accompanying Pydantic model is documentation /
+-- validation only at this stage.
+
+alter table public.scores
+  add column if not exists logistics_filters jsonb;
+
+comment on column public.scores.logistics_filters is
+  'Structured logistics fields extracted by the Phase 2 grader: '
+  '{remote_status, salary_min, salary_max, salary_currency, salary_unit, '
+  'location_city, location_country}. Powers /jobs logistics chips and '
+  'filter pills. Filter-only — NOT used in scoring or sort order. See '
+  'plan-wyrdfold-logistics-chips.md for the extraction contract.';
+
+-- No CHECK constraint on the JSON shape; the API layer (Pydantic
+-- LogisticsFilters model) enforces field types and the remote_status
+-- enum at read/write time.


### PR DESCRIPTION
## Summary

First half of the logistics chips work, following the updated approach in \`plan-wyrdfold-logistics-chips.md\` (pivoted earlier today to extending the Phase 2 grader rather than regex extraction).

Ships:
- **Migration**: \`scores.logistics_filters jsonb\` (nullable).
- **Pydantic model**: \`app/models/logistics.py\` with \`LogisticsFilters\`: \`remote_status\` enum, salary min/max/currency/unit, location city/country, plus a \`has_any_signal()\` helper for the FE chip renderer.
- **9 unit tests** locking the shape (enum validation, salary bounds, country code caps, round-trip through dict).

## Behaviorally neutral

Nothing reads or writes the column yet. The Phase 2 prompt change (the half that actually populates the JSON) is a separate PR because it touches the live grader and wants a more careful review. Once that lands, this schema is already in place.

## Out of scope (follow-ups)

- Phase 2 prompt change to emit \`logistics_filters\` in JSON output.
- Backfill rerun via existing Phase 2 backfill scripts.
- \`/jobs?remote_only=…&min_salary=…&country=…\` filter params.
- FE \`LogisticsChips\` component + filter pills above the job list.

## Test plan

- [x] \`ruff check\`, \`mypy\` clean
- [x] \`pytest -q\` 1091 passed (9 new)
- [x] Supabase Preview will exercise the migration