### PR TITLE
perf(wyrdfold): memoize insights chart arrays to skip unrelated re-renders

### DIFF
--- a/apps/wyrdfold/src/app/(app)/insights/InsightsDashboard.tsx
+++ b/apps/wyrdfold/src/app/(app)/insights/InsightsDashboard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import dynamic from 'next/dynamic';
 import { Download } from 'lucide-react';
 import {
@@ -157,6 +157,30 @@ export default function InsightsDashboard() {
   const showSkillFreqSkeleton = loading.skillsCost && !skillsCost;
   const showCostSkeleton = loading.skillsCost && !skillsCost;
 
+  // Stable per-chart array references so an unrelated slice resolution
+  // (e.g. skillsCost) doesn't fabricate fresh `?? []` fallbacks for the
+  // pipeline/targets charts and trigger a Recharts re-render of charts
+  // whose data hasn't changed (#851 P2).
+  const velocityData = useMemo(() => pipeline?.velocity ?? [], [pipeline]);
+  const funnelData = useMemo(() => pipeline?.funnel ?? [], [pipeline]);
+  const scoreDistributionData = useMemo(
+    () => targets?.score_distribution ?? [],
+    [targets]
+  );
+  const targetComparisonData = useMemo(() => targets?.targets ?? [], [targets]);
+  const topSkillsData = useMemo(
+    () => skillsCost?.top_skills ?? [],
+    [skillsCost]
+  );
+  const topMissingData = useMemo(
+    () => skillsCost?.top_missing ?? [],
+    [skillsCost]
+  );
+  const costOverTimeData = useMemo(
+    () => skillsCost?.cost_over_time ?? [],
+    [skillsCost]
+  );
+
   const handleDownload = useCallback(() => {
     downloadInsightsCsv({ period, pipeline, targets, skillsCost });
   }, [period, pipeline, targets, skillsCost]);
@@ -288,7 +312,7 @@ export default function InsightsDashboard() {
           {showVelocitySkeleton ? (
             <ChartSkeleton />
           ) : (
-            <VelocityChart data={pipeline?.velocity ?? []} />
+            <VelocityChart data={velocityData} />
           )}
         </CardContent>
       </Card>
@@ -303,7 +327,7 @@ export default function InsightsDashboard() {
             {showFunnelSkeleton ? (
               <ChartSkeleton />
             ) : (
-              <FunnelChart data={pipeline?.funnel ?? []} />
+              <FunnelChart data={funnelData} />
             )}
           </CardContent>
         </Card>
@@ -317,7 +341,7 @@ export default function InsightsDashboard() {
               <ChartSkeleton />
             ) : (
               <ScoreDistributionChart
-                data={targets?.score_distribution ?? []}
+                data={scoreDistributionData}
                 unscoredCount={targets?.unscored_count ?? 0}
               />
             )}
@@ -340,7 +364,7 @@ export default function InsightsDashboard() {
             {showTargetCmpSkeleton ? (
               <ChartSkeleton />
             ) : (
-              <TargetComparisonChart data={targets?.targets ?? []} />
+              <TargetComparisonChart data={targetComparisonData} />
             )}
           </CardContent>
         </Card>
@@ -358,7 +382,7 @@ export default function InsightsDashboard() {
             {showSkillFreqSkeleton ? (
               <ChartSkeleton />
             ) : (
-              <SkillFrequencyChart data={skillsCost?.top_skills ?? []} />
+              <SkillFrequencyChart data={topSkillsData} />
             )}
           </CardContent>
         </Card>
@@ -378,7 +402,7 @@ export default function InsightsDashboard() {
           {showSkillFreqSkeleton ? (
             <Skeleton variant='rectangular' height={180} />
           ) : (
-            <TopSkillGaps data={skillsCost?.top_missing ?? []} />
+            <TopSkillGaps data={topMissingData} />
           )}
         </CardContent>
       </Card>
@@ -401,7 +425,7 @@ export default function InsightsDashboard() {
           {showCostSkeleton ? (
             <ChartSkeleton />
           ) : (
-            <CostChart data={skillsCost?.cost_over_time ?? []} />
+            <CostChart data={costOverTimeData} />
           )}
         </CardContent>
       </Card>


### PR DESCRIPTION
## Summary
The audit (#851 P2) flagged that each insights chart received a freshly-created \`?? []\` fallback array on every parent render. The \`InsightsDashboard\` parent re-renders on each of three independent setState resolutions (\`pipelineLoading → false\`, \`targetsLoading → false\`, \`skillsCostLoading → false\`), and Recharts re-render is expensive — so a \`skillsCost\` resolution would re-render the velocity/funnel/score-distribution charts whose data hadn't changed at all.

Wraps each chart's fallback in \`useMemo\` keyed on its owning slice (\`pipeline\`, \`targets\`, or \`skillsCost\`). Now a \`skillsCost\` resolution fabricates fresh references only for the three skillsCost charts; the pipeline + targets charts get referentially stable arrays and skip re-render entirely (Recharts shallow-compares data internally).

Closes part of danieljoffe/wyrdfold#8 (P2). PR 4 of 6 for danieljoffe/wyrdfold#8.

## Test plan
- [x] Full wyrdfold suite passes
- [x] Typecheck + lint clean
- [ ] Manual: open React DevTools profiler, switch period, confirm only the charts whose slice changed re-render

🤖 Generated with [Claude Code](https://claude.com/claude-code)