### PR TITLE
feat(wyrdfold-api): OpenRouter LLM client (PR A)

### DIFF
--- a/apps/wyrdfold-api/app/config.py
+++ b/apps/wyrdfold-api/app/config.py
@@ -29,8 +29,12 @@ class Settings(BaseSettings):
     twilio_auth_token: str = Field(default="", repr=False)
     twilio_phone_number: str = ""
 
-    # LLM provider — set to "anthropic" to use the real SDK; mock is the safe default.
-    llm_provider: Literal["mock", "anthropic"] = "mock"
+    # LLM provider — "anthropic" uses the Anthropic SDK direct; "openrouter"
+    # routes the same Anthropic-shaped calls through OpenRouter (one billing
+    # relationship, optional cross-provider fallback). Mock is the safe
+    # default for tests + local dev. See
+    # plan-wyrdfold-openrouter-migration.md for the migration roadmap.
+    llm_provider: Literal["mock", "anthropic", "openrouter"] = "mock"
     anthropic_api_key: str = Field(default="", repr=False)
     anthropic_timeout_seconds: float = Field(default=600.0, ge=1.0, le=3600.0)
     # Bumped from 2 → 5 alongside the V3 prompt rollout. The default-2 budget
@@ -39,6 +43,14 @@ class Settings(BaseSettings):
     # rate-limit retries enough headroom to recover without sacrificing
     # responsiveness. Each retry uses exponential backoff inside the SDK.
     anthropic_max_retries: int = Field(default=5, ge=0, le=10)
+
+    # OpenRouter (PR A of plan-wyrdfold-openrouter-migration.md). Drop-in
+    # replacement for the Anthropic SDK that routes through
+    # https://openrouter.ai. ZDR is enabled account-wide in the OR
+    # dashboard, not per-request.
+    openrouter_api_key: str = Field(default="", repr=False)
+    openrouter_timeout_seconds: float = Field(default=600.0, ge=1.0, le=3600.0)
+    openrouter_max_retries: int = Field(default=3, ge=0, le=10)
 
     # URL validation — enable to validate job URLs during polling.
     validate_poll_urls: bool = True

--- a/apps/wyrdfold-api/app/services/llm/__init__.py
+++ b/apps/wyrdfold-api/app/services/llm/__init__.py
@@ -1,13 +1,17 @@
 """LLM plumbing module.
 
-The `LLMClient` Protocol has two implementations:
+The `LLMClient` Protocol has three implementations:
 
 - `MockLLMClient` — deterministic fake for tests and local dev.
-- `AnthropicLLMClient` — production, uses the official `anthropic` SDK.
+- `AnthropicLLMClient` — production, uses the official `anthropic` SDK
+  pointed at api.anthropic.com.
+- `OpenRouterLLMClient` — same code path as Anthropic but routed
+  through openrouter.ai for unified billing + cross-provider fallback
+  (see plan-wyrdfold-openrouter-migration.md).
 
 `get_default_client()` picks based on `settings.llm_provider` (env var
-`LLM_PROVIDER=mock|anthropic`). Mock is the default so nothing hits the
-real API unless opted in.
+`LLM_PROVIDER=mock|anthropic|openrouter`). Mock is the default so
+nothing hits a real API unless opted in.
 
 Every consumer (derive, tailor, conversation) tags calls with a `purpose`
 string so cost-log rows can be grouped by feature for spend analysis.
@@ -16,11 +20,13 @@ string so cost-log rows can be grouped by feature for spend analysis.
 from app.services.llm.anthropic_client import AnthropicLLMClient
 from app.services.llm.client import LLMClient
 from app.services.llm.mock import MockLLMClient
+from app.services.llm.openrouter_client import OpenRouterLLMClient
 
 __all__ = [
     "AnthropicLLMClient",
     "LLMClient",
     "MockLLMClient",
+    "OpenRouterLLMClient",
     "get_default_client",
 ]
 
@@ -28,9 +34,9 @@ __all__ = [
 def get_default_client() -> LLMClient:
     """Return the configured LLM client.
 
