### PR TITLE
fix(wyrdfold): use {{ .RedirectTo }} in magic-link email template

### DIFF
--- a/supabase/templates/magic-link.html
+++ b/supabase/templates/magic-link.html
@@ -104,7 +104,7 @@
                   <tr>
                     <td bgcolor="#8FC900" style="border-radius: 8px">
                       <a
-                        href="{{ .SiteURL }}/auth/callback?token_hash={{ .TokenHash }}&type=magiclink"
+                        href="{{ .RedirectTo }}?token_hash={{ .TokenHash }}&type=magiclink"
                         style="
                           display: inline-block;
                           padding: 14px 28px;
@@ -132,9 +132,9 @@
                   The link works once and expires in an hour. If it doesn't
                   work, paste this into your browser:<br />
                   <a
-                    href="{{ .SiteURL }}/auth/callback?token_hash={{ .TokenHash }}&type=magiclink"
+                    href="{{ .RedirectTo }}?token_hash={{ .TokenHash }}&type=magiclink"
                     style="color: #bef264; word-break: break-all"
-                    >{{ .SiteURL }}/auth/callback?token_hash={{ .TokenHash
+                    >{{ .RedirectTo }}?token_hash={{ .TokenHash
                     }}&type=magiclink</a
                   >
                 </p>


### PR DESCRIPTION
## Summary

- Magic-link email template was concatenating `{{ .ConfirmationURL }}` (already a full Supabase verify URL) with `/auth/callback?token_hash=...`, producing malformed nested URLs.
- On localhost sign-ins the button resolved to **production** because `{{ .ConfirmationURL }}` follows the project's fixed Site URL — it doesn't honor the per-call `emailRedirectTo`.
- Switch to `{{ .RedirectTo }}?token_hash={{ .TokenHash }}&type=magiclink` so the link honors the dynamic value the login form passes (`${window.location.origin}/auth/callback` in `MagicLinkForm.tsx:124`).

## Why this works

The callback route at `apps/wyrdfold/src/app/auth/callback/route.ts:109` already prioritizes the token-hash flow because it's **cross-browser-safe**. PKCE (`?code=`) requires the code_verifier cookie from the originating browser; emails opened in a different browser fail. The token-hash flow has no such constraint.

## Prerequisite (already in place per user)

Both `http://localhost:3000/auth/callback` and the production callback must remain in the Supabase Redirect URL allowlist for `{{ .RedirectTo }}` to resolve. If allowlist match fails, Supabase silently substitutes Site URL (see `reference_supabase_silent_redirect_fallback.md`).

## Scope

Only the `magic_link` template. The invite flow is a separate template with a different post-link UX (one-time setup landing page) — not touched here.

## Test plan

- [ ] Run `supabase config push --project-ref <prod>` to sync template after merge
- [ ] Send a magic link from localhost dev server → email button URL starts with `http://localhost:3000/auth/callback?token_hash=...`
- [ ] Open same magic link in a different browser → still works (cross-browser token-hash flow)
- [ ] Send a magic link from production → email button URL starts with `https://wyrdfold.com/auth/callback?token_hash=...`
- [ ] Verify `?type=magiclink` round-trips through `asOtpType()` in the callback route

🤖 Generated with [Claude Code](https://claude.com/claude-code)