### PR TITLE
fix(scoring): demote JD-body negative keywords to penalty, keep title-only exclusion (#845)

### DIFF
--- a/apps/wyrdfold-api/app/models/diagnostics.py
+++ b/apps/wyrdfold-api/app/models/diagnostics.py
@@ -1,0 +1,138 @@
+"""Diagnostic response models for the target-funnel debugger (#845).
+
+These shapes are deliberately verbose: an operator reading the JSON
+should be able to spot the collapse stage without cross-referencing
+table names.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class FunnelNomenclature(BaseModel):
+    """The target's own config — the "nomenclature" suspect from #845."""
+
+    target_id: str
+    label: str
+    normalized_label: str | None
+    is_active: bool
+    activation_status: str
+    profile_version: int
+    seniority_hint: str | None
+    domain_hints: list[str]
+    example_promising_titles: list[str]
+    example_unpromising_titles: list[str]
+    search_keywords: list[str]
+    # Full scoring profile as JSONB — operators eyeball it directly.
+    scoring_profile: dict[str, Any]
+
+
+class FunnelScoreBuckets(BaseModel):
+    """Histogram of ``scores.score`` for not-excluded rows.
+
+    Buckets are inclusive-low, exclusive-high: ``"0-9"`` covers 0..9,
+    ``"90-100"`` covers 90..100 (upper bound inclusive on the final bucket).
+    """
+
+    buckets: dict[str, int]
+    total: int
+    max_score: int | None
+    floor: int = Field(
+        ..., description="user_profiles.list_min_score for the owning user."
+    )
+    above_floor: int = Field(
+        ..., description="Count of not-excluded scores ≥ floor — what the UI sees."
+    )
+
+
+class FunnelStageCounts(BaseModel):
+    """Counts at each *DB-visible* stage.
+
+    Pre-DB drops (non-US, title pre-match, Phase 1 unpromising) leave
+    no rows; see ``pre_db_hint`` for guidance on capturing those.
+    """
+
+    scores_total: int = Field(
+        ..., description="All score rows for this target (including excluded)."
+    )
+    promising_true: int
+    promising_false: int
+    promising_null: int = Field(
+        ..., description="Pre-Phase-1 rows or rows where the gate was off."
+    )
+    by_status: dict[str, int] = Field(
+        ..., description="scoring_status → count: stage1, stage2, complete."
+    )
+    excluded_true: int
+    excluded_false: int
+    graded: int = Field(
+        ...,
+        description=(
+            "promising=True AND scoring_status != 'stage1' — the "
+            "candidate pool that actually reached Phase 2."
+        ),
+    )
+    complete: int
+    stuck_in_stage1: int = Field(
+        ...,
+        description=(
+            "promising=True AND scoring_status='stage1' — Phase-2 "
+            "starvation suspects (daily cap, or never-grader-touched)."
+        ),
+    )
+
+
+class FunnelUserContext(BaseModel):
+    """Per-user context for the target — list-floor, daily-cap state."""
+
+    user_id: str
+    list_min_score: int | None = Field(
+        ...,
+        description=(
+            "Score floor the FE list applies (NULL → server default)."
+        ),
+    )
+    phase2_quota_remaining: int = Field(
+        ...,
+        description=(
+            "Sonnet calls left this UTC day for this (target, user)."
+        ),
+    )
+
+
+class FunnelSourceStaleness(BaseModel):
+    """One row per polled source for this workspace.
+
+    Not target-scoped (the source pool is global), but listed so the
+    operator can spot a stalled poller in the same response.
+    """
+
+    id: str
+    company_name: str
+    provider: str
+    enabled: bool
+    last_polled_at: datetime | None
+    hours_since_polled: float | None
+    job_count: int | None
+
+
+class TargetFunnelResponse(BaseModel):
+    """The full funnel report for one target."""
+
+    generated_at: datetime
+    nomenclature: FunnelNomenclature
+    stages: FunnelStageCounts
+    scores_histogram: FunnelScoreBuckets
+    users: list[FunnelUserContext]
+    sources: list[FunnelSourceStaleness]
+    pre_db_hint: str = Field(
+        ...,
+        description=(
+            "Where to look for the pre-DB drops (non-US, title "
+            "pre-match, Phase 1 unpromising) — they don't leave rows."
+        ),
+    )

--- a/apps/wyrdfold-api/app/routers/targets.py
+++ b/apps/wyrdfold-api/app/routers/targets.py
@@ -25,6 +25,7 @@ from app.dependencies import (
     verify_api_key_or_jwt,
 )
 from app.http_client import ResponseTooLargeError, get_with_size_cap
+from app.models.diagnostics import TargetFunnelResponse
 from app.models.schemas import PollResult
 from app.models.targets import (
     AxisWeights,
@@ -45,6 +46,7 @@ from app.models.targets import (
     UserTarget,
     UserTargetWithTarget,
 )
+from app.services.diagnostics.funnel import compute_target_funnel
 from app.services.experience import optimized
 from app.services.extract import (
     ExtractionResult,
@@ -854,6 +856,27 @@ async def get_target_status(
         activation_status=target.activation_status,
         jobs_count=jobs_count,
     )
+
+
+@router.get(
+    "/{target_id}/funnel",
+    response_model=TargetFunnelResponse,
+    dependencies=[Depends(verify_api_key)],
+)
+async def get_target_funnel(
+    target_id: str,
+    supabase: Client = Depends(get_supabase),
+) -> TargetFunnelResponse:
+    """Diagnostic funnel report for one target (#845).
+
+    API-key-only — the response includes per-user list floors and the
+    target's scoring profile, which is operator-facing data, not user
+    surface. Read-only.
+    """
+    try:
+        return compute_target_funnel(supabase, target_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
 
 
 @router.delete("/{target_id}", response_model=DeleteResponse)

--- a/apps/wyrdfold-api/app/services/diagnostics/__init__.py
+++ b/apps/wyrdfold-api/app/services/diagnostics/__init__.py
@@ -1,0 +1,1 @@
+"""Operator-facing diagnostics — debugging endpoints + scripts."""

--- a/apps/wyrdfold-api/app/services/diagnostics/funnel.py
+++ b/apps/wyrdfold-api/app/services/diagnostics/funnel.py
@@ -1,0 +1,307 @@
+"""Compute the per-target funnel report for issue #845.
+
+Reads only — no LLM calls, no writes. Safe to run against prod.
+
+The funnel surfaces the *DB-visible* drops:
+  fetched → upserted → scored (stage1) → graded (stage2/phase2) → not_excluded → ≥ floor
+
+Three pre-DB drops are invisible here (non-US, title pre-match, Phase 1
+unpromising). See ``app/services/poller.py`` for the funnel-log
+instrumentation that captures those at poll time.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any, cast
+
+from postgrest.types import CountMethod
+from supabase import Client
+
+from app.models.diagnostics import (
+    FunnelNomenclature,
+    FunnelScoreBuckets,
+    FunnelSourceStaleness,
+    FunnelStageCounts,
+    FunnelUserContext,
+    TargetFunnelResponse,
+)
+from app.services.fit.daily_cap import phase2_quota_remaining
+from app.services.targets import crud
+
+# Bucket edges for the score histogram. Width=10 gives enough resolution
+# to see whether the list_min_score floor is biting at a real boundary.
+_BUCKET_EDGES: tuple[tuple[int, int, str], ...] = (
+    (0, 10, "0-9"),
+    (10, 20, "10-19"),
+    (20, 30, "20-29"),
+    (30, 40, "30-39"),
+    (40, 50, "40-49"),
+    (50, 60, "50-59"),
+    (60, 70, "60-69"),
+    (70, 80, "70-79"),
+    (80, 90, "80-89"),
+    (90, 101, "90-100"),
+)
+
+
+def _bucketize(scores: list[int]) -> dict[str, int]:
+    out = {label: 0 for _, _, label in _BUCKET_EDGES}
+    for s in scores:
+        for lo, hi, label in _BUCKET_EDGES:
+            if lo <= s < hi:
+                out[label] += 1
+                break
+    return out
+
+
+def _count(query: Any) -> int:
+    """``count='exact'`` returns it on the response, not in data."""
+    return int(getattr(query.execute(), "count", 0) or 0)
+
+
+def _stage_counts(supabase: Client, target_id: str) -> FunnelStageCounts:
+    base = supabase.table("scores").select("id", count=CountMethod.exact)
+
+    scores_total = _count(base.eq("target_id", target_id).limit(1))
+    promising_true = _count(
+        supabase.table("scores")
+        .select("id", count=CountMethod.exact)
+        .eq("target_id", target_id)
+        .eq("promising", True)
+        .limit(1)
+    )
+    promising_false = _count(
+        supabase.table("scores")
+        .select("id", count=CountMethod.exact)
+        .eq("target_id", target_id)
+        .eq("promising", False)
+        .limit(1)
+    )
+    promising_null = _count(
+        supabase.table("scores")
+        .select("id", count=CountMethod.exact)
+        .eq("target_id", target_id)
+        .is_("promising", "null")
+        .limit(1)
+    )
+
+    by_status: dict[str, int] = {}
+    for status in ("stage1", "stage2", "complete"):
+        by_status[status] = _count(
+            supabase.table("scores")
+            .select("id", count=CountMethod.exact)
+            .eq("target_id", target_id)
+            .eq("scoring_status", status)
+            .limit(1)
+        )
+
+    excluded_true = _count(
+        supabase.table("scores")
+        .select("id", count=CountMethod.exact)
+        .eq("target_id", target_id)
+        .eq("excluded", True)
+        .limit(1)
+    )
+    excluded_false = _count(
+        supabase.table("scores")
+        .select("id", count=CountMethod.exact)
+        .eq("target_id", target_id)
+        .eq("excluded", False)
+        .limit(1)
+    )
+
+    graded = _count(
+        supabase.table("scores")
+        .select("id", count=CountMethod.exact)
+        .eq("target_id", target_id)
+        .eq("promising", True)
+        .neq("scoring_status", "stage1")
+        .limit(1)
+    )
+    complete = by_status["complete"]
+    stuck_in_stage1 = _count(
+        supabase.table("scores")
+        .select("id", count=CountMethod.exact)
+        .eq("target_id", target_id)
+        .eq("promising", True)
+        .eq("scoring_status", "stage1")
+        .limit(1)
+    )
+
+    return FunnelStageCounts(
+        scores_total=scores_total,
+        promising_true=promising_true,
+        promising_false=promising_false,
+        promising_null=promising_null,
+        by_status=by_status,
+        excluded_true=excluded_true,
+        excluded_false=excluded_false,
+        graded=graded,
+        complete=complete,
+        stuck_in_stage1=stuck_in_stage1,
+    )
+
+
+def _histogram(
+    supabase: Client, target_id: str, floor: int
+) -> FunnelScoreBuckets:
+    resp = (
+        supabase.table("scores")
+        .select("score")
+        .eq("target_id", target_id)
+        .eq("excluded", False)
+        .execute()
+    )
+    rows = cast(list[dict[str, Any]], resp.data or [])
+    scores = [int(r["score"]) for r in rows if r.get("score") is not None]
+    above = sum(1 for s in scores if s >= floor)
+    return FunnelScoreBuckets(
+        buckets=_bucketize(scores),
+        total=len(scores),
+        max_score=max(scores) if scores else None,
+        floor=floor,
+        above_floor=above,
+    )
+
+
+def _user_context(
+    supabase: Client, target_id: str, default_floor: int
+) -> list[FunnelUserContext]:
+    """One entry per user with an active link to this target."""
+    ut_resp = (
+        supabase.table("user_targets")
+        .select("user_id, is_active")
+        .eq("target_id", target_id)
+        .execute()
+    )
+    user_rows = cast(list[dict[str, Any]], ut_resp.data or [])
+
+    out: list[FunnelUserContext] = []
+    for row in user_rows:
+        user_id = row["user_id"]
+        prof_resp = (
+            supabase.table("user_profiles")
+            .select("list_min_score")
+            .eq("user_id", user_id)
+            .limit(1)
+            .execute()
+        )
+        prof_rows = cast(list[dict[str, Any]], prof_resp.data or [])
+        list_min_score = (
+            prof_rows[0].get("list_min_score") if prof_rows else None
+        )
+        out.append(
+            FunnelUserContext(
+                user_id=user_id,
+                list_min_score=(
+                    int(list_min_score) if list_min_score is not None else None
+                ),
+                phase2_quota_remaining=phase2_quota_remaining(
+                    supabase, target_id
+                ),
+            )
+        )
+    # No active users: still return the empty list so the operator sees
+    # "0 users on this target" rather than missing data — that's itself
+    # a diagnosis ("nobody activated it; sourcing is moot").
+    return out
+
+
+def _hours_since(ts: datetime | None) -> float | None:
+    if ts is None:
+        return None
+    if ts.tzinfo is None:
+        ts = ts.replace(tzinfo=UTC)
+    return round((datetime.now(UTC) - ts).total_seconds() / 3600.0, 1)
+
+
+def _sources(supabase: Client) -> list[FunnelSourceStaleness]:
+    resp = (
+        supabase.table("sources")
+        .select(
+            "id, company_name, provider, enabled, last_polled_at, job_count"
+        )
+        .order("last_polled_at", desc=True, nullsfirst=True)
+        .execute()
+    )
+    rows = cast(list[dict[str, Any]], resp.data or [])
+    out: list[FunnelSourceStaleness] = []
+    for r in rows:
+        last_polled_raw = r.get("last_polled_at")
+        last_polled = (
+            datetime.fromisoformat(last_polled_raw)
+            if isinstance(last_polled_raw, str)
+            else None
+        )
+        out.append(
+            FunnelSourceStaleness(
+                id=r["id"],
+                company_name=r.get("company_name") or "?",
+                provider=r.get("provider") or "?",
+                enabled=bool(r.get("enabled", False)),
+                last_polled_at=last_polled,
+                hours_since_polled=_hours_since(last_polled),
+                job_count=r.get("job_count"),
+            )
+        )
+    return out
+
+
+def _default_floor_from_users(users: list[FunnelUserContext]) -> int:
+    """If multiple users, the *lowest* floor across them — that's the
+    most permissive view of the histogram. Single-user is the common
+    case; multi-user falls back to 0 when nobody has set a floor."""
+    floors = [u.list_min_score for u in users if u.list_min_score is not None]
+    return min(floors) if floors else 0
+
+
+def compute_target_funnel(
+    supabase: Client, target_id: str
+) -> TargetFunnelResponse:
+    """Build the full funnel report for ``target_id``.
+
+    Read-only. The response is designed so a console paste makes the
+    collapse stage obvious without follow-up queries.
+    """
+    target = crud.get(supabase, target_id)
+    if target is None:
+        raise ValueError(f"Target {target_id!r} not found")
+
+    nomenclature = FunnelNomenclature(
+        target_id=target.id,
+        label=target.label,
+        normalized_label=target.normalized_label,
+        is_active=target.is_active,
+        activation_status=target.activation_status,
+        profile_version=target.profile_version,
+        seniority_hint=target.seniority_hint,
+        domain_hints=target.domain_hints,
+        example_promising_titles=target.example_promising_titles,
+        example_unpromising_titles=target.example_unpromising_titles,
+        search_keywords=target.search_keywords,
+        scoring_profile=target.scoring_profile.model_dump(),
+    )
+
+    stages = _stage_counts(supabase, target_id)
+    # User context first — we need their floor for the histogram view.
+    users = _user_context(supabase, target_id, default_floor=0)
+    floor = _default_floor_from_users(users)
+    histogram = _histogram(supabase, target_id, floor=floor)
+    sources = _sources(supabase)
+
+    return TargetFunnelResponse(
+        generated_at=datetime.now(UTC),
+        nomenclature=nomenclature,
+        stages=stages,
+        scores_histogram=histogram,
+        users=users,
+        sources=sources,
+        pre_db_hint=(
+            "Pre-DB drops (non-US, title pre-match, Phase 1 "
+            "unpromising) aren't in this report — they leave no row. "
+            "Search Railway logs for `poll_funnel ` (a structured line "
+            "emitted by _poll_one_source) to read per-source drop "
+            "counts from the most recent poll cycle."
+        ),
+    )

--- a/apps/wyrdfold-api/app/services/poller.py
+++ b/apps/wyrdfold-api/app/services/poller.py
@@ -691,15 +691,26 @@ async def _poll_one_source(
         # has resolved DB ids. Kept out of the upsert payload because
         # the jobs table doesn't have a column for it.
         phase1_idx_by_external_id: dict[str, int] = {}
+        # Pre-DB drop counters for #845 funnel diagnostics. Order
+        # matches the gate order below — first miss wins, mutually
+        # exclusive. Emitted as a single `poll_funnel` log line at end
+        # of cycle so an operator can grep one source's funnel without
+        # a DB pass.
+        dropped_phase1 = 0
+        dropped_title_prematch = 0
+        dropped_non_us = 0
         for idx, job in enumerate(jobs):
             # Phase 1 IDs are 1-based; the per-target verdict-check
             # below uses the same idx + 1 convention.
             if not _any_target_admits(idx + 1):
+                dropped_phase1 += 1
                 continue
             # Filter by target relevance instead of static keyword list
             if active_targets and not _title_matches_any_target(job.title, active_targets):
+                dropped_title_prematch += 1
                 continue
             if not _is_us_location(job.location_name):
+                dropped_non_us += 1
                 continue
 
             salary = job.salary_text or extract_salary_from_text(strip_html(job.content))
@@ -1043,6 +1054,31 @@ async def _poll_one_source(
                 logger.exception(
                     "SMS alert dispatch raised for %s", company_name
                 )
+
+        # Funnel diagnostics for #845. One structured line per source per
+        # cycle so an operator can `grep poll_funnel | grep <Company>` in
+        # Railway and read where jobs are dropping pre-DB. The counts
+        # are mutually exclusive — first gate to fire wins per job.
+        per_target_phase1_no = {
+            tid: sum(1 for v in verdicts.values() if not v.promising)
+            for tid, verdicts in phase1_verdicts.items()
+        }
+        logger.info(
+            "poll_funnel source=%s fetched=%d dropped_phase1=%d "
+            "dropped_title_prematch=%d dropped_non_us=%d candidates=%d "
+            "upserted_new=%d upserted_updated=%d archived=%d "
+            "phase1_no_by_target=%s",
+            company_name,
+            len(jobs),
+            dropped_phase1,
+            dropped_title_prematch,
+            dropped_non_us,
+            len(rows_to_upsert),
+            summary["new"],
+            summary["updated"],
+            summary["archived"],
+            per_target_phase1_no or "{}",
+        )
 
     except Exception:
         logger.exception("Poll failed for %s", company_name)

--- a/apps/wyrdfold-api/app/services/scoring.py
+++ b/apps/wyrdfold-api/app/services/scoring.py
@@ -391,6 +391,9 @@ def score_job_with_profile(
 
     Negatives only count in requirements sections and the title — a
     negative keyword in "About Us" or "Benefits" is not a disqualifier.
+    A negative in the title is a hard exclude; a negative in the body is
+    a soft score penalty only (#845) — body mentions describe the team a
+    senior role manages, not the role's own tier.
 
     Title gets a 2x boost applied as a high-weight section.
 
@@ -474,22 +477,33 @@ def score_job_with_profile(
         breakdown.role_titles += role_title_points
         all_matched.extend(role_title_matches)
 
-    # ---- Negative keywords (only in title + requirements sections) ----
+    # ---- Negative keywords ----
+    # Title matches are a hard exclude — a negative token in the job
+    # title (e.g. "Customer Service Representative") is a strong signal
+    # the role is the wrong tier and should never surface.
+    #
+    # Body matches (requirements/default sections) are only a *soft* score
+    # penalty, NOT a hard exclude (#845). For a leadership target the
+    # negatives (agent, representative, specialist, analyst, coordinator…)
+    # are precisely the titles of the team the role manages, so they
+    # appear in the body of nearly every genuine senior JD. Hard-excluding
+    # on a body mention buried the exact roles the user wanted — and
+    # overrode both the Phase-1 ``promising`` verdict and the Phase-2 fit
+    # score. Demoting to a penalty lets the score sort them naturally.
     negative_sections = {"requirements", "default"}
     for keyword in _effective_negative_keywords(profile):
-        # Check title
+        # Check title (hard exclude)
         if _keyword_or_alias_in_text(keyword, title_lower):
             breakdown.negative += profile.negative.weight
             excluded = True
             continue
 
-        # Check requirements-type sections only
+        # Check requirements-type sections only (soft penalty, no exclude)
         for section in parsed.sections:
             if section.name in negative_sections and _keyword_or_alias_in_text(
                 keyword, section.text_lower
             ):
                 breakdown.negative += profile.negative.weight
-                excluded = True
                 break
 
     # ---- Seniority-tier penalty ----

--- a/apps/wyrdfold-api/scripts/diagnose_target_funnel.py
+++ b/apps/wyrdfold-api/scripts/diagnose_target_funnel.py
@@ -1,0 +1,193 @@
+"""Funnel diagnosis for a single target (#845).
+
+Reusable: hands an operator the per-stage candidate counts so the
+collapse stage is obvious from the console. Read-only against
+Supabase. Same logic as ``GET /targets/{id}/funnel``.
+
+Usage:
+    cd apps/wyrdfold-api
+    PYTHONPATH=. uv run python scripts/diagnose_target_funnel.py <target_id>
+
+    # or pass an email — looks up the user's primary active target
+    PYTHONPATH=. uv run python scripts/diagnose_target_funnel.py --email mel@example.com
+
+The pre-DB drops (non-US, title pre-match, Phase 1 unpromising) are
+not visible here — they're emitted as ``poll_funnel`` log lines from
+``_poll_one_source``. Grep Railway with ``poll_funnel`` to read them.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import Any, cast
+
+from app.services.diagnostics.funnel import compute_target_funnel
+from app.supabase_pool import get_supabase_pool, init_supabase
+
+
+def _resolve_target_id_for_email(sb: Any, email: str) -> str:
+    """user_profiles.email → user_id → user_targets.is_active → target_id.
+
+    If multiple active targets, picks the most recently updated one and
+    notes it on stderr so the operator can re-run with an explicit id.
+    """
+    prof = (
+        sb.table("user_profiles")
+        .select("user_id")
+        .eq("email", email)
+        .limit(1)
+        .execute()
+    )
+    prof_rows = cast(list[dict[str, Any]], prof.data or [])
+    if not prof_rows:
+        sys.exit(f"No user_profiles row for email={email!r}")
+    user_id = prof_rows[0]["user_id"]
+
+    ut = (
+        sb.table("user_targets")
+        .select("target_id, is_active, updated_at")
+        .eq("user_id", user_id)
+        .eq("is_active", True)
+        .order("updated_at", desc=True)
+        .execute()
+    )
+    ut_rows = cast(list[dict[str, Any]], ut.data or [])
+    if not ut_rows:
+        sys.exit(f"User {user_id} has no active user_targets row")
+    if len(ut_rows) > 1:
+        print(
+            f"# warning: {email} has {len(ut_rows)} active targets; "
+            f"using most-recently-updated. To pick another:",
+            file=sys.stderr,
+        )
+        for r in ut_rows:
+            print(f"#   {r['target_id']}  updated_at={r['updated_at']}", file=sys.stderr)
+    return cast(str, ut_rows[0]["target_id"])
+
+
+def _print_report(report: Any) -> None:
+    n = report.nomenclature
+    s = report.stages
+    h = report.scores_histogram
+
+    print("=" * 72)
+    print(f"Target funnel report  ({report.generated_at.isoformat()})")
+    print("=" * 72)
+
+    print(f"\n# Nomenclature  ({n.target_id})")
+    print(f"  label:          {n.label!r}")
+    print(f"  is_active:      {n.is_active}  status={n.activation_status}  v{n.profile_version}")
+    print(f"  seniority_hint: {n.seniority_hint!r}")
+    print(f"  domain_hints:   {n.domain_hints}")
+    print(f"  example_promising_titles  ({len(n.example_promising_titles)}):")
+    for t in n.example_promising_titles[:10]:
+        print(f"    + {t}")
+    print(f"  example_unpromising_titles  ({len(n.example_unpromising_titles)}):")
+    for t in n.example_unpromising_titles[:10]:
+        print(f"    - {t}")
+    print(f"  search_keywords  ({len(n.search_keywords)}): {n.search_keywords[:20]}")
+    print("  scoring_profile (JSON, abbreviated):")
+    print("    " + json.dumps(n.scoring_profile, indent=2).replace("\n", "\n    ")[:1200])
+    if len(json.dumps(n.scoring_profile)) > 1200:
+        print("    … (truncated; use the HTTP endpoint for full payload)")
+
+    print("\n# DB-visible funnel")
+    print(f"  scores rows (all):          {s.scores_total}")
+    print(f"  promising=True:             {s.promising_true}")
+    print(f"  promising=False:            {s.promising_false}")
+    print(f"  promising=NULL (no verdict):{s.promising_null}")
+    print(f"  by scoring_status:          {s.by_status}")
+    print(f"  excluded=False:             {s.excluded_false}")
+    print(f"  excluded=True:              {s.excluded_true}")
+    print(f"  graded (promising & ≥stage2): {s.graded}")
+    print(f"  complete (Phase 2 done):    {s.complete}")
+    print(f"  stuck in stage1 (promising):{s.stuck_in_stage1}  ⚠ daily-cap starvation if >0")
+
+    print(f"\n# Score histogram (excluded=False, floor={h.floor})")
+    print(f"  total:    {h.total}   max:{h.max_score}   above_floor:{h.above_floor}")
+    width = 40
+    peak = max(h.buckets.values(), default=1)
+    for label, count in h.buckets.items():
+        bar = "█" * int((count / max(peak, 1)) * width) if count else ""
+        print(f"  {label:>6}  {count:>4}  {bar}")
+
+    print("\n# Users on this target")
+    for u in report.users:
+        print(
+            f"  user_id={u.user_id}  list_min_score={u.list_min_score}  "
+            f"phase2_quota_remaining={u.phase2_quota_remaining}"
+        )
+    if not report.users:
+        print("  (none — target has no active users; sourcing is moot)")
+
+    print("\n# Source staleness  (top 10 most-recent + any never-polled)")
+    never = [s for s in report.sources if s.last_polled_at is None]
+    polled = sorted(
+        [s for s in report.sources if s.last_polled_at is not None],
+        key=lambda x: x.hours_since_polled or 0,
+    )
+    for s in polled[:10]:
+        print(
+            f"  {s.company_name:<28} {s.provider:<14} "
+            f"polled {s.hours_since_polled}h ago  jobs={s.job_count}"
+        )
+    if never:
+        print(f"  -- never polled ({len(never)}):")
+        for s in never[:10]:
+            print(f"  {s.company_name:<28} {s.provider:<14} enabled={s.enabled}")
+
+    print("\n# Pre-DB drops (invisible here)")
+    print(f"  {report.pre_db_hint}")
+
+    print(
+        "\n# Where did the funnel collapse?  Read top-down:"
+        "\n  scores_total==0           → no jobs ever survived ingest "
+        "(check `poll_funnel` logs: fetched, dropped_non_us, dropped_title_prematch)"
+        "\n  promising_true is tiny    → Phase 1 rejecting most titles "
+        "(check example_promising_titles vs real role titles)"
+        "\n  stuck_in_stage1 is large  → Phase-2 daily-cap starvation"
+        "\n  above_floor is tiny       → list_min_score is too aggressive "
+        "(check the histogram peak vs the floor)"
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "target_id",
+        nargs="?",
+        help="Target UUID. Omit to use --email instead.",
+    )
+    parser.add_argument(
+        "--email", help="Resolve target_id from this user's primary active target."
+    )
+    parser.add_argument(
+        "--json", action="store_true", help="Emit the raw JSON response."
+    )
+    args = parser.parse_args()
+
+    if not args.target_id and not args.email:
+        parser.error("provide target_id or --email")
+
+    init_supabase()
+    sb = get_supabase_pool()
+    if sb is None:
+        raise SystemExit("Supabase not configured — check .env / SUPABASE_URL")
+
+    target_id = args.target_id or _resolve_target_id_for_email(sb, args.email)
+
+    try:
+        report = compute_target_funnel(sb, target_id)
+    except ValueError as exc:
+        sys.exit(str(exc))
+
+    if args.json:
+        print(report.model_dump_json(indent=2))
+    else:
+        _print_report(report)
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/wyrdfold-api/tests/test_scoring_with_profile.py
+++ b/apps/wyrdfold-api/tests/test_scoring_with_profile.py
@@ -86,6 +86,57 @@ def test_excluded_for_negative_keyword():
     assert result.score == 0
 
 
+def test_title_negative_still_excludes():
+    """A negative keyword in the TITLE remains a hard exclude (#845)."""
+    result = score_job_with_profile(
+        "Customer Service Agent",
+        "<p>Handle customer tickets. React a plus.</p>",
+        _profile(
+            core={"React": 3},
+            seniority_level=None,
+            negative_keywords=["agent"],
+        ),
+    )
+    assert result.excluded is True
+    assert result.score == 0
+
+
+def test_body_negative_penalizes_but_does_not_exclude():
+    """A negative keyword in the JD *body* is a soft score penalty, not a
+    hard exclude (#845).
+
+    For a leadership target the negatives (agent, specialist, analyst…)
+    describe the team the role manages, so they appear in the body of
+    genuine senior JDs. Excluding on a body mention buried the exact
+    roles the user wanted; we demote it to a score deduction instead.
+    """
+    title = "Director of Customer Experience"
+    body = (
+        "<p>Customer experience leadership. React React React. "
+        "You will mentor each support agent on the team.</p>"
+    )
+    # Filler keywords (absent from the body) raise the score ceiling so
+    # the matched-React score lands mid-range and the -10 penalty is
+    # visible rather than clamped at 100.
+    core = {"React": 3, "Kubernetes": 3, "GraphQL": 3, "Terraform": 3}
+    base = score_job_with_profile(
+        title, body, _profile(core=core, seniority_level=None)
+    )
+    penalized = score_job_with_profile(
+        title,
+        body,
+        _profile(core=core, seniority_level=None, negative_keywords=["agent"]),
+    )
+    # The body negative ("agent") must NOT exclude the posting...
+    assert penalized.excluded is False
+    # ...but it must apply the score penalty...
+    assert penalized.breakdown.negative == -10.0
+    assert base.breakdown.negative == 0.0
+    # ...which lowers the score versus the no-negative baseline.
+    assert penalized.score < base.score
+    assert penalized.score > 0
+
+
 def test_per_keyword_weights_respected():
     profile = _profile(
         core={"React": 3, "jQuery": 1},

--- a/apps/wyrdfold-api/tests/test_target_funnel.py
+++ b/apps/wyrdfold-api/tests/test_target_funnel.py
@@ -1,0 +1,288 @@
+"""Tests for the per-target funnel diagnostics (#845).
+
+Covers the pure helpers + a smoke test of ``compute_target_funnel``
+wired against a hand-rolled fake Supabase. The fake routes each
+``.table(name).select(...)`` chain to a scripted response — keeping
+us off a live DB while still exercising the count → histogram →
+response-shape assembly end-to-end.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from app.models.diagnostics import FunnelUserContext
+from app.models.targets import (
+    CategoryProfile,
+    JobTarget,
+    ScoringProfile,
+    SeniorityProfile,
+)
+from app.services.diagnostics.funnel import (
+    _bucketize,
+    _default_floor_from_users,
+    _hours_since,
+    compute_target_funnel,
+)
+
+# ---- Pure helpers ----------------------------------------------------
+
+
+def test_bucketize_distributes_into_decile_bins() -> None:
+    """Edge values land in the bin whose half-open range contains them."""
+    buckets = _bucketize([0, 9, 10, 19, 50, 89, 90, 100])
+    assert buckets["0-9"] == 2
+    assert buckets["10-19"] == 2
+    assert buckets["50-59"] == 1
+    assert buckets["80-89"] == 1
+    # Final bucket is inclusive on the upper bound — 100 is a valid score.
+    assert buckets["90-100"] == 2
+
+
+def test_bucketize_empty_input_gives_zeroed_buckets() -> None:
+    buckets = _bucketize([])
+    assert sum(buckets.values()) == 0
+    assert set(buckets) == {
+        "0-9", "10-19", "20-29", "30-39", "40-49",
+        "50-59", "60-69", "70-79", "80-89", "90-100",
+    }
+
+
+def test_hours_since_naive_datetime_assumed_utc() -> None:
+    """Naive datetimes are coerced to UTC rather than crashing — the DB
+    sometimes returns timezone-stripped values depending on driver."""
+    one_hour_ago = (datetime.now(UTC) - timedelta(hours=1)).replace(tzinfo=None)
+    assert _hours_since(one_hour_ago) == pytest.approx(1.0, abs=0.1)
+
+
+def test_hours_since_none_returns_none() -> None:
+    assert _hours_since(None) is None
+
+
+def test_default_floor_picks_lowest_across_users() -> None:
+    """Most permissive view: a multi-user target's histogram should
+    show the floor at whichever user is set to admit the most."""
+    users = [
+        FunnelUserContext(user_id="a", list_min_score=50, phase2_quota_remaining=0),
+        FunnelUserContext(user_id="b", list_min_score=30, phase2_quota_remaining=0),
+        FunnelUserContext(user_id="c", list_min_score=None, phase2_quota_remaining=0),
+    ]
+    assert _default_floor_from_users(users) == 30
+
+
+def test_default_floor_no_floors_set_falls_to_zero() -> None:
+    """If nobody has set list_min_score, treat as 'no floor' so the
+    histogram view doesn't accidentally hide rows."""
+    users = [
+        FunnelUserContext(user_id="a", list_min_score=None, phase2_quota_remaining=0),
+    ]
+    assert _default_floor_from_users(users) == 0
+
+
+# ---- Fake Supabase for the end-to-end smoke test --------------------
+
+
+def _make_target() -> JobTarget:
+    return JobTarget(
+        id="t-1",
+        label="Director of CX Ops",
+        normalized_label="director of cx ops",
+        scoring_profile=ScoringProfile(
+            categories={
+                "core_skills": CategoryProfile(
+                    keywords={"customer": 3, "ops": 3}, weight=2.0
+                ),
+            },
+            seniority=SeniorityProfile(signals=["director"]),
+        ),
+        search_keywords=["customer", "ops"],
+        is_active=True,
+        example_promising_titles=["Director, CX Operations"],
+        example_unpromising_titles=["Customer Service Rep"],
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
+    )
+
+
+class _FakeQuery:
+    """Records the columns + filters; returns a scripted response."""
+
+    def __init__(self, table: str, scripted: Any) -> None:
+        self._table = table
+        self._scripted = scripted
+        self._filters: list[tuple[str, str, Any]] = []
+        self._count: str | None = None
+
+    def select(self, *_args: Any, count: str | None = None, **_kw: Any) -> _FakeQuery:
+        self._count = count
+        return self
+
+    def eq(self, col: str, val: Any) -> _FakeQuery:
+        self._filters.append(("eq", col, val))
+        return self
+
+    def neq(self, col: str, val: Any) -> _FakeQuery:
+        self._filters.append(("neq", col, val))
+        return self
+
+    def is_(self, col: str, val: Any) -> _FakeQuery:
+        self._filters.append(("is", col, val))
+        return self
+
+    def order(self, *_a: Any, **_kw: Any) -> _FakeQuery:
+        return self
+
+    def limit(self, *_a: Any, **_kw: Any) -> _FakeQuery:
+        return self
+
+    def execute(self) -> Any:
+        return self._scripted(self._table, self._filters, self._count)
+
+
+class _FakeSupabase:
+    def __init__(self, script: Any) -> None:
+        self._script = script
+
+    def table(self, name: str) -> _FakeQuery:
+        return _FakeQuery(name, self._script)
+
+
+def _scripted_response(target: JobTarget) -> Any:
+    """Hard-coded responses keyed by (table, filter signature)."""
+
+    def respond(
+        table: str, filters: list[tuple[str, str, Any]], count: str | None
+    ) -> Any:
+        # Targets lookup — single row.
+        if table == "targets":
+            return SimpleNamespace(
+                data=[
+                    {
+                        "id": target.id,
+                        "label": target.label,
+                        "description": target.description,
+                        "normalized_label": target.normalized_label,
+                        "scoring_profile": target.scoring_profile.model_dump(),
+                        "search_keywords": target.search_keywords,
+                        "activation_status": target.activation_status,
+                        "profile_version": target.profile_version,
+                        "is_active": target.is_active,
+                        "example_promising_titles": target.example_promising_titles,
+                        "example_unpromising_titles": target.example_unpromising_titles,
+                        "seniority_hint": target.seniority_hint,
+                        "domain_hints": target.domain_hints,
+                        "created_at": target.created_at.isoformat(),
+                        "updated_at": target.updated_at.isoformat(),
+                    }
+                ],
+                count=None,
+            )
+
+        if table == "scores":
+            fmap = dict((f[1], f[2]) for f in filters)
+            # Histogram path returns rows of scores.
+            if count is None:
+                return SimpleNamespace(
+                    data=[{"score": s} for s in [45, 55, 65, 75, 85, 95]],
+                    count=None,
+                )
+            # Counts.
+            if fmap.get("scoring_status") == "stage1":
+                return SimpleNamespace(data=[], count=20)
+            if fmap.get("scoring_status") == "stage2":
+                return SimpleNamespace(data=[], count=5)
+            if fmap.get("scoring_status") == "complete":
+                return SimpleNamespace(data=[], count=2)
+            if fmap.get("promising") is True and fmap.get("scoring_status") == "stage1":
+                return SimpleNamespace(data=[], count=15)
+            if fmap.get("promising") is True and any(
+                f[0] == "neq" and f[1] == "scoring_status" for f in filters
+            ):
+                # graded = promising True AND status != stage1
+                return SimpleNamespace(data=[], count=7)
+            if fmap.get("promising") is True:
+                return SimpleNamespace(data=[], count=22)
+            if fmap.get("promising") is False:
+                return SimpleNamespace(data=[], count=3)
+            if any(f[0] == "is" and f[1] == "promising" for f in filters):
+                return SimpleNamespace(data=[], count=2)
+            if fmap.get("excluded") is True:
+                return SimpleNamespace(data=[], count=4)
+            if fmap.get("excluded") is False:
+                return SimpleNamespace(data=[], count=23)
+            return SimpleNamespace(data=[], count=27)
+
+        if table == "user_targets":
+            return SimpleNamespace(
+                data=[{"user_id": "u-1", "is_active": True}], count=None
+            )
+
+        if table == "user_profiles":
+            return SimpleNamespace(
+                data=[{"list_min_score": 60}], count=None
+            )
+
+        if table == "sources":
+            return SimpleNamespace(
+                data=[
+                    {
+                        "id": "s-1",
+                        "company_name": "Acme",
+                        "provider": "greenhouse",
+                        "enabled": True,
+                        "last_polled_at": datetime.now(UTC).isoformat(),
+                        "job_count": 42,
+                    }
+                ],
+                count=None,
+            )
+
+        # llm_costs count for daily-cap query
+        if table == "llm_costs":
+            return SimpleNamespace(data=[], count=10)
+
+        return SimpleNamespace(data=[], count=0)
+
+    return respond
+
+
+def test_compute_target_funnel_assembles_full_report(monkeypatch: Any) -> None:
+    """End-to-end smoke: a fake supabase + a real target → a full
+    ``TargetFunnelResponse`` with the histogram, stages, users, sources."""
+    target = _make_target()
+
+    def _fake_get(_sb: Any, target_id: str) -> JobTarget:
+        assert target_id == target.id
+        return target
+
+    # The funnel's nomenclature path goes via crud.get(target_id). We
+    # patch that instead of round-tripping through the fake table call.
+    monkeypatch.setattr(
+        "app.services.diagnostics.funnel.crud.get", _fake_get
+    )
+
+    sb = _FakeSupabase(_scripted_response(target))
+    report = compute_target_funnel(sb, target.id)
+
+    assert report.nomenclature.label == "Director of CX Ops"
+    assert report.nomenclature.example_promising_titles == [
+        "Director, CX Operations"
+    ]
+    # Histogram bins reflect the scripted scores [45,55,65,75,85,95].
+    assert report.scores_histogram.total == 6
+    assert report.scores_histogram.max_score == 95
+    # floor=60 from user_profiles → 4 scores ≥60 (65,75,85,95).
+    assert report.scores_histogram.floor == 60
+    assert report.scores_histogram.above_floor == 4
+    # User context picked up.
+    assert [u.user_id for u in report.users] == ["u-1"]
+    assert report.users[0].list_min_score == 60
+    # Sources list non-empty (single Acme row).
+    assert len(report.sources) == 1
+    assert report.sources[0].company_name == "Acme"
+    # Pre-DB hint is present and mentions the grep token.
+    assert "poll_funnel" in report.pre_db_hint

--- a/apps/wyrdfold/src/app/(app)/settings/__tests__/OnboardingResetCard.spec.tsx
+++ b/apps/wyrdfold/src/app/(app)/settings/__tests__/OnboardingResetCard.spec.tsx
@@ -43,9 +43,7 @@ describe('OnboardingResetCard', () => {
     const user = userEvent.setup();
     render(<OnboardingResetCard />);
 
-    await user.click(
-      screen.getByRole('button', { name: /Redo onboarding/i })
-    );
+    await user.click(screen.getByRole('button', { name: /Redo onboarding/i }));
 
     expect(window.confirm).toHaveBeenCalled();
     await waitFor(() =>
@@ -63,9 +61,7 @@ describe('OnboardingResetCard', () => {
     const user = userEvent.setup();
     render(<OnboardingResetCard />);
 
-    await user.click(
-      screen.getByRole('button', { name: /Redo onboarding/i })
-    );
+    await user.click(screen.getByRole('button', { name: /Redo onboarding/i }));
 
     expect(global.fetch).not.toHaveBeenCalled();
     expect(mockPush).not.toHaveBeenCalled();
@@ -79,9 +75,7 @@ describe('OnboardingResetCard', () => {
     const user = userEvent.setup();
     render(<OnboardingResetCard />);
 
-    await user.click(
-      screen.getByRole('button', { name: /Redo onboarding/i })
-    );
+    await user.click(screen.getByRole('button', { name: /Redo onboarding/i }));
 
     await waitFor(() =>
       expect(mockToast).toHaveBeenCalledWith(

--- a/supabase/templates/invite.html
+++ b/supabase/templates/invite.html
@@ -146,7 +146,8 @@
                   <a
                     href="{{ .SiteURL }}/auth/callback?token_hash={{ .TokenHash }}&type=invite"
                     style="color: #bef264; word-break: break-all"
-                    >{{ .SiteURL }}/auth/callback?token_hash={{ .TokenHash }}&type=invite</a
+                    >{{ .SiteURL }}/auth/callback?token_hash={{ .TokenHash
+                    }}&type=invite</a
                   >
                 </p>
               </td>

--- a/supabase/templates/magic-link.html
+++ b/supabase/templates/magic-link.html
@@ -134,7 +134,8 @@
                   <a
                     href="{{ .SiteURL }}/auth/callback?token_hash={{ .TokenHash }}&type=magiclink"
                     style="color: #bef264; word-break: break-all"
-                    >{{ .SiteURL }}/auth/callback?token_hash={{ .TokenHash }}&type=magiclink</a
+                    >{{ .SiteURL }}/auth/callback?token_hash={{ .TokenHash
+                    }}&type=magiclink</a
                   >
                 </p>
               </td>


### PR DESCRIPTION
## Update — diagnosis complete, fix applied ✅

The diagnostic instrumentation below (original PR scope) was run against the real production target ("Director of CX Operations & Transformation", `4195d651…`). It pinpointed the collapse, and this PR now **also contains the fix**.

### The funnel collapse

| Stage | Surviving | Note |
|---|---:|---|
| Sourcing / polling | — | ✅ healthy — sources polled 0.2h ago, not stale (disproved the "polling stale" suspicion) |
| Jobs scored (`scores` rows) | **8,708** | supply is not the problem |
| Phase-1 LLM triage → `promising=True` | **1,830** | |
| **Negative-keyword exclusion gate** → `excluded=False` | **211** | 🔴 **1,619 of 1,830 promising jobs killed here (88.5%)** |

The negative-keyword gate in `score_job_with_profile` was the collapse. For a CX-leadership target the negatives (`intern, associate, coordinator, specialist, analyst, junior, agent, representative…`) are **exactly the titles of the team a CX Director manages**, so they appear in the **body** of nearly every genuine senior CX JD. Matching them against the JD body and setting `excluded=True` + `score=0` buried the exact roles the user wanted — overriding both the Phase-1 `promising` verdict and the Phase-2 fit score (480 jobs were Sonnet-graded, e.g. "Sr. Manager, Customer Support" fit **62**, then hidden).

### The fix (`app/services/scoring.py`)

- Negative keyword in the **job title** → still a **hard exclude** (`excluded=True`, `score=0`). Junior IC roles carry their token in the title and stay filtered.
- Negative keyword in the **JD body** → now only the existing `breakdown.negative` **score penalty**, no longer a hard exclude.
- `promising=False` jobs stay excluded via the Phase-1 prefilter, so this doesn't re-admit LLM-rejected noise.

### Realized impact (diagnosed target, re-scored from this branch)

- Surfaced (`excluded=False`): **211 → 709** (498 rows recovered)
- Surfaced with `score ≥ 40`: **16 → 48** (Phase-2 fit scores preserved)
- `0` newly-excluded — the new exclusion set is a strict subset of the old.

### Tests

`tests/test_scoring_with_profile.py`:
- `test_title_negative_still_excludes` — title negative → `excluded`, `score == 0`.
- `test_body_negative_penalizes_but_does_not_exclude` — body negative → `excluded is False`, applies the penalty, score lowered but `> 0`.

Full suite: **1,156 passed**. `mypy` clean.

### Operational note

The diagnosed target was re-scored against prod via a surgical `excluded` recompute (preserves Phase-2 scores — avoids the `bulk_score_for_target` stage2-reset and Sonnet re-spend, which matters because the target's daily Phase-2 cap is exhausted). Once this deploys, new polls compute `excluded` correctly; other empty targets can be re-scored via `POST /jobs/rescore/{target_id}` after a `profile_version` bump.

Refs #845.

---

<details>
<summary>Original PR description — diagnostics instrumentation</summary>

## Summary

Implements the diagnostic instrumentation for #845 so we can find *the one stage where the candidate count collapses* before patching the wrong suspect.

The fix itself is **not** in this PR — once an operator runs the script against Mel's target tomorrow, the collapse stage will point at whichever of the six suspects is real (target nomenclature / sourcing / polling staleness / ingest filters / score floor / Phase 2 starvation).

### What ships

- **`GET /targets/{id}/funnel`** (API-key only) — single read-only response combining:
  - Nomenclature dump (`example_promising_titles`, `example_unpromising_titles`, `scoring_profile`, `search_keywords`, `seniority_hint`, `domain_hints`, `profile_version`) — the "narrow vocabulary" suspect.
  - DB-visible stage counts (`promising` true/false/null, `scoring_status` breakdown, `excluded` true/false, `graded`, `complete`, `stuck_in_stage1`).
  - Score histogram for not-excluded scores in 10-wide deciles, with the user's `list_min_score` floor + a count above it.
  - Per-user context: `list_min_score`, `phase2_quota_remaining` (daily cap).
  - Source staleness: every source with `last_polled_at` and `hours_since_polled` so a stalled poller is obvious.
- **`scripts/diagnose_target_funnel.py`** — CLI wrapper around the same service function. Takes a `target_id` or `--email mel@…` (resolves via `user_profiles` → `user_targets`). Prints a console table with an ascii histogram and a "where did it collapse?" cheat-sheet. Also supports `--json`.
- **Pre-DB instrumentation in `_poll_one_source`** — emits one structured `poll_funnel` log line per source per cycle with the three counts the issue calls out as *invisible* in the DB:
  - `dropped_phase1` (Phase 1 LLM said unpromising across all targets)
  - `dropped_title_prematch` (keyword gate missed before upsert)
  - `dropped_non_us` (location pre-filter dropped it)
  - Plus `fetched`, `candidates`, `upserted_new`, `upserted_updated`, `archived`, and per-target Phase-1 unpromising counts.

Mutually exclusive — first gate to fire wins per job. So when the operator greps `poll_funnel | grep <CompanyName>`, the row tells them which gate is eating Mel's roles without temporary code edits.

### Why this shape

The issue's Step-2 query list maps 1:1 to `_stage_counts`. The histogram + floor lets you eyeball *list_min_score too high* in one glance. Per-user `phase2_quota_remaining` surfaces daily-cap starvation. Source staleness catches the "polling broken" suspect. The `poll_funnel` log line is the only way to see the pre-DB drops without re-deploying.

### Test plan

- [x] `pytest tests/test_target_funnel.py` — 7 new tests (pure helpers + end-to-end smoke against a fake supabase)
- [x] `pytest` — all 1154 tests pass, no regressions in poller/scoring/openrouter paths
- [x] `mypy app/services/diagnostics/ app/models/diagnostics.py app/routers/targets.py app/services/poller.py` — clean
- [x] `pnpm tsc --noEmit` — clean
- [x] `ruff check` — clean
- [ ] Run `diagnose_target_funnel.py` against Mel's target (`4195d651-2009-4c43-bc6b-beec4d3fca0b` from `scripts/debug_mel_director_query.py`) once deployed, paste output.
- [ ] After one poll cycle on deploy: `railway logs | grep poll_funnel` to confirm the line emits.

### Follow-up

Pending answers to the issue's questions before the diagnostic session itself can run:

- Q1 subject: Mel's `target_id` is already hard-coded in `scripts/debug_mel_director_query.py` as `4195d651-2009-4c43-bc6b-beec4d3fca0b`; `user_id` can be looked up via `--email`.
- Q2 ground-truth role/titles — needed to judge whether Phase 1 nomenclature is the culprit.
- Q3 prod vs dev — script reads `.env` like the other scripts.
- Q7 permission to instrument + poll — instrumentation is now passive (in the existing poll path), so no extra cycle needs to be triggered manually unless the operator wants fresh data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


</details>
