### PR TITLE
fix(ci): sync publish workflow build target on main

### DIFF
--- a/.github/workflows/publish-shared-ui.yml
+++ b/.github/workflows/publish-shared-ui.yml
@@ -90,7 +90,7 @@ jobs:
           echo "Publishing version: ${VERSION}"
 
       - name: Build
-        run: pnpm nx build @danieljoffe.com/shared-ui
+        run: pnpm nx build @danieljoffe/shared-ui
 
       - name: Publish (dry-run)
         if: inputs.dry-run


### PR DESCRIPTION
## Summary

- The workflow file landed on main in #876 still references the pre-rename Nx project name \`@danieljoffe.com/shared-ui\`.
- #877 fixed develop but main has the same broken copy.
- This PR makes main's copy consistent with develop's.

## Why this matters

When \`workflow_dispatch\` fires with \`--ref develop\`, GitHub executes the develop-branch version (correct, fixed in #877). So #877 alone unblocks the dry-run. This PR keeps main in sync to:

1. Prevent the broken copy from drifting further as the workflow evolves.
2. Make accidental \`--ref main\` dispatches less destructive (they'd still fail other checks, but at least the build step works).

## Diff

One-line change: \`@danieljoffe.com/shared-ui\` → \`@danieljoffe/shared-ui\` on line 93.

## Test plan

- [ ] Merge with admin bypass (same dance as #876, see prior PR comment)
- [ ] Verify \`grep "pnpm nx build" .github/workflows/publish-shared-ui.yml\` shows \`@danieljoffe/shared-ui\` on main
- [ ] develop already has the same fix via #877 — no further action needed there

🤖 Generated with [Claude Code](https://claude.com/claude-code)