### PR TITLE
sec(wyrdfold-api): narrow GET /sources projection to public columns

### DIFF
--- a/apps/wyrdfold-api/app/routers/sources.py
+++ b/apps/wyrdfold-api/app/routers/sources.py
@@ -33,10 +33,21 @@ router = APIRouter(
     dependencies=[Depends(verify_api_key_or_jwt)],
 )
 
+# Public projection for the source-list endpoint. Excludes operational
+# columns (last_polled_at, poll_interval_minutes, created_at) that
+# leaked through the previous select("*") and have no business surfacing
+# to JWT callers — those are operator-tuned cron internals.
+_SOURCE_LIST_COLS = "id, board_token, company_name, provider, enabled, job_count"
+
 
 @router.get("")
 async def list_sources(supabase: Client = Depends(get_supabase)) -> dict[str, Any]:
-    resp = supabase.table("sources").select("*").order("company_name").execute()
+    resp = (
+        supabase.table("sources")
+        .select(_SOURCE_LIST_COLS)
+        .order("company_name")
+        .execute()
+    )
     return {"sources": resp.data or []}
 
 


### PR DESCRIPTION
## Summary
The audit (#850 S5) flagged that \`GET /sources\` used \`select("*")\`, returning internal operational columns to every authenticated caller. \`last_polled_at\`, \`poll_interval_minutes\`, and \`created_at\` are cron internals with no business surfacing to JWT users.

This PR replaces the wildcard with an explicit \`_SOURCE_LIST_COLS\` projection covering only public-meaningful fields:
\`id, board_token, company_name, provider, enabled, job_count\`

Operator mutation endpoints (\`POST /sources\`, \`/seed\`, \`/detect\`, \`/verify\`) are unchanged — they still need full table access.

Closes part of danieljoffe/wyrdfold#7 (S5). PR 9.

## Test plan
- [x] 15 sources router tests pass
- [ ] Manual: hit GET /sources as JWT user, verify no last_polled_at / poll_interval_minutes / created_at in response

🤖 Generated with [Claude Code](https://claude.com/claude-code)