### PR TITLE
sec(wyrdfold-api): scope /jobs/manual scoring to the calling user

### DIFF
--- a/apps/wyrdfold-api/app/routers/jobs.py
+++ b/apps/wyrdfold-api/app/routers/jobs.py
@@ -53,6 +53,7 @@ from app.services.target_scoring import (
 from app.services.targets.crud import get as get_target
 from app.services.targets.crud import get_active as get_active_target
 from app.services.targets.crud import (
+    get_active_for_user,
     get_user_target,
     get_user_target_ids,
     list_user_targets,
@@ -956,6 +957,7 @@ async def add_manual_job(
     request: Request,
     body: ManualJobRequest,
     supabase: Client = Depends(get_supabase),
+    user_id: str | None = Depends(get_current_user_id_optional),
 ) -> ManualJobResponse:
     """Add a job posting by URL. Extracts metadata via cascade."""
     warnings: list[str] = []
@@ -1099,12 +1101,21 @@ async def add_manual_job(
         data = cast(dict[str, Any], resp_db.data[0])
         posting_id = data.get("id")
 
-    # Score against all active targets (stages 1+2 inline for manual entry).
+    # Score against the caller's active targets (stages 1+2 inline for manual
+    # entry). Scoping to the JWT caller's targets is a privacy boundary: the
+    # previous global fan-out wrote scores for every user's active target,
+    # surfacing one user's pasted URL in every other user's /jobs list via
+    # the scores→user_targets join. Operator/api-key callers (user_id is None)
+    # retain the global fan-out for back-compat with cron + admin tooling.
     # Each per-target scoring call is independent and IO-bound (the Supabase
     # SDK is sync, so we hand each one to the threadpool and gather). For 10
     # active targets this turns ~10 sequential round-trips into ~1 wall-time.
     if posting_id and title:
-        active_targets = get_active_target(supabase)
+        active_targets = (
+            get_active_for_user(supabase, user_id)
+            if user_id is not None
+            else get_active_target(supabase)
+        )
         parsed = parse_jd(description_html)
         results = await asyncio.gather(
             *[

--- a/apps/wyrdfold-api/tests/test_manual_job.py
+++ b/apps/wyrdfold-api/tests/test_manual_job.py
@@ -97,7 +97,7 @@ class TestManualJobEndpoint:
         from app.routers.jobs import add_manual_job
 
         body = ManualJobRequest(url="https://example.com/jobs/123")
-        result = await add_manual_job(request=MagicMock(), body=body, supabase=mock_supabase)
+        result = await add_manual_job(request=MagicMock(), body=body, user_id=None, supabase=mock_supabase)
 
         assert result.success is True
         assert result.posting_id == "posting-uuid-1"
@@ -131,7 +131,7 @@ class TestManualJobEndpoint:
             title="My Custom Title",
             company_name="Override Corp",
         )
-        result = await add_manual_job(request=MagicMock(), body=body, supabase=mock_supabase)
+        result = await add_manual_job(request=MagicMock(), body=body, user_id=None, supabase=mock_supabase)
 
         assert result.success is True
         # User overrides should win
@@ -149,7 +149,7 @@ class TestManualJobEndpoint:
 
         body = ManualJobRequest(url="not-a-url")
         with pytest.raises(HTTPException) as exc_info:
-            await add_manual_job(request=MagicMock(), body=body, supabase=MagicMock())
+            await add_manual_job(request=MagicMock(), body=body, user_id=None, supabase=MagicMock())
         assert exc_info.value.status_code == 400
         assert "Malformed" in exc_info.value.detail
 
@@ -162,7 +162,7 @@ class TestManualJobEndpoint:
 
         body = ManualJobRequest(url="https://www.ziprecruiter.com/jobs/123")
         with pytest.raises(HTTPException) as exc_info:
-            await add_manual_job(request=MagicMock(), body=body, supabase=MagicMock())
+            await add_manual_job(request=MagicMock(), body=body, user_id=None, supabase=MagicMock())
         assert exc_info.value.status_code == 400
         assert "Banned" in exc_info.value.detail
 
@@ -175,7 +175,7 @@ class TestManualJobEndpoint:
         from app.routers.jobs import add_manual_job
 
         body = ManualJobRequest(url="https://example.com/opaque-page")
-        result = await add_manual_job(request=MagicMock(), body=body, supabase=MagicMock())
+        result = await add_manual_job(request=MagicMock(), body=body, user_id=None, supabase=MagicMock())
 
         assert result.success is False
         assert result.needs_manual_fields is True
@@ -199,7 +199,7 @@ class TestManualJobEndpoint:
             title="Manually Entered Job",
             company_name="Some Company",
         )
-        result = await add_manual_job(request=MagicMock(), body=body, supabase=mock_supabase)
+        result = await add_manual_job(request=MagicMock(), body=body, user_id=None, supabase=mock_supabase)
 
         assert result.success is True
         assert result.posting_id == "posting-uuid-3"
@@ -223,7 +223,7 @@ class TestManualJobEndpoint:
         from app.routers.jobs import add_manual_job
 
         body = ManualJobRequest(url=url)
-        await add_manual_job(request=MagicMock(), body=body, supabase=mock_supabase)
+        await add_manual_job(request=MagicMock(), body=body, user_id=None, supabase=mock_supabase)
 
         upsert_call = mock_supabase.table.return_value.upsert.call_args
         row = upsert_call[0][0]
@@ -242,7 +242,7 @@ class TestManualJobEndpoint:
 
         body = ManualJobRequest(url="https://example.com/jobs/123")
         with pytest.raises(HTTPException) as exc_info:
-            await add_manual_job(request=MagicMock(), body=body, supabase=MagicMock())
+            await add_manual_job(request=MagicMock(), body=body, user_id=None, supabase=MagicMock())
         assert exc_info.value.status_code == 400
         assert "fetch" in exc_info.value.detail.lower()
 
@@ -259,6 +259,6 @@ class TestManualJobEndpoint:
 
         body = ManualJobRequest(url="https://legit.com/jobs/123")
         with pytest.raises(HTTPException) as exc_info:
-            await add_manual_job(request=MagicMock(), body=body, supabase=MagicMock())
+            await add_manual_job(request=MagicMock(), body=body, user_id=None, supabase=MagicMock())
         assert exc_info.value.status_code == 400
         assert "banned" in exc_info.value.detail.lower()


### PR DESCRIPTION
## Summary
The audit (#850 S3) flagged that postings created via \`/jobs/manual\` had "no user association," surfacing in other users' lists.

**Root cause:** the endpoint scored every manual posting against ALL globally-active targets (\`get_active\` across all users) and wrote scores into the \`scores\` table for every user-target join. User B's \`/jobs\` list, filtered through their own \`user_targets\`, then picked up user A's pasted URL.

**Fix:** when the caller is a JWT user, score only against that user's active targets (\`get_active_for_user\`). Operator/api-key callers (\`user_id is None\`) keep the global fan-out for back-compat with cron and admin tooling.

The shared \`jobs\` row itself is unchanged — that's the correct dedup behavior when two users paste the same URL. Only the per-target scoring fan-out is scoped.

Closes part of danieljoffe/wyrdfold#7 (S3). PR 8 of 7+ for Sprint 2.

## Test plan
- [x] All 1190 wyrdfold-api tests pass
- [x] Ruff clean
- [ ] Manual: user A pastes URL X via /jobs/manual; verify scores row only for user A's targets
- [ ] Manual: user B's /jobs list does not surface user A's URL
- [ ] Manual: operator (api-key) call still fans out globally

🤖 Generated with [Claude Code](https://claude.com/claude-code)