### PR TITLE
fix(wyrdfold): mark onboarding complete on skip so dashboard guard does not bounce

### DIFF
--- a/apps/wyrdfold/src/app/onboarding/OnboardingWizard.tsx
+++ b/apps/wyrdfold/src/app/onboarding/OnboardingWizard.tsx
@@ -81,6 +81,17 @@ export default function OnboardingWizard() {
   }, []);
 
   const handleSkip = useCallback(() => {
+    // Mark onboarding complete on skip so the user isn't bounced back to
+    // /onboarding by the dashboard's completed_at gate. CompletionScreen
+    // hits the same endpoint on the "happy path" finish; the API is
+    // idempotent (user_profile.py:404 short-circuits if completed_at is
+    // already set) so re-completing after a finish is a no-op.
+    //
+    // Fired-and-not-awaited: the navigation should feel instant. If the
+    // POST fails for any reason the user lands on /targets anyway and
+    // the dashboard guard will redirect them back on next visit — same
+    // behavior as before this fix, never worse.
+    void fetch('/api/profile/onboarding/complete', { method: 'POST' });
     router.push('/targets');
   }, [router]);
 

--- a/apps/wyrdfold/src/app/onboarding/__tests__/OnboardingWizard.spec.tsx
+++ b/apps/wyrdfold/src/app/onboarding/__tests__/OnboardingWizard.spec.tsx
@@ -126,8 +126,17 @@ jest.mock('../../_components/ConversationChat', () => ({
   ),
 }));
 
+const originalFetch = global.fetch;
+const mockFetch = jest.fn();
+
 beforeEach(() => {
   jest.clearAllMocks();
+  mockFetch.mockResolvedValue({ ok: true, status: 200 });
+  global.fetch = mockFetch as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
 });
 
 describe('OnboardingWizard — initial state', () => {
@@ -155,6 +164,17 @@ describe('OnboardingWizard — initial state', () => {
     await user.click(screen.getByRole('button', { name: /skip for now/i }));
 
     expect(mockPush).toHaveBeenCalledWith('/targets');
+  });
+
+  it('marks onboarding complete on Skip so the dashboard guard does not bounce back', async () => {
+    const user = userEvent.setup();
+    render(<OnboardingWizard />);
+
+    await user.click(screen.getByRole('button', { name: /skip for now/i }));
+
+    expect(mockFetch).toHaveBeenCalledWith('/api/profile/onboarding/complete', {
+      method: 'POST',
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
\`handleSkip\` in \`OnboardingWizard\` only pushed to \`/targets\` without recording a completion timestamp. The dashboard guard (\`dashboard/page.tsx:46\`) redirects any visitor with \`onboarding_completed_at == null\` back to \`/onboarding\` — so a user who clicked "Skip for now" landed on \`/targets\`, then bounced to \`/onboarding\` the moment they navigated to the dashboard. The opposite of what the skip button promised.

## Fix
\`handleSkip\` now fires \`POST /api/profile/onboarding/complete\` before navigating. The endpoint is idempotent (\`user_profile.py:404\` short-circuits when \`completed_at\` is already set), so the \`CompletionScreen\` happy-path POST and this skip POST can both run without double-writes.

Fire-and-not-awaited so the navigation feels instant. On POST failure the user still lands on \`/targets\` and the dashboard guard catches them on next visit — never worse than prior behavior.

## Test plan
- [x] Existing skip-path test still asserts \`/targets\` navigation
- [x] New test asserts the completion POST fires on skip
- [ ] Manual: fresh user clicks Skip on PathChooser → lands on /targets → navigates to /dashboard → stays on /dashboard (no redirect)

🤖 Generated with [Claude Code](https://claude.com/claude-code)