### PR TITLE
sec(wyrdfold-api): bound write-body size on OptimizedDocUpsert

### DIFF
--- a/apps/wyrdfold-api/app/models/experience.py
+++ b/apps/wyrdfold-api/app/models/experience.py
@@ -156,8 +156,8 @@ class OptimizedDocUpsert(BaseModel):
     markdown_view: str | None = Field(default=None, max_length=500_000)
     source: OptimizedDocSource = "llm"
 
-    # Hard ceiling on the serialized payload — generous (a realistic profile
-    # is 10–50 KB JSON) but bounded so an attacker can't push megabytes of
+    # Hard ceiling on the serialized payload: generous (a realistic profile
+    # is 10-50 KB JSON) but bounded so an attacker can't push megabytes of
     # nested arrays through the unprotected nested-string surface.
     _MAX_PAYLOAD_BYTES = 500_000
 

--- a/apps/wyrdfold-api/app/models/experience.py
+++ b/apps/wyrdfold-api/app/models/experience.py
@@ -11,7 +11,7 @@ import uuid
 from datetime import datetime
 from typing import Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 ConversationType = Literal["onboarding", "update"]
 TurnRole = Literal["user", "assistant", "system"]
@@ -153,8 +153,22 @@ class ProseDocCreate(BaseModel):
 class OptimizedDocUpsert(BaseModel):
     prose_doc_id: str | None = None
     payload: OptimizedPayload
-    markdown_view: str | None = None
+    markdown_view: str | None = Field(default=None, max_length=500_000)
     source: OptimizedDocSource = "llm"
+
+    # Hard ceiling on the serialized payload — generous (a realistic profile
+    # is 10–50 KB JSON) but bounded so an attacker can't push megabytes of
+    # nested arrays through the unprotected nested-string surface.
+    _MAX_PAYLOAD_BYTES = 500_000
+
+    @model_validator(mode="after")
+    def _bound_payload_size(self) -> "OptimizedDocUpsert":
+        size = len(self.payload.model_dump_json().encode("utf-8"))
+        if size > self._MAX_PAYLOAD_BYTES:
+            raise ValueError(
+                f"payload too large: {size} bytes (max {self._MAX_PAYLOAD_BYTES})"
+            )
+        return self
 
 
 class PreferencesUpsert(BaseModel):


### PR DESCRIPTION
## Summary
The audit (#850 S4) flagged three unbounded write bodies. Two — \`ProseDocCreate.content\` (500 KB) and \`TurnAppend.content\` (50 KB) — already have \`Field(max_length=…)\` bounds. **OptimizedDocUpsert** was the actual gap: both \`payload\` (a nested \`OptimizedPayload\`) and \`markdown_view\` accepted arbitrarily large input.

This PR adds:
- \`markdown_view: max_length=500_000\` (matches prose content ceiling)
- A \`@model_validator(mode='after')\` on \`OptimizedDocUpsert\` that JSON-serializes \`payload\` and rejects bodies >500 KB

500 KB is generous (a realistic profile is 10–50 KB) but bounds the nested-string surface so an attacker can't push megabytes through the otherwise-unprotected role/skill/outcome leaf fields without us bounding every individual string.

Closes part of danieljoffe/wyrdfold#7 (S4). PR 7 of 7 for Sprint 2.

## Test plan
- [x] All 1190 wyrdfold-api tests pass
- [ ] Manual: POST /experience/optimized with a 600 KB payload → 422
- [ ] Manual: POST /experience/optimized with a normal payload (~20 KB) → 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)