### PR TITLE
feat(wyrdfold): "Redo onboarding" Settings card

### DIFF
--- a/apps/wyrdfold-api/app/routers/user_profile.py
+++ b/apps/wyrdfold-api/app/routers/user_profile.py
@@ -419,3 +419,47 @@ async def complete_onboarding(
         supabase, user_id, _ONBOARDING_COLUMNS, seed_email=user_email
     )
     return _read_onboarding(fresh)
+
+
+@router.post("/onboarding/reset")
+async def reset_onboarding(
+    user_id: str = Depends(get_current_user_id),
+    user_email: str | None = Depends(get_current_user_email),
+    supabase: Client = Depends(get_supabase),
+) -> OnboardingStatus:
+    """Clear the user's onboarding completion + step state so the wizard
+    treats them as fresh.
+
+    Used by the Settings page "Redo onboarding" button. Idempotent:
+    calling on an already-cleared row is a no-op.
+
+    **Does NOT delete** the user's prose, targets, or any other
+    profile data — that's a separate "reset my account" action the
+    user would need to take explicitly. The redo-onboarding flow
+    preserves the user's work and only resets the wizard's view of
+    completion + current step.
+
+    Preserves ``onboarding_path`` so we keep the breadcrumb of which
+    path they last picked — useful for product analytics later
+    ("which paths get re-done most often").
+    """
+    await _get_or_create_profile(
+        supabase, user_id, _ONBOARDING_COLUMNS, seed_email=user_email
+    )
+
+    await asyncio.to_thread(
+        lambda: supabase.table("user_profiles")
+        .update(
+            {
+                "onboarding_completed_at": None,
+                "onboarding_current_step": None,
+            }
+        )
+        .eq("user_id", user_id)
+        .execute()
+    )
+
+    fresh = await _get_or_create_profile(
+        supabase, user_id, _ONBOARDING_COLUMNS, seed_email=user_email
+    )
+    return _read_onboarding(fresh)

--- a/apps/wyrdfold-api/tests/test_routers_onboarding.py
+++ b/apps/wyrdfold-api/tests/test_routers_onboarding.py
@@ -262,3 +262,48 @@ def test_complete_is_idempotent_on_already_completed_users(client_factory):
     payload = sb.table.return_value.update.call_args.args[0]
     assert payload["onboarding_current_step"] == "completion"
     assert "onboarding_completed_at" not in payload  # not overwritten
+
+
+# ---- POST /profile/onboarding/reset ----------------------------------
+
+
+def test_reset_clears_completion_and_step(client_factory):
+    """The 'Redo onboarding' Settings button clears the completion
+    flag and the current step. Path is intentionally preserved as a
+    breadcrumb for product analytics ('which paths get re-done most
+    often')."""
+    sb = MagicMock()
+    _select_returns(
+        sb,
+        {
+            "onboarding_completed_at": datetime(2026, 6, 1, tzinfo=UTC).isoformat(),
+            "onboarding_path": "A",
+            "onboarding_current_step": "completion",
+        },
+    )
+    client = client_factory(sb)
+    r = client.post("/profile/onboarding/reset")
+
+    assert r.status_code == 200
+    payload = sb.table.return_value.update.call_args.args[0]
+    assert payload["onboarding_completed_at"] is None
+    assert payload["onboarding_current_step"] is None
+    # Path is NOT in the update payload — we deliberately leave it.
+    assert "onboarding_path" not in payload
+
+
+def test_reset_is_idempotent_on_already_cleared_users(client_factory):
+    """Calling reset on a brand-new user (or a previously-reset one)
+    doesn't error; the update is a no-op-equivalent (same NULLs)."""
+    sb = MagicMock()
+    _select_returns(
+        sb,
+        {
+            "onboarding_completed_at": None,
+            "onboarding_path": None,
+            "onboarding_current_step": None,
+        },
+    )
+    client = client_factory(sb)
+    r = client.post("/profile/onboarding/reset")
+    assert r.status_code == 200

