### PR TITLE
sec(wyrdfold-api): add per-user HTTP rate limiting via slowapi

### DIFF
--- a/apps/wyrdfold-api/app/config.py
+++ b/apps/wyrdfold-api/app/config.py
@@ -19,6 +19,12 @@ class Settings(BaseSettings):
     score_normalizer: int = 30
     allowed_hosts: str = ""
 
+    # HTTP rate limiting (slowapi). In-memory backend — sufficient while the
+    # API runs as a single Railway replica. Switch to Redis when scaling to
+    # multiple replicas, otherwise limits become per-instance and bypassable.
+    # Tests disable via RATE_LIMIT_ENABLED=false in conftest.
+    rate_limit_enabled: bool = True
+
     # Sentry — leave DSN empty to disable (local dev, tests).
     sentry_dsn: str = Field(default="", repr=False)
     sentry_environment: str = "development"

--- a/apps/wyrdfold-api/app/main.py
+++ b/apps/wyrdfold-api/app/main.py
@@ -5,6 +5,8 @@ from contextlib import asynccontextmanager
 
 from fastapi import FastAPI, Request, Response
 from fastapi.responses import JSONResponse
+from slowapi.errors import RateLimitExceeded
+from slowapi.middleware import SlowAPIMiddleware
 from starlette.middleware.cors import CORSMiddleware
 from starlette.middleware.gzip import GZipMiddleware
 from starlette.middleware.trustedhost import TrustedHostMiddleware
@@ -13,6 +15,7 @@ from starlette.types import Receive, Scope, Send
 from app.config import Settings, settings
 from app.http_client import close_http_client
 from app.observability import init_sentry
