### PR TITLE
feat(wyrdfold): onboarding completion + step tracking (Stage 1)

### DIFF
--- a/apps/wyrdfold-api/app/models/user_profile.py
+++ b/apps/wyrdfold-api/app/models/user_profile.py
@@ -1,6 +1,7 @@
 """Pydantic models for user profile — notification + identity fields."""
 
 import re
+from datetime import datetime
 from typing import Literal
 
 from pydantic import BaseModel, Field, field_validator
@@ -138,3 +139,53 @@ class ResumeStyleSettingsUpdate(BaseModel):
 
     preset: ResumeStylePreset | None = None
     accent: ResumeStyleAccent | None = None
+
+
+# ---------------------------------------------------------------------------
+# Onboarding completion + step tracking
+# ---------------------------------------------------------------------------
+
+# Mirrors the Step union in apps/wyrdfold/src/app/onboarding/OnboardingWizard.tsx.
+# Step names are hyphenated by FE convention (CSS-class friendly) — keep
+# parity rather than enforcing snake_case at the schema boundary.
+OnboardingStep = Literal[
+    "path-chooser",
+    "identity",
+    "upload-resume",
+    "add-job",
+    "pick-targets",
+    "conversation",
+    "completion",
+]
+
+# Three onboarding paths (see STEPS_BY_PATH in OnboardingWizard.tsx).
+# A = full setup (resume + JD + targets); B = resume + targets;
+# C = conversation + targets.
+OnboardingPath = Literal["A", "B", "C"]
+
+
+class OnboardingStatus(BaseModel):
+    """Read model for the user's onboarding progress.
+
+    A user is considered "onboarded" when ``completed_at`` is non-null.
+    Until then, the dashboard redirects them to the wizard. The wizard
+    consumes ``current_step`` + ``path`` to resume mid-flow (Stage 2
+    of plan-wyrdfold-onboarding-completion-tracking.md; for now the
+    fields are populated but not yet read by the wizard).
+    """
+
+    completed_at: datetime | None = None
+    path: OnboardingPath | None = None
+    current_step: OnboardingStep | None = None
+
+
+class OnboardingStepUpdate(BaseModel):
+    """Write model for PATCH /profile/onboarding/step.
+
+    Both fields are optional — most transitions only update ``current_step``,
+    but ``path`` is set once on the PathChooser → Identity transition.
+    Server treats unset fields as "leave the column alone."
+    """
+
+    path: OnboardingPath | None = None
+    current_step: OnboardingStep | None = None

