### PR TITLE
fix(wyrdfold-api): drop /v1 from OpenRouter base_url

### DIFF
--- a/apps/wyrdfold-api/app/services/llm/openrouter_client.py
+++ b/apps/wyrdfold-api/app/services/llm/openrouter_client.py
@@ -1,7 +1,7 @@
 """OpenRouter-backed LLMClient.
 
 PR A of plan-wyrdfold-openrouter-migration.md. The OpenRouter API at
-https://openrouter.ai/api/v1 exposes a fully Anthropic-compatible
+https://openrouter.ai/api/v1/messages exposes a fully Anthropic-compatible
 /messages endpoint — including prompt caching (cache_control:
 ephemeral), tool-use forced calls, and streaming — using the same
 shape the Anthropic SDK speaks natively.
@@ -31,7 +31,11 @@ from __future__ import annotations
 from app.models.llm import ModelId
 from app.services.llm.anthropic_client import AnthropicLLMClient
 
-_OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
+# Anthropic SDK appends "/v1/messages" to base_url internally. Omit the
+# /v1 here or we'd hit /api/v1/v1/messages (404). OpenRouter's docs show
+# the full path with /v1 because they're documenting the raw HTTP path,
+# not the SDK's base_url field.
+_OPENROUTER_BASE_URL = "https://openrouter.ai/api"
 
 # Map our internal ModelId to OpenRouter's namespaced slugs. OR uses
 # dotted version numbers (4.6 not 4-6); the upstream API call passes

--- a/apps/wyrdfold-api/tests/test_openrouter_client.py
+++ b/apps/wyrdfold-api/tests/test_openrouter_client.py
@@ -47,6 +47,18 @@ def test_constructor_points_sdk_at_openrouter_base_url() -> None:
     assert _OPENROUTER_BASE_URL in base
 
 
+def test_base_url_does_not_include_v1_segment() -> None:
+    """The Anthropic SDK appends '/v1/messages' to base_url internally.
+    Reason: setting base_url='https://openrouter.ai/api/v1' produced
+    requests to '/api/v1/v1/messages' (404) in production. The base
+    must stop at '/api' so the SDK's append yields '/api/v1/messages'.
+    """
+    assert not _OPENROUTER_BASE_URL.rstrip("/").endswith("/v1"), (
+        "OpenRouter base_url must NOT include '/v1' — the Anthropic SDK "
+        "appends '/v1/messages' itself. Double-/v1 causes a silent 404."
+    )
+
+
 def test_anthropic_client_default_base_url_is_unaffected() -> None:
     """Regression: the new base_url constructor knob has a None default
     so non-OR callers still hit the Anthropic endpoint."""


### PR DESCRIPTION
## Summary

- The Anthropic SDK appends `/v1/messages` to `base_url` internally. Our constant was `https://openrouter.ai/api/v1`, so every request landed on `/api/v1/v1/messages` → 404.
- Every Phase 2 fit call + the `/analysis` endpoint has been silently 500'ing since the OpenRouter env-var flip went out.
- Fix: drop `/v1` from the base URL constant. The SDK's append then produces the correct `/api/v1/messages` path.
- Added a regression test that fails if `/v1` is ever re-added to `_OPENROUTER_BASE_URL`.

## Evidence (from Railway logs)

\`\`\`
httpx.HTTPStatusError: Client error '404 Not Found' for url 'https://openrouter.ai/api/v1/v1/messages'
\`\`\`

## Test plan

- [x] `uv run pytest apps/wyrdfold-api/tests/test_openrouter_client.py` — 7 passed (incl. new regression test)
- [ ] After deploy, re-run `scripts/check_openrouter_rollout.py` — expect dotted model slugs (`claude-sonnet-4.6`) in `llm_costs` and `logistics_filters` populated on new `scores` rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)