### PR TITLE
fix(ci): update publish workflow build target to renamed Nx project

### DIFF
--- a/.github/workflows/publish-shared-ui.yml
+++ b/.github/workflows/publish-shared-ui.yml
@@ -90,7 +90,7 @@ jobs:
           echo "Publishing version: ${VERSION}"
 
       - name: Build
-        run: pnpm nx build @danieljoffe.com/shared-ui
+        run: pnpm nx build @danieljoffe/shared-ui
 
       - name: Publish (dry-run)
         if: inputs.dry-run


### PR DESCRIPTION
## Summary

- Build step still ran \`pnpm nx build @danieljoffe.com/shared-ui\` — the pre-rename name.
- #871 renamed the Nx project to \`@danieljoffe/shared-ui\` (no dots — npm scopes reject them).
- Nx project lookup is exact, so the workflow failed before reaching the dry-run step.

## Evidence

From the failed run [27231148702](https://github.com/danieljoffe/danieljoffe.com/actions/runs/27231148702/job/80411352815):
\`\`\`
NX  Cannot find project '@danieljoffe.com/shared-ui'
\`\`\`

## Fix

One-line change to the build step. Comment on line 72 explaining the legacy name kept as historical context.

## Test plan

- [ ] Merge
- [ ] Re-dispatch dry-run: \`gh workflow run publish-shared-ui.yml --ref develop -f dry-run=true\`
- [ ] Build step succeeds → \`npm pack --dry-run\` output appears in log

🤖 Generated with [Claude Code](https://claude.com/claude-code)