### PR TITLE
perf(wyrdfold): wrap auth.jwt() in scalar subquery on RLS policies

### DIFF
--- a/supabase/migrations/20260608130000_rls_wrap_auth_jwt_subquery.sql
+++ b/supabase/migrations/20260608130000_rls_wrap_auth_jwt_subquery.sql
@@ -1,0 +1,48 @@
+-- Wrap auth.jwt() in a scalar subquery on the job_feedback and
+-- target_learning_log RLS policies so Postgres evaluates it once per
+-- query instead of once per row.
+--
+-- The original policies (migrations 20260601130000_job_feedback.sql and
+-- 20260601140000_target_learning_log.sql) used the unwrapped form:
+--
+--     using (auth.jwt() ->> 'sub' = user_id)
+--
+-- which the planner treats as a STABLE function call referenced in a
+-- per-row filter — re-evaluating the JWT lookup for every row scanned.
+-- Wrapping in `(SELECT …)` lets the planner pull it out of the scan as
+-- a scalar InitPlan, evaluated exactly once. Same semantics, dramatic
+-- perf win at scale. This is the Supabase-documented pattern for any
+-- `auth.*()` call inside a policy.
+--
+-- DROP + CREATE per policy is forward-only safe: Postgres replaces the
+-- policy atomically in the same transaction, no window where the table
+-- is unprotected.
+
+-- ----- job_feedback ---------------------------------------------------------
+
+drop policy if exists "job_feedback_self_select" on public.job_feedback;
+create policy "job_feedback_self_select"
+  on public.job_feedback for select
+  using ((select auth.jwt() ->> 'sub') = user_id);
+
+drop policy if exists "job_feedback_self_insert" on public.job_feedback;
+create policy "job_feedback_self_insert"
+  on public.job_feedback for insert
+  with check ((select auth.jwt() ->> 'sub') = user_id);
+
+drop policy if exists "job_feedback_self_update" on public.job_feedback;
+create policy "job_feedback_self_update"
+  on public.job_feedback for update
+  using ((select auth.jwt() ->> 'sub') = user_id);
+
+drop policy if exists "job_feedback_self_delete" on public.job_feedback;
+create policy "job_feedback_self_delete"
+  on public.job_feedback for delete
+  using ((select auth.jwt() ->> 'sub') = user_id);
+
+-- ----- target_learning_log --------------------------------------------------
+
+drop policy if exists "target_learning_log_self_select" on public.target_learning_log;
+create policy "target_learning_log_self_select"
+  on public.target_learning_log for select
+  using ((select auth.jwt() ->> 'sub') = user_id);


### PR DESCRIPTION
## Summary
Five RLS policies on \`job_feedback\` (×4) and \`target_learning_log\` (×1) used the unwrapped form:

```sql
using (auth.jwt() ->> 'sub' = user_id)
```

Postgres treats that as a STABLE function call in a per-row filter and re-evaluates the JWT lookup for every row scanned — fine on a 10-row table, painful at scale.

This migration replaces each with the Supabase-documented wrapped form:

```sql
using ((select auth.jwt() ->> 'sub') = user_id)
```

The scalar subquery lets the planner pull \`auth.jwt() ->> 'sub'\` out of the scan as a single InitPlan, evaluated once per query. Same semantics, dramatic perf win as feedback / learning-log tables grow.

DROP + CREATE per policy in one migration is forward-only safe — Postgres swaps the policy atomically.

Closes part of danieljoffe/wyrdfold#7 (P7). PR 6 of 7 for Sprint 2.

## Test plan
- [ ] Migration applies cleanly in Supabase preview
- [ ] \`EXPLAIN ANALYZE\` on \`select * from job_feedback where user_id = '<sub>'\` shows the auth.jwt() call as an InitPlan, not a per-row filter
- [ ] Existing per-user reads still return only the caller's rows (RLS still enforced)
- [ ] Service-role bypass unaffected (API server still CRUDs without per-user impersonation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)