### PR TITLE
chore: register publish-shared-ui workflow on main

### DIFF
--- a/.github/workflows/publish-shared-ui.yml
+++ b/.github/workflows/publish-shared-ui.yml
@@ -1,0 +1,132 @@
+# Manual publish workflow for the @danieljoffe/shared-ui npm package.
+#
+# Trigger via GitHub Actions UI (Run workflow). Requires the NPM_TOKEN
+# repository secret to be set; without it the publish step exits with a
+# clear "missing secret" error before doing anything destructive.
+#
+# The workflow does NOT auto-fire on push or tag — every publish is a
+# deliberate, human-triggered action. This is intentional for a
+# pre-1.0 library; we'll add tag-based auto-publish later once the API
+# has stabilized.
+#
+# Inputs:
+#   version    — semver to publish. Bumps package.json + tags the commit.
+#                Pass "current" to publish whatever version is in
+#                package.json without a new tag (useful for re-runs).
+#   dry-run    — defaults to true. Runs `npm publish --dry-run` so you
+#                can confirm what would be published before flipping the
+#                switch. Real publish requires explicit dry-run=false.
+#
+# Outputs (on real publish):
+#   - tag v-shared-ui-<version> pushed
+#   - <version> published to npm under the public scope
+#   - GitHub Release auto-created from the tag
+
+name: Publish shared-ui
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Semver to publish (e.g. 0.0.2) or "current" to use package.json as-is
+        required: true
+        default: current
+        type: string
+      dry-run:
+        description: Dry-run (no actual publish, no tag, no release)
+        required: true
+        default: true
+        type: boolean
+
+permissions:
+  contents: write # for tag + release creation on real publish
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment:
+      name: npm-publish
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - uses: ./.github/actions/setup-workspace
+
+      - name: Verify NPM_TOKEN is configured
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          if [ -z "${NPM_TOKEN}" ]; then
+            echo "::error::NPM_TOKEN repository secret is not set. Add it in Settings → Secrets and variables → Actions before publishing."
+            exit 1
+          fi
+          echo "NPM_TOKEN present"
+
+      - name: Verify package name is npm-publishable
+        run: |
+          NAME=$(node -p "require('./libs/shared/ui/package.json').name")
+          echo "Package name: ${NAME}"
+          # npm scope grammar: lowercase letters, digits, hyphens. Dots and
+          # underscores are rejected. The legacy `@danieljoffe.com/shared-ui`
+          # name contains a dot — must be renamed before publish.
+          if ! echo "${NAME}" | grep -Eq '^@[a-z0-9-]+/[a-z0-9-]+$'; then
+            echo "::error::Package name '${NAME}' is not a valid npm scope. Land the rename PR (#839-C) before publishing."
+            exit 1
+          fi
+
+      - name: Bump version
+        if: inputs.version != 'current'
+        run: |
+          cd libs/shared/ui
+          npm version "${{ inputs.version }}" --no-git-tag-version
+
+      - name: Read effective version
+        id: version
+        run: |
+          VERSION=$(node -p "require('./libs/shared/ui/package.json').version")
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Publishing version: ${VERSION}"
+
+      - name: Build
+        run: pnpm nx build @danieljoffe.com/shared-ui
+
+      - name: Publish (dry-run)
+        if: inputs.dry-run
+        working-directory: libs/shared/ui
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > ~/.npmrc
+          npm publish --dry-run
+
+      - name: Publish (real)
+        if: ${{ !inputs.dry-run }}
+        working-directory: libs/shared/ui
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > ~/.npmrc
+          npm publish
+
+      - name: Commit version bump + tag
+        if: ${{ !inputs.dry-run && inputs.version != 'current' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          git add libs/shared/ui/package.json
+          git commit -m "chore(shared-ui): release v${{ steps.version.outputs.version }}"
+          git tag "shared-ui-v${{ steps.version.outputs.version }}"
+          git push origin HEAD --tags
+
+      - name: Create GitHub Release
+        if: ${{ !inputs.dry-run && inputs.version != 'current' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "shared-ui-v${{ steps.version.outputs.version }}" \
+            --title "shared-ui v${{ steps.version.outputs.version }}" \
+            --generate-notes


### PR DESCRIPTION
## Summary

Lands ONLY the publish workflow file on \`main\` so GitHub registers it for \`workflow_dispatch\`. The actual publish logic, package rename, LICENSE, and metadata stay on \`develop\` (#869, #870, #871) and don't need to move yet — Wyrdfold itself is not promoted.

## Why this PR is needed

GitHub's \`workflow_dispatch\` API addresses workflows by their identity on the **default branch** (\`main\`). The file lives on \`develop\` but \`main\` doesn't have it, so:

- \`gh workflow run publish-shared-ui.yml --ref develop\` returns 404
- The workflow doesn't surface in the Actions UI sidebar

## What this changes

- Adds \`.github/workflows/publish-shared-ui.yml\` to \`main\` (identical to the develop version)
- **No app code changes** — Wyrdfold stays unpublished

## How dispatch will work after this lands

\`\`\`bash
gh workflow run publish-shared-ui.yml --ref develop -f dry-run=true
\`\`\`

GitHub sees the file exists on \`main\` (registration check passes), then **executes the develop-branch version** of the workflow — picking up the renamed scope, LICENSE, and package metadata.

## Caveat

If someone accidentally dispatches with \`--ref main\` (the default), the workflow would run against an unprepared codebase (no rename, no LICENSE). The workflow's existing package-name regex check should catch \`@danieljoffe.com/shared-ui\` (dots invalid) and abort, but consider adding an explicit \`if: github.ref != 'refs/heads/main'\` guard in a follow-up.

## Test plan

- [ ] Merge this PR
- [ ] Verify \`publish-shared-ui\` appears in https://github.com/danieljoffe/danieljoffe.com/actions sidebar
- [ ] \`gh workflow run publish-shared-ui.yml --ref develop -f dry-run=true\` returns 204 No Content
- [ ] Dry-run executes successfully against the develop-branch code

🤖 Generated with [Claude Code](https://claude.com/claude-code)