### PR TITLE
sec(wyrdfold): verify Supabase JWT via getUser() in BFF proxy

### DIFF
--- a/apps/wyrdfold/src/lib/api/proxy.test.ts
+++ b/apps/wyrdfold/src/lib/api/proxy.test.ts
@@ -5,11 +5,23 @@
 process.env['WYRDFOLD_API_URL'] = 'http://wyrdfold-api.test';
 
 const mockGetSession = jest.fn();
+const mockGetUser = jest.fn();
 
 jest.mock('@/lib/supabase/auth-server', () => ({
   createAuthServerClient: () =>
-    Promise.resolve({ auth: { getSession: mockGetSession } }),
+    Promise.resolve({
+      auth: { getSession: mockGetSession, getUser: mockGetUser },
+    }),
 }));
+
+// React.cache() de-dupes per-request, but Jest tests share a single
+// "request" so the cache survives across cases unless we reset it. The
+// proxy module's binding is captured at import time; the easiest reset
+// is to re-require the module per test below.
+jest.mock('react', () => {
+  const actual = jest.requireActual('react');
+  return { ...actual, cache: <T>(fn: T): T => fn };
+});
 
 import {
   fetchJsonFromWyrdfoldAPI,
@@ -26,6 +38,10 @@ afterAll(() => {
 
 beforeEach(() => {
   jest.clearAllMocks();
+  mockGetUser.mockResolvedValue({
+    data: { user: { id: 'user-1' } },
+    error: null,
+  });
   mockGetSession.mockResolvedValue({
     data: { session: { access_token: 'jwt-token' } },
   });
@@ -38,8 +54,11 @@ function mockFetch(response: Response): jest.Mock {
 }
 
 describe('proxyToWyrdfoldAPI', () => {
-  it('returns 401 when no Supabase session', async () => {
-    mockGetSession.mockResolvedValueOnce({ data: { session: null } });
+  it('returns 401 when getUser cannot verify the JWT', async () => {
+    mockGetUser.mockResolvedValueOnce({
+      data: { user: null },
+      error: { message: 'invalid token' },
+    });
     const fetchMock = mockFetch(new Response('{}'));
 
     const res = await proxyToWyrdfoldAPI('/experience/optimized');
@@ -49,8 +68,8 @@ describe('proxyToWyrdfoldAPI', () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it('returns 401 when getSession throws', async () => {
-    mockGetSession.mockRejectedValueOnce(new Error('cookie error'));
+  it('returns 401 when getUser throws', async () => {
+    mockGetUser.mockRejectedValueOnce(new Error('cookie error'));
     const fetchMock = mockFetch(new Response('{}'));
 
     const res = await proxyToWyrdfoldAPI('/experience/optimized');

--- a/apps/wyrdfold/src/lib/api/proxy.ts
+++ b/apps/wyrdfold/src/lib/api/proxy.ts
@@ -1,3 +1,5 @@
+import { cache } from 'react';
+
 import { NextResponse } from 'next/server';
 
 import { createAuthServerClient } from '@/lib/supabase/auth-server';
@@ -13,13 +15,30 @@ const DEFAULT_TIMEOUT_MS = 30_000;
 export const LLM_TIMEOUT_MS = 120_000;
 
 /**
- * Resolve the current Supabase session's access token. Returns null when
- * the request has no session — callers should treat that as 401 and skip
- * the upstream round-trip.
+ * Resolve the current Supabase session's access token, verifying the JWT
+ * signature against Supabase Auth first. Returns null when there is no
+ * session OR when the JWT fails verification — callers should treat
+ * either as 401 and skip the upstream round-trip.
+ *
+ * Why verify here when middleware already does it: middleware refreshes
+ * the cookie on `/api/*`, but the proxy used to read the cookie via
+ * `getSession()` which only decodes the JWT locally without checking
+ * the signature against the auth server. The wyrdfold-api re-validates
+ * the JWT on every request via JWKS, so the prior behavior wasn't
+ * exploitable — but the BFF itself was trusting an unverified token
+ * (#851 S1). Standard practice for server-side Supabase code is
+ * `getUser()` first; cheap because `cache()` dedupes within a request
+ * so multiple proxy helpers in the same handler share one verification.
  */
-export async function getAccessToken(): Promise<string | null> {
+export const getAccessToken = cache(async (): Promise<string | null> => {
   try {
     const supabase = await createAuthServerClient();
+    const {
+      data: { user },
+      error,
+    } = await supabase.auth.getUser();
+    if (error || !user) return null;
+    // Now safe to read the (verified) session for its access_token.
     const {
       data: { session },
     } = await supabase.auth.getSession();
@@ -27,7 +46,7 @@ export async function getAccessToken(): Promise<string | null> {
   } catch {
     return null;
   }
-}
+});
 
 /**
  * Server-side JSON GET to wyrdfold-api for use in Server Components.


### PR DESCRIPTION
## Summary
The audit (#851 S1) flagged that \`getAccessToken()\` in \`proxy.ts\` read the JWT from the cookie via \`getSession()\` — which only decodes locally without checking the signature against Supabase Auth. Every proxy helper (\`proxyToWyrdfoldAPI\`, \`fetchJsonFromWyrdfoldAPI\`, streaming, multipart) gated its early-return 401 on this unverified token.

**Exposure was limited** — middleware refreshes the cookie via \`getUser()\` on every \`/api/*\` request, and \`wyrdfold-api\` re-validates the JWT via JWKS — but the BFF itself was trusting an unverified token. Standard Supabase server-side practice is \`getUser()\` first.

### Implementation
- \`getAccessToken\` now calls \`getUser()\` for signature verification, then \`getSession()\` for the (verified) token.
- Wrapped in \`React.cache()\` so the four proxy helpers in a single request share one verification — adds **one** auth-server round-trip per request, not per helper call.
- Cache failures (no user / throw) short-circuit to \`null\` so existing 401 paths still fire.

### Tests
- Updated mocks to add \`getUser\` alongside \`getSession\`.
- Renamed two cases to reflect \`getUser\` semantics.
- \`React.cache\` mocked as identity so \`jest.clearAllMocks()\` between cases still applies.
- All 21 proxy tests pass.

Part of danieljoffe/wyrdfold#8 (S1). First of 6 PRs for danieljoffe/wyrdfold#8.

## Test plan
- [x] All 21 \`proxy.test.ts\` tests pass
- [x] Full wyrdfold suite passes
- [x] Typecheck clean
- [ ] Manual: hit any /api/* route with an invalid Bearer cookie → 401
- [ ] Manual: confirm getUser call deduped across a multi-fetch RSC page

🤖 Generated with [Claude Code](https://claude.com/claude-code)