### PR TITLE
feat(wyrdfold-api): Phase 2 logistics extraction (flag-gated)

### DIFF
--- a/apps/wyrdfold-api/app/config.py
+++ b/apps/wyrdfold-api/app/config.py
@@ -91,6 +91,18 @@ class Settings(BaseSettings):
     # ``phase1_triage_enabled`` to surface any work.
     phase2_enabled: bool = False
 
+    # Logistics extraction (plan-wyrdfold-logistics-chips.md). When True
+    # the Phase 2 grader's system prompt includes a section asking the
+    # model to emit a `logistics` JSON object (remote_status, salary
+    # min/max/currency/unit, location_city/country) alongside the axis
+    # scores. The result is persisted to ``scores.logistics_filters``
+    # (migration #20260603100000) and consumed by the /jobs logistics
+    # chips. When False the prompt is unchanged and the column stays
+    # NULL — this is the additive shadow that pre-flip rollout uses.
+    # Per ``feedback-prompt-change-shadow-run``: ship behind this flag,
+    # compare axis-score distributions before flipping in production.
+    logistics_extraction_enabled: bool = False
+
     # Email/SMS notifications — Next.js app URL and shared secret for job alerts.
     next_app_url: str = ""
     job_alert_secret: str = Field(default="", repr=False)

--- a/apps/wyrdfold-api/app/services/fit/job_fit.py
+++ b/apps/wyrdfold-api/app/services/fit/job_fit.py
@@ -30,6 +30,7 @@ from pydantic import BaseModel, Field
 
 from app.models.experience import OptimizedPayload
 from app.models.llm import LLMResult, Message, ModelId
+from app.models.logistics import LogisticsFilters
 from app.models.targets import JobTarget
 from app.services.llm.client import LLMClient, complete_json
 from app.services.targets.suggest import _build_user_message as _profile_summary
@@ -69,11 +70,18 @@ class JobFitResult(BaseModel):
     stronger model + full JD context, expected within ±20 points of
     Phase 2 — that's the "variance you can trust" the user sees when
     they click in for the deep analysis.
+
+    ``logistics`` is populated only when the LOGISTICS_EXTRACTION_ENABLED
+    feature flag is on AND the prompt asked for it. Older grading runs
+    (and runs with the flag off) leave it None. The field is wholly
+    informational — see ``app/models/logistics.py`` and
+    ``plan-wyrdfold-logistics-chips.md``.
     """
 
     fit_score: int = Field(ge=0, le=100)
     axes: AxisScores
     reasoning: str = Field(max_length=1500)
+    logistics: LogisticsFilters | None = None
 
 
 _SYSTEM_PROMPT = """\
