### PR TITLE
chore(wyrdfold-api): cut tailor.resume max_tokens 8192 -> 4096

### DIFF
--- a/apps/wyrdfold-api/app/services/tailor/tailor.py
+++ b/apps/wyrdfold-api/app/services/tailor/tailor.py
@@ -169,7 +169,15 @@ async def tailor_resume(
         schema=TailoredResume,
         purpose=purpose,
         cache_system=True,
-        max_tokens=8192,
+        # Cut from 8192 to 4096: typical tailored resumes are 1500-3500
+        # output tokens; the 8192 cap was a worst-case ceiling that we
+        # never hit. At Sonnet output $15/Mtok, full-fill would have been
+        # $0.123/call just for output. 4096 keeps real headroom for the
+        # rare long-spec resume while halving the worst-case spend. See
+        # plan-wyrdfold-openrouter-investigation.md Recommendation C.
+        # Reassess by querying llm_costs output_tokens p95 after ~2
+        # weeks of production data.
+        max_tokens=4096,
     )
 
     cleaned, warnings = validate_trace_refs(parsed, optimized)


### PR DESCRIPTION
## Summary

OpenRouter investigation Recommendation C (PR #817), shipped early per direction "let's be aggressive and cut max tokens to 4096 for now and reassess."

Typical tailored resumes are 1500-3500 output tokens; the 8192 cap was a worst-case ceiling we never hit. At Sonnet output \$15/Mtok the cap governed a \$0.123/call worst-case spend — 4096 keeps real headroom for the rare long-spec resume while halving that worst case.

## Reassess after

Two weeks of production data. Query \`llm_costs\` rows for purpose=\`tailor.resume\` and check output_tokens p95. If p95 < 3500, this stays. If anyone bumps it, something changed and warrants investigation.

## Test plan

- [x] \`ruff check\`, \`mypy\` clean
- [x] Tailor pipeline tests (10) still pass