--- a/apps/wyrdfold-api/app/routers/user_profile.py
+++ b/apps/wyrdfold-api/app/routers/user_profile.py
@@ -6,6 +6,7 @@ preventing cross-tenant reads/writes.
 """
 
 import asyncio
+from datetime import UTC, datetime
 from typing import Any, cast
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -23,6 +24,8 @@ from app.models.user_profile import (
     IdentityFieldsUpdate,
     NotificationPreferences,
     NotificationPreferencesUpdate,
+    OnboardingStatus,
+    OnboardingStepUpdate,
     ResumeStyleSettings,
     ResumeStyleSettingsUpdate,
 )
@@ -64,6 +67,10 @@ _PREFS_COLUMNS = (
 _IDENTITY_COLUMNS = "name, email, phone_number, location, linkedin_url, website_url"
 
 _RESUME_STYLE_COLUMNS = "resume_style_settings"
+
+_ONBOARDING_COLUMNS = (
+    "onboarding_completed_at, onboarding_path, onboarding_current_step"
+)
 
 
 async def _get_or_create_profile(
@@ -277,3 +284,138 @@ async def update_resume_style(
         .execute()
     )
     return merged
+
+
+# ---------------------------------------------------------------------------
+# Onboarding progress (plan-wyrdfold-onboarding-completion-tracking.md)
+# ---------------------------------------------------------------------------
+
+
+_KNOWN_STEPS = {
+    "path-chooser",
+    "identity",
+    "upload-resume",
+    "add-job",
+    "pick-targets",
+    "conversation",
+    "completion",
+}
+_KNOWN_PATHS = {"A", "B", "C"}
+
+
+def _read_onboarding(row: dict[str, Any]) -> OnboardingStatus:
+    """Parse the three onboarding columns into a typed status object.
+
+    Unknown ``path`` or ``current_step`` values (e.g. an old wizard
+    version that wrote a step we no longer support) fall back to None
+    rather than 500ing the dashboard — the wizard will treat None as
+    "start from the beginning." This is graceful degradation; the
+    safer-than-crash behaviour matters because this endpoint sits
+    on the dashboard's critical path.
+    """
+    step = row.get("onboarding_current_step")
+    path = row.get("onboarding_path")
+    return OnboardingStatus.model_validate(
+        {
+            "completed_at": row.get("onboarding_completed_at"),
+            "path": path if path in _KNOWN_PATHS else None,
+            "current_step": step if step in _KNOWN_STEPS else None,
+        }
+    )
+
+
+@router.get("/onboarding")
+async def get_onboarding_status(
+    user_id: str = Depends(get_current_user_id),
+    user_email: str | None = Depends(get_current_user_email),
+    supabase: Client = Depends(get_supabase),
+) -> OnboardingStatus:
+    """Return the user's onboarding progress.
+
+    Used by the dashboard server component to decide whether to redirect
+    to /onboarding. Cheap query — only the three onboarding columns
+    flow back.
+    """
+    row = await _get_or_create_profile(
+        supabase, user_id, _ONBOARDING_COLUMNS, seed_email=user_email
+    )
+    return _read_onboarding(row)
+
+
+@router.patch("/onboarding/step")
+async def update_onboarding_step(
+    body: OnboardingStepUpdate,
+    user_id: str = Depends(get_current_user_id),
+    user_email: str | None = Depends(get_current_user_email),
+    supabase: Client = Depends(get_supabase),
+) -> OnboardingStatus:
+    """Update the user's current onboarding step (and optionally path).
+
+    Wizard calls this on every step transition. Both fields are
+    optional — passing only ``current_step`` is the common case;
+    ``path`` is set once when the user picks a path on PathChooser.
+    Idempotent: re-PATCHing the same step is a no-op.
+    """
+    await _get_or_create_profile(
+        supabase, user_id, _ONBOARDING_COLUMNS, seed_email=user_email
+    )
+
+    updates: dict[str, Any] = {}
+    if body.path is not None:
+        updates["onboarding_path"] = body.path
+    if body.current_step is not None:
+        updates["onboarding_current_step"] = body.current_step
+    if updates:
+        await asyncio.to_thread(
+            lambda: supabase.table("user_profiles")
+            .update(updates)
+            .eq("user_id", user_id)
+            .execute()
+        )
+
+    row = await _get_or_create_profile(
+        supabase, user_id, _ONBOARDING_COLUMNS, seed_email=user_email
+    )
+    return _read_onboarding(row)
+
+
+@router.post("/onboarding/complete")
+async def complete_onboarding(
+    user_id: str = Depends(get_current_user_id),
+    user_email: str | None = Depends(get_current_user_email),
+    supabase: Client = Depends(get_supabase),
+) -> OnboardingStatus:
+    """Mark the user's onboarding as complete.
+
+    Idempotent: the wizard's "Continue to dashboard" button calls this
+    on the final step; calling again later (e.g. user navigates back
+    and re-finishes) doesn't overwrite the original completion
+    timestamp — the earlier value is the source of truth for "when
+    did this user actually onboard."
+
+    Also sets current_step to "completion" so a subsequent
+    /onboarding read sees a consistent state.
+    """
+    row = await _get_or_create_profile(
+        supabase, user_id, _ONBOARDING_COLUMNS, seed_email=user_email
+    )
+
+    updates: dict[str, Any] = {"onboarding_current_step": "completion"}
+    if row.get("onboarding_completed_at") is None:
+        # Client-side timestamp is fine here — clock skew between the
+        # API container and the DB is sub-second and we don't render
+        # this value to the user. The PostgREST sync path doesn't have
+        # a clean way to pass a `now()` literal anyway.
+        updates["onboarding_completed_at"] = datetime.now(UTC).isoformat()
+
+    await asyncio.to_thread(
+        lambda: supabase.table("user_profiles")
+        .update(updates)
+        .eq("user_id", user_id)
+        .execute()
+    )
+
+    fresh = await _get_or_create_profile(
+        supabase, user_id, _ONBOARDING_COLUMNS, seed_email=user_email
+    )
+    return _read_onboarding(fresh)

--- a/apps/wyrdfold-api/tests/test_routers_onboarding.py
+++ b/apps/wyrdfold-api/tests/test_routers_onboarding.py
@@ -1,0 +1,264 @@
+"""Router tests for /profile/onboarding/*.
+
+Covers the three endpoints shipped in
+plan-wyrdfold-onboarding-completion-tracking.md PR:
+
+- GET  /profile/onboarding         — read status
+- PATCH /profile/onboarding/step   — set current_step / path
+- POST /profile/onboarding/complete — set completed_at (idempotent)
+
+Schema-level only — we mock Supabase. The actual SQL behaviour is
+covered by the migration's Supabase Preview check.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.dependencies import (
+    get_current_user_email,
+    get_current_user_id,
+    get_supabase,
+    verify_supabase_jwt,
+)
+from app.main import app
+
+
+class _Resp:
+    def __init__(self, data: Any) -> None:
+        self.data = data
+
+
+_TEST_USER_ID = "00000000-0000-0000-0000-000000000001"
+
+
+@pytest.fixture
+def client_factory():
+    def _make(supabase: MagicMock) -> TestClient:
+        app.dependency_overrides[get_supabase] = lambda: supabase
+        app.dependency_overrides[verify_supabase_jwt] = lambda: _TEST_USER_ID
+        app.dependency_overrides[get_current_user_id] = lambda: _TEST_USER_ID
+        app.dependency_overrides[get_current_user_email] = lambda: None
+        return TestClient(app)
+
+    yield _make
+    app.dependency_overrides.clear()
+
+
+def _select_returns(sb: MagicMock, row: dict[str, Any]) -> None:
+    """Match the .select(...).eq(...).limit(...).execute() chain used by
+    _get_or_create_profile."""
+    sb.table.return_value.select.return_value.eq.return_value.limit.return_value.execute.return_value = _Resp(
+        [row]
+    )
+
+
+# ---- GET /profile/onboarding -----------------------------------------
+
+
+def test_get_returns_null_fields_for_brand_new_user(client_factory):
+    sb = MagicMock()
+    _select_returns(
+        sb,
+        {
+            "onboarding_completed_at": None,
+            "onboarding_path": None,
+            "onboarding_current_step": None,
+        },
+    )
+    client = client_factory(sb)
+    r = client.get("/profile/onboarding")
+    assert r.status_code == 200
+    assert r.json() == {
+        "completed_at": None,
+        "path": None,
+        "current_step": None,
+    }
+
+
+def test_get_returns_stored_progress(client_factory):
+    sb = MagicMock()
+    _select_returns(
+        sb,
+        {
+            "onboarding_completed_at": "2026-06-04T12:00:00+00:00",
+            "onboarding_path": "A",
+            "onboarding_current_step": "completion",
+        },
+    )
+    client = client_factory(sb)
+    r = client.get("/profile/onboarding")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["completed_at"] is not None
+    assert body["path"] == "A"
+    assert body["current_step"] == "completion"
+
+
+def test_get_falls_back_to_none_on_unknown_step(client_factory):
+    """An old wizard version persisting a step we no longer support
+    shouldn't 500 the dashboard — it sits on the critical path. The
+    read helper sanitizes unknown values into None so the wizard
+    treats it as "start fresh." This is graceful degradation by
+    design."""
+    sb = MagicMock()
+    _select_returns(
+        sb,
+        {
+            "onboarding_completed_at": None,
+            "onboarding_path": "X",
+            "onboarding_current_step": "step-from-the-future",
+        },
+    )
+    client = client_factory(sb)
+    r = client.get("/profile/onboarding")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["current_step"] is None
+    assert body["path"] is None
+
+
+# ---- PATCH /profile/onboarding/step ----------------------------------
+
+
+def test_patch_step_writes_only_current_step(client_factory):
+    sb = MagicMock()
+    _select_returns(
+        sb,
+        {
+            "onboarding_completed_at": None,
+            "onboarding_path": "A",
+            "onboarding_current_step": "identity",
+        },
+    )
+    client = client_factory(sb)
+    r = client.patch("/profile/onboarding/step", json={"current_step": "identity"})
+
+    assert r.status_code == 200
+    update_call = sb.table.return_value.update.call_args
+    assert update_call is not None
+    assert update_call.args[0] == {"onboarding_current_step": "identity"}
+
+
+def test_patch_step_writes_both_path_and_step(client_factory):
+    sb = MagicMock()
+    _select_returns(
+        sb,
+        {
+            "onboarding_completed_at": None,
+            "onboarding_path": "B",
+            "onboarding_current_step": "identity",
+        },
+    )
+    client = client_factory(sb)
+    r = client.patch(
+        "/profile/onboarding/step",
+        json={"path": "B", "current_step": "identity"},
+    )
+
+    assert r.status_code == 200
+    update_call = sb.table.return_value.update.call_args
+    assert update_call.args[0] == {
+        "onboarding_path": "B",
+        "onboarding_current_step": "identity",
+    }
+
+
+def test_patch_step_rejects_unknown_step_value(client_factory):
+    sb = MagicMock()
+    _select_returns(
+        sb,
+        {
+            "onboarding_completed_at": None,
+            "onboarding_path": None,
+            "onboarding_current_step": None,
+        },
+    )
+    client = client_factory(sb)
+    r = client.patch(
+        "/profile/onboarding/step", json={"current_step": "imaginary-step"}
+    )
+    assert r.status_code == 422
+
+
+def test_patch_step_rejects_unknown_path_value(client_factory):
+    sb = MagicMock()
+    _select_returns(
+        sb,
+        {
+            "onboarding_completed_at": None,
+            "onboarding_path": None,
+            "onboarding_current_step": None,
+        },
+    )
+    client = client_factory(sb)
+    r = client.patch("/profile/onboarding/step", json={"path": "Z"})
+    assert r.status_code == 422
+
+
+def test_patch_step_with_empty_body_no_op(client_factory):
+    """No fields supplied → no update query fires; current state is
+    returned unchanged. Idempotent re-call safety."""
+    sb = MagicMock()
+    _select_returns(
+        sb,
+        {
+            "onboarding_completed_at": None,
+            "onboarding_path": "A",
+            "onboarding_current_step": "identity",
+        },
+    )
+    client = client_factory(sb)
+    r = client.patch("/profile/onboarding/step", json={})
+    assert r.status_code == 200
+    sb.table.return_value.update.assert_not_called()
+
+
+# ---- POST /profile/onboarding/complete -------------------------------
+
+
+def test_complete_sets_timestamp_when_null(client_factory):
+    sb = MagicMock()
+    _select_returns(
+        sb,
+        {
+            "onboarding_completed_at": None,
+            "onboarding_path": "A",
+            "onboarding_current_step": "pick-targets",
+        },
+    )
+    client = client_factory(sb)
+    r = client.post("/profile/onboarding/complete")
+
+    assert r.status_code == 200
+    update_call = sb.table.return_value.update.call_args
+    payload = update_call.args[0]
+    assert payload["onboarding_current_step"] == "completion"
+    assert "onboarding_completed_at" in payload  # timestamp written
+
+
+def test_complete_is_idempotent_on_already_completed_users(client_factory):
+    """Calling complete twice doesn't overwrite the original timestamp.
+    Earlier completion is the source of truth for 'when did this user
+    actually onboard.'"""
+    sb = MagicMock()
+    _select_returns(
+        sb,
+        {
+            "onboarding_completed_at": datetime(2026, 6, 1, tzinfo=UTC).isoformat(),
+            "onboarding_path": "A",
+            "onboarding_current_step": "completion",
+        },
+    )
+    client = client_factory(sb)
+    r = client.post("/profile/onboarding/complete")
+
+    assert r.status_code == 200
+    payload = sb.table.return_value.update.call_args.args[0]
+    assert payload["onboarding_current_step"] == "completion"
+    assert "onboarding_completed_at" not in payload  # not overwritten

--- a/apps/wyrdfold/src/app/(app)/__tests__/dashboard-page.spec.ts
+++ b/apps/wyrdfold/src/app/(app)/__tests__/dashboard-page.spec.ts
@@ -1,0 +1,111 @@
+/**
+ * Tests for the dashboard route (`page.tsx`) — server component that
+ * gates new users into the onboarding wizard via the explicit
+ * `onboarding_completed_at` flag, with a `hasProse` fallback.
+ *
+ * See plan-wyrdfold-onboarding-completion-tracking.md.
+ */
+
+const mockRedirect = jest.fn((target: string) => {
+  // Match Next.js behaviour: `redirect()` throws to abort rendering.
+  throw new Error(`REDIRECT:${target}`);
+});
+
+const mockFetch = jest.fn();
+const mockSentryCapture = jest.fn();
+
+jest.mock('next/navigation', () => ({
+  redirect: (target: string) => mockRedirect(target),
+}));
+
+jest.mock('@/lib/api/proxy', () => ({
+  fetchJsonFromWyrdfoldAPI: (...args: unknown[]) => mockFetch(...args),
+}));
+
+jest.mock('@sentry/nextjs', () => ({
+  captureMessage: (msg: string, opts: unknown) => mockSentryCapture(msg, opts),
+}));
+
+// Re-import after mocks are set up.
+import WyrdfoldDashboard from '../dashboard/page';
+
+describe('WyrdfoldDashboard route', () => {
+  beforeEach(() => {
+    mockRedirect.mockClear();
+    mockFetch.mockClear();
+    mockSentryCapture.mockClear();
+  });
+
+  it('redirects to /onboarding when the flag is null (brand-new user)', async () => {
+    mockFetch.mockResolvedValueOnce({
+      completed_at: null,
+      path: null,
+      current_step: null,
+    });
+
+    await expect(WyrdfoldDashboard()).rejects.toThrow('REDIRECT:/onboarding');
+
+    expect(mockRedirect).toHaveBeenCalledWith('/onboarding');
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledWith('/profile/onboarding');
+    // We bail before the bulk data fetch — keeps the new-user request
+    // cheap on the API.
+    expect(mockSentryCapture).not.toHaveBeenCalled();
+  });
+
+  it('redirects to /onboarding when the onboarding endpoint returns null', async () => {
+    // Degraded API (auth failure, network blip). Safer default is to
+    // route to /onboarding than render a broken empty dashboard.
+    mockFetch.mockResolvedValueOnce(null);
+
+    await expect(WyrdfoldDashboard()).rejects.toThrow('REDIRECT:/onboarding');
+
+    expect(mockRedirect).toHaveBeenCalledWith('/onboarding');
+  });
+
+  it('belt-and-suspenders: redirects + Sentry warning when flag is set but prose is missing', async () => {
+    // Data drift: someone (support? bug?) set the flag without prose
+    // existing. Surface to Sentry so we notice; bounce the user back
+    // to onboarding to recover.
+    mockFetch
+      .mockResolvedValueOnce({
+        completed_at: '2026-06-01T00:00:00Z',
+        path: 'A',
+        current_step: 'completion',
+      })
+      // Then the Promise.all: jobs, prose (null), targets, ...counts
+      .mockResolvedValueOnce({ postings: [], total: 0, page: 1, page_size: 5 })
+      .mockResolvedValueOnce({ prose: null }) // ← prose missing
+      .mockResolvedValue({ targets: [], postings: [], total: 0 });
+
+    await expect(WyrdfoldDashboard()).rejects.toThrow('REDIRECT:/onboarding');
+
+    expect(mockSentryCapture).toHaveBeenCalledWith(
+      'dashboard:onboarding_flag_set_but_no_prose',
+      expect.objectContaining({ level: 'warning' })
+    );
+    expect(mockRedirect).toHaveBeenCalledWith('/onboarding');
+  });
+
+  it('renders the dashboard when the flag is set and prose exists', async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        completed_at: '2026-06-01T00:00:00Z',
+        path: 'A',
+        current_step: 'completion',
+      })
+      .mockResolvedValueOnce({ postings: [], total: 0, page: 1, page_size: 5 })
+      .mockResolvedValueOnce({
+        id: 'p-1',
+        content: 'My experience...',
+        version: 1,
+      })
+      .mockResolvedValue({ targets: [], postings: [], total: 0 });
+
+    const result = await WyrdfoldDashboard();
+
+    expect(mockRedirect).not.toHaveBeenCalled();
+    expect(mockSentryCapture).not.toHaveBeenCalled();
+    expect(result).toBeDefined();
+  });
+});

