### PR TITLE
sec(wyrdfold): wrap request.json() in readJsonBody helper across BFF routes

### DIFF
--- a/apps/wyrdfold/src/app/api/career/experience/conversation/turn/route.ts
+++ b/apps/wyrdfold/src/app/api/career/experience/conversation/turn/route.ts
@@ -1,12 +1,17 @@
 import type { NextRequest } from 'next/server';
 
-import { LLM_TIMEOUT_MS, proxyToWyrdfoldAPI } from '@/lib/api/proxy';
+import {
+  LLM_TIMEOUT_MS,
+  proxyToWyrdfoldAPI,
+  readJsonBody,
+} from '@/lib/api/proxy';
 
 export async function POST(request: NextRequest) {
-  const body = await request.json();
+  const parsed = await readJsonBody(request);
+  if (!parsed.ok) return parsed.response;
   return proxyToWyrdfoldAPI('/experience/conversation/turn', {
     method: 'POST',
-    body,
+    body: parsed.body,
     timeoutMs: LLM_TIMEOUT_MS,
   });
 }

--- a/apps/wyrdfold/src/app/api/career/experience/optimized/route.ts
+++ b/apps/wyrdfold/src/app/api/career/experience/optimized/route.ts
@@ -1,15 +1,16 @@
 import type { NextRequest } from 'next/server';
 
-import { proxyToWyrdfoldAPI } from '@/lib/api/proxy';
+import { proxyToWyrdfoldAPI, readJsonBody } from '@/lib/api/proxy';
 
 export async function GET() {
   return proxyToWyrdfoldAPI('/experience/optimized');
 }
 
 export async function POST(request: NextRequest) {
-  const body = await request.json();
+  const parsed = await readJsonBody(request);
+  if (!parsed.ok) return parsed.response;
   return proxyToWyrdfoldAPI('/experience/optimized', {
     method: 'POST',
-    body,
+    body: parsed.body,
   });
 }

--- a/apps/wyrdfold/src/app/api/career/experience/preferences/route.ts
+++ b/apps/wyrdfold/src/app/api/career/experience/preferences/route.ts
@@ -1,16 +1,17 @@
 import type { NextRequest } from 'next/server';
 
-import { proxyToWyrdfoldAPI } from '@/lib/api/proxy';
+import { proxyToWyrdfoldAPI, readJsonBody } from '@/lib/api/proxy';
 
 export async function GET() {
   return proxyToWyrdfoldAPI('/experience/preferences');
 }
 
 export async function PUT(request: NextRequest) {
-  const body = await request.json();
+  const parsed = await readJsonBody(request);
+  if (!parsed.ok) return parsed.response;
   return proxyToWyrdfoldAPI('/experience/preferences', {
     method: 'PUT',
-    body,
+    body: parsed.body,
   });
 }
 

--- a/apps/wyrdfold/src/app/api/career/experience/prose/route.ts
+++ b/apps/wyrdfold/src/app/api/career/experience/prose/route.ts
@@ -1,12 +1,16 @@
 import type { NextRequest } from 'next/server';
 
-import { proxyToWyrdfoldAPI } from '@/lib/api/proxy';
+import { proxyToWyrdfoldAPI, readJsonBody } from '@/lib/api/proxy';
 
 export async function GET() {
   return proxyToWyrdfoldAPI('/experience/prose');
 }
 
 export async function POST(request: NextRequest) {
-  const body = await request.json();
-  return proxyToWyrdfoldAPI('/experience/prose', { method: 'POST', body });
+  const parsed = await readJsonBody(request);
+  if (!parsed.ok) return parsed.response;
+  return proxyToWyrdfoldAPI('/experience/prose', {
+    method: 'POST',
+    body: parsed.body,
+  });
 }

--- a/apps/wyrdfold/src/app/api/career/experience/turns/route.ts
+++ b/apps/wyrdfold/src/app/api/career/experience/turns/route.ts
@@ -1,6 +1,6 @@
 import type { NextRequest } from 'next/server';
 