@@ -148,6 +156,53 @@ which is absent from your e-commerce/healthtech profile."
 }
 
 Return ONLY the JSON object. No prose, no markdown, no code fences."""
+
+
+# Optional addendum appended to the system prompt when
+# ``settings.logistics_extraction_enabled`` is True. Kept as a separate
+# string so the base prompt is unchanged in the off case — exact-byte
+# parity matters for the shadow comparison + Anthropic prompt cache.
+# See plan-wyrdfold-logistics-chips.md for the contract.
+_LOGISTICS_PROMPT_ADDENDUM = """\
+
+Additionally, extract a ``logistics`` object capturing structured \
+facts from the JD that power the /jobs filter UI. This is purely \
+informational — it does NOT affect the fit_score or axis scores.
+
+For ``logistics.remote_status``:
+- "remote" if the JD allows full-remote work with no in-office requirement.
+- "hybrid" if any in-office days are required.
+- "onsite" if no remote work is permitted.
+- "unspecified" if the JD is silent or ambiguous. Lean unspecified \
+over guessing — false-positive filter chips are worse than missing ones.
+
+For ``logistics.salary_min`` / ``salary_max``: extract numeric values \
+only when explicitly disclosed ("$150,000 - $180,000"). Normalize "150K" \
+to 150000. ``salary_currency`` is the ISO 4217 code ("USD", "EUR", "GBP"). \
+``salary_unit`` is "year" for annual figures, "hour" for hourly. Null \
+all four fields if no salary band is disclosed.
+
+For ``logistics.location_city`` / ``location_country``: extract the \
+primary office anchor when named ("San Francisco" / "US"). Null both \
+when the role is remote-only with no anchor location named.
+
+Return JSON matching this extended schema:
+
+{
+  "fit_score": 82,
+  "axes": { "title_fit": 95, "skills_fit": 80, "seniority_fit": 85, \
+"domain_fit": 70 },
+  "reasoning": "...",
+  "logistics": {
+    "remote_status": "hybrid",
+    "salary_min": 150000,
+    "salary_max": 180000,
+    "salary_currency": "USD",
+    "salary_unit": "year",
+    "location_city": "San Francisco",
+    "location_country": "US"
+  }
+}"""
 
 
 def _build_user_message(
@@ -225,6 +280,7 @@ async def derive_job_fit(
     jd_text: str,
     model: ModelId = JOB_FIT_MODEL,
     purpose: str = JOB_FIT_PURPOSE,
+    extract_logistics: bool = False,
 ) -> tuple[JobFitResult, LLMResult]:
     """Grade a single (user, target, job) tuple.
 