--- a/apps/wyrdfold/src/app/(app)/dashboard/page.tsx
+++ b/apps/wyrdfold/src/app/(app)/dashboard/page.tsx
@@ -1,9 +1,17 @@
 import type { Metadata } from 'next';
+import { redirect } from 'next/navigation';
+import * as Sentry from '@sentry/nextjs';
 import { fetchJsonFromWyrdfoldAPI } from '@/lib/api/proxy';
 import DashboardPage, { type DashboardInitial } from '../DashboardPage';
 import type { JobPosting } from '../jobs/types';
 import { hasProse, type ProseResponse } from '../profile/types';
 import type { UserTargetWithTarget } from '../targets/types';
+
+interface OnboardingStatus {
+  completed_at: string | null;
+  path: 'A' | 'B' | 'C' | null;
+  current_step: string | null;
+}
 
 export const metadata: Metadata = {
   title: 'Dashboard',
@@ -29,6 +37,16 @@ const PIPELINE_STATUSES = [
 ] as const;
 
 export default async function WyrdfoldDashboard() {
+  // Primary gate: explicit onboarding_completed_at flag on user_profiles.
+  // A NULL flag = user hasn't finished the wizard → redirect to it.
+  // See plan-wyrdfold-onboarding-completion-tracking.md.
+  const onboardingStatus = await fetchJsonFromWyrdfoldAPI<OnboardingStatus>(
+    '/profile/onboarding'
+  );
+  if (onboardingStatus?.completed_at == null) {
+    redirect('/onboarding');
+  }
+
   // ``hasProfile`` checks whether the user has authored prose at all —
   // the underlying signal that "they've started onboarding." The
   // upstream ``/experience/prose`` endpoint returns ``{prose: null}``
@@ -58,6 +76,19 @@ export default async function WyrdfoldDashboard() {
     ),
   ]);
 
