### PR TITLE
feat(wyrdfold): per-user LLM cost caps — $5 monthly allowance + throttles

### DIFF
--- a/apps/wyrdfold-api/app/config.py
+++ b/apps/wyrdfold-api/app/config.py
@@ -174,8 +174,8 @@ class Settings(BaseSettings):
     analysis_daily_limit: int = Field(default=20, ge=0)
     # Phase 2 grading quota per target per UTC day (was a hardcoded 100 in
     # daily_cap.py — at ~$0.0035/call that alone exceeded a $5 monthly
-    # allowance; 10/day ≈ $1/month/target).
-    phase2_daily_cap: int = Field(default=10, ge=0)
+    # allowance; 20/day ≈ $2/month/target).
+    phase2_daily_cap: int = Field(default=20, ge=0)
 
     @property
     def allowed_hosts_list(self) -> list[str]:

--- a/apps/wyrdfold-api/app/config.py
+++ b/apps/wyrdfold-api/app/config.py
@@ -159,10 +159,23 @@ class Settings(BaseSettings):
         return [o.strip() for o in self.cors_allowed_origins.split(",") if o.strip()]
 
     # Per-user LLM budget (defense-in-depth). Rolling window over llm_costs.
-    # Set to 0 to disable a window. API-key callers (cron) bypass — system
-    # paths are trusted and gated by the operator.
+    # Set to 0 to disable a window. API-key callers (cron) bypass the HTTP
+    # gate, but background work is charged to the target's activator and
+    # gated against their monthly allowance in the poller.
     user_llm_daily_budget_usd: float = Field(default=5.0, ge=0.0)
     user_llm_hourly_budget_usd: float = Field(default=1.0, ge=0.0)
+    # The overall allowance (Claude-limits model: small windows above for
+    # bursts, this for the month). Rolling 30 days; counts ALL of a user's
+    # llm_costs — interactive and background alike. Per-user override via
+    # user_profiles.llm_monthly_budget_usd (the manual "add credits" lever).
+    user_llm_monthly_budget_usd: float = Field(default=5.0, ge=0.0)
+    # On-click deep job analysis: max LLM-backed runs per user per rolling
+    # 24h. Cache hits don't write llm_costs rows, so re-views stay free.
+    analysis_daily_limit: int = Field(default=20, ge=0)
+    # Phase 2 grading quota per target per UTC day (was a hardcoded 100 in
+    # daily_cap.py — at ~$0.0035/call that alone exceeded a $5 monthly
+    # allowance; 10/day ≈ $1/month/target).
+    phase2_daily_cap: int = Field(default=10, ge=0)
 
     @property
     def allowed_hosts_list(self) -> list[str]:

--- a/apps/wyrdfold-api/app/dependencies.py
+++ b/apps/wyrdfold-api/app/dependencies.py
@@ -283,10 +283,11 @@ def enforce_llm_budget(
 ) -> None:
     """Defense-in-depth budget gate for LLM-touching routes.
 
-    JWT users get checked against rolling daily/hourly cost caps from
-    `llm_costs`. API-key callers (cron/poller/batch) bypass — those
-    system paths are trusted and gated by the operator. Limits are
-    configured via `user_llm_*_budget_usd` settings; 0 disables.
+    JWT users get checked against rolling hourly/daily/monthly cost caps
+    from `llm_costs`. API-key callers (cron/poller/batch) bypass here —
+    background work is charged to the target's activator and gated in
+    the poller. Limits come from `user_llm_*_budget_usd` settings; the
+    monthly cap honors the per-user `user_profiles` override; 0 disables.
     """
     if user_id is None:
         return
@@ -297,4 +298,9 @@ def enforce_llm_budget(
         user_id=user_id,
         daily_limit_usd=s.user_llm_daily_budget_usd,
         hourly_limit_usd=s.user_llm_hourly_budget_usd,
+        monthly_limit_usd=budget.effective_monthly_cap(
+            supabase, user_id=user_id, default_usd=s.user_llm_monthly_budget_usd
+        ),
     )
+
+

--- a/apps/wyrdfold-api/app/models/batch.py
+++ b/apps/wyrdfold-api/app/models/batch.py
@@ -36,7 +36,9 @@ class BatchJob(BaseModel):
 class BatchRequest(BaseModel):
     """Router input for POST /tailor/batch."""
 
-    job_posting_ids: list[str] = Field(min_length=1, max_length=20)
+    # Capped at 10 (was 20): each id is a Sonnet tailor call, so the max
+    # batch is the single most expensive user action in the product.
+    job_posting_ids: list[str] = Field(min_length=1, max_length=10)
     contact: ContactInfo | None = None
     """Optional override; backend resolves from user_profiles when absent (F3-A)."""
     resume_type: ResumeType | None = None

--- a/apps/wyrdfold-api/app/models/user_profile.py
+++ b/apps/wyrdfold-api/app/models/user_profile.py
@@ -189,3 +189,26 @@ class OnboardingStepUpdate(BaseModel):
 
     path: OnboardingPath | None = None
     current_step: OnboardingStep | None = None
+
+
+class LlmUsageWindow(BaseModel):
+    """One budget window: dollars spent vs the cap (0 cap = disabled)."""
+
+    spent_usd: float
+    limit_usd: float
+
+
+class LlmUsageResponse(BaseModel):
+    """Read model for GET /profile/llm-usage — the user's allowance state.
+
+    ``monthly_resets_at`` approximates when capacity starts freeing: the
+    oldest cost row in the rolling 30-day window plus 30 days. Null when
+    the user has no spend in the window.
+    """
+
+    hourly: LlmUsageWindow
+    daily: LlmUsageWindow
+    monthly: LlmUsageWindow
+    monthly_resets_at: datetime | None = None
+    analysis_daily_used: int
+    analysis_daily_limit: int

--- a/apps/wyrdfold-api/app/routers/analysis.py
+++ b/apps/wyrdfold-api/app/routers/analysis.py
@@ -12,10 +12,12 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from supabase import Client
 
 from app.cache import job_list_cache, jobs_cache_prefix
+from app.config import Settings
 from app.dependencies import (
     enforce_llm_budget,
     get_current_user_id_optional,
     get_llm_client,
+    get_settings,
     get_supabase,
     verify_api_key_or_jwt,
 )
@@ -24,7 +26,7 @@ from app.services.analysis import persistence
 from app.services.analysis.analyze import DEFAULT_PURPOSE, analyze_job
 from app.services.analysis.scoring import blend_scores, scorecard_to_numeric
 from app.services.experience import optimized
-from app.services.llm import cost_log
+from app.services.llm import budget, cost_log
 from app.services.llm.client import LLMClient
 from app.services.targets import crud as targets_crud
 
@@ -44,6 +46,7 @@ async def create_analysis(
     supabase: Client = Depends(get_supabase),
     llm: LLMClient = Depends(get_llm_client),
     user_id: str | None = Depends(get_current_user_id_optional),
+    s: Settings = Depends(get_settings),
 ) -> JobAnalysisRecord:
     # 1. Fetch optimized doc (needed for cache key)
     current_optimized = optimized.get_latest(supabase, user_id=user_id)
@@ -79,6 +82,17 @@ async def create_analysis(
             analysis_id=cached.id,
         )
         return cached
+
+    # Cache miss → this run WILL spend LLM money. Count gate sits here,
+    # after the cache check, so re-viewing a cached analysis is always
+    # free and never 429s (cache hits write no llm_costs row).
+    if user_id is not None:
+        budget.check_daily_count(
+            supabase,
+            user_id=user_id,
+            purpose=DEFAULT_PURPOSE,
+            limit=s.analysis_daily_limit,
+        )
 
     # 3. Fetch target (existence check + context for the LLM)
     target = targets_crud.get(supabase, target_id)

