### PR TITLE
perf(wyrdfold-api): collapse batch-resume N+1 into one .in_() query

### DIFF
--- a/apps/wyrdfold-api/app/routers/tailor.py
+++ b/apps/wyrdfold-api/app/routers/tailor.py
@@ -693,19 +693,27 @@ async def create_batch_resumes(
             detail="no optimized doc — derive one via POST /experience/derive first",
         )
 
-    # Verify all job posting IDs exist and fetch their descriptions + target_id
+    # Verify all job posting IDs exist and fetch their descriptions + target_id.
+    # Single .in_() round-trip; .in_() does not guarantee row order, so re-map
+    # by id to preserve the input ordering (downstream uses postings[0] for the
+    # common target_id and processes jobs in request order).
+    resp = (
+        supabase.table("jobs")
+        .select("id, title, description_html, target_id")
+        .in_("id", body.job_posting_ids)
+        .execute()
+    )
+    fetched = {
+        cast(dict[str, Any], row)["id"]: cast(dict[str, Any], row)
+        for row in (resp.data or [])
+    }
+
     warnings: list[str] = []
     postings: list[dict[str, Any]] = []
     for jid in body.job_posting_ids:
-        resp = (
-            supabase.table("jobs")
-            .select("id, title, description_html, target_id")
-            .eq("id", jid)
-            .execute()
-        )
-        if not resp.data:
+        row = fetched.get(jid)
+        if row is None:
             raise HTTPException(status_code=404, detail=f"job posting not found: {jid}")
-        row = cast(dict[str, Any], resp.data[0])
         if not row.get("description_html"):
             warnings.append(f"no_description:{jid}")
         postings.append(row)

--- a/apps/wyrdfold-api/tests/test_batch.py
+++ b/apps/wyrdfold-api/tests/test_batch.py
@@ -112,6 +112,8 @@ def _set_mock_data(supabase: MagicMock, data: list[Any]) -> None:
     # Back-compat for the older single-``eq`` chain (kept for any callers
     # that still go through it during refactoring).
     select.eq.return_value.execute.return_value.data = data
+    # ``create_batch_resumes`` now fetches all postings in one .in_() call.
+    select.in_.return_value.execute.return_value.data = data
 
 
 def _mock_supabase_for_batch(


### PR DESCRIPTION
## Summary
- `POST /tailor/batch` (`apps/wyrdfold-api/app/routers/tailor.py:699`) was issuing one `.eq("id", jid)` round-trip per job. A 20-job batch (the max) took 20 sequential Supabase calls before the background task even started.
- Replaces the loop with a single `.in_("id", ids)` fetch + id→row map.
- Input order is preserved by re-mapping in Python — PostgREST `.in_()` does not guarantee row order, and downstream consumers rely on `postings[0].target_id` and per-index iteration.
- 404-on-missing-id behavior is unchanged (still raised on the first missing id in input order).

Part of danieljoffe/wyrdfold#7 (P2). PR 3 of 5 for Sprint 1.

## Test plan
- [ ] `POST /tailor/batch` with 20 valid job ids — verify all process and order matches request
- [ ] `POST /tailor/batch` with one unknown id — verify 404 with correct id in detail
- [ ] `POST /tailor/batch` with a mix of jobs with/without `description_html` — verify warnings list

🤖 Generated with [Claude Code](https://claude.com/claude-code)