### PR TITLE
perf(wyrdfold-api): content-hash cache for derive_profile_from_jd

### DIFF
--- a/apps/wyrdfold-api/app/routers/targets.py
+++ b/apps/wyrdfold-api/app/routers/targets.py
@@ -967,7 +967,7 @@ async def create_target_from_posting(
     if len(jd_text) >= 50:
         try:
             derived, result = await derive_profile_from_jd(
-                llm, jd_text=jd_text
+                llm, jd_text=jd_text, supabase=supabase
             )
             cost_log.record(
                 supabase,
@@ -1172,9 +1172,9 @@ async def add_reference_jd(
             )
         _, body.jd_text = await _fetch_jd_from_url(body.jd_url)
 
-    # Derive profile from JD via LLM
+    # Derive profile from JD via LLM (cached by content hash + prompt version)
     derived, result = await derive_profile_from_jd(
-        llm, jd_text=body.jd_text
+        llm, jd_text=body.jd_text, supabase=supabase
     )
     cost_log.record(
         supabase,

--- a/apps/wyrdfold-api/app/services/targets/derive_profile.py
+++ b/apps/wyrdfold-api/app/services/targets/derive_profile.py
@@ -8,14 +8,34 @@ Follows the same pattern as app/services/experience/derive.py:
 - Static system prompt (cacheable via Anthropic prompt caching)
 - JD text is the only variable content
 - complete_json() validates output against ScoringProfile
+
+A content-hash cache backed by the ``target_derive_jd_cache`` table
+short-circuits repeat calls for the same (prompt_version, model, jd_text)
+tuple. Bump PROMPT_VERSION whenever SYSTEM_PROMPT changes — per the
+``feedback-llm-cache-prompt-version`` rule, mismatched versions must
+miss-then-rewrite, not return stale output.
 """
 
-from app.models.llm import LLMResult, Message, ModelId
+import hashlib
+import logging
+from datetime import UTC, datetime
+from typing import Any, cast
+
+from supabase import Client
+
+from app.models.llm import LLMResult, LLMUsage, Message, ModelId
 from app.models.targets import DerivedTarget
 from app.services.llm.client import LLMClient, complete_json
 
+logger = logging.getLogger(__name__)
+
 DEFAULT_MODEL: ModelId = "claude-sonnet-4-6"
 DEFAULT_PURPOSE = "target.derive_profile"
+
+# Bump when SYSTEM_PROMPT below materially changes. See module docstring.
+PROMPT_VERSION = "v1"
+
+_CACHE_TABLE = "target_derive_jd_cache"
 
 SYSTEM_PROMPT = """\
 You are a job-search scoring-profile generator. Given a job description,
@@ -117,18 +137,146 @@ but a different ROLE FUNCTION.
 Return ONLY the JSON object. No prose, no markdown, no code fences."""
 
 
+def _cache_key(jd_text: str, *, model: ModelId, prompt_version: str) -> str:
+    """SHA-256 of (prompt_version + model + jd_text).
+
+    Prompt version is part of the key so a prompt change cleanly misses
+    the cache on first hit and rewrites on second — never serves stale
+    output keyed to an older prompt.
+    """
+    h = hashlib.sha256()
+    h.update(prompt_version.encode("utf-8"))
+    h.update(b"\x00")
+    h.update(model.encode("utf-8"))
+    h.update(b"\x00")
+    h.update(jd_text.encode("utf-8"))
+    return h.hexdigest()
+
+
+def _cache_hit_result(model: ModelId) -> LLMResult:
+    """A zero-cost LLMResult stand-in for cache hits.
+
+    Cost-log records still get written so we can count derivations, but
+    the cost/latency/token columns are zeroed — there was no upstream
+    call. ``content`` is "" because callers consume the parsed DerivedTarget,
+    not the raw text.
+    """
+    return LLMResult(
+        content="",
+        model=model,
+        usage=LLMUsage(),
+        cost_usd=0.0,
+        latency_ms=0,
+    )
+
+
+def _get_cached(
+    supabase: Client, key: str
+) -> DerivedTarget | None:
+    """Return the cached DerivedTarget for ``key``, or None on miss."""
+    try:
+        resp = (
+            supabase.table(_CACHE_TABLE)
+            .select("derived_payload")
+            .eq("jd_hash", key)
+            .limit(1)
+            .execute()
+        )
+    except Exception:
+        # Cache layer is best-effort — a Supabase outage must not break
+        # the LLM-derive path. Fall through to a fresh LLM call.
+        logger.warning("derive-jd cache read failed; falling through", exc_info=True)
+        return None
+    rows = cast(list[dict[str, Any]], resp.data or [])
+    if not rows:
+        return None
+    try:
+        return DerivedTarget.model_validate(rows[0]["derived_payload"])
+    except Exception:
+        # A schema drift in stored payloads would otherwise poison the
+        # cache row indefinitely; treat as miss so the LLM rewrites it.
+        logger.warning(
+            "derive-jd cache row failed validation; treating as miss", exc_info=True
+        )
+        return None
+
+
+def _record_cache_hit(supabase: Client, key: str) -> None:
+    """Best-effort hit_count + last_hit_at bump. Failures are swallowed."""
+    try:
+        current = (
+            supabase.table(_CACHE_TABLE)
+            .select("hit_count")
+            .eq("jd_hash", key)
+            .single()
+            .execute()
+        )
+        row = cast(dict[str, Any], current.data or {})
+        next_count = int(row.get("hit_count", 0)) + 1
+        supabase.table(_CACHE_TABLE).update(
+            {
+                "hit_count": next_count,
+                "last_hit_at": datetime.now(UTC).isoformat(),
+            }
+        ).eq("jd_hash", key).execute()
+    except Exception:
+        logger.debug("derive-jd cache hit-count bump failed", exc_info=True)
+
+
+def _persist_cache(
+    supabase: Client,
+    *,
+    key: str,
+    prompt_version: str,
+    model: ModelId,
+    derived: DerivedTarget,
+) -> None:
+    """Best-effort cache write. Failures are swallowed (the derive call
+    has already succeeded; we don't want to fail the user-facing request
+    because the cache row didn't persist)."""
+    try:
+        supabase.table(_CACHE_TABLE).upsert(
+            {
+                "jd_hash": key,
+                "prompt_version": prompt_version,
+                "model": model,
+                "derived_payload": derived.model_dump(mode="json"),
+            },
+            on_conflict="jd_hash",
+        ).execute()
+    except Exception:
+        logger.warning("derive-jd cache write failed", exc_info=True)
+
+
 async def derive_profile_from_jd(
     llm: LLMClient,
     *,
     jd_text: str,
     model: ModelId = DEFAULT_MODEL,
     purpose: str = DEFAULT_PURPOSE,
+    supabase: Client | None = None,
 ) -> tuple[DerivedTarget, LLMResult]:
     """Extract a ScoringProfile + search keywords from a job description.
 
+    When ``supabase`` is provided, looks up a content-hash cache keyed on
+    (PROMPT_VERSION, model, jd_text). Cache hits skip the LLM call and
+    return a zero-cost LLMResult; misses run the LLM and write the result
+    back. Cache failures fall through to a fresh LLM call, so the cache
+    layer can never break the derive path.
+
+    When ``supabase`` is None (legacy callers / tests), behaves exactly
+    like the pre-cache version: always calls the LLM.
+
     Returns (derived, result) so callers can log cost.
     """
-    return await complete_json(
+    if supabase is not None:
+        key = _cache_key(jd_text, model=model, prompt_version=PROMPT_VERSION)
+        cached = _get_cached(supabase, key)
+        if cached is not None:
+            _record_cache_hit(supabase, key)
+            return cached, _cache_hit_result(model)
+
+    derived, result = await complete_json(
         llm,
         model=model,
         system=SYSTEM_PROMPT,
@@ -137,3 +285,14 @@ async def derive_profile_from_jd(
         purpose=purpose,
         cache_system=True,
     )
+
+    if supabase is not None:
+        _persist_cache(
+            supabase,
+            key=_cache_key(jd_text, model=model, prompt_version=PROMPT_VERSION),
+            prompt_version=PROMPT_VERSION,
+            model=model,
+            derived=derived,
+        )
+
+    return derived, result

--- a/apps/wyrdfold-api/app/services/targets/from_input.py
+++ b/apps/wyrdfold-api/app/services/targets/from_input.py
@@ -197,7 +197,9 @@ async def derive_url_target_bg(
     """
     try:
         async with asyncio.timeout(DERIVATION_TIMEOUT_S):
-            derived, derive_result = await derive_profile_from_jd(llm, jd_text=jd_text)
+            derived, derive_result = await derive_profile_from_jd(
+                llm, jd_text=jd_text, supabase=supabase
+            )
             cost_log.record(
                 supabase,
                 user_id=user_id,

--- a/apps/wyrdfold-api/tests/test_targets_from_input.py
+++ b/apps/wyrdfold-api/tests/test_targets_from_input.py
@@ -154,7 +154,7 @@ def stub_llm_helpers(monkeypatch: pytest.MonkeyPatch, recorder: _Recorder) -> _R
             _llm_result(),
         )
 
-    async def fake_derive_jd(llm, *, jd_text):  # type: ignore[no-untyped-def]
+    async def fake_derive_jd(llm, *, jd_text, **_kwargs):  # type: ignore[no-untyped-def]
         recorder.record("derive_from_jd", jd_len=len(jd_text))
         return (
             DerivedTarget(

--- a/supabase/migrations/20260608140000_target_derive_jd_cache.sql
+++ b/supabase/migrations/20260608140000_target_derive_jd_cache.sql
@@ -1,0 +1,41 @@
+-- Content-hash cache for derive_profile_from_jd LLM output.
+--
+-- `POST /targets/{id}/reference-jds` and `from-url` re-run Sonnet on the
+-- same JD every call: same prompt, same input, same output, ~$0.01 + a
+-- few seconds of latency each time. A typical user iterating on reference
+-- JDs (paste, review, tweak the merged profile, re-paste) easily eats
+-- 5-10 redundant calls per target.
+--
+-- Cache key components:
+--   jd_hash         — SHA-256 of (prompt_version + model + jd_text). The
+--                     prompt_version prefix means we never serve stale
+--                     output when the prompt shifts; per the
+--                     `feedback-llm-cache-prompt-version` rule, every
+--                     LLM-output cache MUST include the prompt version.
+--   prompt_version  — stored separately for audit / rollout queries.
+--   model           — different models produce different outputs; key on it.
+--
+-- hit_count is purely observational so we can measure cache effectiveness
+-- without a separate metrics pipeline.
+
+create table if not exists public.target_derive_jd_cache (
+  jd_hash         text primary key,
+  prompt_version  text not null,
+  model           text not null,
+  derived_payload jsonb not null,
+  hit_count       integer not null default 0,
+  created_at      timestamptz not null default now(),
+  last_hit_at     timestamptz
+);
+
+-- Lookups are always by primary key (the hash). Add a covering index on
+-- (prompt_version, created_at) so an operator can sweep "what was cached
+-- before the prompt change?" without a seq scan.
+create index if not exists idx_target_derive_jd_cache_prompt_version
+  on public.target_derive_jd_cache (prompt_version, created_at desc);
+
+-- Service-role only; the API server is the only writer/reader. No RLS
+-- needed because we never expose this table directly to JWT callers —
+-- but flip enable_rls on so a future careless POLICY add doesn't open
+-- it up by accident.
+alter table public.target_derive_jd_cache enable row level security;


### PR DESCRIPTION
## Summary
\`POST /targets/{id}/reference-jds\` and the from-url flow re-ran Sonnet on the same JD every call. Same prompt, same input, same output, ~\$0.01 + a few seconds of latency wasted per repeat. A user iterating on reference JDs easily ate 5-10 redundant calls per target.

This PR adds a **content-hash cache** backed by a new \`target_derive_jd_cache\` table.

### Cache key
SHA-256 of \`(PROMPT_VERSION + model + jd_text)\`. Per the \`feedback-llm-cache-prompt-version\` rule, every LLM-output cache must include the prompt version — mismatched versions cleanly miss + rewrite, never serve stale output. \`PROMPT_VERSION\` is bumped in \`derive_profile.py\` whenever \`SYSTEM_PROMPT\` materially changes.

### Migration
\`20260608140000_target_derive_jd_cache.sql\`:
- \`jd_hash\` (PK) — the SHA-256 cache key
- \`prompt_version\`, \`model\`, \`derived_payload\` — content
- \`hit_count\`, \`last_hit_at\` — observability (measure cache effectiveness without a separate metrics pipeline)
- RLS enabled (service-role only; no policies needed)

### API
\`derive_profile_from_jd()\` takes a new optional \`supabase\` kwarg:
- When set: cache lookup runs first; on hit, a zero-cost \`LLMResult\` stand-in keeps the cost_log path working.
- When \`None\` (tests, legacy callers): behaves exactly like the pre-cache version.

The cache layer is **best-effort**. Any read/write failure falls through to a live LLM call so a Supabase outage cannot break the derive path. Stored payloads that fail validation (schema drift) are treated as misses so a poisoned row can't lock the cache.

Closes part of danieljoffe/wyrdfold#7 (P4). Last open PR for danieljoffe/wyrdfold#7.

## Test plan
- [x] All 1190 wyrdfold-api tests pass
- [x] Ruff + mypy clean
- [ ] Migration applies cleanly in Supabase preview
- [ ] Manual: POST /targets/{id}/reference-jds with same JD twice — second call has cost_usd=0 in cost_log
- [ ] Manual: hit_count increments visible in target_derive_jd_cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)