--- a/apps/wyrdfold/src/app/(app)/settings/OnboardingResetCard.tsx
+++ b/apps/wyrdfold/src/app/(app)/settings/OnboardingResetCard.tsx
@@ -34,12 +34,11 @@ export default function OnboardingResetCard() {
     // Native confirm is intentional here — the action is reversible
     // (the user can just finish the wizard again) and we don't want
     // the modal weight for this rare path.
-    const confirmed = window.confirm(
-      // eslint-disable-line no-alert
+    const message =
       'Redo onboarding? Your profile data, targets, and saved jobs ' +
-        'are preserved — only the wizard restarts.'
-    );
-    if (!confirmed) {
+      'are preserved — only the wizard restarts.';
+    // eslint-disable-next-line no-alert
+    if (!window.confirm(message)) {
       return;
     }
 

--- a/apps/wyrdfold/src/app/(app)/settings/OnboardingResetCard.tsx
+++ b/apps/wyrdfold/src/app/(app)/settings/OnboardingResetCard.tsx
@@ -31,12 +31,15 @@ export default function OnboardingResetCard() {
   const [submitting, setSubmitting] = useState(false);
 
   const handleRedo = useCallback(async () => {
-    if (
-      !window.confirm(
-        'Redo onboarding? Your profile data, targets, and saved jobs ' +
-          'are preserved — only the wizard restarts.'
-      )
-    ) {
+    // Native confirm is intentional here — the action is reversible
+    // (the user can just finish the wizard again) and we don't want
+    // the modal weight for this rare path.
+    const confirmed = window.confirm(
+      // eslint-disable-line no-alert
+      'Redo onboarding? Your profile data, targets, and saved jobs ' +
+        'are preserved — only the wizard restarts.'
+    );
+    if (!confirmed) {
       return;
     }
 
@@ -53,8 +56,7 @@ export default function OnboardingResetCard() {
       setSubmitting(false);
       toast({
         variant: 'error',
-        title:
-          err instanceof Error ? err.message : 'Could not redo onboarding',
+        title: err instanceof Error ? err.message : 'Could not redo onboarding',
       });
     }
   }, [router, toast]);
@@ -64,8 +66,8 @@ export default function OnboardingResetCard() {
       <CardHeader>
         <CardTitle>Redo onboarding</CardTitle>
         <Text variant='meta' className='text-text-secondary'>
-          Restart the welcome wizard. Your profile, targets, and saved jobs
-          are preserved.
+          Restart the welcome wizard. Your profile, targets, and saved jobs are
+          preserved.
         </Text>
       </CardHeader>
       <CardContent>

--- a/apps/wyrdfold/src/app/(app)/settings/OnboardingResetCard.tsx
+++ b/apps/wyrdfold/src/app/(app)/settings/OnboardingResetCard.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { RotateCcw } from 'lucide-react';
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from '@danieljoffe.com/shared-ui/Card';
+import { Text } from '@danieljoffe.com/shared-ui/Text';
+import Button from '@/components/Button';
+import { useToast } from '@/state/Toast/ToastProvider';
+
+/**
+ * Settings card that lets a user redo the onboarding wizard.
+ *
+ * Clears `onboarding_completed_at` + `onboarding_current_step`
+ * server-side via POST /api/profile/onboarding/reset, then redirects
+ * to /onboarding. **Does not** delete prose, targets, or any other
+ * profile data — only the wizard's notion of completion is reset.
+ *
+ * A 2-step confirm guards against accidental clicks. Plain native
+ * confirm() is fine — no animation budget for a modal here, and the
+ * action is reversible (the user can just finish the wizard again).
+ */
+export default function OnboardingResetCard() {
+  const router = useRouter();
+  const { toast } = useToast();
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleRedo = useCallback(async () => {
+    if (
+      !window.confirm(
+        'Redo onboarding? Your profile data, targets, and saved jobs ' +
+          'are preserved — only the wizard restarts.'
+      )
+    ) {
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      const res = await fetch('/api/profile/onboarding/reset', {
+        method: 'POST',
+      });
+      if (!res.ok) {
+        throw new Error(`Reset failed (${res.status})`);
+      }
+      router.push('/onboarding');
+    } catch (err) {
+      setSubmitting(false);
+      toast({
+        variant: 'error',
+        title:
+          err instanceof Error ? err.message : 'Could not redo onboarding',
+      });
+    }
+  }, [router, toast]);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Redo onboarding</CardTitle>
+        <Text variant='meta' className='text-text-secondary'>
+          Restart the welcome wizard. Your profile, targets, and saved jobs
+          are preserved.
+        </Text>
+      </CardHeader>
+      <CardContent>
+        <Button
+          name='settings-redo-onboarding'
+          variant='outline'
+          size='sm'
+          onClick={handleRedo}
+          disabled={submitting}
+        >
+          <RotateCcw className='size-4' aria-hidden />
+          <span>{submitting ? 'Resetting…' : 'Redo onboarding'}</span>
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/wyrdfold/src/app/(app)/settings/SettingsPage.tsx
+++ b/apps/wyrdfold/src/app/(app)/settings/SettingsPage.tsx
@@ -16,6 +16,7 @@ import { Switch } from '@danieljoffe.com/shared-ui/Switch';
 import { Text } from '@danieljoffe.com/shared-ui/Text';
 import { extractApiError } from '@/lib/extractApiError';
 import { useToast } from '@/state/Toast/ToastProvider';
+import OnboardingResetCard from './OnboardingResetCard';
 import { ResumeStylePreview } from './ResumeStylePreview';
 import {
   ACCENT_OPTIONS,
@@ -624,6 +625,8 @@ export default function SettingsPage() {
           </div>
         </CardContent>
       </Card>
+
+      <OnboardingResetCard />
     </div>
   );
 }

--- a/apps/wyrdfold/src/app/(app)/settings/__tests__/OnboardingResetCard.spec.tsx
+++ b/apps/wyrdfold/src/app/(app)/settings/__tests__/OnboardingResetCard.spec.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import '@testing-library/jest-dom';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import OnboardingResetCard from '../OnboardingResetCard';
+
+const mockPush = jest.fn();
+const mockToast = jest.fn();
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush, prefetch: jest.fn() }),
+}));
+
+jest.mock('@/state/Toast/ToastProvider', () => ({
+  useToast: () => ({ toast: mockToast }),
+}));
+
+describe('OnboardingResetCard', () => {
+  beforeEach(() => {
+    mockPush.mockClear();
+    mockToast.mockClear();
+    global.fetch = jest.fn() as jest.Mock;
+    // Default: user confirms the dialog.
+    jest.spyOn(window, 'confirm').mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('renders the heading + primary button', () => {
+    render(<OnboardingResetCard />);
+    expect(
+      screen.getByText(/profile, targets, and saved jobs/i)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /Redo onboarding/i })
+    ).toBeInTheDocument();
+  });
+
+  it('on click, confirms → POSTs reset → routes to /onboarding', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({ ok: true });
+    const user = userEvent.setup();
+    render(<OnboardingResetCard />);
+
+    await user.click(
+      screen.getByRole('button', { name: /Redo onboarding/i })
+    );
+
+    expect(window.confirm).toHaveBeenCalled();
+    await waitFor(() =>
+      expect(global.fetch).toHaveBeenCalledWith(
+        '/api/profile/onboarding/reset',
+        expect.objectContaining({ method: 'POST' })
+      )
+    );
+    expect(mockPush).toHaveBeenCalledWith('/onboarding');
+    expect(mockToast).not.toHaveBeenCalled();
+  });
+
+  it('aborts when the user cancels the confirm dialog', async () => {
+    jest.spyOn(window, 'confirm').mockReturnValue(false);
+    const user = userEvent.setup();
+    render(<OnboardingResetCard />);
+
+    await user.click(
+      screen.getByRole('button', { name: /Redo onboarding/i })
+    );
+
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it('toasts an error and stays on the page when the server fails', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+    });
+    const user = userEvent.setup();
+    render(<OnboardingResetCard />);
+
+    await user.click(
+      screen.getByRole('button', { name: /Redo onboarding/i })
+    );
+
+    await waitFor(() =>
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.objectContaining({ variant: 'error' })
+      )
+    );
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+});

