### PR TITLE
feat(shared-ui): add npm-publish metadata + FSL-1.1-MIT license

### DIFF
--- a/libs/shared/ui/LICENSE.md
+++ b/libs/shared/ui/LICENSE.md
@@ -1,0 +1,117 @@
+# Functional Source License, Version 1.1, MIT Future License
+
+## Abbreviation
+
+FSL-1.1-MIT
+
+## Notice
+
+Copyright 2026 Daniel Joffe
+
+## Terms and Conditions
+
+### Licensor ("We")
+
+The party offering the Software under these Terms and Conditions.
+
+### The Software
+
+The "Software" is each version of the software that we make available
+under these Terms and Conditions, as indicated by our inclusion of these
+Terms and Conditions with the Software.
+
+### License Grant
+
+Subject to your compliance with this License Grant and the Patents,
+Redistribution and Trademark clauses below, we hereby grant you the right
+to use, copy, modify, create derivative works, publish, and redistribute
+the Software, in whole or in part, solely for any Permitted Purpose.
+
+### Permitted Purpose
+
+A Permitted Purpose is any purpose other than a Competing Use. A
+Competing Use means making the Software available to others in a
+commercial product or service that:
+
+1. substitutes for the Software;
+
+2. substitutes for any other product or service we offer using the
+   Software that exists as of the date we make the Software available; or
+
+3. offers the same or substantially similar functionality as the Software.
+
+Permitted Purposes specifically include using the Software:
+
+1. for your internal use and access;
+
+2. for non-commercial education;
+
+3. for non-commercial research; and
+
+4. in connection with professional services that you provide to a
+   licensee using the Software in accordance with these Terms and
+   Conditions.
+
+### Patents
+
+To the extent your use for a Permitted Purpose would necessarily infringe
+our patents, the license grant above includes a license under our patents.
+If you make a claim against any party that the Software infringes or
+contributes to the infringement of any patent, then your patent license
+to the Software ends immediately.
+
+### Redistribution
+
+The Terms and Conditions apply to all copies, modifications and
+derivatives of the Software.
+
+If you redistribute any copies, modifications or derivatives of the
+Software, you must include a copy of or a link to these Terms and
+Conditions and not remove any copyright notices provided in or with the
+Software.
+
+### Disclaimer
+
+THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND,
+INCLUDING WITHOUT LIMITATION WARRANTIES OF MERCHANTABILITY, FITNESS FOR
+A PARTICULAR PURPOSE, NON-INFRINGEMENT AND TITLE.
+
+OUR TOTAL LIABILITY TO YOU FOR ANY DAMAGES ARISING OUT OF OR RELATED TO
+THIS AGREEMENT IS LIMITED TO US$500.
+
+WE WILL NOT BE LIABLE TO YOU FOR ANY LOST PROFITS, REVENUES, OR DATA, OR
+FOR CONSEQUENTIAL, INDIRECT, SPECIAL, INCIDENTAL, OR PUNITIVE DAMAGES.
+
+### Trademarks
+
+Except for displaying the License Details and identifying us as the
+origin of the Software, you have no right under these Terms and
+Conditions to use our trademarks, trade names, service marks or product
+names.
+
+## Grant of Future License
+
+We hereby irrevocably grant you an additional license to use the Software
+under the MIT license that is effective on the second anniversary of the
+date we make the Software available. On or after that date, you may use
+the Software under the MIT license, in which case the following will
+apply:
+
+> Permission is hereby granted, free of charge, to any person obtaining a
+> copy of this software and associated documentation files (the
+> "Software"), to deal in the Software without restriction, including
+> without limitation the rights to use, copy, modify, merge, publish,
+> distribute, sublicense, and/or sell copies of the Software, and to
+> permit persons to whom the Software is furnished to do so, subject to
+> the following conditions:
+>
+> The above copyright notice and this permission notice shall be included
+> in all copies or substantial portions of the Software.
+>
+> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+> OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+> MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+> IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+> CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+> TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+> SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/libs/shared/ui/README.md
+++ b/libs/shared/ui/README.md
@@ -363,3 +363,11 @@ pnpm nx build @danieljoffe.com/shared-ui
 ## Contributing
 
 This library lives in the [danieljoffe.com monorepo](https://github.com/danieljoffe/danieljoffe.com) at `libs/shared/ui/`. See the root `CLAUDE.md` for conventions around the Rule of Three, component patterns, and the shared-ui boundary.
+
+## License
+
+[FSL-1.1-MIT](./LICENSE.md) — Functional Source License 1.1 with MIT Future License.
+
+The Functional Source License grants permission to use, copy, modify, and redistribute the software for any purpose except a Competing Use (a commercial product or service that substitutes for this library or anything we offer using it). Two years after each release, that release automatically re-licenses under the MIT License. Read the [LICENSE](./LICENSE.md) for the full terms.
+
+Practical translation: you can use, fork, and self-host this library freely for personal, internal, educational, or non-competing-commercial work. If you'd like to use it inside a competing commercial offering, [open an issue](https://github.com/danieljoffe/danieljoffe.com/issues) — there's almost certainly a path that works for both of us.

--- a/libs/shared/ui/package.json
+++ b/libs/shared/ui/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@danieljoffe.com/shared-ui",
   "version": "0.0.1",
+  "description": "React component library and design system shared across danieljoffe.com and WyrdFold — Tailwind CSS 4, React 19, server-component-friendly.",
   "type": "module",
   "sideEffects": false,
   "main": "./dist/index.js",
@@ -31,6 +32,39 @@
     },
     "./styles/indigo-theme.css": "./src/styles/indigo-theme.css",
     "./styles/pyre-theme.css": "./src/styles/pyre-theme.css"