-    Reads `settings.llm_provider`. `"anthropic"` requires `ANTHROPIC_API_KEY`
-    (via env or `anthropic_api_key` setting); anything else falls back to
-    the mock.
+    Reads `settings.llm_provider`. `"anthropic"` and `"openrouter"`
+    require their respective API keys to be set (`anthropic_api_key`
+    / `openrouter_api_key`); anything else falls back to the mock.
     """
     from app.config import settings
 
@@ -39,5 +45,11 @@ def get_default_client() -> LLMClient:
             api_key=settings.anthropic_api_key or None,
             timeout=settings.anthropic_timeout_seconds,
             max_retries=settings.anthropic_max_retries,
+        )
+    if settings.llm_provider == "openrouter":
+        return OpenRouterLLMClient(
+            api_key=settings.openrouter_api_key or None,
+            timeout=settings.openrouter_timeout_seconds,
+            max_retries=settings.openrouter_max_retries,
         )
     return MockLLMClient()

--- a/apps/wyrdfold-api/app/services/llm/anthropic_client.py
+++ b/apps/wyrdfold-api/app/services/llm/anthropic_client.py
@@ -45,12 +45,28 @@ class AnthropicLLMClient:
         api_key: str | None = None,
         timeout: float = 600.0,
         max_retries: int = 2,
+        base_url: str | None = None,
     ) -> None:
-        self._client = AsyncAnthropic(
-            api_key=api_key,
-            timeout=timeout,
-            max_retries=max_retries,
-        )
+        # ``base_url`` is an extension point for backends that speak the
+        # Anthropic API shape but live behind a different host — e.g.
+        # OpenRouter (see openrouter_client.py). Default None keeps the
+        # SDK at its built-in https://api.anthropic.com endpoint.
+        kwargs: dict[str, Any] = {
+            "api_key": api_key,
+            "timeout": timeout,
+            "max_retries": max_retries,
+        }
+        if base_url is not None:
+            kwargs["base_url"] = base_url
+        self._client = AsyncAnthropic(**kwargs)
+
+    def _resolve_model(self, model: ModelId) -> str:
+        """Translate an internal ModelId to the string the underlying
+        API expects. Override in subclasses that need to remap (e.g.
+        OpenRouter prepends a provider namespace + uses dotted versions).
+        Default: pass through unchanged.
+        """
+        return model
 
     async def complete(
         self,
@@ -87,7 +103,7 @@ class AnthropicLLMClient:
 
         start = time.perf_counter()
         response = await self._client.messages.create(
-            model=model,
+            model=cast(Any, self._resolve_model(model)),
             max_tokens=max_tokens,
             system=system_param,
             messages=cast(Any, api_messages),
@@ -167,7 +183,7 @@ class AnthropicLLMClient:
 
         start = time.perf_counter()
         response = await self._client.messages.create(
-            model=model,
+            model=cast(Any, self._resolve_model(model)),
             max_tokens=max_tokens,
             system=system_param,
             messages=cast(Any, api_messages),
@@ -247,7 +263,7 @@ class AnthropicLLMClient:
 
         start = time.perf_counter()
         async with self._client.messages.stream(
-            model=model,
+            model=cast(Any, self._resolve_model(model)),
             max_tokens=max_tokens,
             system=system_param,
             messages=cast(Any, api_messages),

--- a/apps/wyrdfold-api/app/services/llm/openrouter_client.py
+++ b/apps/wyrdfold-api/app/services/llm/openrouter_client.py
@@ -1,0 +1,77 @@
+"""OpenRouter-backed LLMClient.
+
+PR A of plan-wyrdfold-openrouter-migration.md. The OpenRouter API at
+https://openrouter.ai/api/v1 exposes a fully Anthropic-compatible
+/messages endpoint — including prompt caching (cache_control:
+ephemeral), tool-use forced calls, and streaming — using the same
+shape the Anthropic SDK speaks natively.
+
+So this client is a thin subclass of AnthropicLLMClient that:
+- points AsyncAnthropic at OpenRouter's base URL via the new
+  ``base_url`` constructor knob,
+- translates our internal ModelId values into OpenRouter's namespaced
+  slugs via the ``_resolve_model`` hook.
+
+Everything else — caching, retries, usage parsing, cost calculation —
+flows through the parent class unchanged. Behaviorally identical for
+Anthropic models; the gateway just bills differently.
+
+ZDR (Zero Data Retention) is enabled account-wide via the OpenRouter
+dashboard, not per-request — that's the operator action documented
+in PR A.
+
+Non-Anthropic models (GPT-5.1, Gemini, DeepSeek) need OpenRouter's
+OpenAI-compatible endpoint, not the Anthropic-compatible one this
+client uses. Routing across providers is the job of PR B; this PR is
+strictly the Anthropic-shaped path.
+"""
+
+from __future__ import annotations
+
+from app.models.llm import ModelId
+from app.services.llm.anthropic_client import AnthropicLLMClient
+
+_OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
+
+# Map our internal ModelId to OpenRouter's namespaced slugs. OR uses
+# dotted version numbers (4.6 not 4-6); the upstream API call passes
+# the string through unchanged, so OR is the one that matters for
+# matching. Extend this dict when ModelId gains new entries.
+_MODEL_SLUG_MAP: dict[str, str] = {
+    "claude-opus-4-7": "anthropic/claude-opus-4.7",
+    "claude-sonnet-4-6": "anthropic/claude-sonnet-4.6",
+    "claude-haiku-4-5": "anthropic/claude-haiku-4.5",
+}
+
+
+class OpenRouterLLMClient(AnthropicLLMClient):
+    """Implements LLMClient via OpenRouter's Anthropic-compatible API.
+
+    Behaviorally identical to AnthropicLLMClient — same caching, same
+    tool-use, same streaming — but routed through OpenRouter so we get
+    one billing relationship + cross-provider fallback as a later
+    capability (PR B).
+    """
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        timeout: float = 600.0,
+        max_retries: int = 3,
+    ) -> None:
+        super().__init__(
+            api_key=api_key,
+            timeout=timeout,
+            max_retries=max_retries,
+            base_url=_OPENROUTER_BASE_URL,
+        )
+
+    def _resolve_model(self, model: ModelId) -> str:
+        slug = _MODEL_SLUG_MAP.get(model)
+        if slug is None:
+            raise ValueError(
+                f"No OpenRouter slug mapped for ModelId={model!r}. "
+                f"Add it to _MODEL_SLUG_MAP in openrouter_client.py."
+            )
+        return slug

--- a/apps/wyrdfold-api/tests/test_openrouter_client.py
+++ b/apps/wyrdfold-api/tests/test_openrouter_client.py
@@ -1,0 +1,87 @@
+"""Tests for OpenRouterLLMClient (PR A of OpenRouter migration).
+
+Covers the model-slug remap + base_url routing. We don't mock the
+actual HTTP call here — the parent class already exercises the
+AsyncAnthropic happy path. What we verify is the *only* thing this
+subclass changes: model translation and SDK construction.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.services.llm.openrouter_client import (
+    _MODEL_SLUG_MAP,
+    _OPENROUTER_BASE_URL,
+    OpenRouterLLMClient,
+)
+
+
+def test_resolves_known_models_to_openrouter_slugs() -> None:
+    """All three ModelId values in the workspace today must have a
+    mapping. New ModelIds need their slug added to the map at the same
+    time as the ModelId Literal — this test surfaces forgotten ones."""
+    client = OpenRouterLLMClient(api_key="sk-or-fake")
+    assert client._resolve_model("claude-sonnet-4-6") == "anthropic/claude-sonnet-4.6"
+    assert client._resolve_model("claude-haiku-4-5") == "anthropic/claude-haiku-4.5"
+    assert client._resolve_model("claude-opus-4-7") == "anthropic/claude-opus-4.7"
+
+
+def test_unknown_model_raises_with_actionable_message() -> None:
+    """If someone adds a new ModelId to the Literal without updating
+    the slug map, the failure must surface immediately at first use —
+    not silently route to a wrong model. The exception text names the
+    file to edit."""
+    client = OpenRouterLLMClient(api_key="sk-or-fake")
+    with pytest.raises(ValueError, match=r"openrouter_client\.py"):
+        client._resolve_model("claude-imaginary-9-0")  # type: ignore[arg-type]
+
+
+def test_constructor_points_sdk_at_openrouter_base_url() -> None:
+    """The whole point of this client is routing to a non-default host.
+    Verify the AsyncAnthropic instance carries the OR base URL."""
+    client = OpenRouterLLMClient(api_key="sk-or-fake")
+    # AsyncAnthropic stores base_url on the sync inner client; assert by
+    # string contains since the SDK may normalize trailing slashes.
+    base = str(client._client.base_url)
+    assert _OPENROUTER_BASE_URL in base
+
+
+def test_anthropic_client_default_base_url_is_unaffected() -> None:
+    """Regression: the new base_url constructor knob has a None default
+    so non-OR callers still hit the Anthropic endpoint."""
+    from app.services.llm.anthropic_client import AnthropicLLMClient
+
+    plain = AnthropicLLMClient(api_key="sk-ant-fake")
+    # When base_url isn't passed, the AsyncAnthropic SDK defaults to
+    # https://api.anthropic.com — assert OR is *not* in there.
+    assert _OPENROUTER_BASE_URL not in str(plain._client.base_url)
+
+
+def test_slug_map_covers_every_model_id() -> None:
+    """Belt-and-suspenders against the same drift as
+    test_unknown_model_raises: iterate the ModelId Literal at runtime
+    via typing.get_args and require a mapping for each."""
+    from typing import get_args
+
+    from app.models.llm import ModelId
+
+    for model in get_args(ModelId):
+        assert model in _MODEL_SLUG_MAP, (
+            f"{model!r} is a ModelId but has no OpenRouter slug. "
+            f"Add it to _MODEL_SLUG_MAP."
+        )
+
+
+def test_get_default_client_returns_openrouter_when_provider_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End-to-end of the LLM_PROVIDER=openrouter env flow."""
+    from app import config as config_mod
+    from app.services.llm import get_default_client
+
+    monkeypatch.setattr(config_mod.settings, "llm_provider", "openrouter")
+    monkeypatch.setattr(config_mod.settings, "openrouter_api_key", "sk-or-fake")
+
+    client = get_default_client()
+    assert isinstance(client, OpenRouterLLMClient)


### PR DESCRIPTION
PR A of [#821](../issues/821). The smallest first PR: zero behavior change at merge, full code path in place for the flag flip.

## What's in

- Third \`LLMClient\` implementation: \`OpenRouterLLMClient\`. Thin subclass of \`AnthropicLLMClient\` that:
  - Points \`AsyncAnthropic\` at \`https://openrouter.ai/api/v1\` via a new \`base_url\` constructor knob (default \`None\` — Anthropic-direct unchanged).
  - Translates internal \`ModelId\` values to OpenRouter slugs via new \`_resolve_model()\` hook.
- \`LLM_PROVIDER\` Literal extended to include \`"openrouter"\`; new \`openrouter_api_key\` / \`openrouter_timeout_seconds\` / \`openrouter_max_retries\` settings.
- \`get_default_client()\` branches on the new value.
- 6 unit tests including a drift-detection one that fails if a \`ModelId\` Literal value gets added without a slug mapping.

## Operator action before flip

- ZDR enabled account-wide in OpenRouter dashboard (privacy → "no logging or training").
- \`OPENROUTER_API_KEY\` set in env where you want it active.

## Rollout

1. Merge — zero behavior change (\`LLM_PROVIDER\` stays at current value).
2. Set \`LLM_PROVIDER=openrouter\` in staging only; watch \`llm_costs\` for 24h.
3. Cost-per-call delta should match the multi-model judge eval (~7% of Anthropic-direct, modulo a 5.5% OR credit-purchase fee).
4. If healthy: swap prod env. If not: revert env var — zero code rollback needed.

## Test plan

- [x] \`ruff check\`, \`mypy\` clean
- [x] \`pytest -q\` 1103 passed (6 new)
- [ ] After merge: smoke test in staging by setting \`LLM_PROVIDER=openrouter\` and running one Phase 2 grade