-import { proxyToWyrdfoldAPI } from '@/lib/api/proxy';
+import { proxyToWyrdfoldAPI, readJsonBody } from '@/lib/api/proxy';
 
 export async function GET(request: NextRequest) {
   return proxyToWyrdfoldAPI('/experience/turns', {
@@ -9,6 +9,10 @@ export async function GET(request: NextRequest) {
 }
 
 export async function POST(request: NextRequest) {
-  const body = await request.json();
-  return proxyToWyrdfoldAPI('/experience/turns', { method: 'POST', body });
+  const parsed = await readJsonBody(request);
+  if (!parsed.ok) return parsed.response;
+  return proxyToWyrdfoldAPI('/experience/turns', {
+    method: 'POST',
+    body: parsed.body,
+  });
 }

--- a/apps/wyrdfold/src/app/api/jobs/[id]/feedback/route.ts
+++ b/apps/wyrdfold/src/app/api/jobs/[id]/feedback/route.ts
@@ -1,6 +1,6 @@
 import type { NextRequest } from 'next/server';
 
-import { proxyToWyrdfoldAPI } from '@/lib/api/proxy';
+import { proxyToWyrdfoldAPI, readJsonBody } from '@/lib/api/proxy';
 
 interface RouteContext {
   params: Promise<{ id: string }>;
@@ -8,10 +8,11 @@ interface RouteContext {
 
 export async function POST(request: NextRequest, ctx: RouteContext) {
   const { id } = await ctx.params;
-  const body = await request.json().catch(() => null);
+  const parsed = await readJsonBody(request);
+  if (!parsed.ok) return parsed.response;
   return proxyToWyrdfoldAPI(`/jobs/${id}/feedback`, {
     method: 'POST',
-    body,
+    body: parsed.body,
   });
 }
 

--- a/apps/wyrdfold/src/app/api/jobs/[id]/status/route.ts
+++ b/apps/wyrdfold/src/app/api/jobs/[id]/status/route.ts
@@ -1,11 +1,15 @@
 import type { NextRequest } from 'next/server';
 
-import { proxyToWyrdfoldAPI } from '@/lib/api/proxy';
+import { proxyToWyrdfoldAPI, readJsonBody } from '@/lib/api/proxy';
 
 type Params = { params: Promise<{ id: string }> };
 
 export async function POST(request: NextRequest, { params }: Params) {
   const { id } = await params;
-  const body = await request.json();
-  return proxyToWyrdfoldAPI(`/jobs/${id}/status`, { method: 'POST', body });
+  const parsed = await readJsonBody(request);
+  if (!parsed.ok) return parsed.response;
+  return proxyToWyrdfoldAPI(`/jobs/${id}/status`, {
+    method: 'POST',
+    body: parsed.body,
+  });
 }

--- a/apps/wyrdfold/src/app/api/jobs/manual/route.ts
+++ b/apps/wyrdfold/src/app/api/jobs/manual/route.ts
@@ -1,8 +1,12 @@
 import type { NextRequest } from 'next/server';
 
-import { proxyToWyrdfoldAPI } from '@/lib/api/proxy';
+import { proxyToWyrdfoldAPI, readJsonBody } from '@/lib/api/proxy';
 
 export async function POST(request: NextRequest) {
-  const body = await request.json();
-  return proxyToWyrdfoldAPI('/jobs/manual', { method: 'POST', body });
+  const parsed = await readJsonBody(request);
+  if (!parsed.ok) return parsed.response;
+  return proxyToWyrdfoldAPI('/jobs/manual', {
+    method: 'POST',
+    body: parsed.body,
+  });
 }

--- a/apps/wyrdfold/src/app/api/jobs/sources/route.ts
+++ b/apps/wyrdfold/src/app/api/jobs/sources/route.ts
@@ -1,6 +1,6 @@
 import type { NextRequest } from 'next/server';
 
-import { proxyToWyrdfoldAPI } from '@/lib/api/proxy';
+import { proxyToWyrdfoldAPI, readJsonBody } from '@/lib/api/proxy';
 
 type SourceAction =
   | { action: 'add'; board_token: string; company_name: string }
@@ -12,7 +12,8 @@ export async function GET() {
 }
 
 export async function POST(request: NextRequest) {
-  const body = (await request.json()) as SourceAction;
-  const path = body.action === 'seed' ? '/sources/seed' : '/sources';
-  return proxyToWyrdfoldAPI(path, { method: 'POST', body });
+  const parsed = await readJsonBody<SourceAction>(request);
+  if (!parsed.ok) return parsed.response;
+  const path = parsed.body.action === 'seed' ? '/sources/seed' : '/sources';
+  return proxyToWyrdfoldAPI(path, { method: 'POST', body: parsed.body });
 }

--- a/apps/wyrdfold/src/app/api/jobs/tailor/[id]/route.ts
+++ b/apps/wyrdfold/src/app/api/jobs/tailor/[id]/route.ts
@@ -1,6 +1,6 @@
 import type { NextRequest } from 'next/server';
 
-import { proxyToWyrdfoldAPI } from '@/lib/api/proxy';
+import { proxyToWyrdfoldAPI, readJsonBody } from '@/lib/api/proxy';
 
 type Params = { params: Promise<{ id: string }> };
 
@@ -11,9 +11,10 @@ export async function GET(_request: NextRequest, { params }: Params) {
 
 export async function PATCH(request: NextRequest, { params }: Params) {
   const { id } = await params;
-  const body = await request.json();
+  const parsed = await readJsonBody(request);
+  if (!parsed.ok) return parsed.response;
   return proxyToWyrdfoldAPI(`/tailor/resumes/${id}`, {
     method: 'PATCH',
-    body,
+    body: parsed.body,
   });
 }

--- a/apps/wyrdfold/src/app/api/jobs/tailor/batch/route.ts
+++ b/apps/wyrdfold/src/app/api/jobs/tailor/batch/route.ts
@@ -1,12 +1,17 @@
 import type { NextRequest } from 'next/server';
 
-import { LLM_TIMEOUT_MS, proxyToWyrdfoldAPI } from '@/lib/api/proxy';
+import {
+  LLM_TIMEOUT_MS,
+  proxyToWyrdfoldAPI,
+  readJsonBody,
+} from '@/lib/api/proxy';
 
 export async function POST(request: NextRequest) {
-  const body = await request.json();
+  const parsed = await readJsonBody(request);
+  if (!parsed.ok) return parsed.response;
   return proxyToWyrdfoldAPI('/tailor/batch', {
     method: 'POST',
-    body,
+    body: parsed.body,
     timeoutMs: LLM_TIMEOUT_MS,
   });
 }

--- a/apps/wyrdfold/src/app/api/jobs/tailor/cover-letter/route.ts
+++ b/apps/wyrdfold/src/app/api/jobs/tailor/cover-letter/route.ts
@@ -1,12 +1,17 @@
 import type { NextRequest } from 'next/server';
 
-import { LLM_TIMEOUT_MS, proxyToWyrdfoldAPI } from '@/lib/api/proxy';
+import {
+  LLM_TIMEOUT_MS,
+  proxyToWyrdfoldAPI,
+  readJsonBody,
+} from '@/lib/api/proxy';
 
 export async function POST(request: NextRequest) {
-  const body = await request.json();
+  const parsed = await readJsonBody(request);
+  if (!parsed.ok) return parsed.response;
   return proxyToWyrdfoldAPI('/tailor/cover-letter', {
     method: 'POST',
-    body,
+    body: parsed.body,
     timeoutMs: LLM_TIMEOUT_MS,
   });
 }

--- a/apps/wyrdfold/src/app/api/jobs/tailor/export-zip/route.ts
+++ b/apps/wyrdfold/src/app/api/jobs/tailor/export-zip/route.ts
@@ -1,12 +1,13 @@
 import type { NextRequest } from 'next/server';
 
-import { proxyToWyrdfoldAPI } from '@/lib/api/proxy';
+import { proxyToWyrdfoldAPI, readJsonBody } from '@/lib/api/proxy';
 
 export async function POST(request: NextRequest) {
-  const body = await request.json();
+  const parsed = await readJsonBody(request);
+  if (!parsed.ok) return parsed.response;
   return proxyToWyrdfoldAPI('/tailor/resumes/export-zip', {
     method: 'POST',
-    body,
+    body: parsed.body,
     binary: true,
   });
 }

--- a/apps/wyrdfold/src/app/api/jobs/tailor/resume/route.ts
+++ b/apps/wyrdfold/src/app/api/jobs/tailor/resume/route.ts
@@ -1,12 +1,17 @@
 import type { NextRequest } from 'next/server';
 
-import { LLM_TIMEOUT_MS, proxyToWyrdfoldAPI } from '@/lib/api/proxy';
+import {
+  LLM_TIMEOUT_MS,
+  proxyToWyrdfoldAPI,
+  readJsonBody,
+} from '@/lib/api/proxy';
 
 export async function POST(request: NextRequest) {
-  const body = await request.json();
+  const parsed = await readJsonBody(request);
+  if (!parsed.ok) return parsed.response;
   return proxyToWyrdfoldAPI('/tailor/resume', {
     method: 'POST',
-    body,
+    body: parsed.body,
     timeoutMs: LLM_TIMEOUT_MS,
   });
 }

--- a/apps/wyrdfold/src/app/api/profile/identity/route.ts
+++ b/apps/wyrdfold/src/app/api/profile/identity/route.ts
@@ -1,15 +1,16 @@
 import type { NextRequest } from 'next/server';
 
-import { proxyToWyrdfoldAPI } from '@/lib/api/proxy';
+import { proxyToWyrdfoldAPI, readJsonBody } from '@/lib/api/proxy';
 
 export async function GET() {
   return proxyToWyrdfoldAPI('/profile/identity');
 }
 
 export async function PATCH(request: NextRequest) {
-  const body = await request.json();
+  const parsed = await readJsonBody(request);
+  if (!parsed.ok) return parsed.response;
   return proxyToWyrdfoldAPI('/profile/identity', {
     method: 'PATCH',
-    body,
+    body: parsed.body,
   });
 }

--- a/apps/wyrdfold/src/app/api/profile/notifications/route.ts
+++ b/apps/wyrdfold/src/app/api/profile/notifications/route.ts
@@ -1,6 +1,6 @@
 import { type NextRequest, NextResponse } from 'next/server';
 
-import { proxyToWyrdfoldAPI } from '@/lib/api/proxy';
+import { proxyToWyrdfoldAPI, readJsonBody } from '@/lib/api/proxy';
 
 // Email alerts are sent by the Next.js layer via Resend; the FastAPI
 // only knows it can call back into us. AND its `email_available` flag
@@ -21,8 +21,9 @@ export async function GET() {
 }
 
 export async function PATCH(request: NextRequest) {
-  const body = (await request.json()) as Record<string, unknown>;
-  if (body['job_notifications_enabled'] === true && !hasResendKey()) {
+  const parsed = await readJsonBody<Record<string, unknown>>(request);
+  if (!parsed.ok) return parsed.response;
+  if (parsed.body['job_notifications_enabled'] === true && !hasResendKey()) {
     return NextResponse.json(
       {
         detail:
@@ -33,6 +34,6 @@ export async function PATCH(request: NextRequest) {
   }
   return proxyToWyrdfoldAPI('/profile/notifications', {
     method: 'PATCH',
-    body,
+    body: parsed.body,
   });
 }

--- a/apps/wyrdfold/src/app/api/profile/onboarding/step/route.ts
+++ b/apps/wyrdfold/src/app/api/profile/onboarding/step/route.ts
@@ -1,14 +1,15 @@
 import { type NextRequest } from 'next/server';
 
-import { proxyToWyrdfoldAPI } from '@/lib/api/proxy';
+import { proxyToWyrdfoldAPI, readJsonBody } from '@/lib/api/proxy';
 
 // PATCH /api/profile/onboarding/step — update the wizard's current_step
 // and/or path. Wizard calls this on every step transition.
 
 export async function PATCH(request: NextRequest) {
-  const body = (await request.json()) as Record<string, unknown>;
+  const parsed = await readJsonBody<Record<string, unknown>>(request);
+  if (!parsed.ok) return parsed.response;
   return proxyToWyrdfoldAPI('/profile/onboarding/step', {
     method: 'PATCH',
-    body,
+    body: parsed.body,
   });
 }

--- a/apps/wyrdfold/src/app/api/profile/resume-style/route.ts
+++ b/apps/wyrdfold/src/app/api/profile/resume-style/route.ts
@@ -1,6 +1,6 @@
 import { type NextRequest } from 'next/server';
 
-import { proxyToWyrdfoldAPI } from '@/lib/api/proxy';
+import { proxyToWyrdfoldAPI, readJsonBody } from '@/lib/api/proxy';
 
 // Resume docx style preset (preset + accent). No capability gating — unlike
 // notifications, this never depends on operator-configured credentials.
@@ -10,9 +10,10 @@ export async function GET() {
 }
 
 export async function PATCH(request: NextRequest) {
-  const body = (await request.json()) as Record<string, unknown>;
+  const parsed = await readJsonBody<Record<string, unknown>>(request);
+  if (!parsed.ok) return parsed.response;
   return proxyToWyrdfoldAPI('/profile/resume-style', {
     method: 'PATCH',
-    body,
+    body: parsed.body,
   });
 }

--- a/apps/wyrdfold/src/app/api/targets/[id]/axis-weights/route.ts
+++ b/apps/wyrdfold/src/app/api/targets/[id]/axis-weights/route.ts
@@ -1,6 +1,6 @@
 import type { NextRequest } from 'next/server';
 
-import { proxyToWyrdfoldAPI } from '@/lib/api/proxy';
+import { proxyToWyrdfoldAPI, readJsonBody } from '@/lib/api/proxy';
 
 type Params = { params: Promise<{ id: string }> };
 
@@ -15,10 +15,11 @@ type Params = { params: Promise<{ id: string }> };
  */
 export async function PATCH(request: NextRequest, { params }: Params) {
   const { id } = await params;
-  const body = await request.json();
+  const parsed = await readJsonBody(request);
+  if (!parsed.ok) return parsed.response;
   return proxyToWyrdfoldAPI(`/targets/${id}/axis-weights`, {
     method: 'PATCH',
-    body,
+    body: parsed.body,
   });
 }
 

--- a/apps/wyrdfold/src/app/api/targets/[id]/reference-jds/route.ts
+++ b/apps/wyrdfold/src/app/api/targets/[id]/reference-jds/route.ts
@@ -1,6 +1,10 @@
 import type { NextRequest } from 'next/server';
 
-import { LLM_TIMEOUT_MS, proxyToWyrdfoldAPI } from '@/lib/api/proxy';
+import {
+  LLM_TIMEOUT_MS,
+  proxyToWyrdfoldAPI,
+  readJsonBody,
+} from '@/lib/api/proxy';
 
 type Params = { params: Promise<{ id: string }> };
 
@@ -11,10 +15,11 @@ export async function GET(_request: NextRequest, { params }: Params) {
 
 export async function POST(request: NextRequest, { params }: Params) {
   const { id } = await params;
-  const body = await request.json();
+  const parsed = await readJsonBody(request);
+  if (!parsed.ok) return parsed.response;
   return proxyToWyrdfoldAPI(`/targets/${id}/reference-jds`, {
     method: 'POST',
-    body,
+    body: parsed.body,
     timeoutMs: LLM_TIMEOUT_MS,
   });
 }

--- a/apps/wyrdfold/src/app/api/targets/[id]/route.ts
+++ b/apps/wyrdfold/src/app/api/targets/[id]/route.ts
@@ -1,6 +1,6 @@
 import type { NextRequest } from 'next/server';
 
-import { proxyToWyrdfoldAPI } from '@/lib/api/proxy';
+import { proxyToWyrdfoldAPI, readJsonBody } from '@/lib/api/proxy';
 
 type Params = { params: Promise<{ id: string }> };
 
@@ -11,8 +11,12 @@ export async function GET(_request: NextRequest, { params }: Params) {
 
 export async function PATCH(request: NextRequest, { params }: Params) {
   const { id } = await params;
-  const body = await request.json();
-  return proxyToWyrdfoldAPI(`/targets/${id}`, { method: 'PATCH', body });
+  const parsed = await readJsonBody(request);
+  if (!parsed.ok) return parsed.response;
+  return proxyToWyrdfoldAPI(`/targets/${id}`, {
+    method: 'PATCH',
+    body: parsed.body,
+  });
 }
 
 export async function DELETE(_request: NextRequest, { params }: Params) {

--- a/apps/wyrdfold/src/app/api/targets/from-manual/route.ts
+++ b/apps/wyrdfold/src/app/api/targets/from-manual/route.ts
@@ -1,12 +1,17 @@
 import type { NextRequest } from 'next/server';
 
-import { LLM_TIMEOUT_MS, proxyToWyrdfoldAPI } from '@/lib/api/proxy';
+import {
+  LLM_TIMEOUT_MS,
+  proxyToWyrdfoldAPI,
+  readJsonBody,
+} from '@/lib/api/proxy';
 
 export async function POST(request: NextRequest) {
-  const body = await request.json();
+  const parsed = await readJsonBody(request);
+  if (!parsed.ok) return parsed.response;
   return proxyToWyrdfoldAPI('/targets/from-manual', {
     method: 'POST',
-    body,
+    body: parsed.body,
     timeoutMs: LLM_TIMEOUT_MS,
   });
 }

--- a/apps/wyrdfold/src/app/api/targets/from-url/route.ts
+++ b/apps/wyrdfold/src/app/api/targets/from-url/route.ts
@@ -1,12 +1,17 @@
 import type { NextRequest } from 'next/server';
 
-import { LLM_TIMEOUT_MS, proxyToWyrdfoldAPI } from '@/lib/api/proxy';
+import {
+  LLM_TIMEOUT_MS,
+  proxyToWyrdfoldAPI,
+  readJsonBody,
+} from '@/lib/api/proxy';
 
 export async function POST(request: NextRequest) {
-  const body = await request.json();
+  const parsed = await readJsonBody(request);
+  if (!parsed.ok) return parsed.response;
   return proxyToWyrdfoldAPI('/targets/from-url', {
     method: 'POST',
-    body,
+    body: parsed.body,
     timeoutMs: LLM_TIMEOUT_MS,
   });
 }

--- a/apps/wyrdfold/src/app/api/targets/route.ts
+++ b/apps/wyrdfold/src/app/api/targets/route.ts
@@ -1,12 +1,13 @@
 import type { NextRequest } from 'next/server';
 
-import { proxyToWyrdfoldAPI } from '@/lib/api/proxy';
+import { proxyToWyrdfoldAPI, readJsonBody } from '@/lib/api/proxy';
 
 export async function GET() {
   return proxyToWyrdfoldAPI('/targets');
 }
 
 export async function POST(request: NextRequest) {
-  const body = await request.json();
-  return proxyToWyrdfoldAPI('/targets', { method: 'POST', body });
+  const parsed = await readJsonBody(request);
+  if (!parsed.ok) return parsed.response;
+  return proxyToWyrdfoldAPI('/targets', { method: 'POST', body: parsed.body });
 }

--- a/apps/wyrdfold/src/lib/api/proxy.ts
+++ b/apps/wyrdfold/src/lib/api/proxy.ts
@@ -104,6 +104,35 @@ function unauthorized(): NextResponse {
   return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 }
 
+/**
+ * Parse a Route Handler's JSON body, returning a discriminated result.
+ *
+ * Calling `await request.json()` raw on a malformed or empty body throws
+ * a `SyntaxError`, which Next.js converts into an unhandled 500 — with a
+ * potential stack leak in dev. ~20+ write routes in this app used the
+ * raw pattern (#851 S2). Wrapping returns a clean 400 instead.
+ *
+ * Usage:
+ *   const parsed = await readJsonBody<MyBody>(request);
+ *   if (!parsed.ok) return parsed.response;
+ *   const body = parsed.body;
+ */
+export async function readJsonBody<T = unknown>(
+  request: Request
+): Promise<{ ok: true; body: T } | { ok: false; response: NextResponse }> {
+  try {
+    return { ok: true, body: (await request.json()) as T };
+  } catch {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { error: 'Invalid JSON body' },
+        { status: 400 }
+      ),
+    };
+  }
+}
+
 function unavailable(err: unknown): NextResponse {
   const detail =
     process.env.NODE_ENV !== 'production' && err instanceof Error


### PR DESCRIPTION
## Summary
The audit (#851 S2) flagged that ~20+ write routes called \`await request.json()\` raw. A malformed or empty body throws a SyntaxError, which Next.js converts into an unhandled 500 (with a potential stack leak in dev) instead of a clean 400.

Adds a \`readJsonBody<T>()\` helper to \`proxy.ts\` that returns a discriminated result:

\`\`\`ts
const parsed = await readJsonBody<MyBody>(request);
if (!parsed.ok) return parsed.response;  // 400 Invalid JSON body
const body = parsed.body;
\`\`\`

Migrates **all 24 write routes** — including the one that previously used \`.catch(() => null)\` to silently forward null upstream. One helper, one place to evolve later if we add zod / shape validation at the BFF.

Closes part of danieljoffe/wyrdfold#8 (S2). Second of 6 PRs for danieljoffe/wyrdfold#8.

## Test plan
- [x] Full wyrdfold test suite passes
- [x] Typecheck clean
- [x] Lint clean
- [ ] Manual: POST any write route with malformed JSON \`{not json\` → 400 \`{ error: 'Invalid JSON body' }\`
- [ ] Manual: POST with valid body → unchanged upstream behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)