+  },
+  "files": [
+    "dist",
+    "src/styles",
+    "README.md",
+    "LICENSE.md"
+  ],
+  "keywords": [
+    "react",
+    "react-19",
+    "ui",
+    "component-library",
+    "design-system",
+    "tailwindcss",
+    "tailwind-css-4",
+    "typescript",
+    "headless",
+    "wyrdfold"
+  ],
+  "author": "Daniel Joffe",
+  "license": "FSL-1.1-MIT",
+  "homepage": "https://github.com/danieljoffe/danieljoffe.com/tree/main/libs/shared/ui",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/danieljoffe/danieljoffe.com.git",
+    "directory": "libs/shared/ui"
+  },
+  "bugs": {
+    "url": "https://github.com/danieljoffe/danieljoffe.com/issues"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   },
   "dependencies": {
     "clsx": "^2.1.0",


### PR DESCRIPTION
## Summary
Preps \`libs/shared/ui\` for npm publication (epic danieljoffe/wyrdfold#2, sub-issue danieljoffe/danieljoffe.com#839):

- **\`package.json\`** — adds the metadata fields a published package needs: \`description\`, \`license\`, \`repository\`, \`homepage\`, \`bugs\`, \`author\`, \`keywords\`, \`files\` allowlist, \`publishConfig.access: "public"\`.
- **\`LICENSE.md\`** — ships **FSL-1.1-MIT** (Functional Source License 1.1 with two-year MIT step-down). Same license as Sentry / Codecov / Element. Source-available now, automatic MIT in 2 years per release. Lets the extraction proceed as a public showcase while leaving a future hosted-version option open.
- **\`README.md\`** — adds a License section translating FSL into plain language.

## What's intentionally NOT in this PR
The package name **stays** \`@danieljoffe.com/shared-ui\` here. npm scopes reject dots, so the rename to \`@danieljoffe/shared-ui\` is a separate PR (#839-C, coming next) that needs to touch ~146 import sites atomically. Everything in this PR is monorepo-local and safe to land independent of the rename.

## Test plan
- [x] Build green (\`pnpm nx build @danieljoffe.com/shared-ui\`)
- [x] No imports affected (no \`name\` or \`exports\` changes)
- [ ] Visual check of LICENSE.md rendering on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)