### PR TITLE
perf(wyrdfold-api): add composite index for jobs status+score filter

### DIFF
--- a/supabase/migrations/20260608120000_jobs_status_score_index.sql
+++ b/supabase/migrations/20260608120000_jobs_status_score_index.sql
@@ -1,0 +1,14 @@
+-- Composite index for the /jobs list hot path.
+--
+-- `apps/wyrdfold-api/app/routers/jobs.py` filters `status` and (optionally)
+-- `score >= min_score`, then orders by `score DESC`. Existing single-column
+-- indexes (`idx_job_postings_score`, `idx_job_postings_status`) force the
+-- planner to combine bitmap scans; a `(status, score DESC)` composite serves
+-- the filter and ordering from one btree.
+--
+-- btree default for DESC is NULLS LAST, which matches user intent (unscored
+-- jobs sort to the end). Single-column legacy indexes are kept — they still
+-- serve queries that filter on score alone or status alone.
+
+CREATE INDEX IF NOT EXISTS idx_jobs_status_score
+  ON public.jobs (status, score DESC);


### PR DESCRIPTION
## Summary
- Adds `idx_jobs_status_score ON public.jobs (status, score DESC)` to serve the `/jobs` list hot path (`apps/wyrdfold-api/app/routers/jobs.py:885`).
- Existing single-column indexes (`idx_job_postings_score`, `idx_job_postings_status`) forced bitmap-scan combinations; the composite serves filter + ordering from one btree.
- Legacy single-column indexes are kept — they still serve score-only and status-only queries.

Part of danieljoffe/wyrdfold#7 (P3). First of 5 Sprint-1 PRs.

## Test plan
- [ ] Migration applies cleanly in Supabase preview
- [ ] `EXPLAIN ANALYZE` on a representative `/jobs?status=…&min_score=…` query shows the new index in use
- [ ] No regression in `/jobs` p95 latency post-deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)