### PR TITLE
fix(wyrdfold): redirect brand-new users from /dashboard to /onboarding

### DIFF
--- a/apps/wyrdfold/src/app/(app)/__tests__/dashboard-page.spec.ts
+++ b/apps/wyrdfold/src/app/(app)/__tests__/dashboard-page.spec.ts
@@ -1,0 +1,80 @@
+/**
+ * Tests for the dashboard route (`page.tsx`) — server component that
+ * gates new users into the onboarding wizard. The presentational
+ * `DashboardPage` is tested separately in `DashboardPage.spec.tsx`.
+ */
+
+const mockRedirect = jest.fn((_target: string) => {
+  // Match Next.js behaviour: `redirect()` throws to abort rendering.
+  throw new Error(`REDIRECT:${_target}`);
+});
+
+const mockFetch = jest.fn();
+
+jest.mock('next/navigation', () => ({
+  redirect: (target: string) => mockRedirect(target),
+}));
+
+jest.mock('@/lib/api/proxy', () => ({
+  fetchJsonFromWyrdfoldAPI: (...args: unknown[]) => mockFetch(...args),
+}));
+
+// Re-import after mocks are set up.
+import WyrdfoldDashboard from '../dashboard/page';
+
+describe('WyrdfoldDashboard route', () => {
+  beforeEach(() => {
+    mockRedirect.mockClear();
+    mockFetch.mockClear();
+  });
+
+  it('redirects to /onboarding when the user has no prose yet', async () => {
+    // First API call is the prose check; subsequent calls don't matter
+    // because we redirect before reaching the Promise.all.
+    mockFetch.mockResolvedValueOnce({ prose: null });
+
+    await expect(WyrdfoldDashboard()).rejects.toThrow('REDIRECT:/onboarding');
+
+    expect(mockRedirect).toHaveBeenCalledWith('/onboarding');
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledWith('/experience/prose');
+  });
+
+  it('redirects to /onboarding when the prose endpoint returns null', async () => {
+    // Some upstream errors surface as a null response (e.g. when the
+    // API JWT verification fails silently). Treat null the same as
+    // empty prose — sending the user to /onboarding is the safer
+    // default than rendering a broken empty dashboard.
+    mockFetch.mockResolvedValueOnce(null);
+
+    await expect(WyrdfoldDashboard()).rejects.toThrow('REDIRECT:/onboarding');
+
+    expect(mockRedirect).toHaveBeenCalledWith('/onboarding');
+  });
+
+  it('renders the dashboard when the user has prose authored', async () => {
+    // Returning user: prose populated. Subsequent fetches (jobs,
+    // targets, counts) all need to return a sensible shape.
+    mockFetch.mockResolvedValueOnce({
+      id: 'p-1',
+      content: 'My experience...',
+      version: 1,
+    });
+    // The Promise.all that follows fires the prose fetch a SECOND time,
+    // plus jobs/targets/N counts. Make every subsequent call return a
+    // benign empty response.
+    mockFetch.mockResolvedValue({
+      prose: { id: 'p-1', content: 'My experience...' },
+      postings: [],
+      total: 0,
+      page: 1,
+      page_size: 5,
+      targets: [],
+    });
+
+    const result = await WyrdfoldDashboard();
+
+    expect(mockRedirect).not.toHaveBeenCalled();
+    expect(result).toBeDefined();
+  });
+});

--- a/apps/wyrdfold/src/app/(app)/dashboard/page.tsx
+++ b/apps/wyrdfold/src/app/(app)/dashboard/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next';
+import { redirect } from 'next/navigation';
 import { fetchJsonFromWyrdfoldAPI } from '@/lib/api/proxy';
 import DashboardPage, { type DashboardInitial } from '../DashboardPage';
 import type { JobPosting } from '../jobs/types';
@@ -29,6 +30,22 @@ const PIPELINE_STATUSES = [
 ] as const;
 
 export default async function WyrdfoldDashboard() {
+  // Fast path: brand-new users land on /dashboard by default (auth
+  // callback's DEFAULT_NEXT). Check whether they have any prose yet —
+  // if not, they haven't started onboarding and the dashboard's empty
+  // state would just be a CTA pointing back at /onboarding. Send them
+  // straight there instead of forcing the empty-CTA detour.
+  //
+  // Note: we check prose-only (not targets). A returning user who has
+  // a profile but happens to have no active targets right now should
+  // see the dashboard's manage-targets CTA, not get sent back to the
+  // onboarding wizard.
+  const earlyProseRes =
+    await fetchJsonFromWyrdfoldAPI<ProseResponse>('/experience/prose');
+  if (earlyProseRes == null || !hasProse(earlyProseRes)) {
+    redirect('/onboarding');
+  }
+
   // ``hasProfile`` checks whether the user has authored prose at all —
   // the underlying signal that "they've started onboarding." The
   // upstream ``/experience/prose`` endpoint returns ``{prose: null}``


### PR DESCRIPTION
## Summary

Piotr (just-invited beta tester) reported the onboarding wizard wasn't surfacing on first login. Investigation: brand-new users get sent to \`/dashboard\` by the auth callback's \`DEFAULT_NEXT = '/dashboard'\`. The dashboard renders an empty-state card with a CTA button pointing at \`/onboarding\`, but users were missing it and landing on what looked like a broken empty app.

## Fix

In the \`/dashboard\` server component, fetch \`/experience/prose\` first; if it's null or empty (no prose = user hasn't started onboarding), \`redirect('/onboarding')\` before fetching the rest of the dashboard state.

**Gate is prose-only, not targets.** A returning user with prose but no active targets still sees the dashboard (its "Manage targets" CTA is the right surface for them). Only users who haven't started onboarding at all get redirected.

## Why not fix in the auth callback?

The callback is a JWT-exchange route — it has no visibility into Supabase user data without an extra round-trip. Doing the check in the dashboard route (which already needed the prose data) is cheaper and keeps auth concerns separate from product flow.

## Test plan

- [x] 3 new unit tests in \`__tests__/dashboard-page.spec.ts\` cover the redirect on no-prose, the redirect on null-response (degraded API), and the dashboard-renders happy path.
- [x] \`pnpm tsc --noEmit\` clean
- [x] \`pnpm nx test wyrdfold\` pass
- [x] \`pnpm nx lint wyrdfold\` clean
- [ ] Manual: invite a fresh test user, confirm they land on \`/onboarding\` immediately after magic-link click.