### PR TITLE
perf(wyrdfold): stop re-triaging known jobs; hoist cycle-wide queries

### DIFF
--- a/apps/wyrdfold-api/app/services/poller.py
+++ b/apps/wyrdfold-api/app/services/poller.py
@@ -620,6 +620,9 @@ async def _resolve_user_targets_for_stage3(
 async def _poll_one_source(
     source: dict[str, Any],
     supabase: Client,
+    *,
+    active_targets: list[JobTarget] | None = None,
+    stage3_users: tuple[dict[str, JobTarget], dict[str, OptimizedDoc]] | None = None,
 ) -> dict[str, Any]:
     """Poll a single job source. Returns a per-source summary dict.
 
@@ -627,6 +630,11 @@ async def _poll_one_source(
       1. Title-only match against each active target (inline, fast)
       2. Full JD match for stage-1 matches (async, after upsert)
       3. LLM analysis for top stage-2 scores (async)
+
+    ``active_targets`` and ``stage3_users`` are cycle-wide constants —
+    callers polling many sources should resolve them once and pass them
+    in rather than paying one targets query plus one user/doc resolution
+    per source. Both fall back to a per-source fetch when omitted.
     """
     summary: dict[str, Any] = {
         "polled": False,
@@ -654,8 +662,27 @@ async def _poll_one_source(
         # so we don't archive jobs that exist on the board but don't match filters.
         all_external_ids: set[str] = {job.external_id for job in jobs}
 
-        # Fetch active targets once — used for title filtering and scoring
-        active_targets = get_active_target(supabase)
+        # Targets are normally resolved once per cycle by the caller; the
+        # fallback keeps direct/legacy callers working.
+        if active_targets is None:
+            active_targets = await asyncio.to_thread(get_active_target, supabase)
+
+        # Existing rows are needed in three places: skipping Phase 1
+        # triage for already-known jobs, the (company, title) dedupe, and
+        # stale-row archiving. Fetch once, up front.
+        existing_query = (
+            supabase.table("jobs")
+            .select("id, external_id, title, company_name")
+            .eq("source_id", source_id)
+            .not_.in_("status", ["saved", "applied", "archived"])
+        )
+        existing_resp = await asyncio.to_thread(
+            execute_with_retry_sync,
+            existing_query.execute,
+            label=f"poll existing {company_name}",
+        )
+        existing_rows = cast(list[dict[str, Any]], existing_resp.data or [])
+        known_external_ids = {r.get("external_id") for r in existing_rows}
 
         # Phase 1: per-target LLM binary title triage (replaces cosine
         # prefilter). See ``app/services/relevance/title_triage.py``.
@@ -664,10 +691,20 @@ async def _poll_one_source(
         # flag so the PR can ship dark; when flag is False the gate
         # admits everything (pass-through) and we rely on downstream
         # keyword scoring for filtering.
+        #
+        # Only NEW external_ids are triaged. Jobs already in the DB were
+        # admitted on a previous cycle; re-triaging them re-paid the LLM
+        # cost for the same titles on every poll. Known jobs simply have
+        # no verdict entry, which the fail-open gate treats as admit.
         phase1_verdicts: dict[str, dict[int, TitleVerdict]] = {}
-        if settings.phase1_triage_enabled and active_targets and jobs:
+        triage_candidates = [
+            (idx, job)
+            for idx, job in enumerate(jobs)
+            if job.external_id not in known_external_ids
+        ]
+        if settings.phase1_triage_enabled and active_targets and triage_candidates:
             llm = get_default_llm_client()
-            titles = [job.title for job in jobs]
+            titles = [job.title for _, job in triage_candidates]
             for active_target in active_targets:
                 # Chunk to PHASE1_BATCH_SIZE per call. Sources usually
                 # return well under one batch (10-200 jobs); larger
@@ -696,10 +733,14 @@ async def _poll_one_source(
                                 "Failed to record Phase 1 cost for target %s",
                                 active_target.id,
                             )
-                    # Shift batch-local ids to global (1-based) job indices.
+                    # Shift batch-local ids (1-based within the triage
+                    # subset) to global 1-based job indices via the
+                    # triage-candidate mapping.
                     for batch_idx, verdict in verdicts.items():
-                        global_idx = start + batch_idx  # batch_idx is 1-based
-                        target_verdicts[global_idx] = verdict
+                        subset_pos = start + batch_idx - 1  # 0-based
+                        if 0 <= subset_pos < len(triage_candidates):
+                            global_idx = triage_candidates[subset_pos][0] + 1
+                            target_verdicts[global_idx] = verdict
                 phase1_verdicts[active_target.id] = target_verdicts
 
         def _any_target_admits(global_job_idx: int) -> bool:
@@ -769,39 +810,18 @@ async def _poll_one_source(
         if settings.validate_poll_urls and rows_to_upsert:
             rows_to_upsert = await _validate_rows(rows_to_upsert)
 
-        # Fetch existing rows BEFORE the upsert so we can dedupe
-        # against in-DB jobs with the same (company, title) but a
-        # different external_id. This catches the case Greenhouse
-        # surfaces the same role under multiple location offices as
-        # separate listings (e.g. Smartsheet's "Professional Services
-        # Business Development Director" at "-REMOTE, USA-" + "Bellevue,
-        # WA, USA"). Within-batch dedupe handles the case where both
-        # arrive in the same poll cycle; cross-batch dedupe (the
-        # existing_by_content lookup below) handles the case where the
-        # duplicate appears across multiple cycles.
-        existing_query = (
-            supabase.table("jobs")
-            .select("id, external_id, title, company_name")
-            .eq("source_id", source_id)
-            .not_.in_("status", ["saved", "applied", "archived"])
-        )
-
         new_rows: list[dict[str, Any]] = []
         if rows_to_upsert:
-            existing_resp = await asyncio.to_thread(
-                execute_with_retry_sync,
-                existing_query.execute,
-                label=f"poll existing {company_name}",
-            )
-
             # Dedupe rows_to_upsert by (company, title). Both within
             # the current batch and against existing rows that have a
-            # different external_id.
+            # different external_id. This catches the case Greenhouse
+            # surfaces the same role under multiple location offices as
+            # separate listings (e.g. Smartsheet's "Professional Services
+            # Business Development Director" at "-REMOTE, USA-" +
+            # "Bellevue, WA, USA").
             rows_to_upsert = _dedupe_by_content(
                 rows_to_upsert,
-                existing=cast(
-                    list[dict[str, Any]], existing_resp.data or []
-                ),
+                existing=existing_rows,
                 source=company_name,
             )
 
@@ -938,9 +958,15 @@ async def _poll_one_source(
             # lives on ``user_targets``. One query maps active target IDs
             # to their owning users, then we group: per user pick the
             # first active target and that user's latest optimized doc.
-            primary_by_user, user_optimized = await _resolve_user_targets_for_stage3(
-                supabase, active_targets, company_name
-            )
+            if stage3_users is not None:
+                primary_by_user, user_optimized = stage3_users
+            else:
+                (
+                    primary_by_user,
+                    user_optimized,
+                ) = await _resolve_user_targets_for_stage3(
+                    supabase, active_targets, company_name
+                )
 
             if settings.phase2_enabled and primary_by_user:
                 # ---- Phase 2: LLM job-fit grading (#6) ----
@@ -1039,12 +1065,9 @@ async def _poll_one_source(
                     logger.exception(
                         "Recency refresh failed for %s", company_name
                     )
-        else:
-            existing_resp = await asyncio.to_thread(existing_query.execute)
 
         # Identify stale jobs no longer on the board
         stale_ids: list[str] = []
-        existing_rows = cast(list[dict[str, Any]], existing_resp.data or [])
         if not jobs and existing_rows:
             # Mass-archive guard: several fetchers (workday in particular)
             # swallow API errors and return [] instead of raising, which is
@@ -1157,16 +1180,22 @@ async def poll_all_sources(supabase: Client) -> PollResult:
     sources_resp = await asyncio.to_thread(sources_query.execute)
     sources = sources_resp.data or []
 
-    # Optimized doc is fetched per-user inside ``_poll_one_source`` now —
-    # the previous shared-doc fetch (``user_id=None``) never returned a
-    # row in the multi-user schema, silently disabling stage 3.
+    # Cycle-wide constants resolved once instead of once per source:
+    # active targets and the stage-3 (user → target/optimized-doc) maps.
+    active_targets = await asyncio.to_thread(get_active_target, supabase)
+    stage3_users = await _resolve_user_targets_for_stage3(
+        supabase, active_targets, "(cycle prefetch)"
+    )
 
     semaphore = asyncio.Semaphore(POLL_CONCURRENCY)
 
     async def _worker(raw_source: Any) -> dict[str, Any]:
         async with semaphore:
             return await _poll_one_source(
-                cast(dict[str, Any], raw_source), supabase
+                cast(dict[str, Any], raw_source),
+                supabase,
+                active_targets=active_targets,
+                stage3_users=stage3_users,
             )
 
     summaries = await asyncio.gather(*(_worker(s) for s in sources))
@@ -1245,11 +1274,21 @@ async def poll_due_sources(supabase: Client) -> PollResult:
             sources_polled=0, new_jobs=0, updated_jobs=0, archived_jobs=0, errors=[]
         )
 
+    active_targets = await asyncio.to_thread(get_active_target, supabase)
+    stage3_users = await _resolve_user_targets_for_stage3(
+        supabase, active_targets, "(cycle prefetch)"
+    )
+
     semaphore = asyncio.Semaphore(POLL_CONCURRENCY)
 
     async def _worker(source: dict[str, Any]) -> dict[str, Any]:
         async with semaphore:
-            return await _poll_one_source(source, supabase)
+            return await _poll_one_source(
+                source,
+                supabase,
+                active_targets=active_targets,
+                stage3_users=stage3_users,
+            )
 
     summaries = await asyncio.gather(*(_worker(s) for s in due))
 

--- a/apps/wyrdfold-api/tests/test_poll_due.py
+++ b/apps/wyrdfold-api/tests/test_poll_due.py
@@ -137,6 +137,8 @@ async def test_poll_due_sources_polls_only_due_rows() -> None:
 
     with (
         patch("app.services.poller.get_latest_optimized") as get_opt,
+        # Cycle-level prefetch — irrelevant to the due-filter under test.
+        patch("app.services.poller.get_active_target", return_value=[]),
         patch("app.services.poller._poll_one_source", new_callable=AsyncMock) as poll_one,
     ):
         get_opt.return_value = None
@@ -169,6 +171,8 @@ async def test_poll_due_sources_aggregates_errors() -> None:
 
     with (
         patch("app.services.poller.get_latest_optimized") as get_opt,
+        # Cycle-level prefetch — irrelevant to the error aggregation under test.
+        patch("app.services.poller.get_active_target", return_value=[]),
         patch("app.services.poller._poll_one_source", new_callable=AsyncMock) as poll_one,
     ):
         get_opt.return_value = None

--- a/apps/wyrdfold-api/tests/test_poller.py
+++ b/apps/wyrdfold-api/tests/test_poller.py
@@ -393,3 +393,71 @@ async def test_nonzero_fetch_still_archives_stale_rows(monkeypatch):
     update_payload = jobs_table.update.call_args.args[0]
     assert update_payload["status"] == "archived"
     jobs_table.update.return_value.in_.assert_called_once_with("id", ["job-1"])
+
+
+# ---- Phase 1 triage: known jobs are not re-triaged --------------------------
+
+
+@pytest.mark.asyncio
+async def test_phase1_triage_skips_known_external_ids(monkeypatch):
+    """Jobs already in the DB must not be re-sent to the Phase 1 LLM on
+    every cycle — only new external_ids are triaged, and verdict indices
+    map back to the jobs' global positions."""
+    from unittest.mock import AsyncMock
+
+    from app.config import settings as live_settings
+    from app.services import poller as poller_mod
+    from app.services.relevance.title_triage import TitleVerdict
+
+    monkeypatch.setattr(live_settings, "phase1_triage_enabled", True)
+
+    existing = [
+        {"id": "job-1", "external_id": "known-1", "title": "Old Role", "company_name": "Acme"},
+    ]
+    supabase, _jobs_table, _sources_table = _make_poll_supabase(existing)
+
+    async def two_job_fetch(_token: str) -> list[StandardJob]:
+        return [
+            StandardJob(
+                external_id="known-1",
+                title="Old Role",
+                location_name="Remote",
+                department=None,
+                content="",
+                updated_at="2026-01-01",
+                absolute_url="https://example.com/j/1",
+            ),
+            StandardJob(
+                external_id="new-1",
+                title="Brand New Role",
+                location_name="Remote",
+                department=None,
+                content="",
+                updated_at="2026-01-01",
+                absolute_url="https://example.com/j/2",
+            ),
+        ]
+
+    target = _target_with_keywords({"react": 3}, ["totally unrelated keyword"])
+    # Triage rejects the (only) submitted title. Id 1 = first title in the
+    # submitted subset, which must be the NEW job.
+    fake_triage = AsyncMock(
+        return_value=({1: TitleVerdict(id=1, promising=False)}, None)
+    )
+
+    monkeypatch.setitem(poller_mod.FETCHERS, "greenhouse", two_job_fetch)
+    monkeypatch.setattr(poller_mod, "get_active_target", lambda _sb: [target])
+    monkeypatch.setattr(poller_mod, "get_default_llm_client", lambda: MagicMock())
+    monkeypatch.setattr(poller_mod, "triage_titles", fake_triage)
+
+    summary = await poller_mod._poll_one_source(dict(_GUARD_SOURCE), supabase)
+
+    assert summary["polled"] is True
+    assert summary["error"] is None
+    # Exactly one triage call, carrying ONLY the new job's title.
+    assert fake_triage.await_count == 1
+    assert fake_triage.await_args.kwargs["titles"] == ["Brand New Role"]
+    # Neither job reaches the upsert (new one rejected by Phase 1, known
+    # one fails the title prematch), so nothing was scored this cycle.
+    assert summary["new"] == 0
+    assert summary["updated"] == 0


### PR DESCRIPTION
> **Stacked on #887** — contains its commit; rebases to a clean diff once #887 merges.

## Summary
- **Phase 1 triage cost no longer recurs per cycle.** The poller re-sent *every* title on *every* board to the LLM triage on *every* poll, per target — including jobs ingested cycles ago. Triage now runs only for external_ids not already in the jobs table; known jobs have no verdict entry, which the existing fail-open gate treats as admit (matching prior semantics for missing verdicts). For a steady-state board this cuts Phase 1 spend to new postings only.
- **Cycle-wide constants hoisted.** `get_active_target` and the stage-3 `user → (target, optimized doc)` resolution ran once **per source**; they're now resolved once per cycle in `poll_all_sources`/`poll_due_sources` and passed down (with per-source fallbacks for direct callers). The targets fetch also moved off the event loop via `asyncio.to_thread`.
- The existing-rows query is fetched once up front and shared by the known-id set, the (company, title) dedupe, and stale archiving — removing the duplicate query path.

### Behavior note
A *known* job that Phase 1 would have re-rejected is now admitted to the candidate loop (it still passes title-prematch/location gates and upserts as an update). It was already in the DB either way; this only refreshes its content, and is consistent with the fail-open contract.

## Test plan
- [x] Full wyrdfold-api suite: **1198 passed**; ruff + mypy clean across the package
- [x] New test: triage receives only the new job's title; verdict indices map back to global job positions

🤖 Generated with [Claude Code](https://claude.com/claude-code)