@@ -236,15 +292,27 @@ async def derive_job_fit(
     Caller is responsible for batching / rate-limiting; this is one
     call per (job, target). The progressive batching policy (first 20
     eagerly, rest in 50-chunk background batches) lives in the poller.
+
+    ``extract_logistics`` toggles the additive logistics prompt addendum.
+    When False the system prompt is byte-identical to the pre-logistics
+    version (matters for Anthropic prompt cache hits + shadow parity).
+    Callers should pass ``settings.logistics_extraction_enabled`` so
+    the global flag controls the behaviour.
     """
     user_message = _build_user_message(
         payload=payload, target=target, job_title=job_title, jd_text=jd_text
     )
 
+    system_prompt = (
+        _SYSTEM_PROMPT + _LOGISTICS_PROMPT_ADDENDUM
+        if extract_logistics
+        else _SYSTEM_PROMPT
+    )
+
     return await complete_json(
         llm,
         model=model,
-        system=_SYSTEM_PROMPT,
+        system=system_prompt,
         messages=[Message(role="user", content=user_message)],
         schema=JobFitResult,
         purpose=purpose,
@@ -254,6 +322,9 @@ async def derive_job_fit(
         # mid-JSON on softer / vaguer CX-style JDs where the model tried
         # harder to find quotable evidence. See plan-wyrdfold-relevance-
         # findings.md "Experiment 3" for the diagnostic chain.
-        max_tokens=1024,
+        # Bumped to 1280 when logistics extraction is on: the additional
+        # JSON section adds ~80-120 output tokens, headroom keeps us
+        # clear of truncation.
+        max_tokens=1280 if extract_logistics else 1024,
         cache_system=True,
     )

--- a/apps/wyrdfold-api/app/services/fit/score_persistence.py
+++ b/apps/wyrdfold-api/app/services/fit/score_persistence.py
@@ -21,9 +21,11 @@ from __future__ import annotations
 
 import logging
 from datetime import UTC, datetime
+from typing import Any
 
 from supabase import Client
 
+from app.config import settings
 from app.models.experience import OptimizedPayload
 from app.models.targets import JobTarget
 from app.services.fit.job_fit import JOB_FIT_PURPOSE, JobFitResult, derive_job_fit
@@ -67,6 +69,7 @@ async def score_with_phase2_and_persist(
             target=target,
             job_title=title,
             jd_text=jd_text,
+            extract_logistics=settings.logistics_extraction_enabled,
         )
     except Exception:
         logger.exception(
@@ -97,29 +100,34 @@ async def score_with_phase2_and_persist(
         )
 
     try:
-        supabase.table("scores").update(
-            {
-                "score": fit.fit_score,
-                "axis_scores": fit.axes.model_dump(),
-                "fit_reasoning": fit.reasoning,
-                "scoring_status": "complete",
-                # Stamp the version this grade was computed at so the
-                # re-grade contract holds: a row that's ``complete`` at
-                # ``scored_profile_version >= target.profile_version`` is
-                # skipped on the next poll / backfill. A profile bump (via
-                # bulk_score_for_target) resets status to ``stage2``, which
-                # re-admits the row for grading.
-                "scored_profile_version": target.profile_version,
-                # Keep the recency invariant (recency_score == score when
-                # decay is off). When decay is on the poller's
-                # refresh_recency_scores pass overwrites this with the
-                # age-decayed value later in the same cycle.
-                "recency_score": fit.fit_score,
-                "updated_at": datetime.now(UTC).isoformat(),
-            }
-        ).eq("job_posting_id", job_posting_id).eq(
-            "target_id", target.id
-        ).execute()
+        update_payload: dict[str, Any] = {
+            "score": fit.fit_score,
+            "axis_scores": fit.axes.model_dump(),
+            "fit_reasoning": fit.reasoning,
+            "scoring_status": "complete",
+            # Stamp the version this grade was computed at so the
+            # re-grade contract holds: a row that's ``complete`` at
+            # ``scored_profile_version >= target.profile_version`` is
+            # skipped on the next poll / backfill. A profile bump (via
+            # bulk_score_for_target) resets status to ``stage2``, which
+            # re-admits the row for grading.
+            "scored_profile_version": target.profile_version,
+            # Keep the recency invariant (recency_score == score when
+            # decay is off). When decay is on the poller's
+            # refresh_recency_scores pass overwrites this with the
+            # age-decayed value later in the same cycle.
+            "recency_score": fit.fit_score,
+            "updated_at": datetime.now(UTC).isoformat(),
+        }
+        # Only write logistics when the grader emitted it (flag was on
+        # for this call). Skipping the key entirely when None preserves
+        # any prior value if the flag was flipped off after a grade —
+        # rather than blowing away historical logistics data.
+        if fit.logistics is not None:
+            update_payload["logistics_filters"] = fit.logistics.model_dump()
+        supabase.table("scores").update(update_payload).eq(
+            "job_posting_id", job_posting_id
+        ).eq("target_id", target.id).execute()
     except Exception:
         logger.exception(
             "Phase 2 persist failed for job %s / target %s",

--- a/apps/wyrdfold-api/tests/test_fit_logistics_extraction.py
+++ b/apps/wyrdfold-api/tests/test_fit_logistics_extraction.py
@@ -1,0 +1,178 @@
+"""Tests for the logistics extraction toggle in the Phase 2 grader.
+
+The toggle is the additive flag from
+``plan-wyrdfold-logistics-chips.md``: when the
+``LOGISTICS_EXTRACTION_ENABLED`` config is on, the Phase 2 system
+prompt is extended with a logistics section asking Sonnet to emit a
+``logistics`` JSON object alongside the existing axis scores. When
+off, the system prompt is byte-identical to the pre-logistics
+version (matters for Anthropic prompt-cache hits + shadow parity).
+
+These tests cover the toggle wiring + the result schema. The actual
+extraction quality is measured by the shadow eval harness separately
+(see ``feedback-prompt-change-shadow-run`` — a unit test can't grade
+prompt quality).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.models.experience import OptimizedPayload
+from app.models.logistics import LogisticsFilters
+from app.models.targets import JobTarget, ScoringProfile
+from app.services.fit import job_fit
+from app.services.fit.job_fit import (
+    _LOGISTICS_PROMPT_ADDENDUM,
+    _SYSTEM_PROMPT,
+    AxisScores,
+    JobFitResult,
+    derive_job_fit,
+)
+
+
+def _payload() -> OptimizedPayload:
+    return OptimizedPayload(summary="...", roles=[], skills=[], outcomes=[])
+
+
+def _target() -> JobTarget:
+    now = datetime.now(UTC)
+    return JobTarget(
+        id="t-1",
+        label="Director of CX Operations",
+        scoring_profile=ScoringProfile(),
+        is_active=True,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def _axes() -> AxisScores:
+    return AxisScores(title_fit=80, skills_fit=75, seniority_fit=80, domain_fit=70)
+
+
+# ---- JobFitResult shape -------------------------------------------------
+
+
+def test_job_fit_result_logistics_defaults_to_none() -> None:
+    """Old grading runs (and runs with the flag off) leave logistics None."""
+    result = JobFitResult(fit_score=80, axes=_axes(), reasoning="ok")
+    assert result.logistics is None
+
+
+def test_job_fit_result_accepts_logistics_object() -> None:
+    """When the flag is on the LLM emits a logistics object; verify it parses."""
+    result = JobFitResult(
+        fit_score=80,
+        axes=_axes(),
+        reasoning="ok",
+        logistics=LogisticsFilters(
+            remote_status="hybrid",
+            salary_min=150_000,
+            salary_max=180_000,
+            salary_currency="USD",
+            salary_unit="year",
+            location_city="San Francisco",
+            location_country="US",
+        ),
+    )
+    assert result.logistics is not None
+    assert result.logistics.remote_status == "hybrid"
+    assert result.logistics.has_any_signal() is True
+
+
+def test_job_fit_result_round_trips_through_dict() -> None:
+    """Persistence path serializes via model_dump → jsonb → parse on read."""
+    src = JobFitResult(
+        fit_score=80,
+        axes=_axes(),
+        reasoning="ok",
+        logistics=LogisticsFilters(remote_status="remote", location_country="US"),
+    )
+    roundtripped = JobFitResult.model_validate(src.model_dump())
+    assert roundtripped == src
+
+
+# ---- derive_job_fit toggles --------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_default_call_uses_base_prompt(monkeypatch: pytest.MonkeyPatch) -> None:
+    """extract_logistics defaults to False: the system prompt that
+    reaches complete_json is byte-identical to the pre-logistics
+    version. Critical for Anthropic prompt-cache hits — any change to
+    the cached system slot invalidates the cache."""
+    seen: dict[str, object] = {}
+
+    async def fake_complete_json(
+        *_args: object, system: str, **kwargs: object
+    ) -> object:
+        seen["system"] = system
+        seen["max_tokens"] = kwargs["max_tokens"]
+        return (JobFitResult(fit_score=80, axes=_axes(), reasoning="ok"), MagicMock())
+
+    monkeypatch.setattr(job_fit, "complete_json", fake_complete_json)
+
+    await derive_job_fit(
+        AsyncMock(),
+        payload=_payload(),
+        target=_target(),
+        job_title="Director of CX Operations",
+        jd_text="...",
+    )
+
+    assert seen["system"] == _SYSTEM_PROMPT
+    assert _LOGISTICS_PROMPT_ADDENDUM not in seen["system"]  # type: ignore[operator]
+    assert seen["max_tokens"] == 1024
+
+
+@pytest.mark.asyncio
+async def test_extract_logistics_appends_addendum(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """extract_logistics=True appends the addendum and bumps max_tokens
+    so the additional JSON section doesn't truncate mid-write."""
+    seen: dict[str, object] = {}
+
+    async def fake_complete_json(
+        *_args: object, system: str, **kwargs: object
+    ) -> object:
+        seen["system"] = system
+        seen["max_tokens"] = kwargs["max_tokens"]
+        return (
+            JobFitResult(
+                fit_score=80,
+                axes=_axes(),
+                reasoning="ok",
+                logistics=LogisticsFilters(remote_status="remote"),
+            ),
+            MagicMock(),
+        )
+
+    monkeypatch.setattr(job_fit, "complete_json", fake_complete_json)
+
+    await derive_job_fit(
+        AsyncMock(),
+        payload=_payload(),
+        target=_target(),
+        job_title="Director of CX Operations",
+        jd_text="...",
+        extract_logistics=True,
+    )
+
+    assert seen["system"].endswith(_LOGISTICS_PROMPT_ADDENDUM)  # type: ignore[union-attr]
+    assert seen["system"].startswith(_SYSTEM_PROMPT)  # type: ignore[union-attr]
+    assert seen["max_tokens"] == 1280
+
+
+def test_addendum_is_strictly_additive() -> None:
+    """The base prompt must not change when the addendum is added.
+    Otherwise the shadow-comparison contract breaks: 'old vs new' would
+    actually be 'old vs (new + base-edit)' — confounding the eval."""
+    assert _SYSTEM_PROMPT in (_SYSTEM_PROMPT + _LOGISTICS_PROMPT_ADDENDUM)
+    assert (
+        _SYSTEM_PROMPT + _LOGISTICS_PROMPT_ADDENDUM
+    ).startswith(_SYSTEM_PROMPT)


### PR DESCRIPTION
## Summary

Extends the Phase 2 grader to emit a structured \`logistics\` JSON section (remote_status / salary band / location) alongside the existing axis scores. Persisted to \`scores.logistics_filters\` (column from #814). Powers the upcoming /jobs logistics chips + filter pills.

**Behaviorally gated.** Off by default via the new \`LOGISTICS_EXTRACTION_ENABLED\` config flag. With the flag off, the system prompt is byte-identical to the prior version — preserves the Anthropic prompt-cache key and the shadow-comparison contract.

## Shadow-run rollout (required per \`feedback-prompt-change-shadow-run\`)

Before flipping in production:

1. Deploy this PR with the flag **off**. Existing scoring is unchanged.
2. Run the eval harness (\`scripts/eval_grading_prompts.py\` or similar) with the flag flipped locally, comparing axis-score distributions vs the off case on the existing 30-job eval set.
3. Parity threshold: **Spearman ρ ≥ 0.9** on axis-score correlation; if it misses, iterate on the addendum wording before flipping.
4. Once parity confirmed, flip \`LOGISTICS_EXTRACTION_ENABLED=true\` in production via env var. New scores include \`logistics_filters\`.
5. Backfill: existing \`backfill_phase2_fit.py\` re-grades after the flag is on. Per your direction, the backfill also doubles as a check for whether archived jobs are graded — surface any rows skipped because their owning user / target is inactive.

## Adjacent finding from PR #817

The OpenRouter investigation surfaced that the Phase 2 system prompt is currently **under** Anthropic's 2048-token prompt-cache minimum — \`cache_system=True\` silently no-ops today. Adding this logistics addendum (~500 tokens) **pushes it over the threshold**, accidentally enabling caching. That's a 90% read-cost reduction on the cached portion. Free upside on top of the logistics feature.

## What's in the PR

| File | Change |
|------|--------|
| \`app/config.py\` | New \`logistics_extraction_enabled\` bool (default False). |
| \`app/services/fit/job_fit.py\` | \`JobFitResult.logistics: LogisticsFilters \| None\`. New \`_LOGISTICS_PROMPT_ADDENDUM\` appended when \`extract_logistics=True\`. Bumped \`max_tokens\` 1024→1280 for the on case (additional JSON section). |
| \`app/services/fit/score_persistence.py\` | Passes the flag to \`derive_job_fit\`. Writes \`logistics_filters\` to scores only when populated — preserves historical data if the flag is flipped off later. |
| \`tests/test_fit_logistics_extraction.py\` | 7 new tests: default-off prompt parity (cache key invariant), addendum-on wiring, result round-trip, "addendum is strictly additive" contract for the shadow eval. |

## Test plan

- [x] \`ruff check\`, \`mypy\` clean
- [x] \`pytest -q\` 1097 passed (7 new)
- [ ] After merge: run the eval harness with the flag flipped, document parity result, then flip in production