+from app.rate_limit import limiter
 from app.routers import (
     analysis,
     experience,
@@ -98,6 +101,34 @@ app = FastAPI(
     version="0.1.0",
     lifespan=lifespan,
 )
+
+# Rate limiting (slowapi). State attachment is required for the middleware
+# and decorator to find the shared limiter; the exception handler converts
+# RateLimitExceeded into a clean JSON 429 instead of slowapi's default
+# plain-text response. See ``app/rate_limit.py`` for key strategy.
+app.state.limiter = limiter
+
+
+@app.exception_handler(RateLimitExceeded)
+async def _rate_limit_exceeded_handler(
+    request: Request, exc: RateLimitExceeded
+) -> JSONResponse:
+    _log.info(
+        "rate_limit_exceeded path=%s detail=%s",
+        request.url.path,
+        exc.detail,
+    )
+    return JSONResponse(
+        status_code=429,
+        content={
+            "detail": "Rate limit exceeded. Slow down and try again shortly.",
+            "limit": str(exc.detail),
+        },
+        headers={"Retry-After": "60"},
+    )
+
+
+app.add_middleware(SlowAPIMiddleware)
 
 
 class _HealthBypassTrustedHost(TrustedHostMiddleware):

--- a/apps/wyrdfold-api/app/rate_limit.py
+++ b/apps/wyrdfold-api/app/rate_limit.py
@@ -1,0 +1,52 @@
+"""HTTP rate limiting via slowapi.
+
+Per-user (JWT-keyed) limits on expensive or fan-out endpoints — LLM-backed
+generation, Brave-fan-out source discovery, URL validation, and user-driven
+job creation. Closes #850 S2 ("no HTTP rate limiting"), which left the API's
+expensive non-LLM endpoints with zero protection.
+
+In-memory backend is correct for the current single-replica Railway deploy.
+When scaling to multiple replicas, swap to a Redis storage URI via
+``Limiter(storage_uri="redis://…")`` — otherwise each replica enforces its
+own bucket and the combined limit is N× the configured ceiling.
+
+Key strategy:
+  - JWT callers are keyed by ``jwt:<sub>`` so limits track real users
+    regardless of IP (NAT, mobile network changes).
+  - Unauthenticated / api-key fallback is keyed by client IP so bad actors
+    can't trivially bypass by dropping the Bearer header.
+  - Failures decoding the JWT (malformed, expired) fall through to IP keying;
+    they'll be rejected by the endpoint's auth dependency anyway, so the
+    limiter just protects against pre-auth flooding.
+"""
+
+from __future__ import annotations
+
+from fastapi import Request
+from slowapi import Limiter
+from slowapi.util import get_remote_address
+
+from app.config import settings
+from app.dependencies import _try_decode_jwt_sub
+
+
+def _user_or_ip_key(request: Request) -> str:
+    """Return ``jwt:<sub>`` when a valid Supabase JWT is present, else
+    ``ip:<host>``.
+
+    Synchronous on the hot path; the JWT decode is cached by PyJWKClient so
+    repeat lookups for the same key id are O(1).
+    """
+    sub = _try_decode_jwt_sub(request, settings)
+    if sub:
+        return f"jwt:{sub}"
+    return f"ip:{get_remote_address(request)}"
+
+
+limiter = Limiter(
+    key_func=_user_or_ip_key,
+    enabled=settings.rate_limit_enabled,
+    # Default limits — endpoints set their own via ``@limiter.limit(...)``,
+    # but this keeps any future undeclared endpoint from being uncovered.
+    default_limits=["120/minute"],
+)

--- a/apps/wyrdfold-api/app/routers/experience.py
+++ b/apps/wyrdfold-api/app/routers/experience.py
@@ -11,7 +11,7 @@ import json
 from collections.abc import AsyncIterator
 from typing import Any
 
-from fastapi import APIRouter, Depends, HTTPException, Query, UploadFile
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, UploadFile
 from fastapi.responses import StreamingResponse
 from pydantic import ValidationError
 from supabase import Client
@@ -45,6 +45,7 @@ from app.models.experience import (
     TurnAppend,
 )
 from app.models.llm import Message
+from app.rate_limit import limiter
 from app.services.conversation import orchestrator
 from app.services.embeddings.client import EmbeddingsClient
 from app.services.experience import (
@@ -331,7 +332,9 @@ async def create_optimized(
 
 
 @router.post("/derive", dependencies=[Depends(enforce_llm_budget)])
+@limiter.limit("10/minute")
 async def derive_optimized(
+    request: Request,
     supabase: Client = Depends(get_supabase),
     llm: LLMClient = Depends(get_llm_client),
     embeddings: EmbeddingsClient = Depends(get_embeddings_client),
@@ -409,7 +412,9 @@ def _sse_event(event: str, data: dict[str, Any]) -> bytes:
 
 
 @router.post("/derive/stream", dependencies=[Depends(enforce_llm_budget)])
+@limiter.limit("10/minute")
 async def derive_optimized_stream(
+    request: Request,
     supabase: Client = Depends(get_supabase),
     llm: LLMClient = Depends(get_llm_client),
     embeddings: EmbeddingsClient = Depends(get_embeddings_client),

--- a/apps/wyrdfold-api/app/routers/jobs.py
+++ b/apps/wyrdfold-api/app/routers/jobs.py
@@ -7,7 +7,7 @@ from typing import Any, cast
 from urllib.parse import urlparse
 
 import httpx
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from postgrest.types import CountMethod
 from supabase import Client
 
@@ -31,6 +31,7 @@ from app.models.schemas import (
     UrlValidateResponse,
 )
 from app.models.targets import AxisWeights
+from app.rate_limit import limiter
 from app.services.extract import (
     MANUAL_SOURCE_ID,
     ExtractionResult,
@@ -935,7 +936,11 @@ def list_jobs(
 
 
 @router.post("/validate-url")
-async def validate_url(body: UrlValidateRequest) -> UrlValidateResponse:
+@limiter.limit("20/minute")
+async def validate_url(
+    request: Request,
+    body: UrlValidateRequest,
+) -> UrlValidateResponse:
     result = await validate_job_url(body.url)
     return UrlValidateResponse(
         is_valid=result.is_valid,
@@ -946,7 +951,9 @@ async def validate_url(body: UrlValidateRequest) -> UrlValidateResponse:
 
 
 @router.post("/manual")
+@limiter.limit("10/minute")
 async def add_manual_job(
+    request: Request,
     body: ManualJobRequest,
     supabase: Client = Depends(get_supabase),
 ) -> ManualJobResponse:

--- a/apps/wyrdfold-api/app/routers/tailor.py
+++ b/apps/wyrdfold-api/app/routers/tailor.py
@@ -22,7 +22,7 @@ import re
 import zipfile
 from typing import Any, cast
 
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request
 from fastapi.responses import Response
 from pydantic import ValidationError
 from supabase import Client
@@ -47,6 +47,7 @@ from app.models.tailor import (
     TailorResponse,
 )
 from app.models.user_profile import ResumeStyleSettings
+from app.rate_limit import limiter
 from app.services.ats_lint import lint_markdown
 from app.services.batch import create_batch, get_batch, process_batch
 from app.services.docx.pandoc_render import (
@@ -87,7 +88,9 @@ router = APIRouter(
     responses={422: {"model": TailorLintFailureResponse | GapGateFailureResponse}},
     dependencies=[Depends(enforce_llm_budget)],
 )
+@limiter.limit("30/minute")
 async def create_tailored_resume(
+    request: Request,
     body: TailorRequest,
     supabase: Client = Depends(get_supabase),
     llm: LLMClient = Depends(get_llm_client),
@@ -206,7 +209,9 @@ async def create_tailored_resume(
     responses={422: {"model": TailorLintFailureResponse | GapGateFailureResponse}},
     dependencies=[Depends(enforce_llm_budget)],
 )
+@limiter.limit("30/minute")
 async def create_tailored_cover_letter(
+    request: Request,
     body: CoverLetterRequest,
     supabase: Client = Depends(get_supabase),
     llm: LLMClient = Depends(get_llm_client),
@@ -675,7 +680,9 @@ async def download_tailored_resume(
 
 
 @router.post("/batch", dependencies=[Depends(enforce_llm_budget)])
+@limiter.limit("5/minute")
 async def create_batch_resumes(
+    request: Request,
     body: BatchRequest,
     background_tasks: BackgroundTasks,
     supabase: Client = Depends(get_supabase),

--- a/apps/wyrdfold-api/app/routers/targets.py
+++ b/apps/wyrdfold-api/app/routers/targets.py
@@ -10,7 +10,7 @@ import logging
 from typing import Any, cast
 
 import httpx
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request
 from postgrest.types import CountMethod
 from supabase import Client
 
@@ -46,6 +46,7 @@ from app.models.targets import (
     UserTarget,
     UserTargetWithTarget,
 )
+from app.rate_limit import limiter
 from app.services.diagnostics.funnel import compute_target_funnel
 from app.services.experience import optimized
 from app.services.extract import (
@@ -568,7 +569,9 @@ async def activate_target(
     "/{target_id}/discover-sources",
     response_model=DiscoveryRunStats,
 )
+@limiter.limit("2/minute;20/day")
 async def discover_sources_for_target_endpoint(
+    request: Request,
     target_id: str,
     supabase: Client = Depends(get_supabase),
     user_id: str = Depends(get_current_user_id),
@@ -779,7 +782,9 @@ async def link_target(
     response_model=JobTarget,
     dependencies=[Depends(enforce_llm_budget)],
 )
+@limiter.limit("10/minute")
 async def derive_target_profile(
+    request: Request,
     target_id: str,
     supabase: Client = Depends(get_supabase),
     llm: LLMClient = Depends(get_llm_client),
@@ -1127,7 +1132,9 @@ async def _fetch_jd_from_url(url: str) -> tuple[str | None, str]:
     status_code=201,
     dependencies=[Depends(enforce_llm_budget)],
 )
+@limiter.limit("10/minute")
 async def add_reference_jd(
+    request: Request,
     target_id: str,
     body: ReferenceJDAdd,
     supabase: Client = Depends(get_supabase),

--- a/apps/wyrdfold-api/pyproject.toml
+++ b/apps/wyrdfold-api/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
   "twilio>=9.0",
   "sentry-sdk[fastapi]>=2.19",
   "apscheduler>=3.11",
+  "slowapi>=0.1.9",
 ]
 
 [dependency-groups]

--- a/apps/wyrdfold-api/tests/conftest.py
+++ b/apps/wyrdfold-api/tests/conftest.py
@@ -5,6 +5,10 @@ os.environ.setdefault("SUPABASE_URL", "https://test-project.supabase.co")
 os.environ.setdefault("WYRDFOLD_API_KEY", "testkey")
 # Force-overwrite so a local .env with restrictive hosts can't break tests.
 os.environ["ALLOWED_HOSTS"] = "*"
+# Disable HTTP rate limiting in tests — many tests hammer the same endpoint
+# from a single TestClient (one IP, no JWT), which would trip the limiter
+# and turn legitimate test runs into flaky 429s.
+os.environ["RATE_LIMIT_ENABLED"] = "false"
 
 from unittest.mock import MagicMock
 

--- a/apps/wyrdfold-api/tests/test_batch.py
+++ b/apps/wyrdfold-api/tests/test_batch.py
@@ -439,6 +439,7 @@ class TestBatchEndpoint:
         ):
             with pytest.raises(HTTPException) as exc_info:
                 await tailor_router.create_batch_resumes(
+                    request=MagicMock(),
                     body=BatchRequest(
                         job_posting_ids=["job-1"],
                         contact=_CONTACT,
@@ -466,6 +467,7 @@ class TestBatchEndpoint:
         ):
             with pytest.raises(HTTPException) as exc_info:
                 await tailor_router.create_batch_resumes(
+                    request=MagicMock(),
                     body=BatchRequest(
                         job_posting_ids=["nonexistent"],
                         contact=_CONTACT,
@@ -517,6 +519,7 @@ class TestBatchEndpoint:
         )
 
         result = await tailor_router.create_batch_resumes(
+            request=MagicMock(),
             body=BatchRequest(
                 job_posting_ids=["job-1"],
                 contact=_CONTACT,

--- a/apps/wyrdfold-api/tests/test_derive.py
+++ b/apps/wyrdfold-api/tests/test_derive.py
@@ -157,7 +157,10 @@ class TestDeriveEndpoint:
 
         llm = MockLLMClient(scripted={DEFAULT_PURPOSE: _sample_payload_json()})
         result = await exp_router.derive_optimized(
-            supabase=MagicMock(), llm=llm, embeddings=MagicMock()
+            request=MagicMock(),
+            supabase=MagicMock(),
+            llm=llm,
+            embeddings=MagicMock(),
         )
 
         assert result is cached
@@ -220,7 +223,10 @@ class TestDeriveEndpoint:
 
         llm = MockLLMClient(scripted={DEFAULT_PURPOSE: _sample_payload_json()})
         result = await exp_router.derive_optimized(
-            supabase=MagicMock(), llm=llm, embeddings=MagicMock()
+            request=MagicMock(),
+            supabase=MagicMock(),
+            llm=llm,
+            embeddings=MagicMock(),
         )
 
         assert result is new_doc
@@ -271,6 +277,7 @@ class TestDeriveStreamEndpoint:
 
         with pytest.raises(HTTPException) as exc_info:
             await exp_router.derive_optimized_stream(
+                request=MagicMock(),
                 supabase=MagicMock(),
                 llm=MockLLMClient(),
                 embeddings=MagicMock(),
@@ -311,7 +318,10 @@ class TestDeriveStreamEndpoint:
 
         llm = MockLLMClient(scripted={DEFAULT_PURPOSE: _sample_payload_json()})
         response = await exp_router.derive_optimized_stream(
-            supabase=MagicMock(), llm=llm, embeddings=MagicMock()
+            request=MagicMock(),
+            supabase=MagicMock(),
+            llm=llm,
+            embeddings=MagicMock(),
         )
 
         events = _parse_sse(await _drain(response))
@@ -368,7 +378,10 @@ class TestDeriveStreamEndpoint:
 
         llm = MockLLMClient(scripted={DEFAULT_PURPOSE: _sample_payload_json()})
         response = await exp_router.derive_optimized_stream(
-            supabase=MagicMock(), llm=llm, embeddings=MagicMock()
+            request=MagicMock(),
+            supabase=MagicMock(),
+            llm=llm,
+            embeddings=MagicMock(),
         )
 
         events = _parse_sse(await _drain(response))

--- a/apps/wyrdfold-api/tests/test_manual_job.py
+++ b/apps/wyrdfold-api/tests/test_manual_job.py
@@ -97,7 +97,7 @@ class TestManualJobEndpoint:
         from app.routers.jobs import add_manual_job
 
         body = ManualJobRequest(url="https://example.com/jobs/123")
-        result = await add_manual_job(body=body, supabase=mock_supabase)
+        result = await add_manual_job(request=MagicMock(), body=body, supabase=mock_supabase)
 
         assert result.success is True
         assert result.posting_id == "posting-uuid-1"
@@ -131,7 +131,7 @@ class TestManualJobEndpoint:
             title="My Custom Title",
             company_name="Override Corp",
         )
-        result = await add_manual_job(body=body, supabase=mock_supabase)
+        result = await add_manual_job(request=MagicMock(), body=body, supabase=mock_supabase)
 
         assert result.success is True
         # User overrides should win
@@ -149,7 +149,7 @@ class TestManualJobEndpoint:
 
         body = ManualJobRequest(url="not-a-url")
         with pytest.raises(HTTPException) as exc_info:
-            await add_manual_job(body=body, supabase=MagicMock())
+            await add_manual_job(request=MagicMock(), body=body, supabase=MagicMock())
         assert exc_info.value.status_code == 400
         assert "Malformed" in exc_info.value.detail
 
@@ -162,7 +162,7 @@ class TestManualJobEndpoint:
 
         body = ManualJobRequest(url="https://www.ziprecruiter.com/jobs/123")
         with pytest.raises(HTTPException) as exc_info:
-            await add_manual_job(body=body, supabase=MagicMock())
+            await add_manual_job(request=MagicMock(), body=body, supabase=MagicMock())
         assert exc_info.value.status_code == 400
         assert "Banned" in exc_info.value.detail
 
@@ -175,7 +175,7 @@ class TestManualJobEndpoint:
         from app.routers.jobs import add_manual_job
 
         body = ManualJobRequest(url="https://example.com/opaque-page")
-        result = await add_manual_job(body=body, supabase=MagicMock())
+        result = await add_manual_job(request=MagicMock(), body=body, supabase=MagicMock())
 
         assert result.success is False
         assert result.needs_manual_fields is True
@@ -199,7 +199,7 @@ class TestManualJobEndpoint:
             title="Manually Entered Job",
             company_name="Some Company",
         )
-        result = await add_manual_job(body=body, supabase=mock_supabase)
+        result = await add_manual_job(request=MagicMock(), body=body, supabase=mock_supabase)
 
         assert result.success is True
         assert result.posting_id == "posting-uuid-3"
@@ -223,7 +223,7 @@ class TestManualJobEndpoint:
         from app.routers.jobs import add_manual_job
 
         body = ManualJobRequest(url=url)
-        await add_manual_job(body=body, supabase=mock_supabase)
+        await add_manual_job(request=MagicMock(), body=body, supabase=mock_supabase)
 
         upsert_call = mock_supabase.table.return_value.upsert.call_args
         row = upsert_call[0][0]
@@ -242,7 +242,7 @@ class TestManualJobEndpoint:
 
         body = ManualJobRequest(url="https://example.com/jobs/123")
         with pytest.raises(HTTPException) as exc_info:
-            await add_manual_job(body=body, supabase=MagicMock())
+            await add_manual_job(request=MagicMock(), body=body, supabase=MagicMock())
         assert exc_info.value.status_code == 400
         assert "fetch" in exc_info.value.detail.lower()
 
@@ -259,6 +259,6 @@ class TestManualJobEndpoint:
 
         body = ManualJobRequest(url="https://legit.com/jobs/123")
         with pytest.raises(HTTPException) as exc_info:
-            await add_manual_job(body=body, supabase=MagicMock())
+            await add_manual_job(request=MagicMock(), body=body, supabase=MagicMock())
         assert exc_info.value.status_code == 400
         assert "banned" in exc_info.value.detail.lower()

--- a/apps/wyrdfold-api/tests/test_resume_lifecycle.py
+++ b/apps/wyrdfold-api/tests/test_resume_lifecycle.py
@@ -286,6 +286,7 @@ class TestSingleResumeStatusBump:
                 # force_fresh skips the reuse short-circuit so we hit the full
                 # generation branch deterministically.
                 await tailor_router.create_tailored_resume(
+                    request=MagicMock(),
                     body=TailorRequest(
                         job_description="Build things.",
                         contact=_CONTACT,
@@ -342,6 +343,7 @@ class TestSingleResumeStatusBump:
                 return_value=MagicMock(ok=True),
             ):
                 await tailor_router.create_tailored_resume(
+                    request=MagicMock(),
                     body=TailorRequest(
                         job_description="Build things.",
                         contact=_CONTACT,

--- a/uv.lock
+++ b/uv.lock
@@ -667,6 +667,18 @@ version = "0.0.0"
 source = { virtual = "." }
 
 [[package]]
+name = "deprecated"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/85/12f0a49a7c4ffb70572b6c2ef13c90c88fd190debda93b23f026b25f9634/deprecated-1.3.1.tar.gz", hash = "sha256:b1b50e0ff0c1fddaa5708a2c6b0a6588bb09b892825ab2b214ac9ea9d92a5223", size = 2932523, upload-time = "2025-10-30T08:19:02.757Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/d0/205d54408c08b13550c733c4b85429e7ead111c7f0014309637425520a9a/deprecated-1.3.1-py2.py3-none-any.whl", hash = "sha256:597bfef186b6f60181535a29fbe44865ce137a5079f295b479886c82729d5f3f", size = 11298, upload-time = "2025-10-30T08:19:00.758Z" },
+]
+
+[[package]]
 name = "deprecation"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1325,6 +1337,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b9/eb/7697f60fbe7042ab4e88f4ee6af496b7f222fffb0a4e3593ef1f29f81652/librt-0.8.1-cp314-cp314t-win32.whl", hash = "sha256:738f08021b3142c2918c03692608baed43bc51144c29e35807682f8070ee2a3a", size = 51328, upload-time = "2026-02-17T16:12:45.148Z" },
     { url = "https://files.pythonhosted.org/packages/7c/72/34bf2eb7a15414a23e5e70ecb9440c1d3179f393d9349338a91e2781c0fb/librt-0.8.1-cp314-cp314t-win_amd64.whl", hash = "sha256:89815a22daf9c51884fb5dbe4f1ef65ee6a146e0b6a8df05f753e2e4a9359bf4", size = 58722, upload-time = "2026-02-17T16:12:46.85Z" },
     { url = "https://files.pythonhosted.org/packages/b2/c8/d148e041732d631fc76036f8b30fae4e77b027a1e95b7a84bb522481a940/librt-0.8.1-cp314-cp314t-win_arm64.whl", hash = "sha256:bf512a71a23504ed08103a13c941f763db13fb11177beb3d9244c98c29fb4a61", size = 48755, upload-time = "2026-02-17T16:12:47.943Z" },
+]
+
+[[package]]
+name = "limits"
+version = "5.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "deprecated" },
+    { name = "packaging" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/71/69/826a5d1f45426c68d8f6539f8d275c0e4fcaa57f0c017ec3100986558a41/limits-5.8.0.tar.gz", hash = "sha256:c9e0d74aed837e8f6f50d1fcebcf5fd8130957287206bc3799adaee5092655da", size = 226104, upload-time = "2026-02-05T07:17:35.859Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/98/cb5ca20618d205a09d5bec7591fbc4130369c7e6308d9a676a28ff3ab22c/limits-5.8.0-py3-none-any.whl", hash = "sha256:ae1b008a43eb43073c3c579398bd4eb4c795de60952532dc24720ab45e1ac6b8", size = 60954, upload-time = "2026-02-05T07:17:34.425Z" },
 ]
 
 [[package]]
@@ -2721,6 +2747,18 @@ wheels = [
 ]
 
 [[package]]
+name = "slowapi"
+version = "0.1.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "limits" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a0/99/adfc7f94ca024736f061257d39118e1542bade7a52e86415a4c4ae92d8ff/slowapi-0.1.9.tar.gz", hash = "sha256:639192d0f1ca01b1c6d95bf6c71d794c3a9ee189855337b4821f7f457dddad77", size = 14028, upload-time = "2024-02-05T12:11:52.13Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2b/bb/f71c4b7d7e7eb3fc1e8c0458a8979b912f40b58002b9fbf37729b8cb464b/slowapi-0.1.9-py3-none-any.whl", hash = "sha256:cfad116cfb84ad9d763ee155c1e5c5cbf00b0d47399a769b227865f5df576e36", size = 14670, upload-time = "2024-02-05T12:11:50.898Z" },
+]
+
+[[package]]
 name = "sniffio"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3300,6 +3338,81 @@ wheels = [
 ]
 
 [[package]]
+name = "wrapt"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2d/9f/06263fcd8ad6c405f05a3905fd7a84dd3176eb5ad46e44bccc0cd16348bb/wrapt-2.2.1.tar.gz", hash = "sha256:6744f504375775d7609c82c8d3d94af1c9a6f05586984536905908ba905277b9", size = 127620, upload-time = "2026-05-22T14:49:43.056Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5f/ac/4370bde262c0e633e6c4f0e56d55095710024cf9a5cecc20c59a10de483c/wrapt-2.2.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:dd57607acc85678925940bd5df0385ff8332083a32fa8d7a43f8767f4997263c", size = 80321, upload-time = "2026-05-22T14:47:43.996Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/79/b8ff3a61e71babf58a8cf4c0d63358e8bad383e15bf7f35e62d2f6b6e4a4/wrapt-2.2.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1ae574d65c9fa8e86f64f6a7c2668f9fcd507b183e0e577619f504b883cb0a6c", size = 81216, upload-time = "2026-05-22T14:47:45.243Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/fd/c0cac1f77c9c4f6fe58a920ca632ce379bb8be928720e11e8d73de28a5e9/wrapt-2.2.1-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9a04c28c10ba7fd12842b109d2edb0678872a2fe65277ca4ff06a0d61edee245", size = 159208, upload-time = "2026-05-22T14:47:47.176Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/4f/744132a7b2fbefa6b81118ec5942eca5fc2e9a129f9055a0c5e46885a549/wrapt-2.2.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3e2f02472a1cbbf3884b365714a810b5947134a95ad6952b554cb8cce9d492b0", size = 160322, upload-time = "2026-05-22T14:47:49.04Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/95/b7cd9a22a06cf93e6482904ee6afc956248983553593fd1009296d1b3b31/wrapt-2.2.1-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:ac2745950b2bff80219c15ebf2fa9d8427eba7e249739f97e55c9d169e47e9e1", size = 153243, upload-time = "2026-05-22T14:47:50.386Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/4a/eb79423192015f46f0db2872e7e04a3dde8d359b83411e8959e7c9287eaa/wrapt-2.2.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:67a97e5b6c457f0cd3cfc19ebb2d84463e60c3ece754cc831e4281a3ca29bb18", size = 159231, upload-time = "2026-05-22T14:47:51.753Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/dc/435015b58ce33c6fc4104158fa91ddb0e809ab03a5751fb7465d1d461456/wrapt-2.2.1-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:c803a3d331796255af51ba2c79ed0ac8275865b516c09e61f248d1e7aff31ce9", size = 152351, upload-time = "2026-05-22T14:47:53.214Z" },
+    { url = "https://files.pythonhosted.org/packages/77/ac/5d203f98df8fd136b95c5227139aea02d34505e18baf812d0c005df61963/wrapt-2.2.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:9b984d1eb252145d6302c1dbd5e87fc6d404d45531447c84eadec04bf1fcb027", size = 158347, upload-time = "2026-05-22T14:47:54.982Z" },
+    { url = "https://files.pythonhosted.org/packages/52/2f/a92427dbdc74e54c1674abbed27e61b2cb5e7a94441b8c1270c70671d928/wrapt-2.2.1-cp311-cp311-win32.whl", hash = "sha256:8a983a603a18c8708f024f7f6991b2e66159219abbf894634c5056243c55f3cd", size = 77562, upload-time = "2026-05-22T14:47:56.275Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/56/987b9c13b3e1c1a3c6de71284076f996b79caec90e75a87c044a40c23db9/wrapt-2.2.1-cp311-cp311-win_amd64.whl", hash = "sha256:9c210a6994b21aa9b29e81c8d11560e8fdab54c117e9cff37870d0a27bde1343", size = 80616, upload-time = "2026-05-22T14:47:57.854Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/25/d01f560888d99d94a959c85533de349ce68d71ace3f2591d6ea8f632cfed/wrapt-2.2.1-cp311-cp311-win_arm64.whl", hash = "sha256:401229e9d63ca09f9b8891ecf83798d26c11bbb445d11ed9f1836b6d4585b38a", size = 79025, upload-time = "2026-05-22T14:47:59.089Z" },
+    { url = "https://files.pythonhosted.org/packages/89/0c/bfae7b9401583b6d05938cd16dedc43857d96da2f8a3d50d78cc515bf6ff/wrapt-2.2.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:3ffad790d9d11d8ecf9f17c4bb671a5b4089e4d8b575c46c5129597f41f836b0", size = 81021, upload-time = "2026-05-22T14:48:00.313Z" },
+    { url = "https://files.pythonhosted.org/packages/26/58/80f6a6599f933f4caecc1cb3ee88a04faf81e8b9bddbd6109c688dd63e0f/wrapt-2.2.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:628f5220c7a904d5fc78f7075c8d7871433eb6d035c94728a22fdf85f193d2a8", size = 81692, upload-time = "2026-05-22T14:48:01.49Z" },
+    { url = "https://files.pythonhosted.org/packages/17/93/fb357cc7847c58a8ae790be718903afa81a28d23e642c843dc4129e8a0b2/wrapt-2.2.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:61acce4257a9883669703c525447c5b4c392edf0f987ae77ec32668440158f0e", size = 169364, upload-time = "2026-05-22T14:48:02.791Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/0b/76b601ee309a8bd556af0eecb184394c20b3c49aa9c8e085aa1ffacc2568/wrapt-2.2.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:727ab4244622cd6ad2390f322642090c877d2e83a608d2653a7643ae5368d926", size = 171079, upload-time = "2026-05-22T14:48:04.22Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/87/ee3f32d5658e3e26d3e0e457922b47a36dd3bfbdfee7f97bb3e802344a66/wrapt-2.2.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:03df9ebed4c73ab93fa8c07e3d41d818dfca1852b15731a3de59457b27814624", size = 160205, upload-time = "2026-05-22T14:48:05.553Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/d0/ae2fd64277a67f5d7bffcf2d05eea1e476263fb2a072baf0b0129ab85984/wrapt-2.2.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:0d9ff006f420b2ec8296aa56ade43ea7da3e997e85769f0aafc5e0661aacb710", size = 168922, upload-time = "2026-05-22T14:48:07.132Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f3/2d541a060c5bbafb9400bca4917e4d78bfd1f239f404782c86831a8f6b29/wrapt-2.2.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:844c858fc3bb7eacc0ba8efa904935d16aac6a4470948ad1e7e55c9f5a2a665f", size = 158388, upload-time = "2026-05-22T14:48:08.629Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/68/8d92c8800c57e93cb116ae9e9d6cbafc34fade5ee9f9107b6f203fb4dc35/wrapt-2.2.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:87bacdaf225117a342a20d9c03438d701c02112f6e3f351ce9b7f32354f14797", size = 167682, upload-time = "2026-05-22T14:48:10.042Z" },
+    { url = "https://files.pythonhosted.org/packages/30/72/83ea3790ea352439442349388e29ff07b76e0686265f9088bbb505d1608d/wrapt-2.2.1-cp312-cp312-win32.whl", hash = "sha256:2f8c90c8afde51969487be4e1343ae049b268854877d415c2510baf833775052", size = 77857, upload-time = "2026-05-22T14:48:11.782Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/cb/99450668dd3502d62a54a1c8aa56e44f34cb8c1261b381cfe2e7926c3b75/wrapt-2.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:6ce32763ac31ce94fe9aada947e479b1975012bff166da409b4b9e4e376cf7e5", size = 80825, upload-time = "2026-05-22T14:48:13.046Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/3a/87512881be64e743f9ee4c66f4cbe8e884974bef2a5989af71f999653ac7/wrapt-2.2.1-cp312-cp312-win_arm64.whl", hash = "sha256:8d1b4d0e0c2119587a31f5c029abd547e0c81d93b89d394566fe1588659eb579", size = 79087, upload-time = "2026-05-22T14:48:14.323Z" },
+    { url = "https://files.pythonhosted.org/packages/88/d1/a1b08f8f4fac8cbb156fa51cf64ee2c7f7f74f9875ba3cf70b3c58368694/wrapt-2.2.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:d2beb1c7cab10603aecdc42f8edd6ff013f9a32e4543474e38e6b77ce9975aeb", size = 80831, upload-time = "2026-05-22T14:48:15.598Z" },
+    { url = "https://files.pythonhosted.org/packages/54/ce/57890814991446a845e09b3445ce8b694f27eb0577004f2c2a36a9772ed4/wrapt-2.2.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e0cb7e4dd71f4c32e5e84843cd3c4cd65dda034314004bbe1d7f99af2426ab80", size = 81375, upload-time = "2026-05-22T14:48:17.071Z" },
+    { url = "https://files.pythonhosted.org/packages/38/65/08d7a6c76ac4493bdb668205ee9c1de1bd5daca61717c3e9aa49b4c01499/wrapt-2.2.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:95821352042722cd9f1108874579a47989d0a7e12a37d87d2fc4af20fd99ab8a", size = 167417, upload-time = "2026-05-22T14:48:18.303Z" },
+    { url = "https://files.pythonhosted.org/packages/62/ce/f1ccbee7a1bfe5cdc6b3da6bab4b45713d628b9294da32a39f563d648140/wrapt-2.2.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:abd621552ede77c4c69be7fac44ba911225b0c812b6ba604e5964cf98085b474", size = 166948, upload-time = "2026-05-22T14:48:19.768Z" },
+    { url = "https://files.pythonhosted.org/packages/86/2a/f85d48d1cd4869aee6704028d257d740a47c1c467b457ce396b4b5b55d07/wrapt-2.2.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e3677c7146ce694874941ba82b57092cc4875445aadf29d72807351023105143", size = 158148, upload-time = "2026-05-22T14:48:21.96Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/5c/93939ad11d4a12358ab1aab219a2ef5efa5612e0db6b9fc65af8af1a891b/wrapt-2.2.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:9a5934eaea872e17936b5f45501eba5ab0bce9a74122e172b663d7c28c459c4a", size = 165905, upload-time = "2026-05-22T14:48:23.373Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/22/b8c2aa89862ff58605934d7abf4b70e6a5a1c33df96656f49035ccdf1c8a/wrapt-2.2.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:f5b9daf6b629fce418e0cc3dd0436eac045188fa35deadb7a7f3941d5b8203f9", size = 156712, upload-time = "2026-05-22T14:48:24.767Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/78/bf00a7b02239c12bb02ddcc3c0b971bfcc36e578c5a44f1ccfef5b458545/wrapt-2.2.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:f53ac9f3ef573326d009ed809beff4efcac6451931c2b8132586da4b9e53ff31", size = 166560, upload-time = "2026-05-22T14:48:26.83Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/93/6390ca9c5b787683cef588d04f57c8d41b9a2323b5597a65f18638c90ef2/wrapt-2.2.1-cp313-cp313-win32.whl", hash = "sha256:1ffa9cfd4bdb581539951b14ae661ff20ed0c3599b3e911a131ee0ec5ac11337", size = 77817, upload-time = "2026-05-22T14:48:28.221Z" },
+    { url = "https://files.pythonhosted.org/packages/97/73/ce10f0e71c0cfaa1a65faadb8efd4852028b3bb9ba28932b8889df769d38/wrapt-2.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:368eac1e20fd0bb03dd3cc42bf9887154c3861b60989389ccb5fac032617d215", size = 80736, upload-time = "2026-05-22T14:48:30.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/4c/89f4a6818fafbbd840330e4fa3873073e1bfc166133a64cac7f8fde7a5e3/wrapt-2.2.1-cp313-cp313-win_arm64.whl", hash = "sha256:c754dafdf5aaf0b401b644a90a30046929a0dd1a536e0ff0ec959a59155d9c7f", size = 79099, upload-time = "2026-05-22T14:48:31.405Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/f2/9a8741c46f8c208ac0a45b25ba170bcb4fb72a2781d5fb97dbd7b6be73cb/wrapt-2.2.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:ed928d0fda15fc0adc8d13305c8b3c0f2fba5b0669950c9e6d019d9162a3b3e8", size = 82802, upload-time = "2026-05-22T14:48:33.307Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/0d/e9c855716a3705eef1416456bdf062b60620726fdc59428ff670fc3c60dc/wrapt-2.2.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:fafb4e739e43544d12cb4abd1605fd4683b6ca6a9ad682b7fd8f4d21973eafa8", size = 83329, upload-time = "2026-05-22T14:48:34.593Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/d6/a88f1c13112b7831adac75cea65d8310e0d696d570c8961844c90a57b865/wrapt-2.2.1-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:74d6a0c31472fe5d814917266b9f46495d7c61ed890af08b468acea92fb89a8d", size = 202937, upload-time = "2026-05-22T14:48:35.859Z" },
+    { url = "https://files.pythonhosted.org/packages/42/65/e29d54aef06a4d898a5b8a25589a0b3769bde454f922fad8f6f89fbfb650/wrapt-2.2.1-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ab5be648d5a0b86b7438864f8df3c705a65cef35a2fd3e5561e3e203167e0f27", size = 209997, upload-time = "2026-05-22T14:48:38.153Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/91/e4454263516cf0e12640912fbca9a83654e424f0a6ddb79f5cd7ce14bf33/wrapt-2.2.1-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9d8f204c8e3a8bf9ece17e0a83d137fd807440977f8a5e762d59306795011440", size = 194856, upload-time = "2026-05-22T14:48:39.69Z" },
+    { url = "https://files.pythonhosted.org/packages/de/d0/fe0ee202286afdf4a7f77dd29f195703145764d572aec209c5086e57d924/wrapt-2.2.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:d047f6498c973874ba08ac3f97c69a2c4b2211c8de6f4c205f75cb1c9522596e", size = 205654, upload-time = "2026-05-22T14:48:43.456Z" },
+    { url = "https://files.pythonhosted.org/packages/23/b6/87d860dfc6460c246af70b1fd5c8b76df77571b42a493459423ded94fd7d/wrapt-2.2.1-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:7a4fdb9326aab4a5a477a1640e5ad786a8495901009d7e7b038371edd23a9d2b", size = 192206, upload-time = "2026-05-22T14:48:44.858Z" },
+    { url = "https://files.pythonhosted.org/packages/df/46/3eea8cde077d985f239a38c0257087b8064fd9ee9b1a99e282d2c86da4ef/wrapt-2.2.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:c8cc5094b08abeae52da9c73c8a32003623be691a5193df2f4e3eac3d557c394", size = 198428, upload-time = "2026-05-22T14:48:46.319Z" },
+    { url = "https://files.pythonhosted.org/packages/18/dc/b927ee9c7fc67adc3a5658f246a0d275425eb840ba36e7b702e70f18bde8/wrapt-2.2.1-cp313-cp313t-win32.whl", hash = "sha256:9907a4402ab6db12b7077a0ea5d7a4d028ecb22c8eee2b53527080d347cd1562", size = 79448, upload-time = "2026-05-22T14:48:47.901Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/b3/fd30b473fe498c70e6b9a5f328b8d3fbaf1b8c3c481465f59724bba8eb70/wrapt-2.2.1-cp313-cp313t-win_amd64.whl", hash = "sha256:5590d63f5243251641cf543009b4c9314a79d0598fdb8a8e4cfc918494536c53", size = 83021, upload-time = "2026-05-22T14:48:49.201Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/f3/96c39153a8737a6e9aa85adef254ac4195bea3f2d24efc60472ccc3c9e2e/wrapt-2.2.1-cp313-cp313t-win_arm64.whl", hash = "sha256:c318a64b53d97b841d7b5e637517e50a27be64bc695128422953d4b21710954e", size = 80295, upload-time = "2026-05-22T14:48:50.479Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/a3/11d7f34ebbf3231bc907a3e6d5ee051b14d034c1bc7b65a97d5cc00516df/wrapt-2.2.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:6f56a647e4eaf5f0ca40330fb070f566bdf9f7b0db89a1af20d71c28dcd7a0ab", size = 80879, upload-time = "2026-05-22T14:48:51.802Z" },
+    { url = "https://files.pythonhosted.org/packages/13/3c/b74cfd984cef560b900fb1a727af20352d89e1f06bf2e1114dd3f00f5f5a/wrapt-2.2.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:64b7deeda4b70408e382328d8bbe52a256fe9bc63ae3db86d804608367e5422c", size = 81462, upload-time = "2026-05-22T14:48:53.18Z" },
+    { url = "https://files.pythonhosted.org/packages/15/a3/7c8f704b8dc07dfe0a5d01c2edbfd88317aa8e5e3fa7c743eb7a085ae767/wrapt-2.2.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b9cf53ba90717db2e292401de290776c498d4bbfb0d4a559ca2895db8b9dcb5c", size = 167251, upload-time = "2026-05-22T14:48:54.562Z" },
+    { url = "https://files.pythonhosted.org/packages/80/85/a34d1888d97247da6c2ff6118c3a721c73ed8cc4dd198c00208bb73b6f80/wrapt-2.2.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cf3638274ab9d9b724c9baa0b4c04e132cd6faefb78b4dd3dd1a02a4bdaad41e", size = 166316, upload-time = "2026-05-22T14:48:56.065Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/d7/72ffaeb01eebc704afe3fb99e840480f4bda45f0fa66e3381b6a39251c8f/wrapt-2.2.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:aed9658797d0b45d6c49adcfc6b41f66e6f2d0c6de3ec79e16cf4b1855df240f", size = 157952, upload-time = "2026-05-22T14:48:57.924Z" },
+    { url = "https://files.pythonhosted.org/packages/24/5b/36f5d6b024e4edfdd90b140742d11ebcf7836daf5c9daf326c55c24db412/wrapt-2.2.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:1d676ee388bc42a04d56dd7deb5605244dac2e35cc2fadbb43c9fa25bbd93508", size = 166130, upload-time = "2026-05-22T14:48:59.384Z" },
+    { url = "https://files.pythonhosted.org/packages/81/06/9296d9e97bfdef5483dfcc859d57b095b257144b2bc5300ab521e06f4bc7/wrapt-2.2.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e395f7bc31851ef9b612050368cb446e9bc14cd7454b025018980349caf25ae5", size = 156604, upload-time = "2026-05-22T14:49:00.921Z" },
+    { url = "https://files.pythonhosted.org/packages/53/37/16953929ed6776175720e58fc966e779926d8d71e2c7b2273230590ca71f/wrapt-2.2.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5f1845c2a8cc1180ccccfa45785dd06f562730d19ef75be180334254012b6283", size = 166007, upload-time = "2026-05-22T14:49:02.332Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/73/20ee58c0612dae7c31131a7095345812ed2c7b389019e175f68cde34e5b4/wrapt-2.2.1-cp314-cp314-win32.whl", hash = "sha256:436addbc4bb4fc0a88c702577f51195d7d73683a7f3e0e5b253d8404d7847243", size = 78327, upload-time = "2026-05-22T14:49:03.722Z" },
+    { url = "https://files.pythonhosted.org/packages/22/b3/ef7c3295d02e0448a71c639a36a057f46d524d057c9486291a7a3039e65c/wrapt-2.2.1-cp314-cp314-win_amd64.whl", hash = "sha256:50972a1d974ea07725a7f6b1cec5f8759008afd030a0024843ebe7d52de47f2b", size = 81144, upload-time = "2026-05-22T14:49:05.093Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/dc/7bdf336953f99f4ceb0a584bb8870e42c8f26f93ea10c87834dad62f1668/wrapt-2.2.1-cp314-cp314-win_arm64.whl", hash = "sha256:1c9934ea5d92957e3cd0adbc0845539dccfd62710ebe16195a8c66c53954db36", size = 79569, upload-time = "2026-05-22T14:49:06.413Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/6d/6dfae80150ff1919c356d1dd528f049bcdfaae29b4d284bc957e022caef4/wrapt-2.2.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:17de18fc12cea55b8a9587314cb830573e37fb33b247a7515696350863714188", size = 82892, upload-time = "2026-05-22T14:49:07.925Z" },
+    { url = "https://files.pythonhosted.org/packages/82/7b/4e34766a7d7804ffce9e71befe47e9b3225dc350c49c94493c4ab39fd3a5/wrapt-2.2.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a9dec1aca52dddde7df94818310fa2fe79739c8f385b2014c4cb1035f5508199", size = 83333, upload-time = "2026-05-22T14:49:09.257Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/57/0b34db3e8de44ccfece62d7b337abd1631dd810f5adc5f3db571727836b5/wrapt-2.2.1-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:69f2e9244542cb34dd59c7f073445b9e54ad9f3fce8d93606c368a1b499fc413", size = 202899, upload-time = "2026-05-22T14:49:10.572Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/45/ac0c459f154b99d92789a6cba7ca727185b83513b986f8ec7fe2aacddcbf/wrapt-2.2.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2d83966dc7f4f45e8b97b5933685ac2e6e67fc0e19246ea314bceb9a8970c956", size = 209986, upload-time = "2026-05-22T14:49:12.229Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/e4/77e37ff33ad018fa81ade52c25fa327b80b56f81d734279a63614fcb4cbc/wrapt-2.2.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:78b0aa6bfb7be8deed0ab23e7aa028cc5210c29bc2d32a04d52b50e517a7307e", size = 194893, upload-time = "2026-05-22T14:49:14.139Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/9d/7ea651d1ab032fc5fa222fbec91d0f8a1397f6ae04ebb93fa7219aa921d7/wrapt-2.2.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:05d5cb74d1b232ec8cfa130a8f900708699ff2491d97b8f85a4cdc5996294b85", size = 205636, upload-time = "2026-05-22T14:49:15.714Z" },
+    { url = "https://files.pythonhosted.org/packages/09/af/8e88031a701275b9085c54e64bc88c0b1cd55c77eadd400691c371cd76c4/wrapt-2.2.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f6518b94edb9150452e9aba08027d4cc293433753ec1fbefb4629a21cbc74181", size = 192267, upload-time = "2026-05-22T14:49:17.283Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/a8/e657ca876b06710194f243d81c4b0896ade646e244bdbec2d87c8c56a8bd/wrapt-2.2.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ed55af48b3eb28f43228ca2306788892bcb629eb2b5c4876e2a3659872c2f17a", size = 198378, upload-time = "2026-05-22T14:49:18.785Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/59/822efe4ea722a3961331bfa35b7d90937790d2c20f0616de1997ccc3aebd/wrapt-2.2.1-cp314-cp314t-win32.whl", hash = "sha256:2e08688ab16525897da6589d56d0aebaf417bbe91c2d8e3b96203b1efa596e85", size = 80226, upload-time = "2026-05-22T14:49:20.264Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/31/2a7dc5f6abb2fca0b6e1610e120419f603650aceb4f1d3ac4cae0354e162/wrapt-2.2.1-cp314-cp314t-win_amd64.whl", hash = "sha256:fd0135d34387f5fd087d9be368ea77ea89cf2451dc1cd1c622d35021bcb3ab50", size = 83835, upload-time = "2026-05-22T14:49:21.634Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/c0/782b86e28d1ceebeb74cccea12d2cd3d2ba0bd68e3dec20b1bc5873f6127/wrapt-2.2.1-cp314-cp314t-win_arm64.whl", hash = "sha256:f70db64e8266d7c45d3b735f2e08eeb434b5e03da9a479ae42b2e2e486a21a00", size = 80722, upload-time = "2026-05-22T14:49:23.59Z" },
+    { url = "https://files.pythonhosted.org/packages/53/46/29ac9daf11a86c22a8c38cd9236c62928ccae83f7ceb06bd3b0467cf9d05/wrapt-2.2.1-py3-none-any.whl", hash = "sha256:3aafea2975caef8ca49400640dde02cc7426e798f24870ed01f490bc3cffd32f", size = 61000, upload-time = "2026-05-22T14:49:41.593Z" },
+]
+
+[[package]]
 name = "wyrdfold-api"
 version = "0.1.0"
 source = { virtual = "apps/wyrdfold-api" }
@@ -3316,6 +3429,7 @@ dependencies = [
     { name = "python-docx" },
     { name = "python-multipart" },
     { name = "sentry-sdk", extra = ["fastapi"] },
+    { name = "slowapi" },
     { name = "supabase" },
     { name = "twilio" },
     { name = "uvicorn", extra = ["standard"] },
@@ -3346,6 +3460,7 @@ requires-dist = [
     { name = "python-docx", specifier = ">=1.1" },
     { name = "python-multipart", specifier = ">=0.0.18" },
     { name = "sentry-sdk", extras = ["fastapi"], specifier = ">=2.19" },
+    { name = "slowapi", specifier = ">=0.1.9" },
     { name = "supabase", specifier = ">=2.13" },
     { name = "twilio", specifier = ">=9.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.34" },


### PR DESCRIPTION
## Summary
Closes danieljoffe/wyrdfold#7 S2 — the API had no HTTP rate limiting at all. LLM budget enforcement is post-hoc only, and expensive non-LLM endpoints (manual job creation, URL validation, Brave-fan-out source discovery) were completely unprotected.

This PR wires **slowapi** into the FastAPI app with per-user (JWT-sub keyed) limits on the costly endpoints, falling back to IP keying when no JWT is present.

### Limits applied

| Endpoint | Limit |
|---|---|
| `/tailor/resume`, `/tailor/cover-letter` | 30/min |
| `/tailor/batch` (20-job fan-out) | 5/min |
| `/experience/derive`, `/derive/stream` | 10/min |
| `/targets/{id}/derive-profile`, `/reference-jds` | 10/min |
| `/targets/{id}/discover-sources` (~90 Brave queries per call) | 2/min, 20/day |
| `/jobs/manual` | 10/min |
| `/jobs/validate-url` | 20/min |

### Key strategy
- JWT callers keyed by `jwt:<sub>` — limits track real users regardless of IP (NAT, mobile).
- Unauth / api-key fallback keyed by `ip:<host>`.
- Failed JWT decodes fall through to IP keying; the endpoint's auth dependency rejects them anyway.
- 429 responses return a clean JSON envelope with a `Retry-After` header.

### Storage backend
In-memory — correct for the current single Railway replica. **When scaling to multiple replicas, swap to Redis** (`Limiter(storage_uri='redis://…')`); otherwise each replica enforces its own bucket and the combined limit is N× the configured ceiling. Documented at the top of `rate_limit.py`.

### Tests
- New `RATE_LIMIT_ENABLED=false` env (default True) in `conftest.py` bypasses the limiter in tests so a single TestClient IP doesn't trip 429s.
- Slowapi wraps the function even when disabled and requires a `Request` arg — direct handler calls in tests (test_batch, test_derive, test_resume_lifecycle, test_manual_job) now pass `request=MagicMock()`.
- All 1190 wyrdfold-api tests pass locally.

Part of danieljoffe/wyrdfold#7 (S2). **PR 5 of 5 for Sprint 1.**

## Test plan
- [x] All 1190 wyrdfold-api tests pass
- [x] Ruff clean
- [ ] Manual: hit `/tailor/resume` 31× as one user → 31st returns 429
- [ ] Manual: hit `/jobs/manual` from two different JWTs → independent buckets
- [ ] Manual: confirm `Retry-After: 60` header on 429

🤖 Generated with [Claude Code](https://claude.com/claude-code)