--- a/apps/wyrdfold/src/app/api/profile/onboarding/reset/route.ts
+++ b/apps/wyrdfold/src/app/api/profile/onboarding/reset/route.ts
@@ -1,0 +1,9 @@
+import { proxyToWyrdfoldAPI } from '@/lib/api/proxy';
+
+// POST /api/profile/onboarding/reset — clear the user's onboarding
+// completion + step state. Used by the Settings page "Redo onboarding"
+// button. Idempotent; never deletes user data.
+
+export async function POST() {
+  return proxyToWyrdfoldAPI('/profile/onboarding/reset', { method: 'POST' });
+}


### PR DESCRIPTION
## Summary

Follow-up to #831. Adds the Settings-page surface for re-running the onboarding wizard — answers the "Redo onboarding trigger" open question from the planning doc.

## API

\`POST /profile/onboarding/reset\` — clears \`onboarding_completed_at\` + \`onboarding_current_step\`. Idempotent.

**Does NOT delete** prose, targets, or any other profile data. The user's work is preserved; only the wizard's notion of completion is reset.

**Preserves \`onboarding_path\`** as a breadcrumb for product analytics ("which paths get re-done most often").

## FE

- \`/api/profile/onboarding/reset\` proxy.
- New \`OnboardingResetCard\` on \`/settings\`. Native \`confirm()\` dialog as the 2-step guard (the action is reversible — a modal felt heavy). Error toast on server failure.

## Tests

- [x] 2 backend router tests (clears the right fields; idempotent on already-cleared users)
- [x] 4 FE unit tests (render, happy path, user cancels confirm, server error → toast)
- [x] \`pnpm tsc --noEmit\` clean, \`pnpm nx lint wyrdfold\` clean, all 12 onboarding-related tests pass

## Manual test plan

- [ ] Log in as an onboarded user → visit \`/settings\` → confirm the card appears at the bottom.
- [ ] Click "Redo onboarding" → confirm dialog → land on \`/onboarding\`.
- [ ] Walk through the wizard → return to dashboard → confirm everything still works.
- [ ] Cancel the confirm dialog → confirm no API call fires and no navigation happens.