### PR TITLE
perf(wyrdfold): raise discovery yield per Brave query

### DIFF
--- a/apps/wyrdfold-api/app/services/source_discovery.py
+++ b/apps/wyrdfold-api/app/services/source_discovery.py
@@ -25,7 +25,11 @@ from supabase import Client
 
 from app.config import settings
 from app.models.targets import JobTarget
-from app.services.ats_detect import DetectResult, detect_ats
+
+# ``_parse_input`` is intentionally shared with the detector: discovery uses
+# it as a cheap pre-probe grouping key so 20 hits on the same board cost one
+# probe instead of 20.
+from app.services.ats_detect import DetectResult, _parse_input, detect_ats
 
 logger = logging.getLogger(__name__)
 
@@ -61,6 +65,9 @@ class DiscoveryRunStats:
     duplicates: int
     unclassified: int
     filtered: int
+    # URLs skipped without probing because an earlier hit in the same run
+    # already parsed to the same (provider, slug) key.
+    deduped: int = 0
 
 
 @dataclass(slots=True)
@@ -362,19 +369,28 @@ async def run_discovery_for_target(
     # concurrently. The cap applies to the *number of queries*, not the
     # number of URLs we process — once the cap is exhausted we stop adding
     # to the plan but still process everything we already pulled.
-    query_plan: list[tuple[str, str]] = []
-    for keyword in keywords:
-        for site_filter in _ATS_SITE_FILTERS:
-            if len(query_plan) >= cap:
-                break
-            query_plan.append((keyword, site_filter))
-        if len(query_plan) >= cap:
-            logger.info(
-                "discovery cap of %d queries hit for target %s — truncating plan",
-                cap,
-                target.id,
-            )
-            break
+    #
+    # The full combination list is shuffled before truncation. The previous
+    # in-order walk truncated the same keyword-order prefix every run, so
+    # combinations past the cap were never queried on ANY run (there is no
+    # persisted cursor — "roll over to the next run" never happened).
+    # Random sampling covers the whole keyword x site space across repeated
+    # runs without needing rotation state.
+    query_plan = [
+        (keyword, site_filter)
+        for keyword in keywords
+        for site_filter in _ATS_SITE_FILTERS
+    ]
+    random.shuffle(query_plan)
+    if len(query_plan) > cap:
+        logger.info(
+            "discovery cap of %d queries hit for target %s — sampling %d of %d combos",
+            cap,
+            target.id,
+            cap,
+            len(query_plan),
+        )
+        query_plan = query_plan[:cap]
     queries_issued = len(query_plan)
 
     # Concurrency: 8 simultaneous Brave queries. Brave's free tier docs
@@ -391,9 +407,14 @@ async def run_discovery_for_target(
             kw: str, site: str
         ) -> tuple[str, str, list[str]]:
             async with brave_semaphore:
+                # Keyword left unquoted on purpose. Exact-phrase quoting
+                # ("director of cx operations") missed boards whose posting
+                # titles phrase the role differently — and any hit on an ATS
+                # host is a valid board regardless of phrasing; the keyword
+                # only biases results toward companies hiring for the role.
                 urls = await _brave_search(
                     brave_client,
-                    query=f'"{kw}" site:{site}',
+                    query=f"{kw} site:{site}",
                     count=per_query_count,
                 )
             return kw, site, urls
@@ -418,8 +439,36 @@ async def run_discovery_for_target(
             hits.append(_SearchHit(keyword=kw, site_filter=site, url=url))
 
     # Process hits sequentially — see the comment on ``brave_semaphore``.
+    deduped = 0
+    seen_parse_keys: set[tuple[str | None, str]] = set()
     for hit in hits:
         urls_examined += 1
+
+        # Cheap pre-probe grouping: 20 result URLs for the same board all
+        # parse to the same (provider, slug). Probing each one cost up to
+        # 20 sequential detect_ats round-trips per company before this.
+        parse_key = _parse_input(hit.url)
+        if parse_key in seen_parse_keys:
+            deduped += 1
+            continue
+        seen_parse_keys.add(parse_key)
+
+        # Known-token short-circuit: for the slug-token providers the
+        # parsed slug IS the board_token, so a URL on a board we already
+        # poll needs no probe at all. (Composite-token providers like
+        # Workday fall through to the post-probe check below.)
+        provider_hint, slug = parse_key
+        if provider_hint is not None and slug in existing_tokens:
+            duplicates += 1
+            _log_discovery(
+                supabase,
+                target_id=target.id,
+                hit=hit,
+                detect=None,
+                outcome="duplicate",
+            )
+            continue
+
         # detect_ats has its own httpx client — it manages probe
         # cadence + provider fallback internally.
         detect = await detect_ats(hit.url)
@@ -487,6 +536,7 @@ async def run_discovery_for_target(
         duplicates=duplicates,
         unclassified=unclassified,
         filtered=filtered,
+        deduped=deduped,
     )
 
 

--- a/apps/wyrdfold-api/tests/test_source_discovery.py
+++ b/apps/wyrdfold-api/tests/test_source_discovery.py
@@ -201,6 +201,108 @@ async def test_discovery_dedupes_existing_board_tokens(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_discovery_existing_token_skips_probe_entirely(monkeypatch):
+    """A URL whose parsed slug is already a known board_token should be
+    counted as duplicate without a detect_ats probe at all."""
+    from app.config import settings as live_settings
+
+    monkeypatch.setattr(live_settings, "brave_search_api_key", "test-key")
+    monkeypatch.setattr(live_settings, "discovery_query_cap_per_run", 1)
+
+    supabase = _make_supabase(existing_tokens=["example"])
+    fake_brave = AsyncMock(return_value=["https://boards.greenhouse.io/example"])
+    fake_detect = AsyncMock()
+
+    with (
+        patch("app.services.source_discovery._brave_search", fake_brave),
+        patch("app.services.source_discovery.detect_ats", fake_detect),
+    ):
+        stats = await run_discovery_for_target(supabase, _make_target())
+
+    assert stats.duplicates == 1
+    assert fake_detect.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_discovery_dedupes_same_board_urls_before_probing(monkeypatch):
+    """Multiple result URLs that parse to the same (provider, slug) should
+    cost exactly one detect_ats probe."""
+    from app.config import settings as live_settings
+
+    monkeypatch.setattr(live_settings, "brave_search_api_key", "test-key")
+    monkeypatch.setattr(live_settings, "discovery_query_cap_per_run", 1)
+
+    supabase = _make_supabase(existing_tokens=[])
+    fake_brave = AsyncMock(
+        return_value=[
+            "https://boards.greenhouse.io/example/jobs/123",
+            "https://boards.greenhouse.io/example/jobs/456",
+            "https://boards.greenhouse.io/example",
+        ]
+    )
+    fake_detect = AsyncMock(
+        return_value=DetectResult(
+            provider="greenhouse",
+            board_token="example",
+            company_name="Example Co",
+            job_count=5,
+        )
+    )
+
+    with (
+        patch("app.services.source_discovery._brave_search", fake_brave),
+        patch("app.services.source_discovery.detect_ats", fake_detect),
+    ):
+        stats = await run_discovery_for_target(supabase, _make_target())
+
+    assert fake_detect.await_count == 1
+    assert stats.inserted == 1
+    assert stats.deduped == 2
+    assert stats.urls_examined == 3
+
+
+@pytest.mark.asyncio
+async def test_discovery_queries_are_unquoted(monkeypatch):
+    """Keywords must not be wrapped in exact-phrase quotes — quoting missed
+    boards whose titles phrase the role differently."""
+    from app.config import settings as live_settings
+
+    monkeypatch.setattr(live_settings, "brave_search_api_key", "test-key")
+    monkeypatch.setattr(live_settings, "discovery_query_cap_per_run", 1)
+
+    supabase = _make_supabase()
+    fake_brave = AsyncMock(return_value=[])
+
+    with patch("app.services.source_discovery._brave_search", fake_brave):
+        await run_discovery_for_target(supabase, _make_target())
+
+    query = fake_brave.await_args.kwargs["query"]
+    assert '"' not in query
+    assert query.startswith("director of cx site:")
+
+
+@pytest.mark.asyncio
+async def test_discovery_cap_samples_across_full_combo_space(monkeypatch):
+    """With cap >= total combos, every keyword × site pair is queried
+    exactly once (shuffling must sample, never duplicate or drop)."""
+    from app.config import settings as live_settings
+
+    monkeypatch.setattr(live_settings, "brave_search_api_key", "test-key")
+    monkeypatch.setattr(live_settings, "discovery_query_cap_per_run", 100)
+
+    supabase = _make_supabase()
+    fake_brave = AsyncMock(return_value=[])
+    target = _make_target(keywords=["a", "b"])
+
+    with patch("app.services.source_discovery._brave_search", fake_brave):
+        stats = await run_discovery_for_target(supabase, target)
+
+    assert stats.queries_issued == 12  # 2 keywords x 6 site filters
+    queries = sorted(c.kwargs["query"] for c in fake_brave.await_args_list)
+    assert len(queries) == len(set(queries)) == 12
+
+
+@pytest.mark.asyncio
 async def test_discovery_unclassified_urls_are_logged_but_not_inserted(monkeypatch):
     """detect_ats returning None should bump unclassified and skip insert."""
     from app.config import settings as live_settings


### PR DESCRIPTION
## Summary
Three independent changes to maximize boards discovered per Brave query (monthly quota is the binding constraint):

1. **Pre-probe dedupe** — result URLs are grouped by their parsed `(provider, slug)` key before probing. 20 hits for the same company previously cost up to 20 sequential `detect_ats` round-trips; now 1. URLs whose slug is already a known `board_token` short-circuit to `duplicate` with **zero** probes (previously every known board got re-probed on every run).
2. **Plan sampling instead of prefix truncation** — the query cap truncated the same in-order prefix every run, so `(keyword × site)` combos past the cap were *never* queried (the "roll over to the next run" comment was aspirational — there is no cursor). The full combo list is now shuffled before truncation, so repeated runs cover the whole space.
3. **Unquoted keywords** — `'"{kw}" site:…'` exact-phrase matching missed boards that phrase the role differently. Any hit on an ATS host is a valid board regardless of phrasing.

`DiscoveryRunStats` gains a `deduped` counter (defaulted, additive — existing constructors unaffected).

## Test plan
- [x] 39 passed (4 new tests: known-token probe skip, same-board pre-probe dedupe, unquoted query shape, full-combo-space sampling)
- [x] ruff + mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)