### PR TITLE
feat(wyrdfold): cron-facing bulk source-discovery endpoint

### DIFF
--- a/apps/wyrdfold-api/app/main.py
+++ b/apps/wyrdfold-api/app/main.py
@@ -18,6 +18,7 @@ from app.observability import init_sentry
 from app.rate_limit import limiter
 from app.routers import (
     analysis,
+    discovery,
     experience,
     feedback,
     insights,
@@ -256,6 +257,7 @@ async def _unhandled_exception_handler(request: Request, exc: Exception) -> JSON
 
 
 app.include_router(analysis.router)
+app.include_router(discovery.router)
 app.include_router(experience.router)
 app.include_router(feedback.router)
 app.include_router(insights.router)

--- a/apps/wyrdfold-api/app/routers/discovery.py
+++ b/apps/wyrdfold-api/app/routers/discovery.py
@@ -1,0 +1,81 @@
+"""Cron-facing bulk source discovery.
+
+The per-target endpoint (``/targets/{id}/discover-sources``) is JWT-gated
+and operator-triggered. This router is the API-key-gated counterpart for
+scheduled callers (pg_cron, GitHub Actions, Railway cron) — it walks every
+active target and runs discovery for each, so new boards keep appearing
+without anyone pressing a button.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel, Field
+from supabase import Client
+
+from app.dependencies import get_supabase, verify_api_key
+from app.services.source_discovery import DiscoveryRunStats, run_discovery_for_target
+from app.services.targets import crud
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(
+    prefix="/discovery", tags=["discovery"], dependencies=[Depends(verify_api_key)]
+)
+
+
+class BulkDiscoveryResult(BaseModel):
+    """Aggregate of one discovery pass across all active targets."""
+
+    targets_processed: int = 0
+    queries_issued: int = 0
+    urls_examined: int = 0
+    inserted: int = 0
+    duplicates: int = 0
+    unclassified: int = 0
+    filtered: int = 0
+    errors: list[str] = Field(default_factory=list)
+    per_target: list[DiscoveryRunStats] = Field(default_factory=list)
+
+
+@router.post("/run", response_model=BulkDiscoveryResult)
+async def run_discovery_all_targets(
+    supabase: Client = Depends(get_supabase),
+) -> BulkDiscoveryResult:
+    """Run source discovery for every active target, sequentially.
+
+    Sequential on purpose: each per-target run already fans its Brave
+    queries out under an internal semaphore, and the per-run query cap
+    applies per target — running targets concurrently would multiply the
+    burst against Brave's rate limit without finishing meaningfully
+    sooner. A failed target is recorded and skipped; the rest still run.
+    """
+    targets = crud.get_active(supabase)
+    result = BulkDiscoveryResult()
+
+    for target in targets:
+        try:
+            stats = await run_discovery_for_target(supabase, target)
+        except Exception:
+            logger.exception("bulk discovery failed for target %s", target.id)
+            result.errors.append(f"{target.id}: discovery failed")
+            continue
+        result.targets_processed += 1
+        result.queries_issued += stats.queries_issued
+        result.urls_examined += stats.urls_examined
+        result.inserted += stats.inserted
+        result.duplicates += stats.duplicates
+        result.unclassified += stats.unclassified
+        result.filtered += stats.filtered
+        result.per_target.append(stats)
+
+    logger.info(
+        "bulk discovery: %d targets, %d queries, %d inserted, %d errors",
+        result.targets_processed,
+        result.queries_issued,
+        result.inserted,
+        len(result.errors),
+    )
+    return result

--- a/apps/wyrdfold-api/tests/test_routers_discovery.py
+++ b/apps/wyrdfold-api/tests/test_routers_discovery.py
@@ -1,0 +1,87 @@
+"""Tests for the cron-facing bulk discovery router."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from fastapi.testclient import TestClient
+
+from app.dependencies import get_supabase, verify_api_key
+from app.main import app
+from app.services.source_discovery import DiscoveryRunStats
+
+
+def _stats(target_id: str, *, inserted: int = 0) -> DiscoveryRunStats:
+    return DiscoveryRunStats(
+        target_id=target_id,
+        queries_issued=6,
+        urls_examined=12,
+        inserted=inserted,
+        duplicates=1,
+        unclassified=2,
+        filtered=3,
+    )
+
+
+def _client(supabase: MagicMock) -> TestClient:
+    app.dependency_overrides[get_supabase] = lambda: supabase
+    app.dependency_overrides[verify_api_key] = lambda: None
+    return TestClient(app)
+
+
+def teardown_function() -> None:
+    app.dependency_overrides.clear()
+
+
+def test_run_all_aggregates_per_target_stats() -> None:
+    supabase = MagicMock()
+    t1, t2 = MagicMock(id="t-1"), MagicMock(id="t-2")
+
+    fake_run = AsyncMock(side_effect=[_stats("t-1", inserted=4), _stats("t-2", inserted=1)])
+    with (
+        patch("app.routers.discovery.crud.get_active", return_value=[t1, t2]),
+        patch("app.routers.discovery.run_discovery_for_target", fake_run),
+    ):
+        resp = _client(supabase).post("/discovery/run")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["targets_processed"] == 2
+    assert body["queries_issued"] == 12
+    assert body["inserted"] == 5
+    assert body["errors"] == []
+    assert [t["target_id"] for t in body["per_target"]] == ["t-1", "t-2"]
+
+
+def test_run_all_records_error_and_continues() -> None:
+    supabase = MagicMock()
+    t1, t2 = MagicMock(id="t-1"), MagicMock(id="t-2")
+
+    fake_run = AsyncMock(side_effect=[RuntimeError("brave down"), _stats("t-2", inserted=2)])
+    with (
+        patch("app.routers.discovery.crud.get_active", return_value=[t1, t2]),
+        patch("app.routers.discovery.run_discovery_for_target", fake_run),
+    ):
+        resp = _client(supabase).post("/discovery/run")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["targets_processed"] == 1
+    assert body["inserted"] == 2
+    assert body["errors"] == ["t-1: discovery failed"]
+
+
+def test_run_all_with_no_active_targets_is_a_noop() -> None:
+    supabase = MagicMock()
+    with patch("app.routers.discovery.crud.get_active", return_value=[]):
+        resp = _client(supabase).post("/discovery/run")
+
+    assert resp.status_code == 200
+    assert resp.json()["targets_processed"] == 0
+
+
+def test_run_all_requires_api_key() -> None:
+    app.dependency_overrides[get_supabase] = lambda: MagicMock()
+    # No verify_api_key override — the real dependency must reject.
+    resp = TestClient(app).post("/discovery/run")
+    assert resp.status_code in (401, 403)


### PR DESCRIPTION
## Summary
Source discovery only ran from the JWT-gated, operator-triggered `/targets/{id}/discover-sources` endpoint — the `diagnose_supply` pass for #845 showed it had effectively never run for the live target, so the sources table only grew by hand.

Adds `POST /discovery/run` (API-key gated, mirroring `/poll` / `/poll/due`) which runs `run_discovery_for_target` for **every active target**, sequentially, and returns a `BulkDiscoveryResult` with per-target stats plus aggregates. Sequential by design: each target's run already fans Brave queries out under its own semaphore and the per-run query cap is per target — concurrency would just multiply the burst against Brave's rate limit.

A per-target failure is logged into `errors` and the pass continues.

## Wiring it up
Point any external cron at it, e.g. nightly:
```
curl -X POST https://<api>/discovery/run -H "X-API-Key: $WYRDFOLD_API_KEY"
```

## Test plan
- [x] 16 passed (4 new router tests: aggregation, error-and-continue, no-targets noop, API-key required)
- [x] ruff clean, mypy clean across 142 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)