### PR TITLE
fix(wyrdfold): US-location filter dropped real US jobs via substring matches

### DIFF
--- a/apps/wyrdfold-api/app/services/poller.py
+++ b/apps/wyrdfold-api/app/services/poller.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import logging
+import re
 from collections.abc import Callable, Coroutine
 from datetime import UTC, datetime, timedelta
 from typing import Any, cast
@@ -121,6 +122,7 @@ _NON_US_HINTS: tuple[str, ...] = (
     "poland",
     "warsaw",
     "czech",
+    "czechia",
     "prague",
     "portugal",
     "lisbon",
@@ -277,17 +279,57 @@ def _title_matches_target(title: str, keywords: list[str]) -> bool:
     return False
 
 
+# Word-boundary pattern over the hints. Plain substring matching produced
+# false drops on US locations that merely *contain* a hint: "india" ⊂
+# "Indianapolis, Indiana", "rome" ⊂ "Rome, GA", etc.
+_NON_US_RE = re.compile(
+    r"\b(?:" + "|".join(re.escape(h) for h in _NON_US_HINTS) + r")\b"
+)
+
+# Explicit US markers that short-circuit the non-US rejection. Needed for
+# US cities that share a name with a non-US hint city: "Dublin, OH",
+# "Dublin, CA", "Athens, GA", "Milan, MI" are all real US locations that
+# the hint list would otherwise reject.
+_US_COUNTRY_RE = re.compile(r"\b(?:usa|u\.s\.a?|united states)\b", re.I)
+
+_US_STATE_ABBREVS: frozenset[str] = frozenset(
+    {
+        "AL", "AK", "AZ", "AR", "CA", "CO", "CT", "DE", "FL", "GA",
+        "HI", "ID", "IL", "IN", "IA", "KS", "KY", "LA", "ME", "MD",
+        "MA", "MI", "MN", "MS", "MO", "MT", "NE", "NV", "NH", "NJ",
+        "NM", "NY", "NC", "ND", "OH", "OK", "OR", "PA", "RI", "SC",
+        "SD", "TN", "TX", "UT", "VT", "VA", "WA", "WV", "WI", "WY",
+        "DC",
+    }
+)
+
+# ", XX" with XX upper-case — the standard "City, ST" form. Checked against
+# the original casing so lowercase words ("ca" in "Africa") can't match.
+_US_STATE_ABBREV_RE = re.compile(r",\s*([A-Z]{2})\b")
+
+
 def _is_us_location(location: str | None) -> bool:
     """Return True if the location looks like it's in the US (or is ambiguous).
 
     Permissive by design: empty/None and generic 'Remote' pass through,
     since many US companies list remote roles with no country. Rejects
-    only when a known non-US country or major city name is detected.
+    only when a known non-US country or major city name is detected as a
+    whole word AND no explicit US marker (country name or "City, ST"
+    state abbreviation) is present. The US marker wins ties on purpose —
+    a rare "Berlin, DE" style ISO-code listing slips through as US, which
+    the downstream scoring tolerates far better than silently dropping
+    every "Dublin, CA".
     """
     if not location:
         return True
-    loc = location.lower()
-    return not any(hint in loc for hint in _NON_US_HINTS)
+    if _US_COUNTRY_RE.search(location):
+        return True
+    if any(
+        m.group(1) in _US_STATE_ABBREVS
+        for m in _US_STATE_ABBREV_RE.finditer(location)
+    ):
+        return True
+    return not _NON_US_RE.search(location.lower())
 
 
 def _content_dedupe_key(

--- a/apps/wyrdfold-api/tests/test_poller.py
+++ b/apps/wyrdfold-api/tests/test_poller.py
@@ -171,6 +171,43 @@ class TestIsUsLocation:
         assert _is_us_location("BERLIN, GERMANY") is False
         assert _is_us_location("berlin") is False
 
+    def test_us_locations_containing_hint_substrings_are_allowed(self):
+        """Regression: substring matching dropped real US locations.
+
+        "india" ⊂ "Indianapolis"/"Indiana" was the worst offender; word-
+        boundary matching fixes the fragment cases.
+        """
+        assert _is_us_location("Indianapolis, IN") is True
+        assert _is_us_location("Indianapolis, Indiana") is True
+        assert _is_us_location("Remote - Indiana") is True
+
+    def test_us_cities_sharing_non_us_names_are_allowed_with_state(self):
+        """US cities named after non-US cities pass when a state is present."""
+        assert _is_us_location("Dublin, OH") is True
+        assert _is_us_location("Dublin, CA") is True
+        assert _is_us_location("Athens, GA") is True
+        assert _is_us_location("Rome, GA") is True
+        assert _is_us_location("Milan, MI") is True
+
+    def test_usa_marker_wins_over_city_hint(self):
+        assert _is_us_location("Dublin, Ohio, USA") is True
+        assert _is_us_location("Athens (United States)") is True
+
+    def test_non_us_versions_still_rejected(self):
+        assert _is_us_location("Dublin, Ireland") is False
+        assert _is_us_location("Athens, Greece") is False
+        assert _is_us_location("Rome, Italy") is False
+        assert _is_us_location("Milan") is False
+        assert _is_us_location("Bangalore, India") is False
+
+    def test_czechia_rejected(self):
+        assert _is_us_location("Prague, Czechia") is False
+
+    def test_lowercase_state_letters_do_not_count_as_us_marker(self):
+        # ", ca" lowercase isn't the "City, ST" form — "toronto, canada"
+        # style strings must not accidentally hit the state fastpath.
+        assert _is_us_location("toronto, canada") is False
+
 
 # ---- AND-semantics ingestion gate ------------------------------------------
 #


### PR DESCRIPTION
## Summary
`_is_us_location` rejected on a plain substring scan of ~90 non-US hints, which silently dropped real US jobs at ingestion:

- `"india" in "indianapolis, indiana"` → every Indianapolis/Indiana job dropped
- `Dublin, OH` / `Dublin, CA` / `Athens, GA` / `Rome, GA` / `Milan, MI` → dropped via city-name collisions

Changes:
- Hints now match as **whole words** (compiled word-boundary regex), fixing the fragment cases.
- An explicit US marker — `USA`/`United States` or an uppercase `City, ST` state abbreviation — short-circuits rejection, fixing the shared-city-name cases. The marker wins ties by design (a rare ISO-style `Berlin, DE` slips through as US; a false admit is far cheaper here than the false drops, matching the filter's documented permissive philosophy).
- Adds `czechia` to hints (word-boundary matching no longer reaches it via `czech`).

## Impact
Directly increases jobs ingested per board — these drops happened pre-upsert, before any scoring could see the job.

## Test plan
- [x] 78 passed: `test_poller.py`, `test_poller_dedupe.py`, `test_poll_due.py`, `test_jobs_location_filter.py` (new regression tests for Indianapolis, Dublin/Athens/Rome/Milan, lowercase 'toronto, canada' non-bypass)
- [x] ruff + mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)