### PR TITLE
perf(wyrdfold-api): offload pandoc render to a worker thread

### DIFF
--- a/apps/wyrdfold-api/app/routers/tailor.py
+++ b/apps/wyrdfold-api/app/routers/tailor.py
@@ -15,6 +15,7 @@ GET   /tailor/resumes/{id}/download     — serves the `.docx` bytes.
 All 422 responses carry the LintFailureResponse shape.
 """
 
+import asyncio
 import io
 import logging
 import re
@@ -623,7 +624,7 @@ async def download_tailored_resume(
             )
 
         try:
-            data = md_to_docx(row.payload_md, style)
+            data = await asyncio.to_thread(md_to_docx, row.payload_md, style)
         except PandocNotInstalledError as exc:
             raise HTTPException(status_code=500, detail=str(exc)) from exc
         except PandocRenderError as exc:

--- a/apps/wyrdfold-api/app/services/tailor/pipeline.py
+++ b/apps/wyrdfold-api/app/services/tailor/pipeline.py
@@ -13,6 +13,7 @@ result into an HTTP response.
 
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass
 
 from supabase import Client
@@ -132,7 +133,9 @@ async def run_tailor_pipeline(
             warnings=trace_warnings,
             llm_result=llm_result,
         )
-    docx_bytes = md_to_docx(payload_md)
+    # pandoc is a sync subprocess; offload to a worker thread so the event
+    # loop keeps serving other requests during the ~hundreds-of-ms render.
+    docx_bytes = await asyncio.to_thread(md_to_docx, payload_md)
     lint = lint_docx(docx_bytes)
     if not lint.ok:
         return PipelineLintFailure(
@@ -266,7 +269,7 @@ async def run_cover_letter_pipeline(
             warnings=trace_warnings,
             llm_result=llm_result,
         )
-    docx_bytes = md_to_docx(payload_md)
+    docx_bytes = await asyncio.to_thread(md_to_docx, payload_md)
     lint = lint_docx(docx_bytes, document_type="cover_letter")
     if not lint.ok:
         return CoverLetterPipelineLintFailure(


### PR DESCRIPTION
## Summary
- `md_to_docx()` is a blocking `subprocess.run(pandoc, timeout=30)`. Called from async handlers, it stalls the event loop for every resume/cover-letter render (hundreds of ms per call, worse under load).
- Wraps the three async call sites with `asyncio.to_thread(md_to_docx, …)` so the loop keeps serving other requests during the render:
  - `apps/wyrdfold-api/app/services/tailor/pipeline.py:135` (resume)
  - `apps/wyrdfold-api/app/services/tailor/pipeline.py:269` (cover letter)
  - `apps/wyrdfold-api/app/routers/tailor.py:626` (resume download)
- Sync `md_to_docx()` itself is unchanged — tests/scripts that call it synchronously still work.

Part of danieljoffe/wyrdfold#7 (P1). PR 2 of 5 for Sprint 1.

## Test plan
- [ ] Existing `test_pandoc_smoke.py` + `test_docx_style.py` pass (still sync — they don't touch the changed paths)
- [ ] Manual: render a resume + cover letter end-to-end, verify identical bytes vs. main
- [ ] Verify concurrent renders no longer serialize on the event loop (curl two `/tailor/resume` calls in parallel and observe overlapping work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)