### PR TITLE
fix(wyrdfold): discovery never inserted Greenhouse or Workday boards

### DIFF
--- a/apps/wyrdfold-api/app/services/ats_detect.py
+++ b/apps/wyrdfold-api/app/services/ats_detect.py
@@ -40,6 +40,69 @@ _URL_PATTERNS: list[tuple[re.Pattern[str], str]] = [
 # Slug must be URL-safe, lowercase, 2-80 chars
 _SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9._-]{0,79}$")
 
+# Workday host: ``{tenant}.wd{n}.myworkdayjobs.com``. The tenant alone isn't
+# enough to poll — ``fetch_workday_jobs`` needs the full
+# ``{base_url}|{tenant}|{site}`` token, and the site only appears in the URL
+# path. We therefore parse Workday URLs separately instead of routing them
+# through the slug-based probers.
+_WORKDAY_HOST_RE = re.compile(
+    r"^(?P<tenant>[a-z0-9-]+)\.wd\d+\.myworkdayjobs\.com$", re.I
+)
+
+# Leading path segment that's a locale ("en-US", "fr-FR", "de"), not the
+# career-site name.
+_WORKDAY_LOCALE_RE = re.compile(r"^[a-z]{2}(-[A-Za-z]{2})?$")
+
+
+def _parse_workday_url(raw: str) -> tuple[str, str, str] | None:
+    """Extract ``(base_url, tenant, site)`` from a myworkdayjobs.com URL.
+
+    Returns None when the URL isn't a Workday host or carries no site
+    segment (the bare tenant root is unpollable — see comment on
+    ``_WORKDAY_HOST_RE``).
+    """
+    if "myworkdayjobs.com" not in raw.lower():
+        return None
+    parsed = urlparse(raw if "://" in raw else f"https://{raw.lstrip('/')}")
+    host = (parsed.hostname or "").lower()
+    m = _WORKDAY_HOST_RE.match(host)
+    if not m:
+        return None
+    segments = [s for s in (parsed.path or "").split("/") if s]
+    if segments and _WORKDAY_LOCALE_RE.match(segments[0]):
+        segments = segments[1:]
+    if not segments:
+        return None
+    return f"https://{host}", m.group("tenant").lower(), segments[0]
+
+
+async def _probe_workday(
+    base_url: str, tenant: str, site: str, client: httpx.AsyncClient
+) -> DetectResult | None:
+    """Probe Workday's CXS list endpoint for the board's total job count."""
+    url = f"{base_url}/wday/cxs/{tenant}/{site}/jobs"
+    try:
+        resp = await client.post(
+            url,
+            json={"appliedFacets": {}, "limit": 1, "offset": 0, "searchText": ""},
+        )
+    except httpx.HTTPError:
+        return None
+    if resp.status_code != 200:
+        return None
+    data = resp.json()
+    if not isinstance(data, dict):
+        return None
+    total = data.get("total")
+    if not isinstance(total, int):
+        return None
+    return DetectResult(
+        provider="workday",
+        board_token=f"{base_url}|{tenant}|{site}",
+        company_name=tenant.replace("-", " ").title(),
+        job_count=total,
+    )
+
 
 def _parse_input(raw: str) -> tuple[str | None, str]:
     """Parse user input into (provider_hint, slug).
@@ -72,7 +135,11 @@ def _parse_input(raw: str) -> tuple[str | None, str]:
 
 
 async def _probe_greenhouse(slug: str, client: httpx.AsyncClient) -> DetectResult | None:
-    url = f"{GREENHOUSE_BASE}/{slug}"
+    # Probe the jobs list, not the board root. The root endpoint
+    # (``/v1/boards/{slug}``) returns only ``{name, content}`` — the old
+    # ``len(data.get("departments", []))`` count was always 0, which made
+    # source discovery filter every Greenhouse board as a dead board.
+    url = f"{GREENHOUSE_BASE}/{slug}/jobs"
     try:
         resp = await client.get(url)
     except httpx.HTTPError:
@@ -80,12 +147,27 @@ async def _probe_greenhouse(slug: str, client: httpx.AsyncClient) -> DetectResul
     if resp.status_code != 200:
         return None
     data = resp.json()
-    job_count = len(data.get("departments", []))
+    jobs = data.get("jobs")
+    if not isinstance(jobs, list):
+        return None
+
+    # The display name lives on the board root; fetch it best-effort and
+    # fall back to the slug if it's unavailable.
+    company_name = slug
+    try:
+        meta_resp = await client.get(f"{GREENHOUSE_BASE}/{slug}")
+        if meta_resp.status_code == 200:
+            meta = meta_resp.json()
+            if isinstance(meta, dict):
+                company_name = meta.get("name") or slug
+    except httpx.HTTPError:
+        pass
+
     return DetectResult(
         provider="greenhouse",
         board_token=slug,
-        company_name=data.get("name", slug),
-        job_count=job_count,
+        company_name=company_name,
+        job_count=len(jobs),
     )
 
 
@@ -164,12 +246,26 @@ _PROBE_ORDER = ["greenhouse", "lever", "ashby", "smartrecruiters"]
 
 async def detect_ats(raw_input: str) -> DetectResult | None:
     """Parse input (URL or company name), probe ATS providers, return first match."""
+    client = get_http_client()
+
+    # Workday URLs carry the site in the path, which the slug-based probers
+    # can't represent — handle them before the generic parse. Previously
+    # every Workday hit from discovery fell through to the other four
+    # probers and came back unclassified.
+    workday_parts = _parse_workday_url(raw_input)
+    if workday_parts is not None:
+        return await _probe_workday(*workday_parts, client)
+
     provider_hint, slug = _parse_input(raw_input)
 
     if not slug:
         return None
 
-    client = get_http_client()
+    if provider_hint == "workday":
+        # Workday URL without a site segment — unpollable, and probing the
+        # tenant slug against the other ATSs would just waste four requests.
+        return None
+
     # If we know the provider from the URL, just probe that one
     if provider_hint and provider_hint in _PROBERS:
         return await _PROBERS[provider_hint](slug, client)

--- a/apps/wyrdfold-api/tests/test_ats_detect.py
+++ b/apps/wyrdfold-api/tests/test_ats_detect.py
@@ -85,9 +85,12 @@ def _make_http_response(status: int, json_data: object) -> MagicMock:
 @pytest.mark.asyncio
 async def test_detect_greenhouse_from_url():
     mock_client = AsyncMock()
-    mock_client.get.return_value = _make_http_response(
-        200, {"name": "Stripe", "departments": [{}, {}]}
-    )
+    # First GET probes /{slug}/jobs for the live count, second fetches the
+    # board root for the display name.
+    mock_client.get.side_effect = [
+        _make_http_response(200, {"jobs": [{"id": 1}, {"id": 2}]}),
+        _make_http_response(200, {"name": "Stripe", "content": "..."}),
+    ]
     mock_client.__aenter__ = AsyncMock(return_value=mock_client)
     mock_client.__aexit__ = AsyncMock(return_value=False)
 
@@ -98,6 +101,45 @@ async def test_detect_greenhouse_from_url():
     assert result.provider == "greenhouse"
     assert result.board_token == "stripe"
     assert result.company_name == "Stripe"
+    assert result.job_count == 2
+
+
+@pytest.mark.asyncio
+async def test_detect_greenhouse_counts_jobs_not_departments():
+    """Regression: the board root has no ``departments`` key, so the old
+    probe reported job_count=0 for every board and discovery filtered all
+    Greenhouse boards as dead."""
+    mock_client = AsyncMock()
+    mock_client.get.side_effect = [
+        _make_http_response(200, {"jobs": [{"id": n} for n in range(5)]}),
+        _make_http_response(200, {"name": "Acme"}),
+    ]
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("app.services.ats_detect.httpx.AsyncClient", return_value=mock_client):
+        result = await detect_ats("https://boards.greenhouse.io/acme")
+
+    assert result is not None
+    assert result.job_count == 5
+
+
+@pytest.mark.asyncio
+async def test_detect_greenhouse_name_fetch_failure_falls_back_to_slug():
+    mock_client = AsyncMock()
+    mock_client.get.side_effect = [
+        _make_http_response(200, {"jobs": [{"id": 1}]}),
+        httpx.HTTPError("boom"),
+    ]
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("app.services.ats_detect.httpx.AsyncClient", return_value=mock_client):
+        result = await detect_ats("https://boards.greenhouse.io/acme")
+
+    assert result is not None
+    assert result.company_name == "acme"
+    assert result.job_count == 1
 
 
 @pytest.mark.asyncio
@@ -195,7 +237,10 @@ async def test_detect_handles_network_error():
 async def test_detect_careers_page_url_probes_all():
     """A generic careers URL extracts the domain stem and probes all providers."""
     mock_client = AsyncMock()
-    mock_client.get.return_value = _make_http_response(200, {"name": "Notion", "departments": []})
+    mock_client.get.side_effect = [
+        _make_http_response(200, {"jobs": [{"id": 1}]}),
+        _make_http_response(200, {"name": "Notion"}),
+    ]
     mock_client.__aenter__ = AsyncMock(return_value=mock_client)
     mock_client.__aexit__ = AsyncMock(return_value=False)
 
@@ -205,6 +250,77 @@ async def test_detect_careers_page_url_probes_all():
     assert result is not None
     assert result.provider == "greenhouse"
     assert result.board_token == "notion"
+
+
+# --- Workday detection ---
+
+
+@pytest.mark.asyncio
+async def test_detect_workday_from_posting_url():
+    """A Workday job-posting URL yields a pollable {base}|{tenant}|{site} token."""
+    mock_client = AsyncMock()
+    mock_client.post.return_value = _make_http_response(
+        200, {"total": 137, "jobPostings": [{"title": "Engineer"}]}
+    )
+
+    with patch("app.services.ats_detect.httpx.AsyncClient", return_value=mock_client):
+        result = await detect_ats(
+            "https://salesforce.wd12.myworkdayjobs.com/en-US/External_Career_Site"
+            "/job/Japan---Tokyo/Senior-Manager--Sales_JR343895"
+        )
+
+    assert result is not None
+    assert result.provider == "workday"
+    assert result.board_token == (
+        "https://salesforce.wd12.myworkdayjobs.com|salesforce|External_Career_Site"
+    )
+    assert result.company_name == "Salesforce"
+    assert result.job_count == 137
+    # The probe hits the CXS list endpoint with a limit-1 page.
+    args, kwargs = mock_client.post.call_args
+    assert args[0] == (
+        "https://salesforce.wd12.myworkdayjobs.com/wday/cxs/salesforce"
+        "/External_Career_Site/jobs"
+    )
+    assert kwargs["json"]["limit"] == 1
+
+
+@pytest.mark.asyncio
+async def test_detect_workday_without_locale_segment():
+    mock_client = AsyncMock()
+    mock_client.post.return_value = _make_http_response(200, {"total": 3})
+
+    with patch("app.services.ats_detect.httpx.AsyncClient", return_value=mock_client):
+        result = await detect_ats("https://acme.wd5.myworkdayjobs.com/careers")
+
+    assert result is not None
+    assert result.board_token == "https://acme.wd5.myworkdayjobs.com|acme|careers"
+
+
+@pytest.mark.asyncio
+async def test_detect_workday_root_url_returns_none_without_probing():
+    """A site-less Workday URL is unpollable — no fallback probes fired."""
+    mock_client = AsyncMock()
+
+    with patch("app.services.ats_detect.httpx.AsyncClient", return_value=mock_client):
+        result = await detect_ats("https://acme.wd5.myworkdayjobs.com")
+
+    assert result is None
+    mock_client.get.assert_not_called()
+    mock_client.post.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_detect_workday_probe_failure_returns_none():
+    mock_client = AsyncMock()
+    mock_client.post.return_value = _make_http_response(404, {})
+
+    with patch("app.services.ats_detect.httpx.AsyncClient", return_value=mock_client):
+        result = await detect_ats(
+            "https://acme.wd5.myworkdayjobs.com/en-US/careers"
+        )
+
+    assert result is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- **Greenhouse**: `_probe_greenhouse` probed `/v1/boards/{slug}` and counted `data["departments"]` — a key that endpoint never returns (verified live: it returns only `{name, content}`). `job_count` was therefore always 0, and `run_discovery_for_target` filtered **every** Greenhouse board as a dead board. The probe now hits `/{slug}/jobs` and counts actual postings; the board root is fetched best-effort for the display name.
- **Workday**: `*.myworkdayjobs.com` is one of the six Brave site filters, but `detect_ats` had no Workday prober — the URL pattern matched, fell through to the other four probers, and every hit logged as `unclassified`. Workday URLs are now parsed directly into the `{base_url}|{tenant}|{site}` token `fetch_workday_jobs` expects and verified via the CXS list endpoint (`total`). Site-less Workday root URLs return `None` without burning four wasted probes.

## Impact
Source discovery can now actually grow the supply of Greenhouse and Workday boards — previously only Lever/Ashby/SmartRecruiters hits could ever be inserted.

## Test plan
- [x] `pytest tests/test_ats_detect.py tests/test_source_discovery.py tests/test_routers_sources.py` — 53 passed
- [x] ruff + mypy clean
- [x] Verified Greenhouse API shape live (`/v1/boards/stripe` has no `departments`; `/v1/boards/stripe/jobs` returns 500 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)