### PR TITLE
feat(wyrdfold-api): user-safe error messages for LLM provider failures

### DIFF
--- a/apps/wyrdfold-api/app/main.py
+++ b/apps/wyrdfold-api/app/main.py
@@ -28,6 +28,7 @@ from app.routers import (
 )
 from app.scheduler import start_scheduler_if_enabled
 from app.services.llm.cost_log_buffer import buffer as cost_log_buffer
+from app.services.llm.errors import LLMServiceError
 from app.supabase_pool import close_supabase, get_supabase_pool, init_supabase
 
 _log = logging.getLogger("app")
@@ -157,6 +158,43 @@ async def _log_slow_requests(
             duration_ms,
         )
     return response
+
+
+@app.exception_handler(LLMServiceError)
+async def _llm_service_error_handler(
+    request: Request, exc: LLMServiceError
+) -> JSONResponse:
+    """Translate typed LLM provider failures into a user-safe JSON
+    response. Sentry breadcrumb keeps the upstream status + provider
+    reason searchable without exposing them to end users.
+
+    See ``app/services/llm/errors.py`` for the categorization. All
+    cases default to HTTP 503 with a friendly ``detail`` string the
+    FE can render via ``extractApiError`` verbatim — no vendor
+    messages (e.g. OpenRouter's ``"Insufficient credits..."``) ever
+    reach the user.
+    """
+    _log.warning(
+        "llm_service_error path=%s reason=%s upstream_status=%s",
+        request.url.path,
+        exc.reason,
+        exc.upstream_status,
+    )
+    # ``capture_exception`` is a no-op when Sentry isn't initialized,
+    # so the import is cheap and safe in tests.
+    try:
+        import sentry_sdk
+
+        sentry_sdk.set_tag("llm.reason", exc.reason)
+        if exc.upstream_status is not None:
+            sentry_sdk.set_tag("llm.upstream_status", str(exc.upstream_status))
+        sentry_sdk.capture_exception(exc)
+    except ImportError:  # pragma: no cover
+        pass
+    return JSONResponse(
+        status_code=exc.http_status,
+        content={"detail": exc.user_message, "code": exc.reason},
+    )
 
 
 @app.exception_handler(Exception)

--- a/apps/wyrdfold-api/app/services/llm/anthropic_client.py
+++ b/apps/wyrdfold-api/app/services/llm/anthropic_client.py
@@ -22,7 +22,7 @@ import time
 from collections.abc import AsyncIterator
 from typing import Any, cast
 
