### PR TITLE
perf(wyrdfold): defer target derivation to BackgroundTask (5-9s → instant)

### DIFF
--- a/apps/wyrdfold-api/app/routers/targets.py
+++ b/apps/wyrdfold-api/app/routers/targets.py
@@ -251,16 +251,19 @@ async def create_target(
 )
 async def create_target_from_manual(
     body: TargetFromManual,
+    background_tasks: BackgroundTasks,
     supabase: Client = Depends(get_supabase),
     llm: LLMClient = Depends(get_llm_client),
     user_id: str = Depends(get_current_user_id),
 ) -> CreateOrLinkResult:
     """Create-or-link a target from user-typed title + description.
 
-    LLM normalizes the input into a canonical ``TargetSuggestion``, matches
-    against existing targets, and either links the user to the match or
-    creates a new target (with a profile derived from label + experience)
-    and links the user. The user always ends up with a ``user_targets`` row.
+    LLM normalizes the input into a canonical ``TargetSuggestion`` and
+    matches against existing targets — the only inline LLM call. The user
+    is linked immediately and an optimistic ``CreateOrLinkResult`` returns
+    right away; the scoring-profile derivation + fit score run in a
+    BackgroundTask (new targets start in ``deriving`` status). The user
+    always ends up with a ``user_targets`` row.
     """
     doc = optimized.get_latest(supabase, user_id=user_id)
     if doc is None:
@@ -276,6 +279,7 @@ async def create_target_from_manual(
     return await from_input.from_manual(
         supabase,
         llm,
+        background_tasks,
         user_id=user_id,
         label=body.label,
         description=body.description,
@@ -291,17 +295,19 @@ async def create_target_from_manual(
 )
 async def create_target_from_url(
     body: TargetFromUrl,
+    background_tasks: BackgroundTasks,
     supabase: Client = Depends(get_supabase),
     llm: LLMClient = Depends(get_llm_client),
     user_id: str = Depends(get_current_user_id),
 ) -> CreateOrLinkResult:
     """Create-or-link a target from a JD URL.
 
-    Validates and fetches the URL, extracts title + JD text, derives a
-    scoring profile via LLM, then matches against existing targets. On
-    match the JD is appended as a reference and the composite profile is
-    re-merged (corpus building); on no match a new target is created. The
-    user is always linked.
+    Validates and fetches the URL, extracts title + JD text, then matches
+    against existing targets by label (no LLM call inline). The user is
+    linked immediately and an optimistic result returns; profile
+    derivation, reference-JD corpus building, profile re-merge, and fit
+    score all run in a BackgroundTask (new targets start in ``deriving``
+    status). The user is always linked.
     """
     doc = optimized.get_latest(supabase, user_id=user_id)
     if doc is None:
@@ -324,6 +330,7 @@ async def create_target_from_url(
     return await from_input.from_url(
         supabase,
         llm,
+        background_tasks,
         user_id=user_id,
         final_url=final_url,
         extracted_title=extracted_title,

--- a/apps/wyrdfold-api/app/services/targets/from_input.py
+++ b/apps/wyrdfold-api/app/services/targets/from_input.py
@@ -22,6 +22,7 @@ the ``_activate_pipeline`` BackgroundTask pattern in ``routers/targets``.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 
 from fastapi import BackgroundTasks
@@ -66,6 +67,13 @@ from app.services.targets.normalize_manual import (
 )
 
 logger = logging.getLogger(__name__)
+
+# Hard ceiling for a deferred derivation (profile + fit-score LLM calls).
+# A hung LLM call would otherwise leave the target stuck in "deriving"
+# forever — the timeout cancels the work and flips the target to "error"
+# so the frontend stops polling and surfaces the failure. Sized well above
+# the observed 5-9s happy path while still bounding the worst case.
+DERIVATION_TIMEOUT_S = 60.0
 
 
 # ---- Deferred fit-score helper ---------------------------------------------
@@ -119,38 +127,50 @@ async def derive_manual_target_bg(
 
     Runs as a ``BackgroundTask``. The target already exists in
     ``activation_status="deriving"``; on success it flips to ``idle`` with
-    the derived scoring profile, on failure to ``error``.
+    the derived scoring profile, on failure (or timeout) to ``error``.
     """
     try:
-        derived, derive_result = await derive_profile_from_label(llm, label=label, payload=payload)
-        cost_log.record(
-            supabase,
-            user_id=user_id,
-            purpose=DERIVE_LABEL_PURPOSE,
-            result=derive_result,
-            metadata={"user_id": user_id, "label": label},
-        )
-        updated = crud.update(
-            supabase,
+        async with asyncio.timeout(DERIVATION_TIMEOUT_S):
+            derived, derive_result = await derive_profile_from_label(
+                llm, label=label, payload=payload
+            )
+            cost_log.record(
+                supabase,
+                user_id=user_id,
+                purpose=DERIVE_LABEL_PURPOSE,
+                result=derive_result,
+                metadata={"user_id": user_id, "label": label},
+            )
+            updated = crud.update(
+                supabase,
+                target_id,
+                TargetUpdate(
+                    scoring_profile=derived.scoring_profile,
+                    search_keywords=derived.search_keywords,
+                    example_promising_titles=derived.example_promising_titles,
+                    example_unpromising_titles=derived.example_unpromising_titles,
+                    # Slim shape — populated when the LLM emits them; None is
+                    # treated as "leave unchanged" by crud.update, so the
+                    # canonical description from normalize survives.
+                    description=derived.description,
+                    seniority_hint=derived.seniority_hint,
+                    domain_hints=derived.domain_hints or None,
+                    activation_status="idle",
+                ),
+            )
+            if updated is None:
+                logger.error("Failed to update target %s after deferred derive", target_id)
+                return
+            await _apply_fit_score(
+                supabase, llm, user_id=user_id, target=updated, payload=payload
+            )
+    except TimeoutError:
+        logger.error(
+            "Deferred manual-target derivation timed out after %ss for target %s",
+            DERIVATION_TIMEOUT_S,
             target_id,
-            TargetUpdate(
-                scoring_profile=derived.scoring_profile,
-                search_keywords=derived.search_keywords,
-                example_promising_titles=derived.example_promising_titles,
-                example_unpromising_titles=derived.example_unpromising_titles,
-                # Slim shape — populated when the LLM emits them; None is
-                # treated as "leave unchanged" by crud.update, so the
-                # canonical description from normalize survives.
-                description=derived.description,
-                seniority_hint=derived.seniority_hint,
-                domain_hints=derived.domain_hints or None,
-                activation_status="idle",
-            ),
         )
-        if updated is None:
-            logger.error("Failed to update target %s after deferred derive", target_id)
-            return
-        await _apply_fit_score(supabase, llm, user_id=user_id, target=updated, payload=payload)
+        crud.update(supabase, target_id, TargetUpdate(activation_status="error"))
     except Exception:
         logger.exception("Deferred manual-target derivation failed for target %s", target_id)
         crud.update(supabase, target_id, TargetUpdate(activation_status="error"))
@@ -172,51 +192,64 @@ async def derive_url_target_bg(
     Runs as a ``BackgroundTask`` for both the new-target and matched
     (corpus-building) URL flows. ``is_new`` controls whether the profile
     version is bumped — matched targets bump so lazy re-scoring picks up
-    the newly-merged profile; brand-new targets stay at version 1.
+    the newly-merged profile; brand-new targets stay at version 1. On
+    failure (or timeout) the target flips to ``error``.
     """
     try:
-        derived, derive_result = await derive_profile_from_jd(llm, jd_text=jd_text)
-        cost_log.record(
-            supabase,
-            user_id=user_id,
-            purpose=DERIVE_JD_PURPOSE,
-            result=derive_result,
-            metadata={"user_id": user_id, "jd_url": final_url},
-        )
+        async with asyncio.timeout(DERIVATION_TIMEOUT_S):
+            derived, derive_result = await derive_profile_from_jd(llm, jd_text=jd_text)
+            cost_log.record(
+                supabase,
+                user_id=user_id,
+                purpose=DERIVE_JD_PURPOSE,
+                result=derive_result,
+                metadata={"user_id": user_id, "jd_url": final_url},
+            )
 
-        crud.add_reference_jd(
-            supabase,
-            target_id=target_id,
-            jd_text=jd_text,
-            jd_url=final_url,
-            extracted_profile=derived.scoring_profile,
-        )
-        all_jds = crud.list_reference_jds(supabase, target_id)
-        composite = (
-            merge_profiles([jd.extracted_profile for jd in all_jds])
-            if all_jds
-            else ScoringProfile()
-        )
+            crud.add_reference_jd(
+                supabase,
+                target_id=target_id,
+                jd_text=jd_text,
+                jd_url=final_url,
+                extracted_profile=derived.scoring_profile,
+            )
+            all_jds = crud.list_reference_jds(supabase, target_id)
+            composite = (
+                merge_profiles([jd.extracted_profile for jd in all_jds])
+                if all_jds
+                else ScoringProfile()
+            )
 
-        current = crud.get(supabase, target_id)
-        next_version = (
-            (current.profile_version + 1) if (not is_new and current is not None) else None
-        )
-        updated = crud.update(
-            supabase,
+            current = crud.get(supabase, target_id)
+            next_version = (
+                (current.profile_version + 1)
+                if (not is_new and current is not None)
+                else None
+            )
+            updated = crud.update(
+                supabase,
+                target_id,
+                TargetUpdate(
+                    scoring_profile=composite,
+                    search_keywords=derived.search_keywords,
+                    profile_version=next_version,
+                    activation_status="idle",
+                ),
+            )
+            target = updated or current
+            if target is None:
+                logger.error("Target %s vanished during deferred URL derive", target_id)
+                return
+            await _apply_fit_score(
+                supabase, llm, user_id=user_id, target=target, payload=payload
+            )
+    except TimeoutError:
+        logger.error(
+            "Deferred URL-target derivation timed out after %ss for target %s",
+            DERIVATION_TIMEOUT_S,
             target_id,
-            TargetUpdate(
-                scoring_profile=composite,
-                search_keywords=derived.search_keywords,
-                profile_version=next_version,
-                activation_status="idle",
-            ),
         )
-        target = updated or current
-        if target is None:
-            logger.error("Target %s vanished during deferred URL derive", target_id)
-            return
-        await _apply_fit_score(supabase, llm, user_id=user_id, target=target, payload=payload)
+        crud.update(supabase, target_id, TargetUpdate(activation_status="error"))
     except Exception:
         logger.exception("Deferred URL-target derivation failed for target %s", target_id)
         crud.update(supabase, target_id, TargetUpdate(activation_status="error"))

--- a/apps/wyrdfold-api/app/services/targets/from_input.py
+++ b/apps/wyrdfold-api/app/services/targets/from_input.py
@@ -8,12 +8,23 @@ the new target appears in ``GET /targets/mine`` immediately.
 URL mode also acts as a corpus builder — when the URL maps to an existing
 shared target, the JD is appended as a reference and the composite profile
 is re-merged so all linked users benefit from the new data point.
+
+Performance: the only LLM call that has to run inline is
+``normalize_manual_input`` — its canonical label drives duplicate
+detection via ``find_matching_target``. The expensive steps
+(``derive_profile_*`` + ``derive_fit_score``, 5-9s of sequential Sonnet
+calls) are deferred to a ``BackgroundTask`` so the endpoint can return an
+optimistic ``CreateOrLinkResult`` immediately. New targets are created in
+``activation_status="deriving"`` and flip to ``idle`` (or ``error``) once
+the background work completes; the frontend polls until then. This mirrors
+the ``_activate_pipeline`` BackgroundTask pattern in ``routers/targets``.
 """
 
 from __future__ import annotations
 
 import logging
 
+from fastapi import BackgroundTasks
 from supabase import Client
 
 from app.models.experience import OptimizedPayload
@@ -23,7 +34,6 @@ from app.models.targets import (
     ScoringProfile,
     TargetCreate,
     TargetUpdate,
-    UserTarget,
 )
 from app.services.llm import cost_log
 from app.services.llm.client import LLMClient
@@ -58,18 +68,24 @@ from app.services.targets.normalize_manual import (
 logger = logging.getLogger(__name__)
 
 
-async def _link_with_fit_score(
+# ---- Deferred fit-score helper ---------------------------------------------
+
+
+async def _apply_fit_score(
     supabase: Client,
     llm: LLMClient,
     *,
     user_id: str,
     target: JobTarget,
     payload: OptimizedPayload,
-) -> UserTarget:
-    """Link the user to a target with a derived fit score. Starts inactive."""
-    fit_result, llm_result = await derive_fit_score(
-        llm, payload=payload, target=target
-    )
+) -> None:
+    """Derive a per-user fit score and upsert it onto the user's link.
+
+    The user is already linked (the inline path created the
+    ``user_targets`` row), so this is an idempotent upsert that just fills
+    in ``fit_score`` / ``fit_score_reasoning`` once the LLM returns.
+    """
+    fit_result, llm_result = await derive_fit_score(llm, payload=payload, target=target)
     cost_log.record(
         supabase,
         user_id=user_id,
@@ -77,7 +93,7 @@ async def _link_with_fit_score(
         result=llm_result,
         metadata={"target_id": target.id, "user_id": user_id},
     )
-    return crud.link_user_to_target(
+    crud.link_user_to_target(
         supabase,
         user_id=user_id,
         target_id=target.id,
@@ -87,9 +103,132 @@ async def _link_with_fit_score(
     )
 
 
+# ---- Background derivation tasks --------------------------------------------
+
+
+async def derive_manual_target_bg(
+    supabase: Client,
+    llm: LLMClient,
+    *,
+    user_id: str,
+    target_id: str,
+    label: str,
+    payload: OptimizedPayload,
+) -> None:
+    """Derive profile-from-label then fit score for a new manual target.
+
+    Runs as a ``BackgroundTask``. The target already exists in
+    ``activation_status="deriving"``; on success it flips to ``idle`` with
+    the derived scoring profile, on failure to ``error``.
+    """
+    try:
+        derived, derive_result = await derive_profile_from_label(llm, label=label, payload=payload)
+        cost_log.record(
+            supabase,
+            user_id=user_id,
+            purpose=DERIVE_LABEL_PURPOSE,
+            result=derive_result,
+            metadata={"user_id": user_id, "label": label},
+        )
+        updated = crud.update(
+            supabase,
+            target_id,
+            TargetUpdate(
+                scoring_profile=derived.scoring_profile,
+                search_keywords=derived.search_keywords,
+                example_promising_titles=derived.example_promising_titles,
+                example_unpromising_titles=derived.example_unpromising_titles,
+                # Slim shape — populated when the LLM emits them; None is
+                # treated as "leave unchanged" by crud.update, so the
+                # canonical description from normalize survives.
+                description=derived.description,
+                seniority_hint=derived.seniority_hint,
+                domain_hints=derived.domain_hints or None,
+                activation_status="idle",
+            ),
+        )
+        if updated is None:
+            logger.error("Failed to update target %s after deferred derive", target_id)
+            return
+        await _apply_fit_score(supabase, llm, user_id=user_id, target=updated, payload=payload)
+    except Exception:
+        logger.exception("Deferred manual-target derivation failed for target %s", target_id)
+        crud.update(supabase, target_id, TargetUpdate(activation_status="error"))
+
+
+async def derive_url_target_bg(
+    supabase: Client,
+    llm: LLMClient,
+    *,
+    user_id: str,
+    target_id: str,
+    jd_text: str,
+    final_url: str,
+    payload: OptimizedPayload,
+    is_new: bool,
+) -> None:
+    """Derive profile-from-JD, append the reference JD, re-merge, then fit score.
+
+    Runs as a ``BackgroundTask`` for both the new-target and matched
+    (corpus-building) URL flows. ``is_new`` controls whether the profile
+    version is bumped — matched targets bump so lazy re-scoring picks up
+    the newly-merged profile; brand-new targets stay at version 1.
+    """
+    try:
+        derived, derive_result = await derive_profile_from_jd(llm, jd_text=jd_text)
+        cost_log.record(
+            supabase,
+            user_id=user_id,
+            purpose=DERIVE_JD_PURPOSE,
+            result=derive_result,
+            metadata={"user_id": user_id, "jd_url": final_url},
+        )
+
+        crud.add_reference_jd(
+            supabase,
+            target_id=target_id,
+            jd_text=jd_text,
+            jd_url=final_url,
+            extracted_profile=derived.scoring_profile,
+        )
+        all_jds = crud.list_reference_jds(supabase, target_id)
+        composite = (
+            merge_profiles([jd.extracted_profile for jd in all_jds])
+            if all_jds
+            else ScoringProfile()
+        )
+
+        current = crud.get(supabase, target_id)
+        next_version = (
+            (current.profile_version + 1) if (not is_new and current is not None) else None
+        )
+        updated = crud.update(
+            supabase,
+            target_id,
+            TargetUpdate(
+                scoring_profile=composite,
+                search_keywords=derived.search_keywords,
+                profile_version=next_version,
+                activation_status="idle",
+            ),
+        )
+        target = updated or current
+        if target is None:
+            logger.error("Target %s vanished during deferred URL derive", target_id)
+            return
+        await _apply_fit_score(supabase, llm, user_id=user_id, target=target, payload=payload)
+    except Exception:
+        logger.exception("Deferred URL-target derivation failed for target %s", target_id)
+        crud.update(supabase, target_id, TargetUpdate(activation_status="error"))
+
+
+# ---- Inline create-or-link orchestration -----------------------------------
+
+
 async def from_manual(
     supabase: Client,
     llm: LLMClient,
+    background_tasks: BackgroundTasks,
     *,
     user_id: str,
     label: str,
@@ -98,10 +237,14 @@ async def from_manual(
 ) -> CreateOrLinkResult:
     """Manual flow: user-typed title + description.
 
+    Inline (fast): LLM-normalize the input, match against existing
+    targets, and link the user. Deferred (BackgroundTask): derive the
+    scoring profile (new targets) and the per-user fit score.
+
     1. LLM normalizes input into a canonical ``TargetSuggestion``
     2. Match against existing targets
-    3. If matched, link the user
-    4. If new, derive a profile from label+experience, create, link
+    3. If matched, link the user; defer the fit score
+    4. If new, create in ``deriving`` status, link, defer profile + fit score
     """
     suggestion, norm_result = await normalize_manual_input(
         llm, label=label, description=description, payload=payload
@@ -116,44 +259,47 @@ async def from_manual(
 
     matched = find_matching_target(supabase, suggestion.label)
     if matched is not None:
-        link = await _link_with_fit_score(
-            supabase, llm, user_id=user_id, target=matched, payload=payload
+        link = crud.link_user_to_target(
+            supabase, user_id=user_id, target_id=matched.id, is_active=False
         )
-        return CreateOrLinkResult(
-            user_target=link, target=matched, was_matched=True
+        background_tasks.add_task(
+            _apply_fit_score,
+            supabase,
+            llm,
+            user_id=user_id,
+            target=matched,
+            payload=payload,
         )
+        return CreateOrLinkResult(user_target=link, target=matched, was_matched=True)
 
-    derived, derive_result = await derive_profile_from_label(
-        llm, label=suggestion.label, payload=payload
-    )
-    cost_log.record(
-        supabase,
-        user_id=user_id,
-        purpose=DERIVE_LABEL_PURPOSE,
-        result=derive_result,
-        metadata={"user_id": user_id, "label": suggestion.label},
-    )
-
+    # New target: create immediately in "deriving" so it appears in the
+    # list with a pending indicator while the background task derives the
+    # scoring profile + fit score.
     target = crud.create(
         supabase,
         payload=TargetCreate(
             label=suggestion.label,
             description=suggestion.description,
-            scoring_profile=derived.scoring_profile,
-            search_keywords=derived.search_keywords,
         ),
     )
-    link = await _link_with_fit_score(
-        supabase, llm, user_id=user_id, target=target, payload=payload
+    target = crud.update(supabase, target.id, TargetUpdate(activation_status="deriving")) or target
+    link = crud.link_user_to_target(supabase, user_id=user_id, target_id=target.id, is_active=False)
+    background_tasks.add_task(
+        derive_manual_target_bg,
+        supabase,
+        llm,
+        user_id=user_id,
+        target_id=target.id,
+        label=suggestion.label,
+        payload=payload,
     )
-    return CreateOrLinkResult(
-        user_target=link, target=target, was_matched=False
-    )
+    return CreateOrLinkResult(user_target=link, target=target, was_matched=False)
 
 
 async def from_url(
     supabase: Client,
     llm: LLMClient,
+    background_tasks: BackgroundTasks,
     *,
     user_id: str,
     final_url: str,
@@ -164,77 +310,44 @@ async def from_url(
 ) -> CreateOrLinkResult:
     """URL flow: validated URL + already-fetched JD.
 
-    The router fetches and validates the URL; this service handles the
-    LLM-derived steps and persistence. When a match is found the JD is
-    appended as a reference and the composite profile is re-merged.
+    Matching keys off the resolved label (not the JD-derived profile), so
+    duplicate detection runs inline without any LLM call. The profile
+    derivation + merge + fit score are all deferred to a BackgroundTask.
     """
-    derived, derive_result = await derive_profile_from_jd(llm, jd_text=jd_text)
-    cost_log.record(
-        supabase,
-        user_id=user_id,
-        purpose=DERIVE_JD_PURPOSE,
-        result=derive_result,
-        metadata={"user_id": user_id, "jd_url": final_url},
-    )
-
     label = (
-        (label_override or "").strip()
-        or (extracted_title or "").strip()
-        or "Untitled Target"
+        (label_override or "").strip() or (extracted_title or "").strip() or "Untitled Target"
     )[:200]
 
     matched = find_matching_target(supabase, label)
-
     if matched is not None:
-        crud.add_reference_jd(
+        link = crud.link_user_to_target(
+            supabase, user_id=user_id, target_id=matched.id, is_active=False
+        )
+        background_tasks.add_task(
+            derive_url_target_bg,
             supabase,
+            llm,
+            user_id=user_id,
             target_id=matched.id,
             jd_text=jd_text,
-            jd_url=final_url,
-            extracted_profile=derived.scoring_profile,
+            final_url=final_url,
+            payload=payload,
+            is_new=False,
         )
-        all_jds = crud.list_reference_jds(supabase, matched.id)
-        composite = (
-            merge_profiles([jd.extracted_profile for jd in all_jds])
-            if all_jds
-            else ScoringProfile()
-        )
-        updated = crud.update(
-            supabase,
-            matched.id,
-            TargetUpdate(
-                scoring_profile=composite,
-                search_keywords=derived.search_keywords,
-                profile_version=matched.profile_version + 1,
-            ),
-        )
-        target = updated or matched
-        link = await _link_with_fit_score(
-            supabase, llm, user_id=user_id, target=target, payload=payload
-        )
-        return CreateOrLinkResult(
-            user_target=link, target=target, was_matched=True
-        )
+        return CreateOrLinkResult(user_target=link, target=matched, was_matched=True)
 
-    target = crud.create(
+    target = crud.create(supabase, payload=TargetCreate(label=label))
+    target = crud.update(supabase, target.id, TargetUpdate(activation_status="deriving")) or target
+    link = crud.link_user_to_target(supabase, user_id=user_id, target_id=target.id, is_active=False)
+    background_tasks.add_task(
+        derive_url_target_bg,
         supabase,
-        payload=TargetCreate(
-            label=label,
-            scoring_profile=derived.scoring_profile,
-            search_keywords=derived.search_keywords,
-        ),
-    )
-    crud.add_reference_jd(
-        supabase,
+        llm,
+        user_id=user_id,
         target_id=target.id,
         jd_text=jd_text,
-        jd_url=final_url,
-        extracted_profile=derived.scoring_profile,
+        final_url=final_url,
+        payload=payload,
+        is_new=True,
     )
-    refreshed = crud.get(supabase, target.id) or target
-    link = await _link_with_fit_score(
-        supabase, llm, user_id=user_id, target=refreshed, payload=payload
-    )
-    return CreateOrLinkResult(
-        user_target=link, target=refreshed, was_matched=False
-    )
+    return CreateOrLinkResult(user_target=link, target=target, was_matched=False)

--- a/apps/wyrdfold-api/tests/test_targets_from_input.py
+++ b/apps/wyrdfold-api/tests/test_targets_from_input.py
@@ -17,6 +17,7 @@ orchestration — the underlying pieces have their own dedicated tests.
 
 from __future__ import annotations
 
+import asyncio
 from datetime import UTC, datetime
 from typing import Any
 from unittest.mock import MagicMock
@@ -387,6 +388,40 @@ async def test_derive_manual_target_bg_marks_error_on_failure(
     assert stub_crud.by_name("link") == []
 
 
+@pytest.mark.asyncio
+async def test_derive_manual_target_bg_marks_error_on_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+    stub_llm_helpers: _Recorder,
+    stub_crud: _Recorder,
+) -> None:
+    """A derive that exceeds the timeout is cancelled and flips to 'error'."""
+    supabase = MagicMock()
+    # Shrink the ceiling so the test doesn't actually wait.
+    monkeypatch.setattr(from_input, "DERIVATION_TIMEOUT_S", 0.05)
+
+    async def hang(llm, *, label, payload):  # type: ignore[no-untyped-def]
+        await asyncio.sleep(1)
+        raise AssertionError("should have timed out")
+
+    monkeypatch.setattr(from_input, "derive_profile_from_label", hang)
+
+    await from_input.derive_manual_target_bg(
+        supabase,
+        MagicMock(),
+        user_id="user-1",
+        target_id="new",
+        label="Senior Frontend Engineer",
+        payload=OptimizedPayload(),
+    )
+
+    update_bodies = [c["body"] for c in stub_crud.by_name("update")]
+    assert any(b.activation_status == "error" for b in update_bodies)
+    # Timed out before any profile update / fit score landed.
+    assert all(b.activation_status != "idle" for b in update_bodies)
+    assert "fit_score" not in stub_llm_helpers.names()
+    assert stub_crud.by_name("link") == []
+
+
 # ---- from_url: inline path --------------------------------------------------
 
 
@@ -624,4 +659,37 @@ async def test_derive_url_target_bg_marks_error_on_failure(
 
     update_bodies = [c["body"] for c in stub_crud.by_name("update")]
     assert any(b.activation_status == "error" for b in update_bodies)
+    assert stub_crud.by_name("link") == []
+
+
+@pytest.mark.asyncio
+async def test_derive_url_target_bg_marks_error_on_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+    stub_llm_helpers: _Recorder,
+    stub_crud: _Recorder,
+) -> None:
+    """A JD derive that exceeds the timeout flips the target to 'error'."""
+    supabase = MagicMock()
+    monkeypatch.setattr(from_input, "DERIVATION_TIMEOUT_S", 0.05)
+
+    async def hang(llm, *, jd_text):  # type: ignore[no-untyped-def]
+        await asyncio.sleep(1)
+        raise AssertionError("should have timed out")
+
+    monkeypatch.setattr(from_input, "derive_profile_from_jd", hang)
+
+    await from_input.derive_url_target_bg(
+        supabase,
+        MagicMock(),
+        user_id="user-1",
+        target_id="new",
+        jd_text="x" * 200,
+        final_url="https://example.com/jobs/abc",
+        payload=OptimizedPayload(),
+        is_new=True,
+    )
+
+    update_bodies = [c["body"] for c in stub_crud.by_name("update")]
+    assert any(b.activation_status == "error" for b in update_bodies)
+    assert all(b.activation_status != "idle" for b in update_bodies)
     assert stub_crud.by_name("link") == []

--- a/apps/wyrdfold-api/tests/test_targets_from_input.py
+++ b/apps/wyrdfold-api/tests/test_targets_from_input.py
@@ -1,9 +1,18 @@
-"""Orchestration tests for ``from_input.from_manual`` / ``from_input.from_url``.
+"""Orchestration tests for ``from_input`` (create-or-link + deferred derive).
 
-These tests exercise the create-or-link routing layer: which helpers get
-called, in what order, and what shape the orchestration returns. The LLM
-and crud helpers are monkeypatched so the focus stays on orchestration —
-the underlying pieces have their own dedicated tests.
+The inline path (``from_manual`` / ``from_url``) only runs the normalize
+LLM call (manual) or no LLM call (URL) before linking the user and
+returning. The expensive ``derive_profile_*`` + ``derive_fit_score`` work
+is scheduled onto a ``BackgroundTask`` — these tests assert both halves:
+
+* the inline path links + schedules the right background function without
+  touching derive/fit, and
+* the background functions (``derive_manual_target_bg`` /
+  ``derive_url_target_bg``) derive the profile, flip the activation status,
+  and upsert the fit score — marking the target ``error`` on failure.
+
+The LLM and crud helpers are monkeypatched so the focus stays on
+orchestration — the underlying pieces have their own dedicated tests.
 """
 
 from __future__ import annotations
@@ -13,6 +22,7 @@ from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
+from fastapi import BackgroundTasks
 
 from app.models.experience import OptimizedPayload
 from app.models.llm import LLMResult, LLMUsage
@@ -49,6 +59,7 @@ def _target(
     label: str = "Senior Frontend Engineer",
     profile_version: int = 1,
     description: str | None = None,
+    activation_status: str = "idle",
 ) -> JobTarget:
     now = datetime.now(UTC)
     return JobTarget(
@@ -58,7 +69,7 @@ def _target(
         normalized_label=label.lower().strip(),
         scoring_profile=ScoringProfile(),
         search_keywords=["frontend"],
-        activation_status="idle",
+        activation_status=activation_status,
         profile_version=profile_version,
         is_active=False,
         created_at=now,
@@ -70,7 +81,7 @@ def _user_target(
     *,
     user_id: str = "user-1",
     target_id: str = "t-1",
-    fit_score: int = 80,
+    fit_score: int | None = None,
 ) -> UserTarget:
     now = datetime.now(UTC)
     return UserTarget(
@@ -79,7 +90,7 @@ def _user_target(
         target_id=target_id,
         is_active=False,
         fit_score=fit_score,
-        fit_score_reasoning="Strong fit.",
+        fit_score_reasoning="Strong fit." if fit_score is not None else None,
         created_at=now,
         updated_at=now,
     )
@@ -118,17 +129,11 @@ def recorder() -> _Recorder:
 
 
 @pytest.fixture
-def stub_llm_helpers(
-    monkeypatch: pytest.MonkeyPatch, recorder: _Recorder
-) -> _Recorder:
+def stub_llm_helpers(monkeypatch: pytest.MonkeyPatch, recorder: _Recorder) -> _Recorder:
     """Stub all LLM-driven helpers and cost_log so the orchestration runs offline."""
 
     async def fake_normalize(llm, *, label, description, payload):  # type: ignore[no-untyped-def]
-        recorder.record(
-            "normalize",
-            label=label,
-            description=description,
-        )
+        recorder.record("normalize", label=label, description=description)
         return (
             TargetSuggestion(
                 label="Senior Frontend Engineer",
@@ -174,48 +179,61 @@ def stub_llm_helpers(
 
 
 @pytest.fixture
-def stub_crud(
-    monkeypatch: pytest.MonkeyPatch, recorder: _Recorder
-) -> _Recorder:
-    """Stub crud helpers; specific tests override defaults via monkeypatch."""
+def stub_crud(monkeypatch: pytest.MonkeyPatch, recorder: _Recorder) -> _Recorder:
+    """Stub crud link/update; specific tests override create/get as needed."""
 
     def fake_link(supabase, **kwargs):  # type: ignore[no-untyped-def]
         recorder.record("link", **kwargs)
         return _user_target(
-            user_id=kwargs["user_id"], target_id=kwargs["target_id"]
+            user_id=kwargs["user_id"],
+            target_id=kwargs["target_id"],
+            fit_score=kwargs.get("fit_score"),
+        )
+
+    def fake_update(supabase, target_id, body):  # type: ignore[no-untyped-def]
+        recorder.record("update", target_id=target_id, body=body)
+        return _target(
+            id=target_id,
+            activation_status=body.activation_status or "idle",
+            profile_version=body.profile_version or 1,
         )
 
     monkeypatch.setattr(crud, "link_user_to_target", fake_link)
+    monkeypatch.setattr(crud, "update", fake_update)
     return recorder
 
 
-# ---- from_manual: matched path ----------------------------------------------
+def _scheduled(bg: BackgroundTasks) -> list[tuple[Any, dict[str, Any]]]:
+    """(func, kwargs) for each task queued on a BackgroundTasks instance."""
+    return [(t.func, t.kwargs) for t in bg.tasks]
+
+
+# ---- from_manual: inline path -----------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_from_manual_matched_links_without_creating(
+async def test_from_manual_matched_links_inline_defers_fit_score(
     monkeypatch: pytest.MonkeyPatch,
     stub_llm_helpers: _Recorder,
     stub_crud: _Recorder,
 ) -> None:
-    """When normalize finds an existing target, no derive/create runs."""
+    """Matched → link inline (no fit yet), schedule the fit-score task only."""
     supabase = MagicMock()
     matched = _target(id="existing")
-    monkeypatch.setattr(
-        from_input, "find_matching_target", lambda _s, _l: matched
-    )
+    monkeypatch.setattr(from_input, "find_matching_target", lambda _s, _l: matched)
 
     create_calls: list[TargetCreate] = []
+    monkeypatch.setattr(
+        crud,
+        "create",
+        lambda _s, *, payload: create_calls.append(payload) or matched,  # type: ignore[func-returns-value]
+    )
 
-    def fake_create(_s, *, payload):  # type: ignore[no-untyped-def]
-        create_calls.append(payload)
-        return matched
-
-    monkeypatch.setattr(crud, "create", fake_create)
-
+    bg = BackgroundTasks()
     result = await from_input.from_manual(
         supabase,
         MagicMock(),
+        bg,
         user_id="user-1",
         label="sr fe eng",
         description=None,
@@ -224,41 +242,48 @@ async def test_from_manual_matched_links_without_creating(
 
     assert result.was_matched is True
     assert result.target.id == "existing"
+    # Inline: normalize only — no derive/fit/create.
     assert "normalize" in stub_llm_helpers.names()
     assert "derive_from_label" not in stub_llm_helpers.names()
+    assert "fit_score" not in stub_llm_helpers.names()
     assert create_calls == []
-    # Always links inactive
+    # Linked inactive with no fit score yet.
     link_kwargs = stub_crud.by_name("link")[0]
     assert link_kwargs["is_active"] is False
     assert link_kwargs["target_id"] == "existing"
-    assert link_kwargs["fit_score"] == 82
-
-
-# ---- from_manual: new path --------------------------------------------------
+    assert link_kwargs.get("fit_score") is None
+    # Deferred: fit-score task only.
+    scheduled = _scheduled(bg)
+    assert len(scheduled) == 1
+    func, kwargs = scheduled[0]
+    assert func is from_input._apply_fit_score
+    assert kwargs["target"].id == "existing"
+    assert kwargs["user_id"] == "user-1"
 
 
 @pytest.mark.asyncio
-async def test_from_manual_new_creates_then_links(
+async def test_from_manual_new_creates_deriving_and_schedules_derivation(
     monkeypatch: pytest.MonkeyPatch,
     stub_llm_helpers: _Recorder,
     stub_crud: _Recorder,
 ) -> None:
-    """No match → derive profile from label → create → link."""
+    """New → create in 'deriving', link inline, schedule full derivation."""
     supabase = MagicMock()
     monkeypatch.setattr(from_input, "find_matching_target", lambda _s, _l: None)
 
     created = _target(id="new", label="Senior Frontend Engineer")
     create_calls: list[TargetCreate] = []
+    monkeypatch.setattr(
+        crud,
+        "create",
+        lambda _s, *, payload: create_calls.append(payload) or created,  # type: ignore[func-returns-value]
+    )
 
-    def fake_create(_s, *, payload):  # type: ignore[no-untyped-def]
-        create_calls.append(payload)
-        return created
-
-    monkeypatch.setattr(crud, "create", fake_create)
-
+    bg = BackgroundTasks()
     result = await from_input.from_manual(
         supabase,
         MagicMock(),
+        bg,
         user_id="user-1",
         label="sr fe eng",
         description="frontend roles at growth-stage companies",
@@ -267,98 +292,120 @@ async def test_from_manual_new_creates_then_links(
 
     assert result.was_matched is False
     assert result.target.id == "new"
-    assert "derive_from_label" in stub_llm_helpers.names()
+    # Returned target carries the deriving status for the FE pending UI.
+    assert result.target.activation_status == "deriving"
+    # Inline: normalize only, no derive/fit.
+    assert stub_llm_helpers.names().count("normalize") == 1
+    assert "derive_from_label" not in stub_llm_helpers.names()
+    assert "fit_score" not in stub_llm_helpers.names()
+    # Created from the canonical suggestion (label + description), empty profile.
     assert len(create_calls) == 1
     assert create_calls[0].label == "Senior Frontend Engineer"
-    # Description from canonicalized suggestion, not raw user input
     assert create_calls[0].description == "Canonical description."
-    assert create_calls[0].search_keywords == ["frontend engineer"]
+    assert create_calls[0].search_keywords == []
+    # Status flipped to 'deriving' inline.
+    update_call = stub_crud.by_name("update")[0]
+    assert update_call["body"].activation_status == "deriving"
+    # Linked inactive, no fit score yet.
     link_kwargs = stub_crud.by_name("link")[0]
     assert link_kwargs["target_id"] == "new"
     assert link_kwargs["is_active"] is False
+    assert link_kwargs.get("fit_score") is None
+    # Deferred: the manual derivation task.
+    scheduled = _scheduled(bg)
+    assert len(scheduled) == 1
+    func, kwargs = scheduled[0]
+    assert func is from_input.derive_manual_target_bg
+    assert kwargs["target_id"] == "new"
+    assert kwargs["label"] == "Senior Frontend Engineer"
 
 
-# ---- from_manual: cost logging ----------------------------------------------
+# ---- derive_manual_target_bg: background path -------------------------------
 
 
 @pytest.mark.asyncio
-async def test_from_manual_logs_each_llm_call(
+async def test_derive_manual_target_bg_derives_profile_and_fit(
     monkeypatch: pytest.MonkeyPatch,
     stub_llm_helpers: _Recorder,
     stub_crud: _Recorder,
 ) -> None:
+    """Background: derive profile → status idle → fit score upserted."""
     supabase = MagicMock()
-    monkeypatch.setattr(from_input, "find_matching_target", lambda _s, _l: None)
-    monkeypatch.setattr(
-        crud, "create", lambda _s, *, payload: _target(id="new")
-    )
 
-    await from_input.from_manual(
+    await from_input.derive_manual_target_bg(
         supabase,
         MagicMock(),
         user_id="user-1",
-        label="sr fe eng",
-        description=None,
+        target_id="new",
+        label="Senior Frontend Engineer",
         payload=OptimizedPayload(),
     )
 
+    names = stub_llm_helpers.names()
+    assert "derive_from_label" in names
+    assert "fit_score" in names
+    # Profile update sets keywords and flips status to idle.
+    update_body: TargetUpdate = stub_crud.by_name("update")[0]["body"]
+    assert update_body.search_keywords == ["frontend engineer"]
+    assert update_body.activation_status == "idle"
+    # Fit score upserted onto the link.
+    link_kwargs = stub_crud.by_name("link")[0]
+    assert link_kwargs["fit_score"] == 82
+    assert link_kwargs["is_active"] is False
+    # Cost logged for both deferred calls.
     purposes = [c["purpose"] for c in stub_llm_helpers.by_name("cost_log")]
-    assert "target.normalize_manual" in purposes
     assert "target.derive_from_label" in purposes
     assert "target.fit_score" in purposes
 
 
-# ---- from_url: matched path (corpus building) -------------------------------
-
-
 @pytest.mark.asyncio
-async def test_from_url_matched_appends_reference_and_bumps_version(
+async def test_derive_manual_target_bg_marks_error_on_failure(
     monkeypatch: pytest.MonkeyPatch,
     stub_llm_helpers: _Recorder,
     stub_crud: _Recorder,
 ) -> None:
-    """Match → add reference JD → re-merge → bump profile_version → link."""
+    """A failing derive flips the target to 'error' and never links a fit."""
+    supabase = MagicMock()
+
+    async def boom(llm, *, label, payload):  # type: ignore[no-untyped-def]
+        raise RuntimeError("LLM down")
+
+    monkeypatch.setattr(from_input, "derive_profile_from_label", boom)
+
+    await from_input.derive_manual_target_bg(
+        supabase,
+        MagicMock(),
+        user_id="user-1",
+        target_id="new",
+        label="Senior Frontend Engineer",
+        payload=OptimizedPayload(),
+    )
+
+    update_bodies = [c["body"] for c in stub_crud.by_name("update")]
+    assert any(b.activation_status == "error" for b in update_bodies)
+    assert "fit_score" not in stub_llm_helpers.names()
+    assert stub_crud.by_name("link") == []
+
+
+# ---- from_url: inline path --------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_from_url_matched_links_inline_defers_derivation(
+    monkeypatch: pytest.MonkeyPatch,
+    stub_llm_helpers: _Recorder,
+    stub_crud: _Recorder,
+) -> None:
+    """Matched URL → link inline, schedule corpus-building derivation (is_new=False)."""
     supabase = MagicMock()
     matched = _target(id="existing", profile_version=4)
-    monkeypatch.setattr(
-        from_input, "find_matching_target", lambda _s, _l: matched
-    )
+    monkeypatch.setattr(from_input, "find_matching_target", lambda _s, _l: matched)
 
-    add_ref_calls: list[dict[str, Any]] = []
-
-    def fake_add_ref(_s, *, target_id, jd_text, jd_url, extracted_profile):  # type: ignore[no-untyped-def]
-        add_ref_calls.append(
-            {
-                "target_id": target_id,
-                "jd_url": jd_url,
-                "jd_text_len": len(jd_text),
-            }
-        )
-        return _ref_jd(target_id=target_id, jd_url=jd_url)
-
-    monkeypatch.setattr(crud, "add_reference_jd", fake_add_ref)
-    monkeypatch.setattr(
-        crud,
-        "list_reference_jds",
-        lambda _s, _t: [_ref_jd(target_id="existing"), _ref_jd(target_id="existing")],
-    )
-
-    update_calls: list[TargetUpdate] = []
-
-    def fake_update(_s, _id, body):  # type: ignore[no-untyped-def]
-        update_calls.append(body)
-        return _target(id="existing", profile_version=5)
-
-    monkeypatch.setattr(crud, "update", fake_update)
-    monkeypatch.setattr(
-        from_input,
-        "merge_profiles",
-        lambda _profiles: ScoringProfile(),
-    )
-
+    bg = BackgroundTasks()
     result = await from_input.from_url(
         supabase,
         MagicMock(),
+        bg,
         user_id="user-1",
         final_url="https://example.com/jobs/123",
         extracted_title="Senior Frontend Engineer",
@@ -368,54 +415,45 @@ async def test_from_url_matched_appends_reference_and_bumps_version(
     )
 
     assert result.was_matched is True
-    assert result.target.profile_version == 5
-    assert add_ref_calls == [
-        {
-            "target_id": "existing",
-            "jd_url": "https://example.com/jobs/123",
-            "jd_text_len": 200,
-        }
-    ]
-    assert len(update_calls) == 1
-    assert update_calls[0].profile_version == 5  # bumped from 4
+    assert result.target.id == "existing"
+    # No LLM call inline for the URL flow — neither derive nor fit.
+    assert "derive_from_jd" not in stub_llm_helpers.names()
+    assert "fit_score" not in stub_llm_helpers.names()
     link_kwargs = stub_crud.by_name("link")[0]
     assert link_kwargs["target_id"] == "existing"
     assert link_kwargs["is_active"] is False
-
-
-# ---- from_url: new path -----------------------------------------------------
+    scheduled = _scheduled(bg)
+    assert len(scheduled) == 1
+    func, kwargs = scheduled[0]
+    assert func is from_input.derive_url_target_bg
+    assert kwargs["is_new"] is False
+    assert kwargs["target_id"] == "existing"
+    assert kwargs["jd_text"] == "x" * 200
 
 
 @pytest.mark.asyncio
-async def test_from_url_new_creates_with_reference_jd(
+async def test_from_url_new_creates_deriving_and_schedules(
     monkeypatch: pytest.MonkeyPatch,
     stub_llm_helpers: _Recorder,
     stub_crud: _Recorder,
 ) -> None:
+    """New URL → create in 'deriving', link, schedule derivation (is_new=True)."""
     supabase = MagicMock()
     monkeypatch.setattr(from_input, "find_matching_target", lambda _s, _l: None)
 
     created = _target(id="new", label="Senior Frontend Engineer")
     create_calls: list[TargetCreate] = []
+    monkeypatch.setattr(
+        crud,
+        "create",
+        lambda _s, *, payload: create_calls.append(payload) or created,  # type: ignore[func-returns-value]
+    )
 
-    def fake_create(_s, *, payload):  # type: ignore[no-untyped-def]
-        create_calls.append(payload)
-        return created
-
-    monkeypatch.setattr(crud, "create", fake_create)
-
-    add_ref_calls: list[dict[str, Any]] = []
-
-    def fake_add_ref(_s, *, target_id, jd_text, jd_url, extracted_profile):  # type: ignore[no-untyped-def]
-        add_ref_calls.append({"target_id": target_id, "jd_url": jd_url})
-        return _ref_jd(target_id=target_id, jd_url=jd_url)
-
-    monkeypatch.setattr(crud, "add_reference_jd", fake_add_ref)
-    monkeypatch.setattr(crud, "get", lambda _s, _id: created)
-
+    bg = BackgroundTasks()
     result = await from_input.from_url(
         supabase,
         MagicMock(),
+        bg,
         user_id="user-1",
         final_url="https://example.com/jobs/abc",
         extracted_title="Senior Frontend Engineer",
@@ -426,125 +464,164 @@ async def test_from_url_new_creates_with_reference_jd(
 
     assert result.was_matched is False
     assert result.target.id == "new"
+    assert result.target.activation_status == "deriving"
+    assert "derive_from_jd" not in stub_llm_helpers.names()
     assert len(create_calls) == 1
     assert create_calls[0].label == "Senior Frontend Engineer"
-    assert add_ref_calls == [
-        {"target_id": "new", "jd_url": "https://example.com/jobs/abc"}
-    ]
-    link_kwargs = stub_crud.by_name("link")[0]
-    assert link_kwargs["target_id"] == "new"
-
-
-# ---- from_url: label resolution ----------------------------------------------
+    scheduled = _scheduled(bg)
+    assert len(scheduled) == 1
+    func, kwargs = scheduled[0]
+    assert func is from_input.derive_url_target_bg
+    assert kwargs["is_new"] is True
+    assert kwargs["target_id"] == "new"
 
 
 @pytest.mark.asyncio
-async def test_from_url_prefers_label_override_over_extracted(
+@pytest.mark.parametrize(
+    ("label_override", "extracted_title", "expected"),
+    [
+        ("My Custom Label", "Different Extracted Title", "My Custom Label"),
+        (None, "Extracted Title", "Extracted Title"),
+        (None, None, "Untitled Target"),
+    ],
+)
+async def test_from_url_label_resolution(
     monkeypatch: pytest.MonkeyPatch,
     stub_llm_helpers: _Recorder,
     stub_crud: _Recorder,
+    label_override: str | None,
+    extracted_title: str | None,
+    expected: str,
 ) -> None:
+    """Label precedence: override > extracted title > 'Untitled Target'."""
     supabase = MagicMock()
     seen_labels: list[str] = []
-
-    def fake_match(_s, label):  # type: ignore[no-untyped-def]
-        seen_labels.append(label)
-        return None
-
-    monkeypatch.setattr(from_input, "find_matching_target", fake_match)
-
-    created = _target(id="new", label="My Custom Label")
     monkeypatch.setattr(
-        crud, "create", lambda _s, *, payload: created
+        from_input,
+        "find_matching_target",
+        lambda _s, label: seen_labels.append(label) or None,  # type: ignore[func-returns-value]
     )
-    monkeypatch.setattr(
-        crud, "add_reference_jd", lambda _s, **kw: _ref_jd()
-    )
-    monkeypatch.setattr(crud, "get", lambda _s, _id: created)
+    monkeypatch.setattr(crud, "create", lambda _s, *, payload: _target(id="new", label=expected))
 
+    bg = BackgroundTasks()
     await from_input.from_url(
         supabase,
         MagicMock(),
+        bg,
         user_id="user-1",
         final_url="https://example.com/jobs/x",
-        extracted_title="Different Extracted Title",
+        extracted_title=extracted_title,
         jd_text="x" * 200,
-        label_override="My Custom Label",
+        label_override=label_override,
         payload=OptimizedPayload(),
     )
 
-    assert seen_labels == ["My Custom Label"]
+    assert seen_labels == [expected]
+
+
+# ---- derive_url_target_bg: background path -----------------------------------
 
 
 @pytest.mark.asyncio
-async def test_from_url_falls_back_to_extracted_title(
+async def test_derive_url_target_bg_new_does_not_bump_version(
+    monkeypatch: pytest.MonkeyPatch,
+    stub_llm_helpers: _Recorder,
+    stub_crud: _Recorder,
+) -> None:
+    """New URL target: derive JD → add ref → merge → status idle, version untouched."""
+    supabase = MagicMock()
+
+    add_ref_calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(
+        crud,
+        "add_reference_jd",
+        lambda _s, **kw: (
+            add_ref_calls.append(kw)
+            or _ref_jd(**{"target_id": kw["target_id"], "jd_url": kw["jd_url"]})
+        ),  # type: ignore[func-returns-value]
+    )
+    monkeypatch.setattr(crud, "list_reference_jds", lambda _s, _t: [_ref_jd(target_id="new")])
+    monkeypatch.setattr(crud, "get", lambda _s, _id: _target(id="new"))
+    monkeypatch.setattr(from_input, "merge_profiles", lambda _p: ScoringProfile())
+
+    await from_input.derive_url_target_bg(
+        supabase,
+        MagicMock(),
+        user_id="user-1",
+        target_id="new",
+        jd_text="x" * 200,
+        final_url="https://example.com/jobs/abc",
+        payload=OptimizedPayload(),
+        is_new=True,
+    )
+
+    assert "derive_from_jd" in stub_llm_helpers.names()
+    assert add_ref_calls and add_ref_calls[0]["target_id"] == "new"
+    update_body: TargetUpdate = stub_crud.by_name("update")[0]["body"]
+    assert update_body.activation_status == "idle"
+    assert update_body.profile_version is None  # new → no bump
+    # Fit score follows.
+    assert stub_crud.by_name("link")[0]["fit_score"] == 82
+
+
+@pytest.mark.asyncio
+async def test_derive_url_target_bg_matched_bumps_version(
+    monkeypatch: pytest.MonkeyPatch,
+    stub_llm_helpers: _Recorder,
+    stub_crud: _Recorder,
+) -> None:
+    """Matched URL target: profile_version bumps from the current value."""
+    supabase = MagicMock()
+
+    monkeypatch.setattr(crud, "add_reference_jd", lambda _s, **kw: _ref_jd())
+    monkeypatch.setattr(
+        crud,
+        "list_reference_jds",
+        lambda _s, _t: [_ref_jd(target_id="existing"), _ref_jd(target_id="existing")],
+    )
+    monkeypatch.setattr(crud, "get", lambda _s, _id: _target(id="existing", profile_version=4))
+    monkeypatch.setattr(from_input, "merge_profiles", lambda _p: ScoringProfile())
+
+    await from_input.derive_url_target_bg(
+        supabase,
+        MagicMock(),
+        user_id="user-1",
+        target_id="existing",
+        jd_text="x" * 200,
+        final_url="https://example.com/jobs/123",
+        payload=OptimizedPayload(),
+        is_new=False,
+    )
+
+    update_body: TargetUpdate = stub_crud.by_name("update")[0]["body"]
+    assert update_body.profile_version == 5  # bumped from 4
+    assert update_body.activation_status == "idle"
+
+
+@pytest.mark.asyncio
+async def test_derive_url_target_bg_marks_error_on_failure(
     monkeypatch: pytest.MonkeyPatch,
     stub_llm_helpers: _Recorder,
     stub_crud: _Recorder,
 ) -> None:
     supabase = MagicMock()
-    seen_labels: list[str] = []
-    monkeypatch.setattr(
-        from_input,
-        "find_matching_target",
-        lambda _s, label: seen_labels.append(label) or None,  # type: ignore[func-returns-value]
-    )
 
-    created = _target(id="new", label="Extracted Title")
-    monkeypatch.setattr(
-        crud, "create", lambda _s, *, payload: created
-    )
-    monkeypatch.setattr(
-        crud, "add_reference_jd", lambda _s, **kw: _ref_jd()
-    )
-    monkeypatch.setattr(crud, "get", lambda _s, _id: created)
+    async def boom(llm, *, jd_text):  # type: ignore[no-untyped-def]
+        raise RuntimeError("LLM down")
 
-    await from_input.from_url(
+    monkeypatch.setattr(from_input, "derive_profile_from_jd", boom)
+
+    await from_input.derive_url_target_bg(
         supabase,
         MagicMock(),
         user_id="user-1",
-        final_url="https://example.com/jobs/y",
-        extracted_title="Extracted Title",
+        target_id="new",
         jd_text="x" * 200,
-        label_override=None,
+        final_url="https://example.com/jobs/abc",
         payload=OptimizedPayload(),
+        is_new=True,
     )
 
-    assert seen_labels == ["Extracted Title"]
-
-
-@pytest.mark.asyncio
-async def test_from_url_uses_untitled_target_when_no_label_available(
-    monkeypatch: pytest.MonkeyPatch,
-    stub_llm_helpers: _Recorder,
-    stub_crud: _Recorder,
-) -> None:
-    supabase = MagicMock()
-    seen_labels: list[str] = []
-    monkeypatch.setattr(
-        from_input,
-        "find_matching_target",
-        lambda _s, label: seen_labels.append(label) or None,  # type: ignore[func-returns-value]
-    )
-
-    created = _target(id="new", label="Untitled Target")
-    monkeypatch.setattr(
-        crud, "create", lambda _s, *, payload: created
-    )
-    monkeypatch.setattr(
-        crud, "add_reference_jd", lambda _s, **kw: _ref_jd()
-    )
-    monkeypatch.setattr(crud, "get", lambda _s, _id: created)
-
-    await from_input.from_url(
-        supabase,
-        MagicMock(),
-        user_id="user-1",
-        final_url="https://example.com/jobs/z",
-        extracted_title=None,
-        jd_text="x" * 200,
-        label_override=None,
-        payload=OptimizedPayload(),
-    )
-
-    assert seen_labels == ["Untitled Target"]
+    update_bodies = [c["body"] for c in stub_crud.by_name("update")]
+    assert any(b.activation_status == "error" for b in update_bodies)
+    assert stub_crud.by_name("link") == []

--- a/apps/wyrdfold/src/app/(app)/targets/TargetCard.tsx
+++ b/apps/wyrdfold/src/app/(app)/targets/TargetCard.tsx
@@ -6,6 +6,7 @@ import { Badge } from '@danieljoffe.com/shared-ui/Badge';
 import { Card, CardContent } from '@danieljoffe.com/shared-ui/Card';
 import { Dropdown } from '@danieljoffe.com/shared-ui/Dropdown';
 import type { DropdownItem } from '@danieljoffe.com/shared-ui/Dropdown';
+import { Spinner } from '@danieljoffe.com/shared-ui/Spinner';
 import { cn } from '@/lib/cn';
 import type { JobTarget } from './types';
 
@@ -63,6 +64,12 @@ export default function TargetCard({
   const detailHref = `/targets/${target.id}`;
   const categoryCount = Object.keys(target.scoring_profile.categories).length;
   const keywordCount = countKeywords(target);
+  // The scoring profile + fit score are derived in a backend BackgroundTask
+  // after creation, so a freshly-added target shows up here before its
+  // profile exists. ``deriving`` drives the pending UI; ``failed`` surfaces
+  // a derivation error so the card isn't stuck spinning forever.
+  const deriving = target.activation_status === 'deriving';
+  const failed = target.activation_status === 'error';
 
   function handleNavigate() {
     router.push(detailHref);
@@ -73,13 +80,17 @@ export default function TargetCard({
       label: 'View jobs',
       icon: <Briefcase className='size-4' aria-hidden />,
       onClick: () => onViewJobs(target.id),
-      disabled: !isActive,
+      // No jobs to view until the target is active *and* its profile exists.
+      disabled: !isActive || deriving,
     },
     {
       label: isActive ? 'Deactivate' : 'Activate',
       icon: <Power className='size-4' aria-hidden />,
       onClick: () =>
         isActive ? onDeactivate(target.id) : onActivate(target.id),
+      // Activating runs the poll pipeline against the scoring profile — wait
+      // for derivation to finish before it can be activated.
+      disabled: deriving && !isActive,
     },
     { label: '', divider: true },
     {
@@ -142,9 +153,13 @@ export default function TargetCard({
 
         <dl className='grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-xs'>
           <dt className='text-text-tertiary'>Categories</dt>
-          <dd className='text-right text-text-secondary'>{categoryCount}</dd>
+          <dd className='text-right text-text-secondary'>
+            {deriving ? '—' : categoryCount}
+          </dd>
           <dt className='text-text-tertiary'>Keywords</dt>
-          <dd className='text-right text-text-secondary'>{keywordCount}</dd>
+          <dd className='text-right text-text-secondary'>
+            {deriving ? '—' : keywordCount}
+          </dd>
           <dt className='text-text-tertiary'>Updated</dt>
           <dd className='text-right text-text-secondary'>
             {new Date(target.updated_at).toLocaleDateString()}
@@ -153,17 +168,32 @@ export default function TargetCard({
 
         <hr className='-mx-4 border-border' />
 
-        <div className='flex justify-end'>
-          <span className='inline-flex items-center gap-1.5 text-xs text-text-secondary'>
-            <span
-              className={cn(
-                'inline-block size-2 rounded-full',
-                isActive ? 'bg-success' : 'bg-text-tertiary'
-              )}
-              aria-hidden
-            />
-            {isActive ? 'Active' : 'Inactive'}
-          </span>
+        <div className='flex justify-end' aria-live='polite'>
+          {deriving ? (
+            <span className='inline-flex items-center gap-1.5 text-xs text-text-secondary'>
+              <Spinner size='sm' aria-label='Building scoring profile' />
+              Building…
+            </span>
+          ) : failed ? (
+            <span className='inline-flex items-center gap-1.5 text-xs text-error'>
+              <span
+                className='inline-block size-2 rounded-full bg-error'
+                aria-hidden
+              />
+              Derivation failed
+            </span>
+          ) : (
+            <span className='inline-flex items-center gap-1.5 text-xs text-text-secondary'>
+              <span
+                className={cn(
+                  'inline-block size-2 rounded-full',
+                  isActive ? 'bg-success' : 'bg-text-tertiary'
+                )}
+                aria-hidden
+              />
+              {isActive ? 'Active' : 'Inactive'}
+            </span>
+          )}
         </div>
       </CardContent>
     </Card>

--- a/apps/wyrdfold/src/app/(app)/targets/TargetsList.tsx
+++ b/apps/wyrdfold/src/app/(app)/targets/TargetsList.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { Plus, Sparkles } from 'lucide-react';
 import { Badge } from '@danieljoffe.com/shared-ui/Badge';
@@ -32,6 +32,25 @@ interface PendingTarget {
 
 interface TargetsListProps {
   initialTargets: UserTargetWithTarget[];
+}
+
+/** Poll cadence + cap for the deriving-target refresh loop. */
+const DERIVE_POLL_INTERVAL_MS = 2500;
+const DERIVE_POLL_MAX_ATTEMPTS = 40; // ~100s ceiling; derivation is 5-9s
+
+/**
+ * A just-created target's scoring profile and fit score are derived in a
+ * backend BackgroundTask, so the optimistic response lands before they
+ * exist. "Still deriving" = the profile is being built (`deriving` status)
+ * or the per-user fit score hasn't been written yet. `error` is terminal —
+ * the card surfaces the failure rather than polling forever.
+ */
+function isDeriving(entry: UserTargetWithTarget): boolean {
+  if (entry.target.activation_status === 'error') return false;
+  return (
+    entry.target.activation_status === 'deriving' ||
+    entry.user_target.fit_score === null
+  );
 }
 
 export default function TargetsList({ initialTargets }: TargetsListProps) {
@@ -128,6 +147,80 @@ export default function TargetsList({ initialTargets }: TargetsListProps) {
 
   const [pendingTargets, setPendingTargets] = useState<PendingTarget[]>([]);
 
+  // Target ids whose profile/fit score is still being derived in the
+  // background. Seeded from create/link responses below, and from any
+  // target the server reports as `deriving` (so a reload mid-derivation
+  // resumes polling). The effect below polls each until it settles.
+  const [derivingIds, setDerivingIds] = useState<Set<string>>(() => new Set());
+
+  const pollKey = useMemo(() => {
+    const ids = new Set(derivingIds);
+    for (const t of targets) {
+      if (t.target.activation_status === 'deriving') ids.add(t.target.id);
+    }
+    return [...ids].sort().join(',');
+  }, [derivingIds, targets]);
+
+  useEffect(() => {
+    if (!pollKey) return;
+    const ids = pollKey.split(',');
+    let cancelled = false;
+    let attempts = 0;
+    let timer: ReturnType<typeof setTimeout>;
+
+    const settle = (id: string) =>
+      setDerivingIds(prev => {
+        if (!prev.has(id)) return prev;
+        const next = new Set(prev);
+        next.delete(id);
+        return next;
+      });
+
+    const tick = async () => {
+      attempts += 1;
+      const results = await Promise.all(
+        ids.map(async id => {
+          try {
+            const res = await fetch(`/api/targets/${id}/user-target`);
+            if (!res.ok) return null;
+            return (await res.json()) as UserTargetWithTarget;
+          } catch {
+            // Transient network error — try again on the next tick.
+            return null;
+          }
+        })
+      );
+      if (cancelled) return;
+
+      const byId = new Map(
+        results
+          .filter((e): e is UserTargetWithTarget => e !== null)
+          .map(e => [e.target.id, e])
+      );
+      // Reflect the latest server state on each card (profile counts,
+      // fit-score badge, status indicator).
+      setTargets(prev => prev.map(t => byId.get(t.target.id) ?? t));
+      for (const [id, entry] of byId) {
+        if (!isDeriving(entry)) settle(id);
+      }
+
+      if (attempts >= DERIVE_POLL_MAX_ATTEMPTS) {
+        ids.forEach(settle);
+        // Backstop: pull authoritative state in case a poll was missed.
+        router.refresh();
+        return;
+      }
+      // Schedule the next poll only after this one resolves (no overlap).
+      timer = setTimeout(() => void tick(), DERIVE_POLL_INTERVAL_MS);
+    };
+
+    timer = setTimeout(() => void tick(), DERIVE_POLL_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [pollKey, router]);
+
   const runCreate = useCallback(
     async (
       endpoint: '/api/targets/from-manual' | '/api/targets/from-url',
@@ -166,10 +259,18 @@ export default function TargetsList({ initialTargets }: TargetsListProps) {
         // Use the response directly so the new card shows even if /mine
         // is slow or fails. Replace any existing entry with the same
         // target id (covers the was_matched=true relink path).
+        const entry = {
+          user_target: result.user_target,
+          target: result.target,
+        };
         setTargets(prev => [
-          { user_target: result.user_target, target: result.target },
+          entry,
           ...prev.filter(t => t.target.id !== result.target.id),
         ]);
+        // Profile + fit score derive in the background — poll until ready.
+        if (isDeriving(entry)) {
+          setDerivingIds(prev => new Set(prev).add(entry.target.id));
+        }
       } catch (e) {
         toast({
           variant: 'error',
@@ -267,6 +368,9 @@ export default function TargetsList({ initialTargets }: TargetsListProps) {
           entry,
           ...prev.filter(t => t.target.id !== entry.target.id),
         ]);
+        if (isDeriving(entry)) {
+          setDerivingIds(prev => new Set(prev).add(entry.target.id));
+        }
       } catch (e) {
         toast({
           variant: 'error',

--- a/apps/wyrdfold/src/app/(app)/targets/__tests__/TargetCard.spec.tsx
+++ b/apps/wyrdfold/src/app/(app)/targets/__tests__/TargetCard.spec.tsx
@@ -140,4 +140,64 @@ describe('TargetCard', () => {
     );
     expect(screen.getByText('Inactive')).toBeInTheDocument();
   });
+
+  it('shows a building indicator and dashes counts while deriving', () => {
+    render(
+      <TargetCard
+        target={makeTarget({ activation_status: 'deriving' })}
+        fitScore={null}
+        fitScoreReasoning={null}
+        isActive={false}
+        onActivate={noop}
+        onDeactivate={noop}
+        onDelete={noop}
+        onViewJobs={noop}
+      />
+    );
+    expect(screen.getByText(/building/i)).toBeInTheDocument();
+    // Category/keyword counts are placeholders until derivation completes.
+    expect(screen.getAllByText('—').length).toBeGreaterThanOrEqual(2);
+    expect(screen.queryByText('Inactive')).toBeNull();
+  });
+
+  it('disables Activate in the dropdown while deriving', async () => {
+    const user = userEvent.setup();
+    const onActivate = jest.fn();
+    const { container } = render(
+      <TargetCard
+        target={makeTarget({ activation_status: 'deriving', is_active: false })}
+        fitScore={null}
+        fitScoreReasoning={null}
+        isActive={false}
+        onActivate={onActivate}
+        onDeactivate={noop}
+        onDelete={noop}
+        onViewJobs={noop}
+      />
+    );
+    const trigger = container.querySelector(
+      '[aria-haspopup="menu"]'
+    ) as HTMLElement;
+    await user.click(trigger);
+    const activate = screen.getByRole('menuitem', { name: /activate/i });
+    expect(activate).toHaveAttribute('aria-disabled', 'true');
+    await user.click(activate);
+    expect(onActivate).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a failure state when derivation errored', () => {
+    render(
+      <TargetCard
+        target={makeTarget({ activation_status: 'error' })}
+        fitScore={null}
+        fitScoreReasoning={null}
+        isActive={false}
+        onActivate={noop}
+        onDeactivate={noop}
+        onDelete={noop}
+        onViewJobs={noop}
+      />
+    );
+    expect(screen.getByText(/derivation failed/i)).toBeInTheDocument();
+  });
 });

--- a/apps/wyrdfold/src/app/(app)/targets/__tests__/TargetsList.spec.tsx
+++ b/apps/wyrdfold/src/app/(app)/targets/__tests__/TargetsList.spec.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import '@testing-library/jest-dom';
-import { render, screen } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import TargetsList from '../TargetsList';
 import {
   emptyScoringProfile,
@@ -10,8 +10,13 @@ import {
 } from '../types';
 
 const mockPush = jest.fn();
+const mockRefresh = jest.fn();
 jest.mock('next/navigation', () => ({
-  useRouter: () => ({ push: mockPush, prefetch: jest.fn() }),
+  useRouter: () => ({
+    push: mockPush,
+    prefetch: jest.fn(),
+    refresh: mockRefresh,
+  }),
 }));
 
 const mockToast = jest.fn();
@@ -26,15 +31,26 @@ jest.mock('../CreateTargetModal', () => ({
   default: () => null,
 }));
 
-function makeEntry(id: string, label: string): UserTargetWithTarget {
+function makeEntry(
+  id: string,
+  label: string,
+  overrides: {
+    activation_status?: string;
+    fit_score?: number | null;
+    categories?: JobTarget['scoring_profile']['categories'];
+  } = {}
+): UserTargetWithTarget {
   const target: JobTarget = {
     id,
     label,
     description: null,
     normalized_label: null,
-    scoring_profile: emptyScoringProfile(),
+    scoring_profile: {
+      ...emptyScoringProfile(),
+      categories: overrides.categories ?? {},
+    },
     search_keywords: [],
-    activation_status: 'ready',
+    activation_status: overrides.activation_status ?? 'ready',
     profile_version: 1,
     is_active: true,
     created_at: '2026-01-01T00:00:00Z',
@@ -45,7 +61,7 @@ function makeEntry(id: string, label: string): UserTargetWithTarget {
     user_id: 'user',
     target_id: id,
     is_active: true,
-    fit_score: null,
+    fit_score: overrides.fit_score ?? null,
     fit_score_reasoning: null,
     created_at: '2026-01-01T00:00:00Z',
     updated_at: '2026-04-30T00:00:00Z',
@@ -82,5 +98,90 @@ describe('TargetsList', () => {
     expect(
       screen.getByRole('button', { name: /suggest from experience/i })
     ).toBeInTheDocument();
+  });
+
+  describe('deriving polling', () => {
+    const originalFetch = global.fetch;
+    afterEach(() => {
+      jest.useRealTimers();
+      global.fetch = originalFetch;
+    });
+
+    function mockFetchResolving(entry: UserTargetWithTarget): jest.Mock {
+      const fetchMock = jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => entry,
+      });
+      global.fetch = fetchMock as unknown as typeof fetch;
+      return fetchMock;
+    }
+
+    it('polls a deriving target and swaps in the derived profile + fit score', async () => {
+      jest.useFakeTimers();
+      const derived = makeEntry('t-1', 'Senior Frontend Engineer', {
+        activation_status: 'ready',
+        fit_score: 88,
+        categories: {
+          frontend: { keywords: { react: 3 }, weight: 1 },
+        },
+      });
+      const fetchMock = mockFetchResolving(derived);
+
+      render(
+        <TargetsList
+          initialTargets={[
+            makeEntry('t-1', 'Senior Frontend Engineer', {
+              activation_status: 'deriving',
+              fit_score: null,
+            }),
+          ]}
+        />
+      );
+
+      // Starts in the deriving state.
+      expect(screen.getByText(/building/i)).toBeInTheDocument();
+
+      // Advance to the first poll; the settled response replaces the card.
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(2500);
+      });
+
+      expect(fetchMock).toHaveBeenCalledWith('/api/targets/t-1/user-target');
+      await waitFor(() => {
+        expect(screen.queryByText(/building/i)).toBeNull();
+      });
+      expect(screen.getByText('88')).toBeInTheDocument();
+    });
+
+    it('stops polling once the target settles', async () => {
+      jest.useFakeTimers();
+      const derived = makeEntry('t-1', 'Senior Frontend Engineer', {
+        activation_status: 'ready',
+        fit_score: 75,
+        categories: { frontend: { keywords: { react: 3 }, weight: 1 } },
+      });
+      const fetchMock = mockFetchResolving(derived);
+
+      render(
+        <TargetsList
+          initialTargets={[
+            makeEntry('t-1', 'Senior Frontend Engineer', {
+              activation_status: 'deriving',
+            }),
+          ]}
+        />
+      );
+
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(2500);
+      });
+      const callsAfterSettle = fetchMock.mock.calls.length;
+
+      // Further time passes — no additional polls once settled.
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(2500 * 3);
+      });
+      expect(fetchMock.mock.calls.length).toBe(callsAfterSettle);
+    });
   });
 });


### PR DESCRIPTION
## Problem

Creating a WyrdFold target blocked the POST response for **5-9 seconds**. The endpoint ran three Sonnet LLM calls **sequentially and inline** before returning:

1. `normalize_manual_input`
2. `derive_profile_from_label` / `derive_profile_from_jd`
3. `derive_fit_score`

The optimistic card couldn't render until all three finished, so "Add target" felt frozen.

## Fix

Only the call that gates duplicate detection stays inline; the rest is deferred to a `BackgroundTask`, mirroring the existing `_activate_pipeline` pattern in `routers/targets.py`.

### Backend (`apps/wyrdfold-api`)
- **Manual flow**: run `normalize_manual_input` inline (needed for `find_matching_target`). New targets are created immediately in `activation_status="deriving"`, the user is linked, and an optimistic `CreateOrLinkResult` returns right away. `derive_profile_from_label` + `derive_fit_score` run in `derive_manual_target_bg`, which flips the target to `idle` on success / `error` on failure.
- **URL flow**: matching keys off the resolved label, so it needs **no inline LLM call at all**. Profile derivation, reference-JD corpus building, profile re-merge, and fit score all run in `derive_url_target_bg` (`is_new` controls the version bump).
- Matched targets defer the per-user fit score too (linked first, fit filled in by the background task).
- `create_target_from_manual` / `create_target_from_url` now take `BackgroundTasks`.

### Frontend (`apps/wyrdfold`)
- `TargetCard` renders a "Building…" pending state (dashed counts, spinner) while `activation_status === 'deriving'`, and a "Derivation failed" state on `error`. View jobs / Activate are disabled mid-derive.
- `TargetsList` polls `/targets/{id}/user-target` for any deriving / fit-pending target and swaps in the derived profile + fit-score badge once ready — surgical per-card update, no full reload. Attempt-capped (~100s) with a `router.refresh()` backstop, and resumes polling on reload mid-derive.

## Tests
- Rewrote the `from_input` orchestration tests: the inline path links + schedules the correct background task **without** touching derive/fit; dedicated background-task tests cover derive → status flip → fit upsert, and failure → `status="error"`.
- Added `TargetCard` deriving/error tests and `TargetsList` polling tests (settles and stops polling).
- `pnpm tsc --noEmit` clean; full `mypy` (139 files) clean; `ruff` clean; all 460 wyrdfold unit tests + 12 `from_input` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)