--- a/apps/wyrdfold-api/app/routers/experience.py
+++ b/apps/wyrdfold-api/app/routers/experience.py
@@ -96,7 +96,9 @@ async def create_prose(
 
 
 @router.post("/prose/consolidate", dependencies=[Depends(enforce_llm_budget)])
+@limiter.limit("3/minute")
 async def consolidate_prose(
+    request: Request,
     supabase: Client = Depends(get_supabase),
     llm: LLMClient = Depends(get_llm_client),
     user_id: str | None = Depends(get_current_user_id_optional),
@@ -159,7 +161,9 @@ async def consolidate_prose(
 
 
 @router.post("/upload-resume", dependencies=[Depends(enforce_llm_budget)])
+@limiter.limit("3/minute")
 async def upload_resume(
+    request: Request,
     file: UploadFile,
     auto_derive: bool = Query(default=False),
     supabase: Client = Depends(get_supabase),
@@ -622,7 +626,9 @@ async def append_turn(
 
 
 @router.post("/conversation/turn", dependencies=[Depends(enforce_llm_budget)])
+@limiter.limit("10/minute")
 async def conversation_turn(
+    request: Request,
     body: TurnRequest,
     supabase: Client = Depends(get_supabase),
     llm: LLMClient = Depends(get_llm_client),

--- a/apps/wyrdfold-api/app/routers/targets.py
+++ b/apps/wyrdfold-api/app/routers/targets.py
@@ -271,7 +271,9 @@ async def create_target(
     status_code=201,
     dependencies=[Depends(enforce_llm_budget)],
 )
+@limiter.limit("5/minute")
 async def create_target_from_manual(
+    request: Request,
     body: TargetFromManual,
     background_tasks: BackgroundTasks,
     supabase: Client = Depends(get_supabase),
@@ -315,7 +317,9 @@ async def create_target_from_manual(
     status_code=201,
     dependencies=[Depends(enforce_llm_budget)],
 )
+@limiter.limit("5/minute")
 async def create_target_from_url(
+    request: Request,
     body: TargetFromUrl,
     background_tasks: BackgroundTasks,
     supabase: Client = Depends(get_supabase),
@@ -375,7 +379,9 @@ def list_targets(
     response_model=MatchedSuggestions,
     dependencies=[Depends(enforce_llm_budget)],
 )
+@limiter.limit("3/minute")
 async def suggest(
+    request: Request,
     supabase: Client = Depends(get_supabase),
     llm: LLMClient = Depends(get_llm_client),
     user_id: str = Depends(get_current_user_id),
@@ -408,7 +414,9 @@ async def suggest(
     response_model=LateralSuggestions,
     dependencies=[Depends(enforce_llm_budget)],
 )
+@limiter.limit("3/minute")
 async def suggest_lateral(
+    request: Request,
     supabase: Client = Depends(get_supabase),
     llm: LLMClient = Depends(get_llm_client),
     user_id: str = Depends(get_current_user_id),

--- a/apps/wyrdfold-api/app/routers/user_profile.py
+++ b/apps/wyrdfold-api/app/routers/user_profile.py
@@ -22,6 +22,8 @@ from app.dependencies import (
 from app.models.user_profile import (
     IdentityFields,
     IdentityFieldsUpdate,
+    LlmUsageResponse,
+    LlmUsageWindow,
     NotificationPreferences,
     NotificationPreferencesUpdate,
     OnboardingStatus,
@@ -463,3 +465,80 @@ async def reset_onboarding(
         supabase, user_id, _ONBOARDING_COLUMNS, seed_email=user_email
     )
     return _read_onboarding(fresh)
+
+
+@router.get("/llm-usage", response_model=LlmUsageResponse)
+async def get_llm_usage(
+    supabase: Client = Depends(get_supabase),
+    user_id: str = Depends(get_current_user_id),
+) -> LlmUsageResponse:
+    """The user's allowance state across all budget windows.
+
+    Mirrors exactly what the budget gates enforce (same spend queries),
+    so the FE can render "X of Y used" without guessing.
+    """
+    from datetime import timedelta
+
+    from app.services.analysis.analyze import DEFAULT_PURPOSE
+    from app.services.llm import budget, cost_log
+
+    now = datetime.now(UTC)
+
+    def _snapshot() -> LlmUsageResponse:
+        monthly_cap = budget.effective_monthly_cap(
+            supabase, user_id=user_id, default_usd=settings.user_llm_monthly_budget_usd
+        )
+        month_since = now - timedelta(days=budget.MONTHLY_WINDOW_DAYS)
+        spent_month = cost_log.total_spend(supabase, user_id=user_id, since=month_since)
+
+        # Approximate refill point: oldest cost row in the window + 30d.
+        resets_at = None
+        oldest = cast(
+            list[dict[str, Any]],
+            supabase.table("llm_costs")
+            .select("created_at")
+            .eq("user_id", user_id)
+            .gte("created_at", month_since.isoformat())
+            .order("created_at")
+            .limit(1)
+            .execute()
+            .data
+            or [],
+        )
+        if oldest:
+            oldest_dt = datetime.fromisoformat(
+                str(oldest[0]["created_at"]).replace("Z", "+00:00")
+            )
+            resets_at = oldest_dt + timedelta(days=budget.MONTHLY_WINDOW_DAYS)
+
+        analysis_used = (
+            supabase.table("llm_costs")
+            .select("id", count="exact")  # type: ignore[arg-type]
+            .eq("user_id", user_id)
+            .eq("purpose", DEFAULT_PURPOSE)
+            .gte("created_at", (now - timedelta(hours=24)).isoformat())
+            .execute()
+            .count
+            or 0
+        )
+
+        return LlmUsageResponse(
+            hourly=LlmUsageWindow(
+                spent_usd=cost_log.total_spend(
+                    supabase, user_id=user_id, since=now - timedelta(hours=1)
+                ),
+                limit_usd=settings.user_llm_hourly_budget_usd,
+            ),
+            daily=LlmUsageWindow(
+                spent_usd=cost_log.total_spend(
+                    supabase, user_id=user_id, since=now - timedelta(hours=24)
+                ),
+                limit_usd=settings.user_llm_daily_budget_usd,
+            ),
+            monthly=LlmUsageWindow(spent_usd=spent_month, limit_usd=monthly_cap),
+            monthly_resets_at=resets_at,
+            analysis_daily_used=analysis_used,
+            analysis_daily_limit=settings.analysis_daily_limit,
+        )
+
+    return await asyncio.to_thread(_snapshot)

--- a/apps/wyrdfold-api/app/services/fit/daily_cap.py
+++ b/apps/wyrdfold-api/app/services/fit/daily_cap.py
@@ -20,18 +20,20 @@ from datetime import UTC, datetime, time
 
 from supabase import Client
 
+from app.config import settings
 from app.services.fit.job_fit import JOB_FIT_PURPOSE
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_DAILY_CAP = 100
-"""Default per-target Phase 2 quota per UTC day.
+DEFAULT_DAILY_CAP = settings.phase2_daily_cap
+"""Per-target Phase 2 quota per UTC day (``PHASE2_DAILY_CAP`` env,
+default 10 — resolved once at process start).
 
-Tuned for: 5 active targets * 100 calls/day * $0.0035 = ~$1.75/day
-ceiling on Phase 2 spend across the system. Per-target quota matches
-"first page renders fast + rest defer" semantics — the user always
-gets some fresh Phase 2 grades, even when a high-volume poll cycle
-would otherwise blow the entire budget on one target.
+Was a hardcoded 100, which alone cost ~$10.50/month/target against the
+$5/month per-user allowance; 10/day ≈ $1/month/target. Per-target quota
+keeps "first page renders fast + rest defer" semantics — the user gets
+some fresh Phase 2 grades each day; the rest stay ``promising`` and
+either get next-day quota or grade on click-through.
 """
 
 

--- a/apps/wyrdfold-api/app/services/fit/daily_cap.py
+++ b/apps/wyrdfold-api/app/services/fit/daily_cap.py
@@ -27,10 +27,10 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_DAILY_CAP = settings.phase2_daily_cap
 """Per-target Phase 2 quota per UTC day (``PHASE2_DAILY_CAP`` env,
-default 10 — resolved once at process start).
+default 20 — resolved once at process start).
 
 Was a hardcoded 100, which alone cost ~$10.50/month/target against the
-$5/month per-user allowance; 10/day ≈ $1/month/target. Per-target quota
+$5/month per-user allowance; 20/day ≈ $2/month/target. Per-target quota
 keeps "first page renders fast + rest defer" semantics — the user gets
 some fresh Phase 2 grades each day; the rest stay ``promising`` and
 either get next-day quota or grade on click-through.

--- a/apps/wyrdfold-api/app/services/llm/budget.py
+++ b/apps/wyrdfold-api/app/services/llm/budget.py
@@ -1,21 +1,61 @@
 """Per-user LLM budget guard (defense-in-depth on cost).
 
 Reads recent rows from ``llm_costs`` for the user and refuses new LLM
-calls when the rolling daily or hourly spend exceeds a configured cap.
-API-key callers (cron/poller/batch) are NOT checked here — system paths
-are trusted and gated separately by the operator.
+calls when a rolling hourly/daily/monthly spend cap is exceeded. API-key
+callers (cron/poller/batch) are NOT checked here — background work is
+charged to the target's activator and gated in the poller against the
+same monthly allowance.
 
 The guard is advisory: a single in-flight call can still push spend
-*past* the cap, since cost is recorded only after the LLM returns. Pair
-with provider-side spend alerts for a hard ceiling.
+*past* the cap, since cost is recorded only after the LLM returns. The
+hourly window bounds the worst-case overshoot.
 """
 
 from datetime import UTC, datetime, timedelta
+from typing import Any, cast
 
 from fastapi import HTTPException
 from supabase import Client
 
 from app.services.llm import cost_log
+
+MONTHLY_WINDOW_DAYS = 30
+"""Rolling window for the monthly allowance. Rolling beats calendar-month:
+no first-of-month reset stampede, and it matches how Claude's own usage
+limits behave."""
+
+
+def effective_monthly_cap(
+    supabase: Client, *, user_id: str, default_usd: float
+) -> float:
+    """Resolve the user's monthly allowance: per-user override or default.
+
+    ``user_profiles.llm_monthly_budget_usd`` is the manual "add credits"
+    lever — NULL (or no profile row) means the global default applies.
+    """
+    rows = cast(
+        list[dict[str, Any]],
+        supabase.table("user_profiles")
+        .select("llm_monthly_budget_usd")
+        .eq("user_id", user_id)
+        .execute()
+        .data
+        or [],
+    )
+    override = rows[0].get("llm_monthly_budget_usd") if rows else None
+    return float(cast(float, override)) if override is not None else default_usd
+
+
+def _raise_budget_429(scope: str, limit_usd: float, spent_usd: float) -> None:
+    raise HTTPException(
+        status_code=429,
+        detail={
+            "code": "llm_budget_exceeded",
+            "scope": scope,
+            "limit_usd": limit_usd,
+            "spent_usd": spent_usd,
+        },
+    )
 
 
 def check_user_budget(
@@ -24,11 +64,13 @@ def check_user_budget(
     user_id: str,
     daily_limit_usd: float,
     hourly_limit_usd: float,
+    monthly_limit_usd: float = 0.0,
 ) -> None:
-    """Raise 429 if the user has hit their rolling daily or hourly cap.
+    """Raise 429 if the user has hit a rolling hourly/daily/monthly cap.
 
     Limits of ``0`` disable that window. Hourly is checked first so a
-    spam burst trips the smaller window before exhausting the day.
+    spam burst trips the smaller window before exhausting the day; the
+    monthly allowance is the overall ceiling.
     """
     now = datetime.now(UTC)
 
@@ -37,27 +79,59 @@ def check_user_budget(
             supabase, user_id=user_id, since=now - timedelta(hours=1)
         )
         if spent_hour >= hourly_limit_usd:
-            raise HTTPException(
-                status_code=429,
-                detail={
-                    "code": "llm_budget_exceeded",
-                    "scope": "hourly",
-                    "limit_usd": hourly_limit_usd,
-                    "spent_usd": spent_hour,
-                },
-            )
+            _raise_budget_429("hourly", hourly_limit_usd, spent_hour)
 
     if daily_limit_usd > 0:
         spent_day = cost_log.total_spend(
             supabase, user_id=user_id, since=now - timedelta(hours=24)
         )
         if spent_day >= daily_limit_usd:
-            raise HTTPException(
-                status_code=429,
-                detail={
-                    "code": "llm_budget_exceeded",
-                    "scope": "daily",
-                    "limit_usd": daily_limit_usd,
-                    "spent_usd": spent_day,
-                },
-            )
+            _raise_budget_429("daily", daily_limit_usd, spent_day)
+
+    if monthly_limit_usd > 0:
+        spent_month = cost_log.total_spend(
+            supabase,
+            user_id=user_id,
+            since=now - timedelta(days=MONTHLY_WINDOW_DAYS),
+        )
+        if spent_month >= monthly_limit_usd:
+            _raise_budget_429("monthly", monthly_limit_usd, spent_month)
+
+
+def check_daily_count(
+    supabase: Client,
+    *,
+    user_id: str,
+    purpose: str,
+    limit: int,
+) -> None:
+    """Raise 429 if the user already has ``limit`` llm_costs rows for
+    ``purpose`` in the rolling 24h window.
+
+    Count-based companion to the $-budget: bounds chatty features (deep
+    job analysis) regardless of per-call price. Cache hits never write a
+    cost row, so they neither count nor get blocked. ``limit=0`` disables.
+    """
+    if limit <= 0:
+        return
+    since = (datetime.now(UTC) - timedelta(hours=24)).isoformat()
+    used = (
+        supabase.table("llm_costs")
+        .select("id", count="exact")  # type: ignore[arg-type]
+        .eq("user_id", user_id)
+        .eq("purpose", purpose)
+        .gte("created_at", since)
+        .execute()
+        .count
+        or 0
+    )
+    if used >= limit:
+        raise HTTPException(
+            status_code=429,
+            detail={
+                "code": "analysis_daily_limit",
+                "purpose": purpose,
+                "limit": limit,
+                "used": used,
+            },
+        )

--- a/apps/wyrdfold-api/app/services/poller.py
+++ b/apps/wyrdfold-api/app/services/poller.py
@@ -61,6 +61,7 @@ from app.services.target_scoring import (
     score_title_and_upsert as target_title_score_and_upsert,
 )
 from app.services.targets.crud import get_active as get_active_target
+from app.services.targets.payers import PayerBudgetGate, build_budget_gate
 from app.services.validate import validate_job_url
 from app.services.workday import fetch_workday_jobs
 
@@ -466,6 +467,7 @@ async def _run_llm_scoring_for_row(
     target: JobTarget,
     *,
     current_score: int | None = None,
+    payer_user_id: str | None = None,
 ) -> None:
     """Stage 3: Run LLM analysis and mark target scores as complete.
 
@@ -573,8 +575,9 @@ async def _run_llm_scoring_for_row(
         # Cron path: enqueue instead of inline INSERT. The background
         # buffer batches per-row writes into a single bulk INSERT every
         # few seconds, so a fan-out of N concurrent LLM calls produces
-        # ~1 cost-log INSERT instead of N.
-        enqueue_llm_cost(None, "poll_scoring", llm_result)
+        # ~1 cost-log INSERT instead of N. Charged to the payer (the
+        # user whose optimized doc this run scores against).
+        enqueue_llm_cost(payer_user_id, "poll_scoring", llm_result)
 
         llm_score = scorecard_to_numeric(analysis.scorecard)
         blended = blend_scores(current_score, llm_score)
@@ -662,6 +665,7 @@ async def _resolve_user_targets_for_stage3(
 async def _poll_one_source(
     source: dict[str, Any],
     supabase: Client,
+    budget_gate: PayerBudgetGate | None = None,
 ) -> dict[str, Any]:
     """Poll a single job source. Returns a per-source summary dict.
 
@@ -669,6 +673,10 @@ async def _poll_one_source(
       1. Title-only match against each active target (inline, fast)
       2. Full JD match for stage-1 matches (async, after upsert)
       3. LLM analysis for top stage-2 scores (async)
+
+    ``budget_gate`` is the per-cycle payer/allowance snapshot (built once
+    by the cycle entry points); when None it's computed locally so direct
+    callers and existing tests keep working.
     """
     summary: dict[str, Any] = {
         "polled": False,
@@ -699,6 +707,22 @@ async def _poll_one_source(
         # Fetch active targets once — used for title filtering and scoring
         active_targets = get_active_target(supabase)
 
+        # Payer/allowance snapshot: who pays for each target's LLM work,
+        # and which payers are over their monthly allowance. Built once
+        # per cycle by the entry points; locally as a fallback.
+        gate = budget_gate
+        if gate is None:
+            try:
+                gate = await asyncio.to_thread(
+                    build_budget_gate, supabase, [t.id for t in active_targets]
+                )
+            except Exception:
+                logger.exception(
+                    "Budget gate build failed for %s — deferring LLM work",
+                    company_name,
+                )
+                gate = PayerBudgetGate()
+
         # Phase 1: per-target LLM binary title triage (replaces cosine
         # prefilter). See ``app/services/relevance/title_triage.py``.
         # Verdicts: phase1_verdicts[target.id][1-based job idx] -> bool.
@@ -711,6 +735,20 @@ async def _poll_one_source(
             llm = get_default_llm_client()
             titles = [job.title for job in jobs]
             for active_target in active_targets:
+                if gate.target_blocked(active_target.id):
+                    # Payer over monthly allowance (or unattributable) —
+                    # spend nothing. Empty verdicts → fail-open admit, so
+                    # jobs still ingest (promising, score=NULL) and get
+                    # graded once the payer's window frees up. Same defer
+                    # semantics as the Phase 2 daily cap.
+                    phase1_verdicts[active_target.id] = {}
+                    logger.info(
+                        "Phase 1 deferred for target %s (payer %s over "
+                        "monthly allowance or unknown)",
+                        active_target.id,
+                        gate.payer_for(active_target.id),
+                    )
+                    continue
                 # Chunk to PHASE1_BATCH_SIZE per call. Sources usually
                 # return well under one batch (10-200 jobs); larger
                 # sources spread cost across multiple calls.
@@ -724,7 +762,7 @@ async def _poll_one_source(
                         try:
                             record_llm_cost(
                                 supabase,
-                                user_id=None,
+                                user_id=gate.payer_for(active_target.id),
                                 purpose=PHASE1_PURPOSE,
                                 result=result,
                                 metadata={
@@ -999,6 +1037,17 @@ async def _poll_one_source(
                     cast(dict[str, Any], r) for r in upsert_resp.data or []
                 ]
                 for uid, p2_target in primary_by_user.items():
+                    if gate.user_blocked(uid):
+                        # Over monthly allowance — defer. Jobs keep
+                        # promising=True/score=NULL and get graded when
+                        # the rolling window frees up.
+                        logger.info(
+                            "Phase 2 deferred for user %s / target %s "
+                            "(over monthly allowance)",
+                            uid,
+                            p2_target.id,
+                        )
+                        continue
                     try:
                         await run_phase2_for_jobs(
                             supabase,
@@ -1041,6 +1090,7 @@ async def _poll_one_source(
                     row_data: dict[str, Any],
                     target: JobTarget,
                     doc: OptimizedDoc,
+                    payer: str,
                 ) -> None:
                     async with llm_sem:
                         await _run_llm_scoring_for_row(
@@ -1052,6 +1102,7 @@ async def _poll_one_source(
                             current_score=score_map.get(
                                 cast(str, row_data.get("id", "")), 0
                             ),
+                            payer_user_id=payer,
                         )
 
                 await asyncio.gather(
@@ -1060,9 +1111,13 @@ async def _poll_one_source(
                             cast(dict[str, Any], r),
                             primary_by_user[uid],
                             user_optimized[uid],
+                            uid,
                         )
                         for r in upsert_resp.data or []
                         for uid in primary_by_user
+                        # Over-allowance payers defer — same semantics as
+                        # the Phase 2 branch above.
+                        if not gate.user_blocked(uid)
                     )
                 )
 
@@ -1178,6 +1233,26 @@ async def _poll_one_source(
     return summary
 
 
+async def _cycle_budget_gate(supabase: Client) -> PayerBudgetGate:
+    """Build the payer/allowance snapshot once per poll cycle.
+
+    On any error returns an EMPTY gate, which blocks all targets'
+    LLM work for the cycle (``target_blocked`` is True for unknown
+    targets) — refuse to spend unattributed money rather than crash
+    or fail open. Jobs still ingest; grading defers a cycle.
+    """
+    try:
+        active = await asyncio.to_thread(get_active_target, supabase)
+        return await asyncio.to_thread(
+            build_budget_gate, supabase, [t.id for t in active]
+        )
+    except Exception:
+        logger.exception(
+            "Budget gate build failed — deferring all LLM work this cycle"
+        )
+        return PayerBudgetGate()
+
+
 async def poll_all_sources(supabase: Client) -> PollResult:
     sources_query = supabase.table("sources").select("*").eq("enabled", True)
     sources_resp = await asyncio.to_thread(sources_query.execute)
@@ -1187,12 +1262,13 @@ async def poll_all_sources(supabase: Client) -> PollResult:
     # the previous shared-doc fetch (``user_id=None``) never returned a
     # row in the multi-user schema, silently disabling stage 3.
 
+    budget_gate = await _cycle_budget_gate(supabase)
     semaphore = asyncio.Semaphore(POLL_CONCURRENCY)
 
     async def _worker(raw_source: Any) -> dict[str, Any]:
         async with semaphore:
             return await _poll_one_source(
-                cast(dict[str, Any], raw_source), supabase
+                cast(dict[str, Any], raw_source), supabase, budget_gate
             )
 
     summaries = await asyncio.gather(*(_worker(s) for s in sources))
@@ -1271,11 +1347,12 @@ async def poll_due_sources(supabase: Client) -> PollResult:
             sources_polled=0, new_jobs=0, updated_jobs=0, archived_jobs=0, errors=[]
         )
 
+    budget_gate = await _cycle_budget_gate(supabase)
     semaphore = asyncio.Semaphore(POLL_CONCURRENCY)
 
     async def _worker(source: dict[str, Any]) -> dict[str, Any]:
         async with semaphore:
-            return await _poll_one_source(source, supabase)
+            return await _poll_one_source(source, supabase, budget_gate)
 
     summaries = await asyncio.gather(*(_worker(s) for s in due))
 
@@ -1300,8 +1377,16 @@ async def _poll_one_source_for_target(
     source: dict[str, Any],
     supabase: Client,
     target: JobTarget,
+    payer_user_id: str | None = None,
+    payer_over_budget: bool = False,
 ) -> dict[str, Any]:
-    """Poll a single source for a specific target. Three-stage pipeline."""
+    """Poll a single source for a specific target. Three-stage pipeline.
+
+    ``payer_user_id`` is the user charged for this target's LLM work
+    (the activator); ``payer_over_budget`` skips Phase 1 spend while
+    still ingesting fail-open — both resolved once by
+    ``poll_sources_for_target``.
+    """
     summary: dict[str, Any] = {"polled": False, "new": 0, "updated": 0, "error": None}
     company_name: str = source.get("company_name", "?")
 
@@ -1320,9 +1405,11 @@ async def _poll_one_source_for_target(
 
         # Phase 1 per-target triage (single target). Same semantics as
         # ``_poll_one_source`` but the candidate set is one target, so
-        # ``phase1_verdicts`` collapses to a single dict.
+        # ``phase1_verdicts`` collapses to a single dict. Skipped when
+        # the payer is over their monthly allowance (or unattributable):
+        # empty verdicts → fail-open ingest, grading defers.
         target_verdicts: dict[int, TitleVerdict] = {}
-        if settings.phase1_triage_enabled and jobs:
+        if settings.phase1_triage_enabled and jobs and not payer_over_budget:
             llm = get_default_llm_client()
             titles = [job.title for job in jobs]
             for start in range(0, len(titles), PHASE1_BATCH_SIZE):
@@ -1334,7 +1421,7 @@ async def _poll_one_source_for_target(
                     try:
                         record_llm_cost(
                             supabase,
-                            user_id=None,
+                            user_id=payer_user_id,
                             purpose=PHASE1_PURPOSE,
                             result=result,
                             metadata={
@@ -1486,7 +1573,14 @@ async def _poll_one_source_for_target(
             primary_by_user, user_optimized = await _resolve_user_targets_for_stage3(
                 supabase, [target], company_name
             )
-            if primary_by_user:
+            if primary_by_user and payer_over_budget:
+                logger.info(
+                    "Stage 3 deferred for target %s (payer %s over "
+                    "monthly allowance)",
+                    target.id,
+                    payer_user_id,
+                )
+            elif primary_by_user:
                 llm = get_default_llm_client()
                 llm_sem = asyncio.Semaphore(LLM_CONCURRENCY)
 
@@ -1512,6 +1606,7 @@ async def _poll_one_source_for_target(
                             current_score=score_map_t.get(
                                 cast(str, row_data.get("id", "")), 0
                             ),
+                            payer_user_id=payer_user_id,
                         )
 
                 await asyncio.gather(
@@ -1587,12 +1682,37 @@ async def poll_sources_for_target(supabase: Client, target: JobTarget) -> PollRe
     # ``_poll_one_source_for_target`` now — the previous shared-doc fetch
     # (``user_id=None``) never returned a row in the multi-user schema.
 
+    # Resolve the payer (activator) once for the whole fan-out; their
+    # monthly allowance decides whether Phase 1 spends anything. On
+    # failure: refuse to spend (defer LLM work), keep ingesting.
+    try:
+        gate = await asyncio.to_thread(build_budget_gate, supabase, [target.id])
+    except Exception:
+        logger.exception(
+            "Budget gate build failed for target %s — deferring LLM work",
+            target.id,
+        )
+        gate = PayerBudgetGate()
+    payer = gate.payer_for(target.id)
+    over = gate.target_blocked(target.id)
+    if over:
+        logger.info(
+            "poll_sources_for_target: Phase 1 deferred for target %s "
+            "(payer %s over monthly allowance or unknown)",
+            target.id,
+            payer,
+        )
+
     semaphore = asyncio.Semaphore(POLL_CONCURRENCY)
 
     async def _worker(raw_source: Any) -> dict[str, Any]:
         async with semaphore:
             return await _poll_one_source_for_target(
-                cast(dict[str, Any], raw_source), supabase, target
+                cast(dict[str, Any], raw_source),
+                supabase,
+                target,
+                payer_user_id=payer,
+                payer_over_budget=over,
             )
 
     summaries = await asyncio.gather(*(_worker(s) for s in sources))

--- a/apps/wyrdfold-api/app/services/targets/crud.py
+++ b/apps/wyrdfold-api/app/services/targets/crud.py
@@ -402,15 +402,29 @@ def list_user_targets_with_summary(
 # ---- User-Target junction CRUD ----------------------------------------------
 
 
-MAX_ACTIVE_TARGETS_PER_USER = 5
+MAX_ACTIVE_TARGETS_PER_USER = 1
 """Per-user cap on simultaneously active targets.
 
-Caps fan-out of the upcoming LLM scoring pipeline (Phase 1/2 spend
-scales with active targets) and keeps a single user from scattering
-attention across a long list of marginal targets. Inactive targets are
-not counted — a user can keep arbitrarily many as "saved searches" they
-cycle between.
+Caps fan-out of the LLM scoring pipeline (Phase 1/2 spend scales with
+active targets — each one costs ~$1/month in background grading against
+a $5/month allowance). Inactive targets are not counted — a user can
+keep arbitrarily many as "saved searches" they cycle between. Per-user
+override via ``user_profiles.max_active_targets`` (the operator's "add
+credits" lever).
 """
+
+
+def effective_active_target_cap(supabase: Client, user_id: str) -> int:
+    """The user's active-target cap: per-user override or global default."""
+    resp = (
+        supabase.table("user_profiles")
+        .select("max_active_targets")
+        .eq("user_id", user_id)
+        .execute()
+    )
+    rows = cast(list[dict[str, Any]], resp.data or [])
+    override = rows[0].get("max_active_targets") if rows else None
+    return int(override) if override is not None else MAX_ACTIVE_TARGETS_PER_USER
 
 
 class ActiveTargetLimitError(Exception):
@@ -475,8 +489,9 @@ def link_user_to_target(
         already_active = bool(existing and existing[0].get("is_active"))
         if not already_active:
             current = count_active_for_user(supabase, user_id)
-            if current >= MAX_ACTIVE_TARGETS_PER_USER:
-                raise ActiveTargetLimitError(current, MAX_ACTIVE_TARGETS_PER_USER)
+            cap = effective_active_target_cap(supabase, user_id)
+            if current >= cap:
+                raise ActiveTargetLimitError(current, cap)
 
     row: dict[str, Any] = {
         "user_id": user_id,

--- a/apps/wyrdfold-api/app/services/targets/payers.py
+++ b/apps/wyrdfold-api/app/services/targets/payers.py
@@ -1,0 +1,117 @@
+"""Payer resolution + budget gating for background LLM work.
+
+Background grading (Phase-1 triage, Phase-2 fit) runs under the system
+API key, outside the per-request budget gate. These helpers charge that
+work to the user who activated the target (the "payer") and let the
+poller skip targets whose payer has exhausted their monthly allowance.
+
+Payer rule: the user whose ``user_targets`` link is active; if several,
+the earliest-standing link wins (``created_at`` — NOT ``updated_at``,
+which upserts stamp on every fit-score refresh). Tie-break ``user_id``
+ascending for determinism.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from typing import Any, cast
+
+from supabase import Client
+
+from app.config import settings
+from app.services.llm import cost_log
+from app.services.llm.budget import MONTHLY_WINDOW_DAYS
+
+
+def resolve_target_payers(
+    supabase: Client, target_ids: list[str]
+) -> dict[str, str | None]:
+    """Map each target id to its payer user id (or None if orphaned)."""
+    if not target_ids:
+        return {}
+    resp = (
+        supabase.table("user_targets")
+        .select("target_id,user_id,created_at")
+        .eq("is_active", True)
+        .in_("target_id", target_ids)
+        .order("created_at")
+        .order("user_id")
+        .execute()
+    )
+    rows = cast(list[dict[str, Any]], resp.data or [])
+    payers: dict[str, str | None] = {tid: None for tid in target_ids}
+    for row in rows:
+        tid = row["target_id"]
+        if payers.get(tid) is None:
+            payers[tid] = row["user_id"]
+    return payers
+
+
+@dataclass(frozen=True)
+class PayerBudgetGate:
+    """Per-cycle snapshot of who pays for each target and who is over
+    their monthly allowance. Snapshot semantics: at most one cycle of
+    drift if a payer's spend or links change mid-cycle — acceptable."""
+
+    payer_by_target: dict[str, str | None] = field(default_factory=dict)
+    over_budget_users: frozenset[str] = frozenset()
+
+    def payer_for(self, target_id: str) -> str | None:
+        return self.payer_by_target.get(target_id)
+
+    def target_blocked(self, target_id: str) -> bool:
+        """True when this target's LLM work must be skipped this cycle.
+
+        Blocked when the payer is over budget OR unknown (orphan active
+        target, or activated after the snapshot) — never spend
+        unattributed money. Jobs still ingest fail-open; grading
+        resumes once the payer's window frees up (next cycle for
+        post-snapshot activations).
+        """
+        payer = self.payer_by_target.get(target_id)
+        return payer is None or payer in self.over_budget_users
+
+    def user_blocked(self, user_id: str) -> bool:
+        return user_id in self.over_budget_users
+
+
+def build_budget_gate(
+    supabase: Client, target_ids: list[str]
+) -> PayerBudgetGate:
+    """Build the cycle snapshot: payers, overrides, rolling-30d spends.
+
+    Three queries total (payers IN, overrides IN, one spend RPC per
+    distinct payer) — computed once per poll cycle, not per source/job.
+    A monthly limit of 0 (global or override) disables gating for that
+    user.
+    """
+    payers = resolve_target_payers(supabase, target_ids)
+    distinct = sorted({p for p in payers.values() if p is not None})
+    if not distinct:
+        return PayerBudgetGate(payer_by_target=payers)
+
+    overrides: dict[str, float | None] = {}
+    resp = (
+        supabase.table("user_profiles")
+        .select("user_id,llm_monthly_budget_usd")
+        .in_("user_id", distinct)
+        .execute()
+    )
+    for row in cast(list[dict[str, Any]], resp.data or []):
+        overrides[row["user_id"]] = row.get("llm_monthly_budget_usd")
+
+    since = datetime.now(UTC) - timedelta(days=MONTHLY_WINDOW_DAYS)
+    over: set[str] = set()
+    for uid in distinct:
+        raw = overrides.get(uid)
+        cap = float(raw) if raw is not None else settings.user_llm_monthly_budget_usd
+        if cap <= 0:
+            continue
+        spent = cost_log.total_spend(supabase, user_id=uid, since=since)
+        if spent >= cap:
+            over.add(uid)
+
+    return PayerBudgetGate(
+        payer_by_target=payers, over_budget_users=frozenset(over)
+    )

--- a/apps/wyrdfold-api/scripts/deactivate_all_targets.py
+++ b/apps/wyrdfold-api/scripts/deactivate_all_targets.py
@@ -1,0 +1,40 @@
+"""One-shot operator action (#845 cost stop-gap): deactivate ALL targets.
+
+Sets user_targets.is_active=false for every active link; the DB trigger
+syncs targets.is_active. Verifies both tables after. The poller keeps
+fetching/upserting jobs (zero active targets skips Phase-1, title
+pre-match, and all per-target scoring), so no LLM costs accrue.
+"""
+
+from __future__ import annotations
+
+import os
+
+from supabase import create_client
+
+
+def main() -> None:
+    url = os.environ.get("SUPABASE_URL") or os.environ["NEXT_PUBLIC_SUPABASE_URL"]
+    sb = create_client(url, os.environ["SUPABASE_SERVICE_ROLE_KEY"])
+
+    ut_active = sb.table("user_targets").select("id", count="exact").eq("is_active", True).execute().count or 0
+    t_active = sb.table("targets").select("id", count="exact").eq("is_active", True).execute().count or 0
+    print(f"before: user_targets active={ut_active}, targets active={t_active}")
+
+    if ut_active:
+        sb.table("user_targets").update({"is_active": False}).eq("is_active", True).execute()
+
+    # Trigger should sync targets.is_active; backstop in case any row
+    # was set directly on targets without a user link.
+    t_after_trigger = sb.table("targets").select("id", count="exact").eq("is_active", True).execute().count or 0
+    if t_after_trigger:
+        sb.table("targets").update({"is_active": False}).eq("is_active", True).execute()
+
+    ut_final = sb.table("user_targets").select("id", count="exact").eq("is_active", True).execute().count or 0
+    t_final = sb.table("targets").select("id", count="exact").eq("is_active", True).execute().count or 0
+    print(f"after:  user_targets active={ut_final}, targets active={t_final}")
+    print("OK" if ut_final == 0 and t_final == 0 else "!! STILL ACTIVE ROWS — investigate")
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/wyrdfold-api/scripts/diagnose_funnel.py
+++ b/apps/wyrdfold-api/scripts/diagnose_funnel.py
@@ -1,0 +1,181 @@
+"""Read-only WyrdFold matching-funnel diagnostic (#845).
+
+Dumps, for a single (user, target):
+  - target config (the "nomenclature" suspect)
+  - job_target_scores stage counts + score histogram vs list_min_score
+  - job_sources health (enabled count + last_polled_at staleness)
+  - job_postings supply freshness
+  - a sample of the top-scored jobs for eyeballing
+
+STRICTLY READ-ONLY: only .select() calls, no writes, no LLM, no polling.
+
+Run:
+  set -a && . ../../.env.prod && set +a && \
+  SUPABASE_URL="$NEXT_PUBLIC_SUPABASE_URL" \
+  uv run --package wyrdfold-api python scripts/diagnose_funnel.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+from collections import Counter
+from datetime import UTC, datetime, timedelta
+
+from supabase import create_client
+
+TARGET_ID = "4195d651-2009-4c43-bc6b-beec4d3fca0b"
+USER_ID = "4e0bed0e-05a1-479c-a346-5ff5a940a92b"
+
+
+def _count(query) -> int:
+    return query.execute().count or 0
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--target", default=TARGET_ID)
+    ap.add_argument("--user", default=USER_ID)
+    args = ap.parse_args()
+    t, u = args.target, args.user
+
+    url = os.environ.get("SUPABASE_URL") or os.environ.get("NEXT_PUBLIC_SUPABASE_URL")
+    key = os.environ["SUPABASE_SERVICE_ROLE_KEY"]
+    if not url:
+        raise SystemExit("SUPABASE_URL / NEXT_PUBLIC_SUPABASE_URL not set")
+    sb = create_client(url, key)
+
+    print(f"\n{'='*70}\nWYRDFOLD FUNNEL DIAGNOSTIC (#845)\ntarget={t}\nuser={u}\n{'='*70}")
+
+    # ---- Step 1: target config (nomenclature suspect) -------------------
+    tgt = sb.table("targets").select("*").eq("id", t).execute().data
+    if not tgt:
+        print("!! target not found")
+        return
+    tg = tgt[0]
+    sp = tg.get("scoring_profile") or {}
+    cats = sp.get("categories") or {}
+    print("\n--- STEP 1: TARGET CONFIG ---")
+    print(f"label           : {tg.get('label')!r}")
+    print(f"is_active       : {tg.get('is_active')}")
+    print(f"profile_version : {tg.get('profile_version')}")
+    print(f"activation      : {tg.get('activation_status')}")
+    print(f"seniority_hint  : {tg.get('seniority_hint')}")
+    print(f"search_keywords : {tg.get('search_keywords')}")
+    print(f"example_promising_titles   : {tg.get('example_promising_titles')}")
+    print(f"example_unpromising_titles : {tg.get('example_unpromising_titles')}")
+    print(f"scoring categories ({len(cats)}):")
+    for name, c in cats.items():
+        kws = (c or {}).get("keywords") or {}
+        print(f"   {name} (w={(c or {}).get('weight')}): {list(kws.keys())}")
+    print(f"scoring_profile.seniority : {sp.get('seniority')}")
+    print(f"scoring_profile.negative  : {sp.get('negative')}")
+
+    # ---- Step 2: DB-side funnel counts ----------------------------------
+    sc = lambda: sb.table("scores").select("id", count="exact").eq("target_id", t)  # noqa: E731
+    prof = sb.table("user_profiles").select("list_min_score").eq("user_id", u).execute().data
+    min_score = (prof[0]["list_min_score"] if prof else None)
+
+    total = _count(sc())
+    promising = _count(sc().eq("promising", True))
+    promising_null = _count(sc().is_("promising", "null"))
+    graded = _count(sc().eq("promising", True).neq("scoring_status", "stage1"))
+    complete = _count(sc().eq("scoring_status", "complete"))
+    not_excluded = _count(sc().eq("excluded", False))
+
+    print("\n--- STEP 2: SCORE-TABLE FUNNEL (job_target_scores) ---")
+    print(f"list_min_score (user_profiles) : {min_score}")
+    print(f"total scored rows for target   : {total}")
+    print(f"  promising = TRUE             : {promising}")
+    print(f"  promising = NULL (ungated)   : {promising_null}")
+    print(f"  graded (promising, !=stage1) : {graded}")
+    print(f"  scoring_status = complete    : {complete}")
+    print(f"  excluded = FALSE             : {not_excluded}")
+
+    # score histogram over non-excluded rows
+    rows = (
+        sb.table("scores")
+        .select("score,promising,scoring_status,excluded")
+        .eq("target_id", t)
+        .eq("excluded", False)
+        .limit(5000)
+        .execute()
+        .data
+    )
+    buckets = Counter()
+    for r in rows:
+        s = r.get("score") or 0
+        buckets[(s // 10) * 10] += 1
+    print(f"\nscore histogram (excluded=FALSE, n={len(rows)}):")
+    for lo in range(0, 100, 10):
+        n = buckets.get(lo, 0)
+        bar = "#" * min(n, 60)
+        print(f"  {lo:3d}-{lo+9:<3d} | {n:5d} {bar}")
+    if min_score is not None:
+        clears = sum(n for lo, n in buckets.items() if lo >= (min_score // 10) * 10)
+        print(f"\n>= list_min_score ({min_score}), approx : {clears}")
+
+    # ---- Step 2b: sources health ----------------------------------------
+    src_total = _count(sb.table("sources").select("id", count="exact"))
+    src_enabled = _count(sb.table("sources").select("id", count="exact").eq("enabled", True))
+    srows = (
+        sb.table("sources")
+        .select("company_name,enabled,last_polled_at,poll_interval_minutes")
+        .eq("enabled", True)
+        .limit(2000)
+        .execute()
+        .data
+    )
+    now = datetime.now(UTC)
+    never = sum(1 for s in srows if not s.get("last_polled_at"))
+
+    def _age_days(ts: str | None) -> float | None:
+        if not ts:
+            return None
+        return (now - datetime.fromisoformat(ts.replace("Z", "+00:00"))).total_seconds() / 86400
+
+    ages = [a for s in srows if (a := _age_days(s.get("last_polled_at"))) is not None]
+    stale_1d = sum(1 for a in ages if a > 1)
+    stale_7d = sum(1 for a in ages if a > 7)
+    print("\n--- STEP 2c: SOURCES HEALTH (job_sources) ---")
+    print(f"total sources         : {src_total}")
+    print(f"enabled sources       : {src_enabled}")
+    print(f"  never polled (null) : {never}")
+    print(f"  stale > 1 day       : {stale_1d}")
+    print(f"  stale > 7 days      : {stale_7d}")
+    if ages:
+        print(f"  freshest poll       : {min(ages):.1f} days ago")
+        print(f"  oldest poll         : {max(ages):.1f} days ago")
+
+    # ---- Step 2d: supply freshness --------------------------------------
+    jp_total = _count(sb.table("jobs").select("id", count="exact"))
+    for label, days in (("7d", 7), ("30d", 30)):
+        iso = (now - timedelta(days=days)).isoformat()
+        n = _count(sb.table("jobs").select("id", count="exact").gte("created_at", iso))
+        print(f"\njob_postings total: {jp_total}   created last {label}: {n}" if days == 7 else f"job_postings created last {label}: {n}")
+
+    # ---- Step 2e: sample top-scored jobs --------------------------------
+    sample = (
+        sb.table("scores")
+        .select("score,promising,scoring_status,excluded,jobs(title,company_name,location,created_at)")
+        .eq("target_id", t)
+        .order("score", desc=True)
+        .limit(15)
+        .execute()
+        .data
+    )
+    print("\n--- STEP 2f: TOP-SCORED JOBS FOR THIS TARGET ---")
+    for r in sample:
+        jp = r.get("jobs") or {}
+        print(
+            f"  [{r.get('score'):3}] prom={r.get('promising')!s:5} "
+            f"{r.get('scoring_status'):8} excl={r.get('excluded')!s:5} "
+            f"| {(jp.get('title') or '')[:48]:48} @ {(jp.get('company_name') or '')[:20]:20} "
+            f"| {(jp.get('location') or '')[:22]}"
+        )
+
+    print(f"\n{'='*70}\nDONE\n{'='*70}")
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/wyrdfold-api/scripts/diagnose_supply.py
+++ b/apps/wyrdfold-api/scripts/diagnose_supply.py
@@ -1,0 +1,106 @@
+"""Read-only supply/level cut for #845 — is the collapse supply or scoring?
+
+For the target: classify promising jobs by seniority level (director+ vs
+manager vs other) and at score>=50, and check whether target-driven source
+discovery has run. READ-ONLY.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+
+from supabase import create_client
+
+TARGET_ID = "4195d651-2009-4c43-bc6b-beec4d3fca0b"
+
+DIR_PLUS = re.compile(r"\b(director|head of|vp|vice president|chief|svp|cxo)\b", re.I)
+MANAGER = re.compile(r"\b(manager|lead|supervisor)\b", re.I)
+
+
+def _level(title: str) -> str:
+    if DIR_PLUS.search(title):
+        return "director+"
+    if MANAGER.search(title):
+        return "manager"
+    return "other"
+
+
+def main() -> None:
+    url = os.environ.get("SUPABASE_URL") or os.environ.get("NEXT_PUBLIC_SUPABASE_URL")
+    sb = create_client(url, os.environ["SUPABASE_SERVICE_ROLE_KEY"])
+    t = TARGET_ID
+
+    # All non-excluded scored rows for the target, with title + score.
+    rows = (
+        sb.table("scores")
+        .select("score,promising,jobs(title,location)")
+        .eq("target_id", t)
+        .eq("excluded", False)
+        .limit(5000)
+        .execute()
+        .data
+    )
+    levels: dict[str, int] = {"director+": 0, "manager": 0, "other": 0}
+    promising_levels = {"director+": 0, "manager": 0, "other": 0}
+    ge50_levels = {"director+": 0, "manager": 0, "other": 0}
+    dir_ge40 = []
+    for r in rows:
+        jp = r.get("jobs") or {}
+        title = jp.get("title") or ""
+        lvl = _level(title)
+        levels[lvl] += 1
+        if r.get("promising"):
+            promising_levels[lvl] += 1
+        if (r.get("score") or 0) >= 50:
+            ge50_levels[lvl] += 1
+        if lvl == "director+" and (r.get("score") or 0) >= 40:
+            dir_ge40.append((r.get("score"), title[:60], (jp.get("location") or "")[:24]))
+
+    print(f"\n=== SUPPLY/LEVEL CUT (target {t}) ===")
+    print(f"non-excluded scored rows analyzed: {len(rows)}")
+    print("\nby seniority level (all non-excluded):")
+    for k, v in levels.items():
+        print(f"  {k:10}: {v}")
+    print("\npromising=TRUE by level:")
+    for k, v in promising_levels.items():
+        print(f"  {k:10}: {v}")
+    print("\nscore>=50 by level:")
+    for k, v in ge50_levels.items():
+        print(f"  {k:10}: {v}")
+
+    print(f"\ndirector+ roles scoring >=40 ({len(dir_ge40)}):")
+    for s, title, loc in sorted(dir_ge40, reverse=True)[:30]:
+        print(f"  [{s:3}] {title:60} | {loc}")
+
+    # Has target-driven source discovery run?
+    disc_total = (
+        sb.table("source_discoveries").select("id", count="exact").eq("target_id", t).execute().count
+    )
+    disc_added = (
+        sb.table("source_discoveries")
+        .select("id", count="exact")
+        .eq("target_id", t)
+        .eq("outcome", "inserted")
+        .execute()
+        .count
+    )
+    last = (
+        sb.table("source_discoveries")
+        .select("discovered_at,outcome,detected_company_name")
+        .eq("target_id", t)
+        .order("discovered_at", desc=True)
+        .limit(5)
+        .execute()
+        .data
+    )
+    print("\n=== SOURCE DISCOVERY for this target ===")
+    print(f"discovery rows total : {disc_total}")
+    print(f"outcome=added        : {disc_added}")
+    print("most recent:")
+    for d in last:
+        print(f"  {d.get('discovered_at')}  {d.get('outcome'):10} {d.get('detected_company_name')}")
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/wyrdfold-api/tests/test_consolidate.py
+++ b/apps/wyrdfold-api/tests/test_consolidate.py
@@ -144,7 +144,7 @@ class TestConsolidateEndpoint:
 
         with pytest.raises(HTTPException) as exc_info:
             await exp_router.consolidate_prose(
-                supabase=MagicMock(), llm=MagicMock()
+                request=MagicMock(), supabase=MagicMock(), llm=MagicMock()
             )
         assert exc_info.value.status_code == 404
 
@@ -177,7 +177,7 @@ class TestConsolidateEndpoint:
         )
 
         result = await exp_router.consolidate_prose(
-            supabase=MagicMock(), llm=MockLLMClient()
+            request=MagicMock(), supabase=MagicMock(), llm=MockLLMClient()
         )
         assert result.no_op is True
         assert result.chars_before == result.chars_after
@@ -228,7 +228,9 @@ class TestConsolidateEndpoint:
         # Sanity: input must clear MIN_CONSOLIDATE_CHARS for the LLM to run.
         assert len(bloated) >= MIN_CONSOLIDATE_CHARS
 
-        result = await exp_router.consolidate_prose(supabase=MagicMock(), llm=llm)
+        result = await exp_router.consolidate_prose(
+            request=MagicMock(), supabase=MagicMock(), llm=llm
+        )
 
         assert result.prose.version == 3
         assert result.chars_before == len(bloated)

--- a/apps/wyrdfold-api/tests/test_dependencies.py
+++ b/apps/wyrdfold-api/tests/test_dependencies.py
@@ -331,12 +331,15 @@ def test_get_current_user_id_optional_prefers_jwt_over_api_key():
     assert get_current_user_id_optional(req, key="testkey", s=_settings()) == USER_SUB
 
 
-def _budget_settings(daily: float = 5.0, hourly: float = 1.0) -> Settings:
+def _budget_settings(
+    daily: float = 5.0, hourly: float = 1.0, monthly: float = 5.0
+) -> Settings:
     return Settings(
         wyrdfold_api_key="testkey",
         supabase_url=TEST_SUPABASE_URL,
         user_llm_daily_budget_usd=daily,
         user_llm_hourly_budget_usd=hourly,
+        user_llm_monthly_budget_usd=monthly,
     )
 
 
@@ -362,22 +365,57 @@ def test_enforce_llm_budget_jwt_user_invokes_check(monkeypatch):
 
     captured: dict = {}
 
-    def _spy(supabase, *, user_id, daily_limit_usd, hourly_limit_usd):
+    def _spy(
+        supabase, *, user_id, daily_limit_usd, hourly_limit_usd, monthly_limit_usd
+    ):
         captured.update(
             user_id=user_id,
             daily_limit_usd=daily_limit_usd,
             hourly_limit_usd=hourly_limit_usd,
+            monthly_limit_usd=monthly_limit_usd,
         )
 
     monkeypatch.setattr(budget_mod, "check_user_budget", _spy)
+    # The dep resolves the monthly cap (user_profiles override ?? default)
+    # before the check — stub it so no Supabase round-trip happens.
+    monkeypatch.setattr(
+        budget_mod,
+        "effective_monthly_cap",
+        lambda supabase, *, user_id, default_usd: default_usd,
+    )
     enforce_llm_budget(
-        user_id=USER_SUB, supabase=MagicMock(), s=_budget_settings(daily=7.0, hourly=2.0)
+        user_id=USER_SUB,
+        supabase=MagicMock(),
+        s=_budget_settings(daily=7.0, hourly=2.0, monthly=9.0),
     )
     assert captured == {
         "user_id": USER_SUB,
         "daily_limit_usd": 7.0,
         "hourly_limit_usd": 2.0,
+        "monthly_limit_usd": 9.0,
     }
+
+
+def test_enforce_llm_budget_monthly_honors_profile_override(monkeypatch):
+    """The per-user override (the "add credits" lever) wins over the
+    settings default."""
+    from app.services.llm import budget as budget_mod
+
+    captured: dict = {}
+
+    def _spy(supabase, **kw):
+        captured.update(kw)
+
+    monkeypatch.setattr(budget_mod, "check_user_budget", _spy)
+    monkeypatch.setattr(
+        budget_mod,
+        "effective_monthly_cap",
+        lambda supabase, *, user_id, default_usd: 25.0,
+    )
+    enforce_llm_budget(
+        user_id=USER_SUB, supabase=MagicMock(), s=_budget_settings(monthly=5.0)
+    )
+    assert captured["monthly_limit_usd"] == 25.0
 
 
 def test_enforce_llm_budget_propagates_429(monkeypatch):

--- a/apps/wyrdfold-api/tests/test_fit_daily_cap.py
+++ b/apps/wyrdfold-api/tests/test_fit_daily_cap.py
@@ -38,8 +38,10 @@ def test_quota_remaining_at_zero_used_returns_full_cap() -> None:
 
 
 def test_quota_remaining_subtracts_used_from_cap() -> None:
-    supabase = _supabase_with_count(30)
-    assert phase2_quota_remaining(supabase, "t-1") == DEFAULT_DAILY_CAP - 30
+    # Used count below the cap (10 since the cost-caps work) so the
+    # subtraction is exercised without hitting the zero floor.
+    supabase = _supabase_with_count(3)
+    assert phase2_quota_remaining(supabase, "t-1") == DEFAULT_DAILY_CAP - 3
 
 
 def test_quota_remaining_floors_at_zero_when_over_cap() -> None:

--- a/apps/wyrdfold-api/tests/test_llm_cost_caps.py
+++ b/apps/wyrdfold-api/tests/test_llm_cost_caps.py
@@ -1,0 +1,287 @@
+"""Tests for the per-user LLM cost caps (monthly allowance + counters).
+
+Covers the budget windows (monthly), the analysis daily counter, payer
+resolution for background work, and the poll-cycle budget gate.
+"""
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+from app.services.llm import budget
+from app.services.targets.payers import (
+    PayerBudgetGate,
+    build_budget_gate,
+    resolve_target_payers,
+)
+
+# ---- check_user_budget: monthly window --------------------------------------
+
+
+def _spend_by_window(hour: float, day: float, month: float):
+    """Fake cost_log.total_spend keyed on how far back ``since`` reaches."""
+    from datetime import UTC, datetime, timedelta
+
+    def _fake(supabase, user_id, since=None):
+        now = datetime.now(UTC)
+        if since is None:
+            return month
+        if since >= now - timedelta(hours=2):
+            return hour
+        if since >= now - timedelta(hours=25):
+            return day
+        return month
+
+    return _fake
+
+
+def test_monthly_breach_raises_429(monkeypatch):
+    monkeypatch.setattr(
+        budget.cost_log, "total_spend", _spend_by_window(0.0, 0.0, 5.0)
+    )
+    with pytest.raises(HTTPException) as exc:
+        budget.check_user_budget(
+            MagicMock(),
+            user_id="u-1",
+            daily_limit_usd=0,
+            hourly_limit_usd=0,
+            monthly_limit_usd=5.0,
+        )
+    assert exc.value.status_code == 429
+    assert exc.value.detail["scope"] == "monthly"
+    assert exc.value.detail["code"] == "llm_budget_exceeded"
+
+
+def test_monthly_zero_disables(monkeypatch):
+    monkeypatch.setattr(
+        budget.cost_log, "total_spend", _spend_by_window(0.0, 0.0, 999.0)
+    )
+    budget.check_user_budget(
+        MagicMock(),
+        user_id="u-1",
+        daily_limit_usd=0,
+        hourly_limit_usd=0,
+        monthly_limit_usd=0,
+    )  # must not raise
+
+
+def test_under_monthly_cap_passes(monkeypatch):
+    monkeypatch.setattr(
+        budget.cost_log, "total_spend", _spend_by_window(0.0, 0.0, 4.99)
+    )
+    budget.check_user_budget(
+        MagicMock(),
+        user_id="u-1",
+        daily_limit_usd=0,
+        hourly_limit_usd=0,
+        monthly_limit_usd=5.0,
+    )  # must not raise
+
+
+def test_hourly_trips_before_monthly(monkeypatch):
+    """Burst protection: the smaller window raises first."""
+    monkeypatch.setattr(
+        budget.cost_log, "total_spend", _spend_by_window(1.0, 1.0, 5.0)
+    )
+    with pytest.raises(HTTPException) as exc:
+        budget.check_user_budget(
+            MagicMock(),
+            user_id="u-1",
+            daily_limit_usd=5.0,
+            hourly_limit_usd=1.0,
+            monthly_limit_usd=5.0,
+        )
+    assert exc.value.detail["scope"] == "hourly"
+
+
+# ---- effective_monthly_cap ---------------------------------------------------
+
+
+def _supabase_profile(rows: list[dict[str, Any]]) -> MagicMock:
+    supabase = MagicMock()
+    chain = supabase.table.return_value.select.return_value.eq.return_value.execute
+    chain.return_value.data = rows
+    return supabase
+
+
+def test_effective_monthly_cap_default_when_no_profile():
+    sb = _supabase_profile([])
+    assert budget.effective_monthly_cap(sb, user_id="u-1", default_usd=5.0) == 5.0
+
+
+def test_effective_monthly_cap_default_when_override_null():
+    sb = _supabase_profile([{"llm_monthly_budget_usd": None}])
+    assert budget.effective_monthly_cap(sb, user_id="u-1", default_usd=5.0) == 5.0
+
+
+def test_effective_monthly_cap_honors_override():
+    sb = _supabase_profile([{"llm_monthly_budget_usd": 25}])
+    assert budget.effective_monthly_cap(sb, user_id="u-1", default_usd=5.0) == 25.0
+
+
+# ---- check_daily_count (deep-analysis counter) -------------------------------
+
+
+def _supabase_count(count: int) -> MagicMock:
+    supabase = MagicMock()
+    chain = (
+        supabase.table.return_value.select.return_value.eq.return_value
+        .eq.return_value.gte.return_value.execute
+    )
+    chain.return_value.count = count
+    return supabase
+
+
+def test_daily_count_under_limit_passes():
+    budget.check_daily_count(
+        _supabase_count(19), user_id="u-1", purpose="job_analysis", limit=20
+    )  # must not raise
+
+
+def test_daily_count_at_limit_raises_429():
+    with pytest.raises(HTTPException) as exc:
+        budget.check_daily_count(
+            _supabase_count(20), user_id="u-1", purpose="job_analysis", limit=20
+        )
+    assert exc.value.status_code == 429
+    assert exc.value.detail["code"] == "analysis_daily_limit"
+    assert exc.value.detail["limit"] == 20
+    assert exc.value.detail["used"] == 20
+
+
+def test_daily_count_zero_limit_disables():
+    budget.check_daily_count(
+        _supabase_count(10_000), user_id="u-1", purpose="job_analysis", limit=0
+    )  # must not raise
+
+
+# ---- resolve_target_payers ----------------------------------------------------
+
+
+def _supabase_user_targets(rows: list[dict[str, Any]]) -> MagicMock:
+    supabase = MagicMock()
+    chain = (
+        supabase.table.return_value.select.return_value.eq.return_value
+        .in_.return_value.order.return_value.order.return_value.execute
+    )
+    chain.return_value.data = rows
+    return supabase
+
+
+def test_resolve_payers_earliest_active_link_wins():
+    # Rows arrive ordered by (created_at, user_id) — the query's contract.
+    sb = _supabase_user_targets(
+        [
+            {"target_id": "t-1", "user_id": "u-early", "created_at": "2026-01-01"},
+            {"target_id": "t-1", "user_id": "u-late", "created_at": "2026-02-01"},
+            {"target_id": "t-2", "user_id": "u-solo", "created_at": "2026-03-01"},
+        ]
+    )
+    payers = resolve_target_payers(sb, ["t-1", "t-2", "t-orphan"])
+    assert payers == {"t-1": "u-early", "t-2": "u-solo", "t-orphan": None}
+
+
+def test_resolve_payers_empty_input_short_circuits():
+    sb = MagicMock()
+    assert resolve_target_payers(sb, []) == {}
+    sb.table.assert_not_called()
+
+
+# ---- PayerBudgetGate semantics -------------------------------------------------
+
+
+def test_gate_blocks_over_budget_payer_and_orphans():
+    gate = PayerBudgetGate(
+        payer_by_target={"t-1": "u-over", "t-2": "u-ok", "t-3": None},
+        over_budget_users=frozenset({"u-over"}),
+    )
+    assert gate.target_blocked("t-1") is True  # payer over budget
+    assert gate.target_blocked("t-2") is False
+    assert gate.target_blocked("t-3") is True  # orphan: never spend unattributed
+    assert gate.target_blocked("t-unknown") is True  # post-snapshot activation
+    assert gate.user_blocked("u-over") is True
+    assert gate.user_blocked("u-ok") is False
+
+
+def test_empty_gate_blocks_everything():
+    """The refuse-to-spend fallback when the snapshot build fails."""
+    gate = PayerBudgetGate()
+    assert gate.target_blocked("any-target") is True
+    assert gate.user_blocked("any-user") is False  # phase-2 keys on users it knows
+
+
+# ---- build_budget_gate ----------------------------------------------------------
+
+
+def test_build_gate_classifies_over_budget_payer(monkeypatch):
+    import app.services.targets.payers as payers_mod
+
+    monkeypatch.setattr(
+        payers_mod,
+        "resolve_target_payers",
+        lambda sb, ids: {"t-1": "u-over", "t-2": "u-ok"},
+    )
+    # No overrides → settings default cap applies.
+    sb = MagicMock()
+    profile_chain = (
+        sb.table.return_value.select.return_value.in_.return_value.execute
+    )
+    profile_chain.return_value.data = []
+    monkeypatch.setattr(payers_mod.settings, "user_llm_monthly_budget_usd", 5.0)
+    monkeypatch.setattr(
+        payers_mod.cost_log,
+        "total_spend",
+        lambda sb, user_id, since: 6.0 if user_id == "u-over" else 0.5,
+    )
+
+    gate = build_budget_gate(sb, ["t-1", "t-2"])
+    assert gate.target_blocked("t-1") is True
+    assert gate.target_blocked("t-2") is False
+
+
+def test_build_gate_zero_cap_disables_gating(monkeypatch):
+    import app.services.targets.payers as payers_mod
+
+    monkeypatch.setattr(
+        payers_mod, "resolve_target_payers", lambda sb, ids: {"t-1": "u-1"}
+    )
+    sb = MagicMock()
+    sb.table.return_value.select.return_value.in_.return_value.execute.return_value.data = []
+    monkeypatch.setattr(payers_mod.settings, "user_llm_monthly_budget_usd", 0.0)
+    spend_called = False
+
+    def _spend(*a, **kw):
+        nonlocal spend_called
+        spend_called = True
+        return 999.0
+
+    monkeypatch.setattr(payers_mod.cost_log, "total_spend", _spend)
+
+    gate = build_budget_gate(sb, ["t-1"])
+    assert gate.target_blocked("t-1") is False
+    assert spend_called is False  # 0 cap short-circuits the spend query
+
+
+def test_build_gate_override_raises_cap(monkeypatch):
+    """A user_profiles override above the spend keeps the payer unblocked."""
+    import app.services.targets.payers as payers_mod
+
+    monkeypatch.setattr(
+        payers_mod, "resolve_target_payers", lambda sb, ids: {"t-1": "u-vip"}
+    )
+    sb = MagicMock()
+    profile_chain = (
+        sb.table.return_value.select.return_value.in_.return_value.execute
+    )
+    profile_chain.return_value.data = [
+        {"user_id": "u-vip", "llm_monthly_budget_usd": 50}
+    ]
+    monkeypatch.setattr(payers_mod.settings, "user_llm_monthly_budget_usd", 5.0)
+    monkeypatch.setattr(
+        payers_mod.cost_log, "total_spend", lambda sb, user_id, since: 20.0
+    )
+
+    gate = build_budget_gate(sb, ["t-1"])
+    assert gate.target_blocked("t-1") is False  # 20 < 50 override

--- a/apps/wyrdfold-api/tests/test_targets_user_links.py
+++ b/apps/wyrdfold-api/tests/test_targets_user_links.py
@@ -127,11 +127,13 @@ def _mock_supabase_for_link(
     *,
     existing_row: dict[str, Any] | None,
     active_count: int,
+    max_active_override: int | None = None,
 ) -> MagicMock:
     """Build a Supabase mock that returns deterministic answers for the
-    two reads link_user_to_target performs before its upsert: (1) "is
-    this (user, target) pair already linked, and was it active?" and
-    (2) "how many active links does this user already have?".
+    three reads link_user_to_target performs before its upsert: (1) "is
+    this (user, target) pair already linked, and was it active?",
+    (2) "how many active links does this user already have?", and
+    (3) the per-user ``max_active_targets`` override on user_profiles.
     """
     supabase = MagicMock()
     table = supabase.table.return_value
@@ -144,6 +146,15 @@ def _mock_supabase_for_link(
     # MagicMock, so we shim ``.count`` on the same return value.
     existing_chain.return_value.count = active_count
 
+    # Override read: select().eq().execute() — one .eq() shorter, so it's
+    # a distinct chain on the mock.
+    override_chain = table.select.return_value.eq.return_value.execute
+    override_chain.return_value.data = (
+        [{"max_active_targets": max_active_override}]
+        if max_active_override is not None
+        else []
+    )
+
     # Upsert: returns a row that matches what we wrote.
     table.upsert.return_value.execute.return_value.data = [
         _user_target_row(is_active=True)
@@ -152,7 +163,22 @@ def _mock_supabase_for_link(
 
 
 def test_link_user_to_target_allows_when_under_limit() -> None:
-    supabase = _mock_supabase_for_link(existing_row=None, active_count=2)
+    # Cap is 1 (cost-caps work) — "under limit" means zero active links.
+    supabase = _mock_supabase_for_link(existing_row=None, active_count=0)
+
+    result = crud.link_user_to_target(
+        supabase, user_id="user-1", target_id="target-1", is_active=True
+    )
+
+    assert result.is_active is True
+
+
+def test_link_user_to_target_honors_max_active_override() -> None:
+    """A per-user ``max_active_targets`` override (the operator's "add
+    credits" lever) raises the cap above the global default of 1."""
+    supabase = _mock_supabase_for_link(
+        existing_row=None, active_count=2, max_active_override=3
+    )
 
     result = crud.link_user_to_target(
         supabase, user_id="user-1", target_id="target-1", is_active=True

--- a/apps/wyrdfold-api/tests/test_upload_resume.py
+++ b/apps/wyrdfold-api/tests/test_upload_resume.py
@@ -97,6 +97,7 @@ class TestUploadResumeEndpoint:
 
         file = _make_upload_file(docx_bytes)
         result = await exp_router.upload_resume(
+            request=MagicMock(),
             file=file,
             auto_derive=False,
             supabase=supabase,
@@ -120,6 +121,7 @@ class TestUploadResumeEndpoint:
         file = _make_upload_file(b"")
         with pytest.raises(HTTPException) as exc_info:
             await exp_router.upload_resume(
+                request=MagicMock(),
                 file=file,
                 auto_derive=False,
                 supabase=MagicMock(),
@@ -138,6 +140,7 @@ class TestUploadResumeEndpoint:
         file = _make_upload_file(b"plain text", "notes.txt", "text/plain")
         with pytest.raises(HTTPException) as exc_info:
             await exp_router.upload_resume(
+                request=MagicMock(),
                 file=file,
                 auto_derive=False,
                 supabase=MagicMock(),
@@ -155,6 +158,7 @@ class TestUploadResumeEndpoint:
         file = _make_upload_file(b"not a docx", "bad.docx")
         with pytest.raises(HTTPException) as exc_info:
             await exp_router.upload_resume(
+                request=MagicMock(),
                 file=file,
                 auto_derive=False,
                 supabase=MagicMock(),
@@ -176,6 +180,7 @@ class TestUploadResumeEndpoint:
         file = _make_upload_file(docx_bytes)
         with pytest.raises(HTTPException) as exc_info:
             await exp_router.upload_resume(
+                request=MagicMock(),
                 file=file,
                 auto_derive=False,
                 supabase=MagicMock(),
@@ -233,6 +238,7 @@ class TestUploadResumeEndpoint:
         supabase = _mock_supabase()
         file = _make_upload_file(docx_bytes)
         result = await exp_router.upload_resume(
+            request=MagicMock(),
             file=file,
             auto_derive=False,
             supabase=supabase,
@@ -307,6 +313,7 @@ class TestUploadResumeEndpoint:
         supabase = _mock_supabase()
         file = _make_upload_file(docx_bytes)
         result = await exp_router.upload_resume(
+            request=MagicMock(),
             file=file,
             auto_derive=True,
             supabase=supabase,

--- a/apps/wyrdfold/src/app/(app)/settings/LlmUsageCard.tsx
+++ b/apps/wyrdfold/src/app/(app)/settings/LlmUsageCard.tsx
@@ -1,0 +1,128 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Gauge } from 'lucide-react';
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from '@danieljoffe/shared-ui/Card';
+import { Skeleton } from '@danieljoffe/shared-ui/Skeleton';
+import { Text } from '@danieljoffe/shared-ui/Text';
+
+interface UsageWindow {
+  spent_usd: number;
+  limit_usd: number;
+}
+
+interface LlmUsage {
+  hourly: UsageWindow;
+  daily: UsageWindow;
+  monthly: UsageWindow;
+  monthly_resets_at: string | null;
+  analysis_daily_used: number;
+  analysis_daily_limit: number;
+}
+
+function UsageBar({ spent, limit }: { spent: number; limit: number }) {
+  const pct = limit > 0 ? Math.min(100, (spent / limit) * 100) : 0;
+  return (
+    <div
+      className='h-2 w-full overflow-hidden rounded-full bg-surface-tertiary'
+      role='progressbar'
+      aria-valuenow={Math.round(pct)}
+      aria-valuemin={0}
+      aria-valuemax={100}
+      aria-label='Monthly allowance used'
+    >
+      <div
+        className={
+          pct >= 90
+            ? 'h-full rounded-full bg-error'
+            : pct >= 70
+              ? 'h-full rounded-full bg-warning'
+              : 'h-full rounded-full bg-brand-500'
+        }
+        style={{ width: `${pct}%` }}
+      />
+    </div>
+  );
+}
+
+export default function LlmUsageCard() {
+  const [usage, setUsage] = useState<LlmUsage | null>(null);
+  const [failed, setFailed] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      try {
+        const res = await fetch('/api/profile/llm-usage');
+        if (!res.ok) throw new Error(`${res.status}`);
+        const data = (await res.json()) as LlmUsage;
+        if (!cancelled) setUsage(data);
+      } catch {
+        if (!cancelled) setFailed(true);
+      }
+    }
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className='flex items-center gap-2'>
+          <Gauge className='size-4' aria-hidden />
+          AI usage
+        </CardTitle>
+      </CardHeader>
+      <CardContent className='flex flex-col gap-3'>
+        {failed ? (
+          <Text variant='caption' className='text-text-secondary'>
+            Usage data is unavailable right now.
+          </Text>
+        ) : usage === null ? (
+          <div className='flex flex-col gap-2' aria-label='Loading usage'>
+            <Skeleton width='40%' size='sm' />
+            <Skeleton variant='rectangular' height={8} />
+          </div>
+        ) : (
+          <>
+            <div className='flex items-baseline justify-between'>
+              <Text variant='caption' className='text-text-secondary'>
+                Monthly allowance
+              </Text>
+              <Text variant='caption'>
+                ${usage.monthly.spent_usd.toFixed(2)} of $
+                {usage.monthly.limit_usd.toFixed(2)}
+              </Text>
+            </div>
+            <UsageBar
+              spent={usage.monthly.spent_usd}
+              limit={usage.monthly.limit_usd}
+            />
+            <div className='flex items-baseline justify-between'>
+              <Text variant='caption' className='text-text-secondary'>
+                Deep analyses today
+              </Text>
+              <Text variant='caption'>
+                {usage.analysis_daily_used} of {usage.analysis_daily_limit}
+              </Text>
+            </div>
+            {usage.monthly_resets_at && (
+              <Text variant='caption' className='text-text-tertiary'>
+                Allowance frees up around{' '}
+                {new Date(usage.monthly_resets_at).toLocaleDateString()} as
+                usage rolls out of the 30-day window.
+              </Text>
+            )}
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/wyrdfold/src/app/(app)/settings/SettingsPage.tsx
+++ b/apps/wyrdfold/src/app/(app)/settings/SettingsPage.tsx
@@ -16,6 +16,7 @@ import { Switch } from '@danieljoffe/shared-ui/Switch';
 import { Text } from '@danieljoffe/shared-ui/Text';
 import { extractApiError } from '@/lib/extractApiError';
 import { useToast } from '@/state/Toast/ToastProvider';
+import LlmUsageCard from './LlmUsageCard';
 import OnboardingResetCard from './OnboardingResetCard';
 import { ResumeStylePreview } from './ResumeStylePreview';
 import {
@@ -625,6 +626,8 @@ export default function SettingsPage() {
           </div>
         </CardContent>
       </Card>
+
+      <LlmUsageCard />
 
       <OnboardingResetCard />
     </div>

--- a/apps/wyrdfold/src/app/api/profile/llm-usage/route.ts
+++ b/apps/wyrdfold/src/app/api/profile/llm-usage/route.ts
@@ -1,0 +1,5 @@
+import { proxyToWyrdfoldAPI } from '@/lib/api/proxy';
+
+export async function GET() {
+  return proxyToWyrdfoldAPI('/profile/llm-usage');
+}

--- a/apps/wyrdfold/src/lib/__tests__/extractApiError.spec.ts
+++ b/apps/wyrdfold/src/lib/__tests__/extractApiError.spec.ts
@@ -1,0 +1,63 @@
+import { extractApiError } from '../extractApiError';
+
+// jsdom has no fetch Response global; extractApiError only touches
+// `.status` and `.clone().json()`, so a minimal fake suffices.
+function res429(detail: unknown): Response {
+  const fake = {
+    status: 429,
+    clone() {
+      return { json: async () => ({ detail }) };
+    },
+  };
+  return fake as unknown as Response;
+}
+
+describe('extractApiError — cost-cap shapes', () => {
+  it('formats the monthly allowance breach with the rolling-window hint', async () => {
+    const msg = await extractApiError(
+      res429({
+        code: 'llm_budget_exceeded',
+        scope: 'monthly',
+        limit_usd: 5,
+        spent_usd: 5.12,
+      }),
+      'Request failed'
+    );
+    expect(msg).toBe(
+      'Monthly LLM allowance reached ($5.12 of $5.00) — frees up as usage rolls out of the 30-day window.'
+    );
+  });
+
+  it('keeps the hourly wording unchanged', async () => {
+    const msg = await extractApiError(
+      res429({
+        code: 'llm_budget_exceeded',
+        scope: 'hourly',
+        limit_usd: 1,
+        spent_usd: 1.01,
+      }),
+      'Request failed'
+    );
+    expect(msg).toBe(
+      'LLM hourly budget reached ($1.01 of $1.00) — try again in an hour.'
+    );
+  });
+
+  it('formats the analysis daily-count limit with the cached-revisit hint', async () => {
+    const msg = await extractApiError(
+      res429({ code: 'analysis_daily_limit', limit: 20, used: 20 }),
+      'Analysis failed'
+    );
+    expect(msg).toBe(
+      'Daily deep-analysis limit reached (20/day) — more tomorrow. Already-analyzed jobs stay free to revisit.'
+    );
+  });
+
+  it('falls back with status code on unknown structured detail', async () => {
+    const msg = await extractApiError(
+      res429({ code: 'something_else' }),
+      'Request failed'
+    );
+    expect(msg).toBe('Request failed (429)');
+  });
+});

--- a/apps/wyrdfold/src/lib/extractApiError.ts
+++ b/apps/wyrdfold/src/lib/extractApiError.ts
@@ -66,17 +66,39 @@ export async function extractApiError(
       limit_usd?: number;
       spent_usd?: number;
     };
-    const scope = d.scope === 'daily' ? 'daily' : 'hourly';
+    const scope =
+      d.scope === 'monthly'
+        ? 'monthly'
+        : d.scope === 'daily'
+          ? 'daily'
+          : 'hourly';
     const spent =
       typeof d.spent_usd === 'number' ? `$${d.spent_usd.toFixed(2)}` : null;
     const limit =
       typeof d.limit_usd === 'number' ? `$${d.limit_usd.toFixed(2)}` : null;
     const waitHint =
-      scope === 'hourly' ? ' — try again in an hour' : ' — try again tomorrow';
+      scope === 'hourly'
+        ? ' — try again in an hour'
+        : scope === 'daily'
+          ? ' — try again tomorrow'
+          : ' — frees up as usage rolls out of the 30-day window';
+    const label =
+      scope === 'monthly' ? 'Monthly LLM allowance' : `LLM ${scope} budget`;
     if (spent && limit) {
-      return `LLM ${scope} budget reached (${spent} of ${limit})${waitHint}.`;
+      return `${label} reached (${spent} of ${limit})${waitHint}.`;
     }
-    return `LLM ${scope} budget reached${waitHint}.`;
+    return `${label} reached${waitHint}.`;
+  }
+
+  if (
+    detail &&
+    typeof detail === 'object' &&
+    'code' in detail &&
+    (detail as { code: unknown }).code === 'analysis_daily_limit'
+  ) {
+    const d = detail as { limit?: number };
+    const limit = typeof d.limit === 'number' ? ` (${d.limit}/day)` : '';
+    return `Daily deep-analysis limit reached${limit} — more tomorrow. Already-analyzed jobs stay free to revisit.`;
   }
 
   return statusFallback;

--- a/supabase/migrations/20260610090000_user_profiles_llm_overrides.sql
+++ b/supabase/migrations/20260610090000_user_profiles_llm_overrides.sql
@@ -1,0 +1,17 @@
+-- Per-user cost-cap overrides (LLM cost caps work).
+--
+-- NULL = global defaults apply (settings: $5/month allowance, 1 active
+-- target). The operator bumps a user's row when they "add credits" —
+-- the manual lever until a real credits ledger exists.
+--
+-- Note: llm_costs.user_id is a bare UUID (no FK), so cost history
+-- survives account deletion by construction — no FK change needed.
+
+ALTER TABLE public.user_profiles
+  ADD COLUMN IF NOT EXISTS llm_monthly_budget_usd numeric NULL,
+  ADD COLUMN IF NOT EXISTS max_active_targets integer NULL;
+
+COMMENT ON COLUMN public.user_profiles.llm_monthly_budget_usd IS
+  'Per-user monthly LLM allowance override (USD, rolling 30d). NULL = settings default.';
+COMMENT ON COLUMN public.user_profiles.max_active_targets IS
+  'Per-user active-target cap override. NULL = settings default.';


### PR DESCRIPTION
## Summary

The operator pays LLM costs out of pocket from a shared top-up — one user could drain the pool (an activated target alone burned ~$10.50/month in background Sonnet grading). This PR gives every account a hard allowance, modeled on Claude's own limits: small rolling windows for bursts + a monthly ceiling.

- **$5/month rolling allowance per account** — third window in `check_user_budget()`; counts ALL of a user's `llm_costs` (interactive + background). Nullable `user_profiles.llm_monthly_budget_usd` / `max_active_targets` overrides are the manual "add credits" lever (migration included).
- **Background work charged to the activator** — new `payers.py` resolves each target's payer (earliest active `user_targets` link); the poller builds a per-cycle budget gate and **skips Phase-1/Phase-2/Stage-3 for over-allowance payers**. Jobs still ingest fail-open (`promising, score=NULL`) — grading defers, same semantics as the daily cap. Gate-build failure = refuse to spend, never crash a poll.
- **Active targets 5 → 1** (`ACTIVE_LIMIT` flow already renders the dynamic limit).
- **Deep job analysis 20/user/day** — count gate placed *after* the cache check, so cached re-views never count or 429.
- **Phase-2 grading 100 → 10 jobs/target/day** (~$1/month/target, settings-tunable via `PHASE2_DAILY_CAP`).
- **Rate-limit sweep** — slowapi on the previously unguarded LLM endpoints (consolidate/upload/conversation/suggest/lateral/from-manual/from-url); batch tailor max 20 → 10.
- **Visibility** — `GET /profile/llm-usage`, BFF proxy, settings-page usage card, and clear 429 copy for the monthly/analysis-limit shapes.

Also includes (separate commits): word-boundary fix for the US-location ingest filter ("Indianapolis, Indiana" no longer dropped as "india"), and the read-only #845 funnel diagnostic scripts.

## Test plan
- [x] API: ruff + mypy clean (142 files); pytest **1220 passed** (new `test_llm_cost_caps.py`: monthly 429/0-disable/override, daily-count boundary, payer earliest-link resolution, gate blocking semantics incl. orphan + empty-gate refuse-to-spend)
- [x] FE: jest **469 passed** (70 suites, incl. new extractApiError cost-cap spec); lint 0 errors
- [ ] Apply migration `20260610090000_user_profiles_llm_overrides.sql` to prod
- [ ] Post-deploy: re-activate one target → grades ≤20/day, `llm_costs` rows carry the activator's user_id; 21st analysis click 429s with the right copy; 2nd target activation blocked; settings page shows the usage bar

Relates to #845 (re-activation + supply fix become safe once this lands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