-from anthropic import AsyncAnthropic
+from anthropic import APIConnectionError, APIStatusError, APITimeoutError, AsyncAnthropic
 
 from app.models.llm import (
     LLMResult,
@@ -32,6 +32,10 @@ from app.models.llm import (
     LLMUsage,
     Message,
     ModelId,
+)
+from app.services.llm.errors import (
+    LLMUpstreamUnavailableError,
+    translate_api_status_error,
 )
 from app.services.llm.pricing import calculate_cost
 
@@ -68,6 +72,19 @@ class AnthropicLLMClient:
         """
         return model
 
+    @staticmethod
+    def _translate_or_reraise(exc: APIStatusError) -> None:
+        """Convert an SDK status error into a typed LLM service error
+        when the status maps to one of our user-facing transient
+        categories (402/429/5xx/auth). Otherwise re-raise so the
+        unhandled-exception handler logs it as a 500 — those status
+        codes indicate a bug in our request, not a transient outage.
+        """
+        translated = translate_api_status_error(exc)
+        if translated is None:
+            raise exc
+        raise translated from exc
+
     async def complete(
         self,
         *,
@@ -102,12 +119,18 @@ class AnthropicLLMClient:
         ]
 
         start = time.perf_counter()
-        response = await self._client.messages.create(
-            model=cast(Any, self._resolve_model(model)),
-            max_tokens=max_tokens,
-            system=system_param,
-            messages=cast(Any, api_messages),
-        )
+        try:
+            response = await self._client.messages.create(
+                model=cast(Any, self._resolve_model(model)),
+                max_tokens=max_tokens,
+                system=system_param,
+                messages=cast(Any, api_messages),
+            )
+        except APIStatusError as exc:
+            self._translate_or_reraise(exc)
+            raise  # pragma: no cover - _translate_or_reraise always raises
+        except (APIConnectionError, APITimeoutError) as exc:
+            raise LLMUpstreamUnavailableError() from exc
         latency_ms = int((time.perf_counter() - start) * 1000)
 
         # Join every text block. Thinking / tool-use blocks are not expected
@@ -182,14 +205,20 @@ class AnthropicLLMClient:
         tool_choice: dict[str, Any] = {"type": "tool", "name": tool_name}
 
         start = time.perf_counter()
-        response = await self._client.messages.create(
-            model=cast(Any, self._resolve_model(model)),
-            max_tokens=max_tokens,
-            system=system_param,
-            messages=cast(Any, api_messages),
-            tools=cast(Any, [tool]),
-            tool_choice=cast(Any, tool_choice),
-        )
+        try:
+            response = await self._client.messages.create(
+                model=cast(Any, self._resolve_model(model)),
+                max_tokens=max_tokens,
+                system=system_param,
+                messages=cast(Any, api_messages),
+                tools=cast(Any, [tool]),
+                tool_choice=cast(Any, tool_choice),
+            )
+        except APIStatusError as exc:
+            self._translate_or_reraise(exc)
+            raise  # pragma: no cover - _translate_or_reraise always raises
+        except (APIConnectionError, APITimeoutError) as exc:
+            raise LLMUpstreamUnavailableError() from exc
         latency_ms = int((time.perf_counter() - start) * 1000)
 
         # Find the tool_use block. The forced tool_choice guarantees one
@@ -262,17 +291,27 @@ class AnthropicLLMClient:
         ]
 
         start = time.perf_counter()
-        async with self._client.messages.stream(
-            model=cast(Any, self._resolve_model(model)),
-            max_tokens=max_tokens,
-            system=system_param,
-            messages=cast(Any, api_messages),
-        ) as stream:
-            async for text in stream.text_stream:
-                if text:
-                    yield LLMStreamDelta(text=text)
+        # SDK raises APIStatusError on the initial HTTP handshake (which
+        # surfaces from ``async with .stream(...)``) and may raise mid-
+        # stream on chunked-transfer errors. Wrap the whole region so
+        # either path translates uniformly.
+        try:
+            async with self._client.messages.stream(
+                model=cast(Any, self._resolve_model(model)),
+                max_tokens=max_tokens,
+                system=system_param,
+                messages=cast(Any, api_messages),
+            ) as stream:
+                async for text in stream.text_stream:
+                    if text:
+                        yield LLMStreamDelta(text=text)
 
-            final_message = await stream.get_final_message()
+                final_message = await stream.get_final_message()
+        except APIStatusError as exc:
+            self._translate_or_reraise(exc)
+            raise  # pragma: no cover - _translate_or_reraise always raises
+        except (APIConnectionError, APITimeoutError) as exc:
+            raise LLMUpstreamUnavailableError() from exc
 
         latency_ms = int((time.perf_counter() - start) * 1000)
 

--- a/apps/wyrdfold-api/app/services/llm/errors.py
+++ b/apps/wyrdfold-api/app/services/llm/errors.py
@@ -1,0 +1,128 @@
+"""Typed errors for LLM service failures.
+
+The Anthropic SDK (and OpenRouter, which speaks the same shape) raises
+``APIStatusError`` subclasses with vendor-specific messages — e.g.
+``"Insufficient credits. Add more using https://openrouter.ai/..."``
+for a 402, or rate-limit JSON for 429. Letting those bubble untouched
+into the FastAPI response leaks operator concerns to end users (and to
+Sentry stack traces) and gives no signal to the FE about whether the
+failure is retryable.
+
+This module defines a small hierarchy of *intent* — what the failure
+means to the application — and a translator that maps SDK exceptions
+onto it. Routers don't need to catch anything: a single FastAPI
+exception handler (registered in ``app/main.py``) converts these into
+JSON responses with a user-safe ``detail`` string and the appropriate
+HTTP status, while preserving the original cause for Sentry.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class LLMServiceError(Exception):
+    """Base class for all LLM-provider failures we expose to callers.
+
+    ``reason`` is a stable, low-cardinality tag for logging / Sentry
+    grouping (e.g. ``"quota_exhausted"``, ``"rate_limited"``).
+    ``user_message`` is the string the FE / end user should see.
+    ``http_status`` is the response code the exception handler emits.
+    """
+
+    reason: str = "llm_error"
+    user_message: str = (
+        "We couldn't reach the AI service right now. Please try again in a few minutes."
+    )
+    http_status: int = 503
+
+    def __init__(
+        self,
+        user_message: str | None = None,
+        *,
+        reason: str | None = None,
+        http_status: int | None = None,
+        upstream_status: int | None = None,
+    ) -> None:
+        if user_message is not None:
+            self.user_message = user_message
+        if reason is not None:
+            self.reason = reason
+        if http_status is not None:
+            self.http_status = http_status
+        self.upstream_status = upstream_status
+        super().__init__(self.user_message)
+
+
+class LLMQuotaExhaustedError(LLMServiceError):
+    """Provider billing exhausted (402). Operator must top up credits."""
+
+    reason = "quota_exhausted"
+    user_message = (
+        "Our AI service is temporarily unavailable. We've been notified — "
+        "please try again in a little while."
+    )
+    http_status = 503
+
+
+class LLMRateLimitedError(LLMServiceError):
+    """Provider returned 429. Transient — retry after a backoff."""
+
+    reason = "rate_limited"
+    user_message = (
+        "The AI service is busy right now. Please wait a moment and try again."
+    )
+    http_status = 503
+
+
+class LLMUpstreamUnavailableError(LLMServiceError):
+    """Provider returned 5xx or connection failed. Transient."""
+
+    reason = "upstream_unavailable"
+    user_message = (
+        "We couldn't reach the AI service right now. Please try again in a few minutes."
+    )
+    http_status = 503
+
+
+class LLMAuthError(LLMServiceError):
+    """Provider returned 401/403. Misconfigured API key — operator fix."""
+
+    reason = "auth_failed"
+    # Don't expose "API key invalid" to end users. They can't act on it.
+    user_message = (
+        "Our AI service is temporarily unavailable. We've been notified."
+    )
+    http_status = 503
+
+
+# Status codes the Anthropic / OpenRouter API surfaces that we treat as
+# user-facing transient failures. 400/422 are application bugs (bad
+# tool schema, malformed request) and should keep bubbling as 500 so
+# Sentry surfaces them — we don't translate those.
+def translate_api_status_error(exc: Any) -> LLMServiceError | None:
+    """Map an ``anthropic.APIStatusError`` onto a typed app-level error.
+
+    Returns ``None`` if the status code isn't one we treat as
+    user-facing transient (4xx that signals a bug in our request, or
+    anything we haven't classified). Callers should re-raise in that
+    case so the unhandled-exception handler logs it as a 500.
+
+    Accepts ``Any`` rather than importing ``anthropic.APIStatusError``
+    at module scope so this module stays cheap to import in tests that
+    don't have the SDK installed; we just duck-type on
+    ``.status_code``.
+    """
+    status = getattr(exc, "status_code", None)
+    if status is None:
+        return None
+
+    if status == 402:
+        return LLMQuotaExhaustedError(upstream_status=status)
+    if status == 429:
+        return LLMRateLimitedError(upstream_status=status)
+    if status in (401, 403):
+        return LLMAuthError(upstream_status=status)
+    if status in (500, 502, 503, 504, 529):
+        return LLMUpstreamUnavailableError(upstream_status=status)
+    return None

--- a/apps/wyrdfold-api/tests/test_llm_errors.py
+++ b/apps/wyrdfold-api/tests/test_llm_errors.py
@@ -1,0 +1,258 @@
+"""LLM error translation tests.
+
+Covers the typed error layer in ``app/services/llm/errors.py`` plus
+the SDK→typed-error wrapping inside ``AnthropicLLMClient``. The
+contract under test:
+
+- ``anthropic.APIStatusError`` with a *user-facing transient* status
+  (402 quota, 429 rate-limit, 401/403 auth, 5xx upstream) is mapped
+  to the corresponding ``LLMServiceError`` subclass — never leaks
+  raw vendor messages.
+- Status codes we don't classify (400, 422 — these indicate a bug
+  in the request we built) re-raise unchanged so the unhandled-
+  exception handler surfaces them as 500s in Sentry.
+- ``APIConnectionError`` / ``APITimeoutError`` translate to
+  ``LLMUpstreamUnavailableError`` so a flaky network looks the same
+  to the FE as a flaky provider.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+from anthropic import (
+    APIConnectionError,
+    APIStatusError,
+    APITimeoutError,
+)
+
+from app.models.llm import Message
+from app.services.llm.anthropic_client import AnthropicLLMClient
+from app.services.llm.errors import (
+    LLMAuthError,
+    LLMQuotaExhaustedError,
+    LLMRateLimitedError,
+    LLMServiceError,
+    LLMUpstreamUnavailableError,
+    translate_api_status_error,
+)
+
+
+def _api_status_error(status: int, message: str = "boom") -> APIStatusError:
+    """Build a real APIStatusError with a synthetic httpx response so
+    we exercise the same exception type the SDK raises in production.
+    """
+    request = httpx.Request("POST", "https://example.test/v1/messages")
+    response = httpx.Response(status_code=status, request=request)
+    return APIStatusError(message, response=response, body=None)
+
+
+# -- translate_api_status_error ------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("status", "expected_cls", "expected_reason"),
+    [
+        (402, LLMQuotaExhaustedError, "quota_exhausted"),
+        (429, LLMRateLimitedError, "rate_limited"),
+        (401, LLMAuthError, "auth_failed"),
+        (403, LLMAuthError, "auth_failed"),
+        (500, LLMUpstreamUnavailableError, "upstream_unavailable"),
+        (502, LLMUpstreamUnavailableError, "upstream_unavailable"),
+        (503, LLMUpstreamUnavailableError, "upstream_unavailable"),
+        (504, LLMUpstreamUnavailableError, "upstream_unavailable"),
+        (529, LLMUpstreamUnavailableError, "upstream_unavailable"),
+    ],
+)
+def test_translate_maps_user_facing_statuses(
+    status: int, expected_cls: type[LLMServiceError], expected_reason: str
+) -> None:
+    exc = _api_status_error(status)
+    translated = translate_api_status_error(exc)
+    assert isinstance(translated, expected_cls)
+    assert translated.reason == expected_reason
+    assert translated.http_status == 503
+    assert translated.upstream_status == status
+
+
+@pytest.mark.parametrize("status", [400, 404, 409, 413, 422])
+def test_translate_returns_none_for_request_bugs(status: int) -> None:
+    """4xx codes that indicate a malformed request from us aren't
+    user-facing transients — let them bubble as 500s so we notice."""
+    assert translate_api_status_error(_api_status_error(status)) is None
+
+
+def test_translate_returns_none_for_objects_without_status_code() -> None:
+    """Defensive: a raw Exception (no .status_code) should not crash."""
+
+    class _NotAnApiError(Exception):
+        pass
+
+    assert translate_api_status_error(_NotAnApiError("?")) is None
+
+
+# -- AnthropicLLMClient wrapping -----------------------------------------------
+
+
+def _client() -> AnthropicLLMClient:
+    return AnthropicLLMClient(api_key="test-key")
+
+
+def _fake_messages() -> list[Message]:
+    return [Message(role="user", content="hi")]
+
+
+def _set_create_raises(client: AnthropicLLMClient, exc: BaseException) -> None:
+    client._client.messages.create = AsyncMock(side_effect=exc)  # type: ignore[method-assign]
+
+
+async def test_complete_translates_402_to_quota_exhausted() -> None:
+    """The OpenRouter incident: a 402 must surface as a friendly
+    ``LLMQuotaExhaustedError``, never the raw 'Insufficient credits'
+    vendor string."""
+    client = _client()
+    _set_create_raises(client, _api_status_error(402, "Insufficient credits"))
+
+    with pytest.raises(LLMQuotaExhaustedError) as info:
+        await client.complete(
+            model="claude-haiku-4-5",
+            system="sys",
+            messages=_fake_messages(),
+            purpose="test",
+        )
+    assert info.value.upstream_status == 402
+    # Crucially: the user-facing message is ours, not the vendor's.
+    assert "Insufficient credits" not in info.value.user_message
+
+
+async def test_complete_translates_429_to_rate_limited() -> None:
+    client = _client()
+    _set_create_raises(client, _api_status_error(429))
+    with pytest.raises(LLMRateLimitedError):
+        await client.complete(
+            model="claude-haiku-4-5",
+            system="sys",
+            messages=_fake_messages(),
+            purpose="test",
+        )
+
+
+async def test_complete_translates_503_to_upstream_unavailable() -> None:
+    client = _client()
+    _set_create_raises(client, _api_status_error(503))
+    with pytest.raises(LLMUpstreamUnavailableError):
+        await client.complete(
+            model="claude-haiku-4-5",
+            system="sys",
+            messages=_fake_messages(),
+            purpose="test",
+        )
+
+
+async def test_complete_reraises_unclassified_status_codes() -> None:
+    """A 400 (bad request) means our code built a malformed payload —
+    not a transient failure. Bubble it so Sentry surfaces it as a bug.
+    """
+    client = _client()
+    _set_create_raises(client, _api_status_error(400, "tool schema invalid"))
+    with pytest.raises(APIStatusError):
+        await client.complete(
+            model="claude-haiku-4-5",
+            system="sys",
+            messages=_fake_messages(),
+            purpose="test",
+        )
+
+
+async def test_complete_translates_connection_error() -> None:
+    client = _client()
+    request = httpx.Request("POST", "https://example.test/v1/messages")
+    _set_create_raises(client, APIConnectionError(request=request))
+    with pytest.raises(LLMUpstreamUnavailableError):
+        await client.complete(
+            model="claude-haiku-4-5",
+            system="sys",
+            messages=_fake_messages(),
+            purpose="test",
+        )
+
+
+async def test_complete_translates_timeout() -> None:
+    client = _client()
+    request = httpx.Request("POST", "https://example.test/v1/messages")
+    _set_create_raises(client, APITimeoutError(request=request))
+    with pytest.raises(LLMUpstreamUnavailableError):
+        await client.complete(
+            model="claude-haiku-4-5",
+            system="sys",
+            messages=_fake_messages(),
+            purpose="test",
+        )
+
+
+async def test_complete_tool_use_translates_402() -> None:
+    """Same translation contract for the tool-forced call path."""
+    client = _client()
+    _set_create_raises(client, _api_status_error(402))
+    with pytest.raises(LLMQuotaExhaustedError):
+        await client.complete_tool_use(
+            model="claude-haiku-4-5",
+            system="sys",
+            messages=_fake_messages(),
+            tool_name="x",
+            tool_description="x",
+            tool_input_schema={"type": "object"},
+            purpose="test",
+        )
+
+
+async def test_stream_translates_402_on_handshake() -> None:
+    """The Anthropic streaming context raises APIStatusError when the
+    initial HTTP handshake fails (before any tokens stream). Translate
+    that just like the non-streaming path."""
+
+    class _RaisingStream:
+        async def __aenter__(self) -> Any:
+            raise _api_status_error(402)
+
+        async def __aexit__(self, *args: Any) -> None:  # pragma: no cover
+            return None
+
+    client = _client()
+    client._client.messages.stream = MagicMock(return_value=_RaisingStream())  # type: ignore[method-assign]
+
+    with pytest.raises(LLMQuotaExhaustedError):
+        async for _ in client.stream(
+            model="claude-haiku-4-5",
+            system="sys",
+            messages=_fake_messages(),
+            purpose="test",
+        ):
+            pass
+
+
+# -- Public message contract ---------------------------------------------------
+
+
+def test_user_messages_are_safe_strings() -> None:
+    """A regression guard: every typed error's ``user_message`` must
+    be something we'd happily show an end user — no debug crud, no
+    vendor names, no raw URLs, no quote-noise. If anyone adds a new
+    subclass and forgets to override the message thoughtfully, this
+    catches it.
+    """
+    for cls in (
+        LLMQuotaExhaustedError,
+        LLMRateLimitedError,
+        LLMAuthError,
+        LLMUpstreamUnavailableError,
+    ):
+        msg = cls().user_message
+        assert msg
+        assert "openrouter" not in msg.lower()
+        assert "anthropic" not in msg.lower()
+        assert "api key" not in msg.lower()
+        assert "http" not in msg.lower()

--- a/apps/wyrdfold-api/tests/test_llm_exception_handler.py
+++ b/apps/wyrdfold-api/tests/test_llm_exception_handler.py
@@ -1,0 +1,87 @@
+"""Tests for the FastAPI exception handler that converts
+``LLMServiceError`` subclasses into JSON responses.
+
+The handler lives in ``app/main.py``. We register a throwaway test
+route on the app so we can exercise the real request/response cycle
+through Starlette — TestClient gives us the same status code and
+body shape the frontend would receive.
+"""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.services.llm.errors import (
+    LLMAuthError,
+    LLMQuotaExhaustedError,
+    LLMRateLimitedError,
+    LLMUpstreamUnavailableError,
+)
+
+# Register one throwaway route per error case. ``add_api_route`` lets
+# us do this inside the test module without touching production
+# routers. The closures capture the exception class so the route
+# raises the right type.
+
+
+def _register_raising_route(path: str, exc_cls: type[Exception]) -> None:
+    async def _raise() -> None:
+        raise exc_cls()
+
+    app.add_api_route(path, _raise, methods=["GET"])
+
+
+_register_raising_route("/__test/llm/quota", LLMQuotaExhaustedError)
+_register_raising_route("/__test/llm/rate_limit", LLMRateLimitedError)
+_register_raising_route("/__test/llm/auth", LLMAuthError)
+_register_raising_route("/__test/llm/upstream", LLMUpstreamUnavailableError)
+
+
+def test_quota_exhausted_returns_503_with_user_safe_detail() -> None:
+    """The flagship case: a 402 from the provider must reach the user
+    as 503 + friendly text, with the vendor message gone."""
+    client = TestClient(app)
+    res = client.get("/__test/llm/quota")
+    assert res.status_code == 503
+    body = res.json()
+    assert body["code"] == "quota_exhausted"
+    detail = body["detail"]
+    # User-safe: no vendor names, no top-up URL, no debugging hints.
+    assert "openrouter" not in detail.lower()
+    assert "credits" not in detail.lower()
+    assert "https://" not in detail
+    # And actually helpful: tells them what to do.
+    assert "try again" in detail.lower()
+
+
+def test_rate_limited_returns_503_with_wait_hint() -> None:
+    client = TestClient(app)
+    res = client.get("/__test/llm/rate_limit")
+    assert res.status_code == 503
+    body = res.json()
+    assert body["code"] == "rate_limited"
+    assert "busy" in body["detail"].lower() or "wait" in body["detail"].lower()
+
+
+def test_auth_error_does_not_leak_operator_concern_to_user() -> None:
+    """A 401/403 from the provider means our API key is misconfigured —
+    the user can't fix it. The response must NOT say "api key" or
+    similar; just a generic transient message."""
+    client = TestClient(app)
+    res = client.get("/__test/llm/auth")
+    assert res.status_code == 503
+    detail = res.json()["detail"].lower()
+    assert "api key" not in detail
+    assert "auth" not in detail
+    assert "401" not in detail
+    assert "403" not in detail
+
+
+def test_upstream_unavailable_returns_503() -> None:
+    client = TestClient(app)
+    res = client.get("/__test/llm/upstream")
+    assert res.status_code == 503
+    body = res.json()
+    assert body["code"] == "upstream_unavailable"
+    assert body["detail"]


### PR DESCRIPTION
## Summary

The recent OpenRouter 402 incident surfaced to onboarding users as a raw vendor exception:

> APIStatusError: Error code: 402 - {'error': {'message': 'Insufficient credits. Add more using https://openrouter.ai/settings/credits', 'code': 402}}

That message exposes operator concerns (vendor, top-up URL, billing state) and gives the user no actionable signal — they don't know if it's their file, their account, or transient. This PR fixes that and the broader class of \"third-party API errors leak verbatim\" issues.

## Approach

Translate at the boundary, render at the edge.

1. **Typed error layer** (\`app/services/llm/errors.py\`): \`LLMQuotaExhaustedError\`, \`LLMRateLimitedError\`, \`LLMAuthError\`, \`LLMUpstreamUnavailableError\`. Each carries a stable \`reason\` tag (for Sentry grouping), a \`user_message\` (what the FE shows), and an \`http_status\` (503 across the board).

2. **SDK wrapping** in \`AnthropicLLMClient\` (\`complete\`, \`complete_tool_use\`, \`stream\`): \`APIStatusError\` → translator → typed error; \`APIConnectionError\`/\`APITimeoutError\` → \`LLMUpstreamUnavailableError\`. Status codes we don't classify (400/422 — bugs in *our* request) re-raise unchanged so Sentry still flags them as 500s.

3. **FastAPI exception handler** in \`main.py\`: translates typed errors to \`JSONResponse(503, {detail, code})\` with operator concerns stripped. Sets Sentry tags (\`llm.reason\`, \`llm.upstream_status\`) so we can search/alert without leaking to users.

4. **FE: no changes needed**. \`extractApiError\` already renders \`{detail: \"...\"}\` verbatim, so the friendly message flows through to \`ResumeUploader\`'s \`<Alert variant='error'>\` for free.

## Coverage

- \`test_llm_errors.py\` (24 tests): translator mapping for every classified status (402/429/401/403/500/502/503/504/529), re-raise for unclassified (400/404/409/413/422), SDK wrapping for \`complete\` / \`complete_tool_use\` / \`stream\`, network errors, and a regression guard that asserts no \`user_message\` contains vendor names, top-up URLs, or debug crud.
- \`test_llm_exception_handler.py\` (4 tests): real TestClient round-trip per error class — confirms 503 status, \`{detail, code}\` shape, no vendor leak, helpful retry hint.

## Test plan

- [x] \`uv run pytest tests/test_llm_errors.py\` — 24/24 pass
- [x] \`uv run pytest tests/test_llm_anthropic.py\` — 16/16 still pass (happy path untouched)
- [x] \`uv run ruff check\` — clean
- [x] \`uv run mypy app/\` — clean (140 files)
- [x] \`pnpm tsc --noEmit\` — clean
- [ ] Pre-existing 25-test collection failure due to local \`.env\` keys (\`aws_access_key_id\`, \`nx_key\`) not on \`Settings\` model — unrelated to this PR, CI runs with a clean env.
- [ ] Manually verify on preview: simulate a 402 (revoke key briefly or point at a dead provider) and confirm onboarding shows \"Our AI service is temporarily unavailable...\" instead of the raw vendor string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)