+  // Belt-and-suspenders: flag is set but the data isn't there. Could
+  // happen if a support action cleared prose without clearing the
+  // flag, or a bug in the wizard set the flag prematurely. Surface
+  // to Sentry so we notice, and route the user back to /onboarding
+  // rather than render a broken empty dashboard.
+  const proseAuthored = proseRes != null && hasProse(proseRes);
+  if (!proseAuthored) {
+    Sentry.captureMessage('dashboard:onboarding_flag_set_but_no_prose', {
+      level: 'warning',
+    });
+    redirect('/onboarding');
+  }
+
   const counts: Record<string, number> = {};
   countResponses.forEach((res, i) => {
     const status = PIPELINE_STATUSES[i];
@@ -67,7 +98,7 @@ export default async function WyrdfoldDashboard() {
   const initial: DashboardInitial = {
     topMatches: topRes?.postings ?? [],
     counts,
-    hasProfile: proseRes != null && hasProse(proseRes),
+    hasProfile: proseAuthored,
     hasActiveTargets:
       targetsRes?.targets?.some(t => t.user_target.is_active) ?? false,
   };

--- a/apps/wyrdfold/src/app/api/profile/onboarding/complete/route.ts
+++ b/apps/wyrdfold/src/app/api/profile/onboarding/complete/route.ts
@@ -1,0 +1,12 @@
+import { proxyToWyrdfoldAPI } from '@/lib/api/proxy';
+
+// POST /api/profile/onboarding/complete — mark the user's onboarding
+// as complete. Idempotent (server preserves the original timestamp).
+// Wizard calls this from the CompletionScreen "Continue to dashboard"
+// button.
+
+export async function POST() {
+  return proxyToWyrdfoldAPI('/profile/onboarding/complete', {
+    method: 'POST',
+  });
+}

--- a/apps/wyrdfold/src/app/api/profile/onboarding/route.ts
+++ b/apps/wyrdfold/src/app/api/profile/onboarding/route.ts
@@ -1,0 +1,11 @@
+import { proxyToWyrdfoldAPI } from '@/lib/api/proxy';
+
+// Onboarding completion + step tracking. Backed by /profile/onboarding
+// on wyrdfold-api. The dashboard server component reads this to decide
+// whether to bounce a brand-new user into /onboarding.
+//
+// See plan-wyrdfold-onboarding-completion-tracking.md.
+
+export async function GET() {
+  return proxyToWyrdfoldAPI('/profile/onboarding');
+}

--- a/apps/wyrdfold/src/app/api/profile/onboarding/step/route.ts
+++ b/apps/wyrdfold/src/app/api/profile/onboarding/step/route.ts
@@ -1,0 +1,14 @@
+import { type NextRequest } from 'next/server';
+
+import { proxyToWyrdfoldAPI } from '@/lib/api/proxy';
+
+// PATCH /api/profile/onboarding/step — update the wizard's current_step
+// and/or path. Wizard calls this on every step transition.
+
+export async function PATCH(request: NextRequest) {
+  const body = (await request.json()) as Record<string, unknown>;
+  return proxyToWyrdfoldAPI('/profile/onboarding/step', {
+    method: 'PATCH',
+    body,
+  });
+}

--- a/apps/wyrdfold/src/app/onboarding/CompletionScreen.tsx
+++ b/apps/wyrdfold/src/app/onboarding/CompletionScreen.tsx
@@ -1,12 +1,37 @@
 'use client';
 
-import { CheckCircle, ArrowRight } from 'lucide-react';
+import { useCallback, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { CheckCircle, ArrowRight, Loader2 } from 'lucide-react';
 import { Card } from '@danieljoffe.com/shared-ui/Card';
 import { Text } from '@danieljoffe.com/shared-ui/Text';
 import { Heading } from '@danieljoffe.com/shared-ui/Heading';
 import Button from '@/components/Button';
 
 export default function CompletionScreen() {
+  const router = useRouter();
+  const [submitting, setSubmitting] = useState(false);
+
+  // Mark onboarding complete server-side, then navigate. The completion
+  // call is idempotent on the API, so a double-click or retry from a
+  // network hiccup won't overwrite the original timestamp.
+  //
+  // If the completion call fails (network blip, API down) we still
+  // navigate — the user has finished the wizard from their perspective,
+  // and Sentry will catch the failure. The downside is the dashboard
+  // gate will redirect them back here once; better than blocking the
+  // happy path on a transient failure.
+  const handleContinue = useCallback(async () => {
+    setSubmitting(true);
+    try {
+      await fetch('/api/profile/onboarding/complete', { method: 'POST' });
+    } catch {
+      // Swallow — Sentry instrumentation covers this; navigation
+      // proceeds so the user doesn't feel stuck.
+    }
+    router.push('/targets');
+  }, [router]);
+
   return (
     <div className='flex flex-col items-center gap-6'>
       <Card padding='lg' className='w-full text-center'>
@@ -32,14 +57,23 @@ export default function CompletionScreen() {
 
       <Button
         name='onboarding-go-to-targets'
-        as='link'
-        href='/targets'
         variant='primary'
         size='lg'
         className='w-full justify-center'
+        onClick={handleContinue}
+        disabled={submitting}
       >
-        <span>Go to Targets</span>
-        <ArrowRight className='size-4' aria-hidden />
+        {submitting ? (
+          <>
+            <Loader2 className='size-4 animate-spin' aria-hidden />
+            <span>Finishing up…</span>
+          </>
+        ) : (
+          <>
+            <span>Go to Targets</span>
+            <ArrowRight className='size-4' aria-hidden />
+          </>
+        )}
       </Button>
     </div>
   );

--- a/apps/wyrdfold/src/app/onboarding/__tests__/CompletionScreen.spec.tsx
+++ b/apps/wyrdfold/src/app/onboarding/__tests__/CompletionScreen.spec.tsx
@@ -1,30 +1,26 @@
 import React from 'react';
 import '@testing-library/jest-dom';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { axe, toHaveNoViolations } from 'jest-axe';
 import CompletionScreen from '../CompletionScreen';
 
 expect.extend(toHaveNoViolations);
 
-// CompletionScreen renders Button as=link → next/link. Mock to a real <a>.
-jest.mock('next/link', () => {
-  return function MockLink(
-    props: React.AnchorHTMLAttributes<HTMLAnchorElement> & { href: string }
-  ) {
-    const { href, children, ...rest } = props;
-    return (
-      <a href={href} {...rest}>
-        {children}
-      </a>
-    );
-  };
-});
+const mockPush = jest.fn();
 
 jest.mock('next/navigation', () => ({
-  useRouter: () => ({ prefetch: jest.fn(), push: jest.fn() }),
+  useRouter: () => ({ prefetch: jest.fn(), push: mockPush }),
 }));
 
 describe('CompletionScreen', () => {
+  beforeEach(() => {
+    mockPush.mockClear();
+    global.fetch = jest.fn(() =>
+      Promise.resolve({ ok: true, json: async () => ({}) })
+    ) as jest.Mock;
+  });
+
   it("renders the 'all set' heading", () => {
     render(<CompletionScreen />);
     expect(
@@ -39,11 +35,36 @@ describe('CompletionScreen', () => {
     ).toBeInTheDocument();
   });
 
-  it('renders a "Go to Targets" link pointing to /targets', () => {
+  it('renders the "Go to Targets" continue button', () => {
     render(<CompletionScreen />);
-    const link = screen.getByRole('link', { name: /go to targets/i });
-    expect(link).toBeInTheDocument();
-    expect(link).toHaveAttribute('href', '/targets');
+    expect(
+      screen.getByRole('button', { name: /go to targets/i })
+    ).toBeInTheDocument();
+  });
+
+  it('marks onboarding complete on click, then navigates to /targets', async () => {
+    const user = userEvent.setup();
+    render(<CompletionScreen />);
+
+    await user.click(screen.getByRole('button', { name: /go to targets/i }));
+
+    await waitFor(() => expect(mockPush).toHaveBeenCalledWith('/targets'));
+    expect(global.fetch).toHaveBeenCalledWith(
+      '/api/profile/onboarding/complete',
+      expect.objectContaining({ method: 'POST' })
+    );
+  });
+
+  it('still navigates to /targets when the complete call fails (network)', async () => {
+    // Sentry catches the failure; the user shouldn't feel stuck on
+    // the final screen because of a transient blip.
+    (global.fetch as jest.Mock).mockRejectedValueOnce(new Error('boom'));
+    const user = userEvent.setup();
+    render(<CompletionScreen />);
+
+    await user.click(screen.getByRole('button', { name: /go to targets/i }));
+
+    await waitFor(() => expect(mockPush).toHaveBeenCalledWith('/targets'));
   });
 
   it('has no accessibility violations', async () => {

--- a/supabase/migrations/20260604200000_user_profiles_onboarding_tracking.sql
+++ b/supabase/migrations/20260604200000_user_profiles_onboarding_tracking.sql
@@ -1,0 +1,48 @@
+-- Onboarding completion + step tracking on user_profiles.
+--
+-- See plan-wyrdfold-onboarding-completion-tracking.md.
+--
+-- Replaces the implicit "hasProse" gate (PR #829) with an explicit
+-- timestamp. Adds onboarding_path + onboarding_current_step so a future
+-- PR can let the OnboardingWizard resume from where the user left off.
+--
+-- Backfill: every existing user_profile whose user has authored prose
+-- (experience_prose rows with non-empty content) is treated as having
+-- completed onboarding at their last profile update. WyrdFold has 3
+-- active users at migration time, so the impact scope is contained.
+
+alter table public.user_profiles
+  add column if not exists onboarding_completed_at timestamptz,
+  add column if not exists onboarding_path text
+    check (onboarding_path is null or onboarding_path in ('A', 'B', 'C')),
+  add column if not exists onboarding_current_step text;
+
+comment on column public.user_profiles.onboarding_completed_at is
+  'Set by the OnboardingWizard when the user finishes the wizard. NULL = '
+  'user has not completed onboarding; the FE dashboard redirects them to '
+  '/onboarding. Belt-and-suspenders: the dashboard also keeps a hasProse '
+  'fallback check so a user with this set but no profile data still gets '
+  'redirected (with a Sentry warning).';
+
+comment on column public.user_profiles.onboarding_path is
+  'Which of the three onboarding paths the user picked: A (full setup), '
+  'B (upload resume + pick targets), or C (conversation + pick targets). '
+  'NULL until the user makes a choice on the PathChooser step.';
+
+comment on column public.user_profiles.onboarding_current_step is
+  'Wizard step the user was last on (e.g. ''identity'', ''upload-resume'', '
+  '''pick-targets''). Updated on every wizard transition; the wizard reads '
+  'it on mount to resume mid-flow. NULL = user has not started onboarding.';
+
+-- Backfill: users with prose are considered onboarded. The
+-- experience_prose_docs table is versioned per user; the existence of
+-- any non-empty row is enough signal.
+update public.user_profiles up
+set onboarding_completed_at = up.updated_at
+where onboarding_completed_at is null
+  and exists (
+    select 1 from public.experience_prose_docs ep
+    where ep.user_id = up.user_id
+      and ep.content is not null
+      and length(ep.content) > 0
+  );


### PR DESCRIPTION
## Summary

Implements [#830](../pull/830). Replaces the implicit \`hasProse\` gate from #829 with an explicit \`onboarding_completed_at\` timestamp on \`user_profiles\`. Adds \`onboarding_path\` and \`onboarding_current_step\` columns for the upcoming wizard-resume work (Stage 2 PR — not in this PR).

## Supersedes #829's gate

The PR #829 dashboard redirect (gate on \`hasProse\`) is replaced by the new gate on \`onboarding_completed_at\`. The \`hasProse\` check stays as a belt-and-suspenders fallback: flag-set + prose-missing = Sentry warning + redirect anyway.

## What's in

**Schema** (\`20260604200000_user_profiles_onboarding_tracking.sql\`)
- \`user_profiles.onboarding_completed_at timestamptz\`
- \`user_profiles.onboarding_path text CHECK in ('A','B','C')\`
- \`user_profiles.onboarding_current_step text\`
- Backfill: existing users with \`experience_prose_docs\` rows get \`completed_at = updated_at\`

**API** (wyrdfold-api)
- \`GET /profile/onboarding\` — read status
- \`PATCH /profile/onboarding/step\` — set current_step + optional path
- \`POST /profile/onboarding/complete\` — set timestamp (idempotent)
- Closed \`Literal\` enums for step + path; unknown values gracefully → None
- 10 router tests

**FE** (wyrdfold)
- 3 new proxy routes under \`/api/profile/onboarding/\`
- Dashboard server component: primary gate + belt-and-suspenders fallback
- CompletionScreen: "Go to Targets" now marks complete server-side before navigating
- 4 new dashboard-page tests, updated CompletionScreen test

## Test plan

- [x] \`ruff check\`, \`mypy\` clean (1113 backend tests pass)
- [x] \`pnpm tsc --noEmit\` clean
- [x] CompletionScreen + dashboard-page tests pass (10 tests)
- [ ] Manually: invite Piotr again; confirm he lands on /onboarding, finishes the wizard, lands on /targets, returns to /dashboard, sees the populated dashboard.

## Out of scope (Stage 2 follow-up)

- Wizard reads \`onboarding_current_step\` on mount + writes on transitions (refresh-safe resume mid-flow). Schema is in place for it; FE plumbing is the next PR.
- "Redo onboarding" trigger in Settings.