### PR TITLE
fix(wyrdfold): stop redirect loop for users without prose

### DIFF
--- a/apps/wyrdfold/src/app/(app)/__tests__/dashboard-page.spec.ts
+++ b/apps/wyrdfold/src/app/(app)/__tests__/dashboard-page.spec.ts
@@ -63,10 +63,13 @@ describe('WyrdfoldDashboard route', () => {
     expect(mockRedirect).toHaveBeenCalledWith('/onboarding');
   });
 
-  it('belt-and-suspenders: redirects + Sentry warning when flag is set but prose is missing', async () => {
-    // Data drift: someone (support? bug?) set the flag without prose
-    // existing. Surface to Sentry so we notice; bounce the user back
-    // to onboarding to recover.
+  it('renders the empty-state dashboard + emits Sentry warning when flag is set but prose is missing', async () => {
+    // Data drift OR legitimate Path A/B user who skipped the resume
+    // step (e.g. upload failed mid-flow). Surface to Sentry so we
+    // notice; render the dashboard's existing empty state ("Set up
+    // profile" CTA) rather than bouncing back to /onboarding — the
+    // wizard restarts at path-chooser, so bouncing creates a redirect
+    // loop for any user without prose.
     mockFetch
       .mockResolvedValueOnce({
         completed_at: '2026-06-01T00:00:00Z',
@@ -78,13 +81,14 @@ describe('WyrdfoldDashboard route', () => {
       .mockResolvedValueOnce({ prose: null }) // ← prose missing
       .mockResolvedValue({ targets: [], postings: [], total: 0 });
 
-    await expect(WyrdfoldDashboard()).rejects.toThrow('REDIRECT:/onboarding');
+    const result = await WyrdfoldDashboard();
 
     expect(mockSentryCapture).toHaveBeenCalledWith(
       'dashboard:onboarding_flag_set_but_no_prose',
       expect.objectContaining({ level: 'warning' })
     );
-    expect(mockRedirect).toHaveBeenCalledWith('/onboarding');
+    expect(mockRedirect).not.toHaveBeenCalled();
+    expect(result).toBeDefined();
   });
 
   it('renders the dashboard when the flag is set and prose exists', async () => {

--- a/apps/wyrdfold/src/app/(app)/dashboard/page.tsx
+++ b/apps/wyrdfold/src/app/(app)/dashboard/page.tsx
@@ -76,17 +76,21 @@ export default async function WyrdfoldDashboard() {
     ),
   ]);
 
-  // Belt-and-suspenders: flag is set but the data isn't there. Could
-  // happen if a support action cleared prose without clearing the
-  // flag, or a bug in the wizard set the flag prematurely. Surface
-  // to Sentry so we notice, and route the user back to /onboarding
-  // rather than render a broken empty dashboard.
+  // Flag is set but prose isn't there. Causes: a Path A/B user who
+  // skipped the resume step (or whose upload failed mid-flow — see
+  // the OpenRouter 402 incident), or data drift from a support action.
+  // We still surface to Sentry so we notice the latter, but we no
+  // longer bounce back to /onboarding: the OnboardingWizard always
+  // restarts at ``path-chooser``, which means any user who lands here
+  // legitimately (resume skipped) gets trapped in a redirect loop.
+  // DashboardPage's ``!hasProfile`` branch already renders a graceful
+  // empty state with a "Set up profile" CTA, which is what the user
+  // actually needs.
   const proseAuthored = proseRes != null && hasProse(proseRes);
   if (!proseAuthored) {
     Sentry.captureMessage('dashboard:onboarding_flag_set_but_no_prose', {
       level: 'warning',
     });
-    redirect('/onboarding');
   }
 
   const counts: Record<string, number> = {};


### PR DESCRIPTION
## Summary

A user reported finishing onboarding, clicking the Dashboard nav, and getting bounced back to the onboarding wizard's first step. Reproduces 100% for Path A/B users who skipped (or failed) the resume-upload step.

## Root cause

\`dashboard/page.tsx\` had a *belt-and-suspenders* guard: if \`onboarding_completed_at\` was set but no prose existed, it called \`redirect('/onboarding')\` and logged to Sentry. The intent was to recover from data drift, but:

- \`OnboardingWizard\` always starts at \`path-chooser\` (no resume-from-step), so the bounce restarts the whole wizard.
- A Path A/B user who legitimately skipped the resume step (or whose resume upload failed silently — see the recent OpenRouter 402 incident) has the flag set with no prose. They land on the wizard, finish again, click Dashboard, bounce. Loop.
- \`DashboardPage\` already has a graceful \`!hasProfile\` empty state with a "Set up profile" CTA — exactly the experience these users need.

## Fix

- Drop the \`redirect('/onboarding')\` on missing-prose.
- Keep the Sentry warning so we still see genuine data drift.
- Update the test to match: empty-state renders, warning fires, no redirect.

## Test plan

- [x] \`pnpm nx test wyrdfold --testPathPatterns dashboard-page\` — 4/4 pass
- [x] \`pnpm tsc --noEmit\` — clean
- [ ] Manually verify in preview: complete onboarding skipping the resume step, click Dashboard, expect the empty-state CTA instead of a wizard restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)