### PR TITLE
perf(wyrdfold): stream insights initial data from server page.tsx

### DIFF
--- a/apps/wyrdfold/src/app/(app)/insights/InsightsDashboard.tsx
+++ b/apps/wyrdfold/src/app/(app)/insights/InsightsDashboard.tsx
@@ -13,7 +13,7 @@ import { Skeleton } from '@danieljoffe.com/shared-ui/Skeleton';
 import { StatsCard } from '@danieljoffe.com/shared-ui/StatsCard';
 import { Text } from '@danieljoffe.com/shared-ui/Text';
 import Button from '@/components/Button';
-import { useInsights } from '@/hooks/useInsights';
+import { useInsights, type InsightsInitial } from '@/hooks/useInsights';
 import { cn } from '@/lib/cn';
 import { downloadInsightsCsv } from './exportCsv';
 import type { Period } from './types';
@@ -145,9 +145,16 @@ function absDelta(
 
 const PRIOR_LABEL = 'vs prior period';
 
-export default function InsightsDashboard() {
-  const [period, setPeriod] = useState<Period>('30d');
-  const { pipeline, targets, skillsCost, loading, error } = useInsights(period);
+export default function InsightsDashboard({
+  initial,
+}: {
+  initial?: InsightsInitial;
+} = {}) {
+  const [period, setPeriod] = useState<Period>(initial?.period ?? '30d');
+  const { pipeline, targets, skillsCost, loading, error } = useInsights(
+    period,
+    initial
+  );
 
   const showKpiSkeleton = loading.pipeline && !pipeline;
   const showVelocitySkeleton = loading.pipeline && !pipeline;

--- a/apps/wyrdfold/src/app/(app)/insights/page.tsx
+++ b/apps/wyrdfold/src/app/(app)/insights/page.tsx
@@ -1,13 +1,51 @@
 import type { Metadata } from 'next';
+
 import { Heading } from '@danieljoffe.com/shared-ui/Heading';
 import { Text } from '@danieljoffe.com/shared-ui/Text';
+
+import { fetchJsonFromWyrdfoldAPI } from '@/lib/api/proxy';
+import type { InsightsInitial } from '@/hooks/useInsights';
+
 import InsightsDashboard from './InsightsDashboard';
+import type {
+  Period,
+  PipelineInsights,
+  SkillsCostInsights,
+  TargetInsights,
+} from './types';
 
 export const metadata: Metadata = {
   title: 'Insights',
 };
 
-export default function FittedInsights() {
+const DEFAULT_PERIOD: Period = '30d';
+
+export default async function FittedInsights() {
+  // Fetch the three insights datasets server-side in parallel so the
+  // dashboard paints with data instead of three client→Next→API round-
+  // trips after hydration (#851 P1). Each is null on failure so a
+  // partial outage still renders the slices that did come back.
+  const qs = new URLSearchParams({ period: DEFAULT_PERIOD });
+  const [pipeline, targets, skillsCost] = await Promise.all([
+    fetchJsonFromWyrdfoldAPI<PipelineInsights>('/jobs/insights/pipeline', {
+      searchParams: qs,
+    }),
+    fetchJsonFromWyrdfoldAPI<TargetInsights>('/jobs/insights/targets', {
+      searchParams: qs,
+    }),
+    fetchJsonFromWyrdfoldAPI<SkillsCostInsights>('/jobs/insights/skills-cost', {
+      searchParams: qs,
+    }),
+  ]);
+
+  const initial: InsightsInitial = {
+    period: DEFAULT_PERIOD,
+    pipeline: pipeline ?? undefined,
+    targets: targets ?? undefined,
+    skillsCost: skillsCost ?? undefined,
+    fetchedAt: Date.now(),
+  };
+
   return (
     <div className='flex flex-col gap-6'>
       <div>
@@ -18,7 +56,7 @@ export default function FittedInsights() {
           Track your job search progress
         </Text>
       </div>
-      <InsightsDashboard />
+      <InsightsDashboard initial={initial} />
     </div>
   );
 }

--- a/apps/wyrdfold/src/hooks/useInsights.ts
+++ b/apps/wyrdfold/src/hooks/useInsights.ts
@@ -149,24 +149,70 @@ const INITIAL_LOADING = {
 };
 
 /**
+ * Server-rendered insights bundle passed from `page.tsx` so the dashboard
+ * paints with data instead of three skeletons → three client→Next→API
+ * round-trips (#851 P1). All slices are optional so a partial upstream
+ * failure on the server still renders the bits we did get.
+ */
+export interface InsightsInitial {
+  period: Period;
+  pipeline: PipelineInsights | undefined;
+  targets: TargetInsights | undefined;
+  skillsCost: SkillsCostInsights | undefined;
+  fetchedAt: number;
+}
+
+/**
  * Fetches the three insights endpoints in parallel and tracks their
  * loading + error state independently so the UI can render each card's
  * skeleton/empty/error state in isolation. Returns a memoized object so
  * consumers can `useMemo` keyed on slices without referential thrash.
+ *
+ * When `initial` is supplied AND its period matches the requested period,
+ * the hook seeds state from it and skips the first client fetch — the
+ * server already paid that cost in page.tsx.
  */
-export function useInsights(period: Period): InsightsData {
-  const [state, setState] = useState<InsightsState>({
-    period,
-    pipeline: undefined,
-    targets: undefined,
-    skillsCost: undefined,
-    fetchedAt: undefined,
-    ...INITIAL_LOADING,
-  });
+export function useInsights(
+  period: Period,
+  initial?: InsightsInitial
+): InsightsData {
+  const initialMatches = initial && initial.period === period;
+  const [state, setState] = useState<InsightsState>(() =>
+    initialMatches
+      ? {
+          period,
+          pipeline: initial.pipeline,
+          targets: initial.targets,
+          skillsCost: initial.skillsCost,
+          fetchedAt: initial.fetchedAt,
+          pipelineLoading: false,
+          targetsLoading: false,
+          skillsCostLoading: false,
+          pipelineFailed: false,
+          targetsFailed: false,
+          skillsCostFailed: false,
+        }
+      : {
+          period,
+          pipeline: undefined,
+          targets: undefined,
+          skillsCost: undefined,
+          fetchedAt: undefined,
+          ...INITIAL_LOADING,
+        }
+  );
   const requestRef = useRef(0);
+  // Skip the first client fetch when the server already delivered data
+  // for this period; subsequent period changes or refresh() calls still
+  // hit the API normally.
+  const skipFirstFetchRef = useRef(Boolean(initialMatches));
   const [refreshTick, setRefreshTick] = useState(0);
 
   useEffect(() => {
+    if (skipFirstFetchRef.current) {
+      skipFirstFetchRef.current = false;
+      return;
+    }
     const controller = new AbortController();
     const requestId = ++requestRef.current;
 


### PR DESCRIPTION
## Summary
The audit (#851 P1) flagged that the insights page is a static shell — all three datasets (pipeline, targets, skills/cost) fetched client-side after hydration via \`/api/jobs/insights/*\`. That's a client→Next→API round-trip on top of hydration, each re-resolving the session, and three skeleton flashes before any chart paints.

Moves the initial fetch to the server \`page.tsx\`, mirroring the existing \`DashboardInitial\` pattern:
- \`Promise.all\` over the three insights endpoints for the default \`30d\` period, passed to \`InsightsDashboard\` as an \`initial\` prop.
- The client \`useInsights\` hook still owns period re-fetches and the refresh button — only the very first paint is short-circuited.

### Implementation
- \`useInsights(period, initial?)\` seeds state from \`initial\` when \`initial.period === period\` and skips the first client fetch via a ref flag. Subsequent period changes / \`refresh()\` hit the API normally.
- \`InsightsDashboard\` accepts an optional \`initial\` prop and threads it through; the default-undefined makes the change non-breaking for any caller that omits it.
- \`page.tsx\` becomes async, fetches the three datasets server-side, and builds the \`InsightsInitial\` payload. Each slice is independent so a partial upstream outage still renders what came back.

Closes part of danieljoffe/wyrdfold#8 (P1). PR 3 of 6 for danieljoffe/wyrdfold#8.

## Test plan
- [x] Full wyrdfold test suite passes
- [x] Typecheck clean
- [ ] Manual: load /insights, verify charts paint on first paint (no skeleton flash)
- [ ] Manual: switch period to 7d, verify normal client fetch happens
- [ ] Manual: click refresh button, verify normal client fetch happens

🤖 Generated with [Claude Code](https://claude.com/claude-code)