### PR TITLE
feat(wyrdfold): idle-account lifecycle — defer, auto-pause, rogue-process limits

### DIFF
--- a/apps/wyrdfold-api/app/config.py
+++ b/apps/wyrdfold-api/app/config.py
@@ -177,6 +177,18 @@ class Settings(BaseSettings):
     # allowance; 20/day ≈ $2/month/target).
     phase2_daily_cap: int = Field(default=20, ge=0)
 
+    # Idle-account lifecycle. last_seen_at is stamped on authenticated
+    # requests (throttled in-process); the poller defers a payer's LLM
+    # work after idle_defer_days unseen and the lifecycle sweep
+    # auto-deactivates their targets after idle_deactivate_days. 0
+    # disables each stage. Tracking off in tests via conftest.
+    activity_tracking_enabled: bool = True
+    idle_defer_days: int = Field(default=7, ge=0)
+    idle_deactivate_days: int = Field(default=30, ge=0)
+    # Auto-disable a source after this many consecutive fetch failures
+    # (0 disables the backoff).
+    source_failure_disable_threshold: int = Field(default=10, ge=0)
+
     @property
     def allowed_hosts_list(self) -> list[str]:
         return [h.strip() for h in self.allowed_hosts.split(",") if h.strip()]

--- a/apps/wyrdfold-api/app/dependencies.py
+++ b/apps/wyrdfold-api/app/dependencies.py
@@ -212,6 +212,38 @@ def _try_decode_jwt_sub(request: Request, s: Settings) -> str | None:
     return str(payload["sub"])
 
 
+# Last write per user (time.monotonic seconds). In-process is fine on the
+# single-replica deploy — worst case after a restart is one extra stamp.
+_LAST_SEEN_STAMPED: dict[str, float] = {}
+_LAST_SEEN_THROTTLE_S = 3600.0
+
+
+def _touch_last_seen(user_id: str, s: Settings) -> None:
+    """Fire-and-forget ``user_profiles.last_seen_at`` refresh.
+
+    Drives the idle-account lifecycle (defer/deactivate). Throttled to
+    one write per user per hour, and swallowed on any failure — activity
+    tracking must never affect auth or add a failure mode to requests.
+    """
+    if not s.activity_tracking_enabled:
+        return
+    import time
+
+    now = time.monotonic()
+    last = _LAST_SEEN_STAMPED.get(user_id)
+    if last is not None and now - last < _LAST_SEEN_THROTTLE_S:
+        return
+    _LAST_SEEN_STAMPED[user_id] = now
+    try:
+        from datetime import UTC, datetime
+
+        get_supabase().table("user_profiles").update(
+            {"last_seen_at": datetime.now(UTC).isoformat()}
+        ).eq("user_id", user_id).execute()
+    except Exception:
+        logger.debug("last_seen stamp failed for %s", user_id, exc_info=True)
+
+
 def get_current_user_id(
     request: Request,
     s: Settings = Depends(get_settings),
@@ -223,6 +255,7 @@ def get_current_user_id(
     sub = _try_decode_jwt_sub(request, s)
     if sub is None:
         raise HTTPException(status_code=401, detail="Unauthorized")
+    _touch_last_seen(sub, s)
     return sub
 
 
@@ -270,6 +303,7 @@ def get_current_user_id_optional(
     """
     sub = _try_decode_jwt_sub(request, s)
     if sub is not None:
+        _touch_last_seen(sub, s)
         return sub
     if _api_key_matches(key, s.wyrdfold_api_key):
         return None

--- a/apps/wyrdfold-api/app/services/lifecycle.py
+++ b/apps/wyrdfold-api/app/services/lifecycle.py
@@ -1,0 +1,133 @@
+"""Idle-account lifecycle sweep.
+
+Two cleanups, run from the poll cycle (throttled in the caller):
+
+1. **Auto-deactivate idle users' targets** — users unseen for
+   ``idle_deactivate_days`` get their active ``user_targets`` flipped
+   inactive (the DB trigger syncs ``targets.is_active``), stamped with
+   ``auto_deactivated_at``, and receive one "target paused" email. Only
+   rows transitioned in THIS run are emailed, so at-most-once holds
+   without a dedup table.
+
+2. **Batch reaper** — ``batch_runs`` stuck in ``processing`` beyond
+   ``BATCH_STUCK_HOURS`` flip to ``failed`` so they stop looking alive.
+
+Idempotent by construction: both steps only transition rows, so re-runs
+(e.g. after a restart loses the throttle marker) are no-ops.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import UTC, datetime, timedelta
+from typing import Any, cast
+
+from supabase import Client
+
+from app.config import settings
+from app.services import notify
+
+logger = logging.getLogger(__name__)
+
+BATCH_STUCK_HOURS = 2
+
+
+async def run_lifecycle_sweep(supabase: Client) -> dict[str, int]:
+    """Run both cleanups; returns counts for logging/tests."""
+    deactivated = await _deactivate_idle_targets(supabase)
+    reaped = await _reap_stuck_batches(supabase)
+    if deactivated or reaped:
+        logger.info(
+            "lifecycle sweep: deactivated=%d stuck_batches_failed=%d",
+            deactivated,
+            reaped,
+        )
+    return {"deactivated": deactivated, "batches_reaped": reaped}
+
+
+async def _deactivate_idle_targets(supabase: Client) -> int:
+    if settings.idle_deactivate_days <= 0:
+        return 0
+    cutoff = (
+        datetime.now(UTC) - timedelta(days=settings.idle_deactivate_days)
+    ).isoformat()
+
+    idle_resp = await asyncio.to_thread(
+        lambda: supabase.table("user_profiles")
+        .select("user_id")
+        .lt("last_seen_at", cutoff)
+        .execute()
+    )
+    idle_ids = [
+        r["user_id"]
+        for r in cast(list[dict[str, Any]], idle_resp.data or [])
+        if r.get("user_id")
+    ]
+    if not idle_ids:
+        return 0
+
+    total = 0
+    now_iso = datetime.now(UTC).isoformat()
+    for uid in idle_ids:
+        # Flip + stamp in one filtered update; the returned rows are
+        # exactly the links transitioned in this run.
+        def _flip(user_id: str = uid) -> Any:
+            return (
+                supabase.table("user_targets")
+                .update(
+                    {
+                        "is_active": False,
+                        "auto_deactivated_at": now_iso,
+                        "updated_at": now_iso,
+                    }
+                )
+                .eq("user_id", user_id)
+                .eq("is_active", True)
+                .execute()
+            )
+
+        flip_resp = await asyncio.to_thread(_flip)
+        flipped = cast(list[dict[str, Any]], flip_resp.data or [])
+        if not flipped:
+            continue
+        total += len(flipped)
+
+        target_ids = [r["target_id"] for r in flipped if r.get("target_id")]
+        labels = await _target_labels(supabase, target_ids)
+        try:
+            await notify.send_target_paused_email(
+                supabase, user_id=uid, target_labels=labels
+            )
+        except Exception:
+            # The deactivation already happened; a lost email is the
+            # accepted trade (mirrors job-alert semantics).
+            logger.exception("target-paused email failed for user %s", uid)
+    return total
+
+
+async def _target_labels(supabase: Client, target_ids: list[str]) -> list[str]:
+    if not target_ids:
+        return []
+    resp = await asyncio.to_thread(
+        lambda: supabase.table("targets")
+        .select("label")
+        .in_("id", target_ids)
+        .execute()
+    )
+    return [
+        str(r.get("label") or "")
+        for r in cast(list[dict[str, Any]], resp.data or [])
+    ]
+
+
+async def _reap_stuck_batches(supabase: Client) -> int:
+    cutoff = (datetime.now(UTC) - timedelta(hours=BATCH_STUCK_HOURS)).isoformat()
+    resp = await asyncio.to_thread(
+        lambda: supabase.table("batch_runs")
+        .update({"status": "failed", "updated_at": datetime.now(UTC).isoformat()})
+        .eq("status", "processing")
+        .lt("updated_at", cutoff)
+        .execute()
+    )
+    return len(cast(list[dict[str, Any]], resp.data or []))

--- a/apps/wyrdfold-api/app/services/notify.py
+++ b/apps/wyrdfold-api/app/services/notify.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import Any, cast
 
 import httpx
@@ -73,8 +73,8 @@ async def send_alerts_for_new_jobs(
 
 
 async def _fetch_active_profiles(supabase: Client) -> list[dict[str, Any]]:
-    resp = await asyncio.to_thread(
-        lambda: supabase.table("user_profiles")
+    query = (
+        supabase.table("user_profiles")
         .select(
             "id, email, job_score_threshold,"
             " phone_number, sms_notifications_enabled,"
@@ -82,8 +82,18 @@ async def _fetch_active_profiles(supabase: Client) -> list[dict[str, Any]]:
         )
         .eq("job_notifications_enabled", True)
         .is_("unsubscribed_at", "null")
-        .execute()
     )
+    # Alert hygiene: abandoned users stop receiving job alerts even
+    # before the lifecycle sweep deactivates their targets. NULL
+    # last_seen_at passes (or-filter) — never punish missing data.
+    if settings.idle_deactivate_days > 0:
+        cutoff = (
+            datetime.now(UTC) - timedelta(days=settings.idle_deactivate_days)
+        ).isoformat()
+        query = query.or_(
+            f"last_seen_at.gte.{cutoff},last_seen_at.is.null"
+        )
+    resp = await asyncio.to_thread(query.execute)
     return cast(list[dict[str, Any]], resp.data or [])
 
 
@@ -165,6 +175,64 @@ async def _post_alert(
     body = resp.json()
     resend_id = body.get("resendId")
     return resend_id if isinstance(resend_id, str) else None
+
+
+# ---------------------------------------------------------------------------
+# Idle-lifecycle "target paused" email
+# ---------------------------------------------------------------------------
+
+
+async def send_target_paused_email(
+    supabase: Client, *, user_id: str, target_labels: list[str]
+) -> bool:
+    """One email telling an idle user their target(s) were auto-paused.
+
+    Called by the lifecycle sweep only for rows it just transitioned, so
+    at-most-once holds without a dedup table (a crash between flip and
+    send loses the email — same trade as job alerts). Honors the same
+    opt-out signals as job alerts.
+    """
+    if not settings.next_app_url or not settings.job_alert_secret:
+        return False
+
+    resp = await asyncio.to_thread(
+        lambda: supabase.table("user_profiles")
+        .select("id, email, job_notifications_enabled, unsubscribed_at")
+        .eq("user_id", user_id)
+        .execute()
+    )
+    rows = cast(list[dict[str, Any]], resp.data or [])
+    if not rows:
+        return False
+    profile = rows[0]
+    if not profile.get("job_notifications_enabled") or profile.get("unsubscribed_at"):
+        return False
+
+    payload = {
+        "profileId": profile["id"],
+        "to": profile["email"],
+        "targetLabels": target_labels,
+        "idleDays": settings.idle_deactivate_days,
+    }
+    url = f"{settings.next_app_url.rstrip('/')}/api/email/target-paused"
+    client: httpx.AsyncClient = get_http_client()
+    try:
+        post_resp = await client.post(
+            url,
+            json=payload,
+            headers={"Authorization": f"Bearer {settings.job_alert_secret}"},
+        )
+    except Exception:
+        logger.exception("Target-paused email POST raised for user %s", user_id)
+        return False
+    if post_resp.status_code != 200:
+        logger.warning(
+            "Target-paused email POST failed: status=%s body=%s",
+            post_resp.status_code,
+            post_resp.text[:200],
+        )
+        return False
+    return True
 
 
 # ---------------------------------------------------------------------------

--- a/apps/wyrdfold-api/app/services/poller.py
+++ b/apps/wyrdfold-api/app/services/poller.py
@@ -1162,13 +1162,15 @@ async def _poll_one_source(
                 if existing_job["external_id"] not in all_external_ids:
                     stale_ids.append(existing_job["id"])
 
-        # Archive stale jobs AND update last_polled_at in parallel
+        # Archive stale jobs AND update last_polled_at in parallel.
+        # A successful poll also resets the failure-backoff counter.
         last_polled_query = (
             supabase.table("sources")
             .update(
                 {
                     "last_polled_at": datetime.now(UTC).isoformat(),
                     "job_count": len(jobs),
+                    "consecutive_failures": 0,
                 }
             )
             .eq("id", source_id)
@@ -1245,40 +1247,128 @@ async def _poll_one_source(
     except Exception:
         logger.exception("Poll failed for %s", company_name)
         summary["error"] = f"{company_name}: poll failed"
+        await _record_source_failure(supabase, source)
 
     return summary
 
 
-async def _cycle_budget_gate(supabase: Client) -> PayerBudgetGate:
+async def _record_source_failure(
+    supabase: Client, source: dict[str, Any]
+) -> None:
+    """Failure backoff: count consecutive fetch failures per source and
+    auto-disable at the threshold (a dead board otherwise gets re-fetched
+    every cycle forever). Successful polls reset the counter via the
+    ``last_polled_at`` update. Best-effort — never raises.
+    """
+    threshold = settings.source_failure_disable_threshold
+    if threshold <= 0:
+        return
+    source_id = source.get("id")
+    if not source_id:
+        return
+    try:
+        failures = int(source.get("consecutive_failures") or 0) + 1
+        updates: dict[str, Any] = {"consecutive_failures": failures}
+        if failures >= threshold:
+            updates["enabled"] = False
+            logger.warning(
+                "Source %s disabled after %d consecutive failures",
+                source.get("company_name", source_id),
+                failures,
+            )
+        await asyncio.to_thread(
+            lambda: supabase.table("sources")
+            .update(updates)
+            .eq("id", source_id)
+            .execute()
+        )
+    except Exception:
+        logger.exception(
+            "Failed to record source failure for %s", source_id
+        )
+
+
+async def _cycle_budget_gate(supabase: Client) -> tuple[PayerBudgetGate, bool]:
     """Build the payer/allowance snapshot once per poll cycle.
 
-    On any error returns an EMPTY gate, which blocks all targets'
-    LLM work for the cycle (``target_blocked`` is True for unknown
-    targets) — refuse to spend unattributed money rather than crash
-    or fail open. Jobs still ingest; grading defers a cycle.
+    Returns ``(gate, has_active_targets)`` — the active-target fetch is
+    shared with the paid-provider skip (Firecrawl sources are pointless
+    with no consumer). On any error returns an EMPTY gate, which blocks
+    all targets' LLM work for the cycle (``target_blocked`` is True for
+    unknown targets) — refuse to spend unattributed money rather than
+    crash or fail open. Jobs still ingest; grading defers a cycle.
+    ``has_active_targets`` fails True so a gate error never silently
+    stops paid-source polling that a healthy cycle would run.
     """
     try:
         active = await asyncio.to_thread(get_active_target, supabase)
-        return await asyncio.to_thread(
+        gate = await asyncio.to_thread(
             build_budget_gate, supabase, [t.id for t in active]
         )
+        return gate, bool(active)
     except Exception:
         logger.exception(
             "Budget gate build failed — deferring all LLM work this cycle"
         )
-        return PayerBudgetGate()
+        return PayerBudgetGate(), True
+
+
+# Last lifecycle sweep (time.monotonic). In-process is fine on the
+# single-replica deploy: a restart just causes one harmless early re-run
+# (the sweep is idempotent).
+_LIFECYCLE_LAST_RUN: float = 0.0
+LIFECYCLE_SWEEP_INTERVAL_S = 6 * 3600.0
+
+
+async def _maybe_run_lifecycle_sweep(supabase: Client) -> None:
+    """Run the idle-account sweep at most every 6h, never blocking polls."""
+    global _LIFECYCLE_LAST_RUN
+    import time
+
+    from app.services.lifecycle import run_lifecycle_sweep
+
+    now = time.monotonic()
+    if _LIFECYCLE_LAST_RUN and now - _LIFECYCLE_LAST_RUN < LIFECYCLE_SWEEP_INTERVAL_S:
+        return
+    _LIFECYCLE_LAST_RUN = now
+    try:
+        await run_lifecycle_sweep(supabase)
+    except Exception:
+        logger.exception("Lifecycle sweep failed — continuing with poll cycle")
+
+
+def _drop_paid_sources_if_unconsumed(
+    sources: list[dict[str, Any]], *, has_active_targets: bool
+) -> list[dict[str, Any]]:
+    """Skip paid 'crawl' (Firecrawl) sources when no targets are active.
+
+    Free ATS fetchers keep the supply warm regardless; the paid provider
+    only runs when at least one active target can consume the results.
+    """
+    if has_active_targets:
+        return sources
+    kept = [s for s in sources if s.get("provider") != "crawl"]
+    skipped = len(sources) - len(kept)
+    if skipped:
+        logger.info(
+            "Skipping %d paid crawl source(s): no active targets", skipped
+        )
+    return kept
 
 
 async def poll_all_sources(supabase: Client) -> PollResult:
     sources_query = supabase.table("sources").select("*").eq("enabled", True)
     sources_resp = await asyncio.to_thread(sources_query.execute)
-    sources = sources_resp.data or []
+    all_sources = cast(list[dict[str, Any]], sources_resp.data or [])
 
     # Optimized doc is fetched per-user inside ``_poll_one_source`` now —
     # the previous shared-doc fetch (``user_id=None``) never returned a
     # row in the multi-user schema, silently disabling stage 3.
 
-    budget_gate = await _cycle_budget_gate(supabase)
+    budget_gate, has_active = await _cycle_budget_gate(supabase)
+    sources = _drop_paid_sources_if_unconsumed(
+        all_sources, has_active_targets=has_active
+    )
     semaphore = asyncio.Semaphore(POLL_CONCURRENCY)
 
     async def _worker(raw_source: Any) -> dict[str, Any]:
@@ -1357,13 +1447,18 @@ async def poll_due_sources(supabase: Client) -> PollResult:
     sources_resp = await asyncio.to_thread(sources_query.execute)
     all_enabled = cast(list[dict[str, Any]], sources_resp.data or [])
 
+    # Idle-account housekeeping piggybacks the cron tick (throttled to
+    # ~6h inside; never blocks or fails the poll).
+    await _maybe_run_lifecycle_sweep(supabase)
+
     due = filter_due_sources(all_enabled)
     if not due:
         return PollResult(
             sources_polled=0, new_jobs=0, updated_jobs=0, archived_jobs=0, errors=[]
         )
 
-    budget_gate = await _cycle_budget_gate(supabase)
+    budget_gate, has_active = await _cycle_budget_gate(supabase)
+    due = _drop_paid_sources_if_unconsumed(due, has_active_targets=has_active)
     semaphore = asyncio.Semaphore(POLL_CONCURRENCY)
 
     async def _worker(source: dict[str, Any]) -> dict[str, Any]:

--- a/apps/wyrdfold-api/app/services/targets/payers.py
+++ b/apps/wyrdfold-api/app/services/targets/payers.py
@@ -50,12 +50,14 @@ def resolve_target_payers(
 
 @dataclass(frozen=True)
 class PayerBudgetGate:
-    """Per-cycle snapshot of who pays for each target and who is over
-    their monthly allowance. Snapshot semantics: at most one cycle of
-    drift if a payer's spend or links change mid-cycle — acceptable."""
+    """Per-cycle snapshot of who pays for each target and which payers
+    are blocked — over their monthly allowance OR idle past the defer
+    threshold. Snapshot semantics: at most one cycle of drift if a
+    payer's spend, links, or activity change mid-cycle — acceptable."""
 
     payer_by_target: dict[str, str | None] = field(default_factory=dict)
     over_budget_users: frozenset[str] = frozenset()
+    idle_users: frozenset[str] = frozenset()
 
     def payer_for(self, target_id: str) -> str | None:
         return self.payer_by_target.get(target_id)
@@ -63,28 +65,33 @@ class PayerBudgetGate:
     def target_blocked(self, target_id: str) -> bool:
         """True when this target's LLM work must be skipped this cycle.
 
-        Blocked when the payer is over budget OR unknown (orphan active
-        target, or activated after the snapshot) — never spend
-        unattributed money. Jobs still ingest fail-open; grading
-        resumes once the payer's window frees up (next cycle for
-        post-snapshot activations).
+        Blocked when the payer is over budget, idle, OR unknown (orphan
+        active target, or activated after the snapshot) — never spend
+        money nobody will consume. Jobs still ingest fail-open; grading
+        resumes once the payer's window frees up / they return.
         """
         payer = self.payer_by_target.get(target_id)
-        return payer is None or payer in self.over_budget_users
+        return (
+            payer is None
+            or payer in self.over_budget_users
+            or payer in self.idle_users
+        )
 
     def user_blocked(self, user_id: str) -> bool:
-        return user_id in self.over_budget_users
+        return user_id in self.over_budget_users or user_id in self.idle_users
 
 
 def build_budget_gate(
     supabase: Client, target_ids: list[str]
 ) -> PayerBudgetGate:
-    """Build the cycle snapshot: payers, overrides, rolling-30d spends.
+    """Build the cycle snapshot: payers, overrides + activity, spends.
 
-    Three queries total (payers IN, overrides IN, one spend RPC per
+    Three queries total (payers IN, profiles IN, one spend RPC per
     distinct payer) — computed once per poll cycle, not per source/job.
-    A monthly limit of 0 (global or override) disables gating for that
-    user.
+    A monthly limit of 0 (global or override) disables budget gating;
+    ``idle_defer_days=0`` disables idle gating. A NULL ``last_seen_at``
+    (profile predating the column backfill, or no profile row) is
+    treated as active — never punish missing data.
     """
     payers = resolve_target_payers(supabase, target_ids)
     distinct = sorted({p for p in payers.values() if p is not None})
@@ -92,18 +99,37 @@ def build_budget_gate(
         return PayerBudgetGate(payer_by_target=payers)
 
     overrides: dict[str, float | None] = {}
+    last_seen: dict[str, str | None] = {}
     resp = (
         supabase.table("user_profiles")
-        .select("user_id,llm_monthly_budget_usd")
+        .select("user_id,llm_monthly_budget_usd,last_seen_at")
         .in_("user_id", distinct)
         .execute()
     )
     for row in cast(list[dict[str, Any]], resp.data or []):
         overrides[row["user_id"]] = row.get("llm_monthly_budget_usd")
+        last_seen[row["user_id"]] = row.get("last_seen_at")
 
-    since = datetime.now(UTC) - timedelta(days=MONTHLY_WINDOW_DAYS)
+    now = datetime.now(UTC)
+    since = now - timedelta(days=MONTHLY_WINDOW_DAYS)
     over: set[str] = set()
+    idle: set[str] = set()
+
+    idle_cutoff = (
+        now - timedelta(days=settings.idle_defer_days)
+        if settings.idle_defer_days > 0
+        else None
+    )
     for uid in distinct:
+        if idle_cutoff is not None:
+            seen_raw = last_seen.get(uid)
+            if seen_raw is not None:
+                seen = datetime.fromisoformat(str(seen_raw).replace("Z", "+00:00"))
+                if seen < idle_cutoff:
+                    idle.add(uid)
+                    # Idle already blocks — skip the spend query.
+                    continue
+
         raw = overrides.get(uid)
         cap = float(raw) if raw is not None else settings.user_llm_monthly_budget_usd
         if cap <= 0:
@@ -113,5 +139,7 @@ def build_budget_gate(
             over.add(uid)
 
     return PayerBudgetGate(
-        payer_by_target=payers, over_budget_users=frozenset(over)
+        payer_by_target=payers,
+        over_budget_users=frozenset(over),
+        idle_users=frozenset(idle),
     )

--- a/apps/wyrdfold-api/tests/conftest.py
+++ b/apps/wyrdfold-api/tests/conftest.py
@@ -9,6 +9,10 @@ os.environ["ALLOWED_HOSTS"] = "*"
 # from a single TestClient (one IP, no JWT), which would trip the limiter
 # and turn legitimate test runs into flaky 429s.
 os.environ["RATE_LIMIT_ENABLED"] = "false"
+# Disable last_seen activity stamping — it fires inside the auth deps and
+# would attempt real Supabase writes from tests that only mock per-route
+# clients.
+os.environ["ACTIVITY_TRACKING_ENABLED"] = "false"
 
 from unittest.mock import MagicMock
 

--- a/apps/wyrdfold-api/tests/test_lifecycle.py
+++ b/apps/wyrdfold-api/tests/test_lifecycle.py
@@ -1,0 +1,316 @@
+"""Tests for the idle-account lifecycle sweep + activity stamping."""
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.services import lifecycle
+
+# ---- _deactivate_idle_targets -------------------------------------------------
+
+
+def _supabase_for_sweep(
+    *,
+    idle_user_ids: list[str],
+    flipped_rows_by_user: dict[str, list[dict[str, Any]]],
+) -> MagicMock:
+    """Mock the three queries the sweep runs: idle profiles, the flip
+    update per user, and the labels lookup."""
+    supabase = MagicMock()
+
+    def table(name: str) -> MagicMock:
+        t = MagicMock()
+        if name == "user_profiles":
+            t.select.return_value.lt.return_value.execute.return_value.data = [
+                {"user_id": uid} for uid in idle_user_ids
+            ]
+        elif name == "user_targets":
+            # .update().eq(user_id).eq(is_active).execute() — return the
+            # rows for whichever user this call is for. MagicMock can't
+            # branch on eq args easily; queue per-call side effects.
+            t.update.return_value.eq.return_value.eq.return_value.execute.side_effect = [
+                MagicMock(data=flipped_rows_by_user.get(uid, []))
+                for uid in idle_user_ids
+            ]
+        elif name == "targets":
+            t.select.return_value.in_.return_value.execute.return_value.data = [
+                {"label": "Director of CX"}
+            ]
+        elif name == "batch_runs":
+            t.update.return_value.eq.return_value.lt.return_value.execute.return_value.data = []
+        return t
+
+    supabase.table.side_effect = table
+    return supabase
+
+
+@pytest.mark.asyncio
+async def test_sweep_deactivates_idle_users_and_emails_once(monkeypatch):
+    sb = _supabase_for_sweep(
+        idle_user_ids=["u-idle"],
+        flipped_rows_by_user={
+            "u-idle": [{"target_id": "t-1", "user_id": "u-idle"}]
+        },
+    )
+    email_spy = AsyncMock(return_value=True)
+    monkeypatch.setattr(lifecycle.notify, "send_target_paused_email", email_spy)
+
+    result = await lifecycle.run_lifecycle_sweep(sb)
+
+    assert result["deactivated"] == 1
+    email_spy.assert_awaited_once()
+    kwargs = email_spy.await_args.kwargs
+    assert kwargs["user_id"] == "u-idle"
+    assert kwargs["target_labels"] == ["Director of CX"]
+
+
+@pytest.mark.asyncio
+async def test_sweep_skips_users_with_no_active_links(monkeypatch):
+    """Idempotency: an idle user whose links are already inactive gets no
+    update rows back → no email, count 0."""
+    sb = _supabase_for_sweep(
+        idle_user_ids=["u-idle"], flipped_rows_by_user={"u-idle": []}
+    )
+    email_spy = AsyncMock()
+    monkeypatch.setattr(lifecycle.notify, "send_target_paused_email", email_spy)
+
+    result = await lifecycle.run_lifecycle_sweep(sb)
+
+    assert result["deactivated"] == 0
+    email_spy.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_sweep_disabled_when_threshold_zero(monkeypatch):
+    monkeypatch.setattr(lifecycle.settings, "idle_deactivate_days", 0)
+    sb = MagicMock()
+    sb.table.return_value.update.return_value.eq.return_value.lt.return_value.execute.return_value.data = []
+
+    result = await lifecycle.run_lifecycle_sweep(sb)
+
+    assert result["deactivated"] == 0
+
+
+@pytest.mark.asyncio
+async def test_email_failure_does_not_block_deactivation(monkeypatch):
+    sb = _supabase_for_sweep(
+        idle_user_ids=["u-idle"],
+        flipped_rows_by_user={
+            "u-idle": [{"target_id": "t-1", "user_id": "u-idle"}]
+        },
+    )
+    monkeypatch.setattr(
+        lifecycle.notify,
+        "send_target_paused_email",
+        AsyncMock(side_effect=RuntimeError("resend down")),
+    )
+
+    result = await lifecycle.run_lifecycle_sweep(sb)
+
+    assert result["deactivated"] == 1  # flip happened despite email failure
+
+
+# ---- batch reaper --------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_reaper_fails_stuck_processing_batches():
+    sb = MagicMock()
+
+    def table(name: str) -> MagicMock:
+        t = MagicMock()
+        if name == "user_profiles":
+            t.select.return_value.lt.return_value.execute.return_value.data = []
+        elif name == "batch_runs":
+            t.update.return_value.eq.return_value.lt.return_value.execute.return_value.data = [
+                {"id": "b-1"},
+                {"id": "b-2"},
+            ]
+        return t
+
+    sb.table.side_effect = table
+    result = await lifecycle.run_lifecycle_sweep(sb)
+    assert result["batches_reaped"] == 2
+
+
+# ---- activity stamp (dependencies) ----------------------------------------------
+
+
+def test_touch_last_seen_throttles_and_respects_flag(monkeypatch):
+    from app import dependencies as deps
+
+    writes: list[str] = []
+
+    class _FakeTable:
+        def update(self, payload):
+            return self
+
+        def eq(self, *_a):
+            return self
+
+        def execute(self):
+            writes.append("write")
+            return MagicMock()
+
+    fake_sb = MagicMock()
+    fake_sb.table.return_value = _FakeTable()
+    monkeypatch.setattr(deps, "get_supabase", lambda: fake_sb)
+    monkeypatch.setattr(deps, "_LAST_SEEN_STAMPED", {})
+
+    s_enabled = MagicMock(activity_tracking_enabled=True)
+    deps._touch_last_seen("u-1", s_enabled)
+    deps._touch_last_seen("u-1", s_enabled)  # within the hour → throttled
+    assert writes == ["write"]
+
+    s_disabled = MagicMock(activity_tracking_enabled=False)
+    monkeypatch.setattr(deps, "_LAST_SEEN_STAMPED", {})
+    deps._touch_last_seen("u-2", s_disabled)
+    assert writes == ["write"]  # flag off → no new write
+
+
+def test_touch_last_seen_swallows_failures(monkeypatch):
+    from app import dependencies as deps
+
+    def _boom():
+        raise RuntimeError("supabase down")
+
+    monkeypatch.setattr(deps, "get_supabase", _boom)
+    monkeypatch.setattr(deps, "_LAST_SEEN_STAMPED", {})
+    s = MagicMock(activity_tracking_enabled=True)
+    deps._touch_last_seen("u-1", s)  # must not raise
+
+
+# ---- gate idle blocking ----------------------------------------------------------
+
+
+def test_gate_blocks_idle_payer(monkeypatch):
+    import app.services.targets.payers as payers_mod
+    from app.services.targets.payers import build_budget_gate
+
+    monkeypatch.setattr(
+        payers_mod,
+        "resolve_target_payers",
+        lambda sb, ids: {"t-idle": "u-idle", "t-fresh": "u-fresh"},
+    )
+    old = (datetime.now(UTC) - timedelta(days=8)).isoformat()
+    fresh = (datetime.now(UTC) - timedelta(hours=1)).isoformat()
+    sb = MagicMock()
+    sb.table.return_value.select.return_value.in_.return_value.execute.return_value.data = [
+        {"user_id": "u-idle", "llm_monthly_budget_usd": None, "last_seen_at": old},
+        {"user_id": "u-fresh", "llm_monthly_budget_usd": None, "last_seen_at": fresh},
+    ]
+    monkeypatch.setattr(payers_mod.settings, "idle_defer_days", 7)
+    monkeypatch.setattr(payers_mod.settings, "user_llm_monthly_budget_usd", 5.0)
+    monkeypatch.setattr(
+        payers_mod.cost_log, "total_spend", lambda sb, user_id, since: 0.0
+    )
+
+    gate = build_budget_gate(sb, ["t-idle", "t-fresh"])
+    assert gate.target_blocked("t-idle") is True
+    assert gate.user_blocked("u-idle") is True
+    assert gate.target_blocked("t-fresh") is False
+
+
+def test_gate_null_last_seen_not_blocked(monkeypatch):
+    """NULL last_seen_at (pre-backfill rows / missing profile) is treated
+    as active — never punish missing data."""
+    import app.services.targets.payers as payers_mod
+    from app.services.targets.payers import build_budget_gate
+
+    monkeypatch.setattr(
+        payers_mod, "resolve_target_payers", lambda sb, ids: {"t-1": "u-1"}
+    )
+    sb = MagicMock()
+    sb.table.return_value.select.return_value.in_.return_value.execute.return_value.data = [
+        {"user_id": "u-1", "llm_monthly_budget_usd": None, "last_seen_at": None},
+    ]
+    monkeypatch.setattr(payers_mod.settings, "idle_defer_days", 7)
+    monkeypatch.setattr(payers_mod.settings, "user_llm_monthly_budget_usd", 5.0)
+    monkeypatch.setattr(
+        payers_mod.cost_log, "total_spend", lambda sb, user_id, since: 0.0
+    )
+
+    gate = build_budget_gate(sb, ["t-1"])
+    assert gate.target_blocked("t-1") is False
+
+
+def test_gate_idle_defer_zero_disables(monkeypatch):
+    import app.services.targets.payers as payers_mod
+    from app.services.targets.payers import build_budget_gate
+
+    monkeypatch.setattr(
+        payers_mod, "resolve_target_payers", lambda sb, ids: {"t-1": "u-1"}
+    )
+    ancient = (datetime.now(UTC) - timedelta(days=365)).isoformat()
+    sb = MagicMock()
+    sb.table.return_value.select.return_value.in_.return_value.execute.return_value.data = [
+        {"user_id": "u-1", "llm_monthly_budget_usd": None, "last_seen_at": ancient},
+    ]
+    monkeypatch.setattr(payers_mod.settings, "idle_defer_days", 0)
+    monkeypatch.setattr(payers_mod.settings, "user_llm_monthly_budget_usd", 5.0)
+    monkeypatch.setattr(
+        payers_mod.cost_log, "total_spend", lambda sb, user_id, since: 0.0
+    )
+
+    gate = build_budget_gate(sb, ["t-1"])
+    assert gate.target_blocked("t-1") is False
+
+
+# ---- paid-source skip -------------------------------------------------------------
+
+
+def test_drop_paid_sources_when_no_active_targets():
+    from app.services.poller import _drop_paid_sources_if_unconsumed
+
+    sources = [
+        {"id": "s-1", "provider": "greenhouse"},
+        {"id": "s-2", "provider": "crawl"},
+        {"id": "s-3", "provider": "lever"},
+    ]
+    kept = _drop_paid_sources_if_unconsumed(sources, has_active_targets=False)
+    assert [s["id"] for s in kept] == ["s-1", "s-3"]
+
+    kept_all = _drop_paid_sources_if_unconsumed(sources, has_active_targets=True)
+    assert kept_all == sources
+
+
+# ---- source failure backoff ---------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_source_failure_increments_and_disables_at_threshold(monkeypatch):
+    from app.services import poller
+
+    monkeypatch.setattr(poller.settings, "source_failure_disable_threshold", 10)
+    captured: list[dict[str, Any]] = []
+    sb = MagicMock()
+
+    def _capture_update(payload):
+        captured.append(payload)
+        chain = MagicMock()
+        chain.eq.return_value.execute.return_value = MagicMock()
+        return chain
+
+    sb.table.return_value.update.side_effect = _capture_update
+
+    await poller._record_source_failure(
+        sb, {"id": "s-1", "company_name": "Dead Co", "consecutive_failures": 3}
+    )
+    assert captured[-1] == {"consecutive_failures": 4}
+
+    await poller._record_source_failure(
+        sb, {"id": "s-1", "company_name": "Dead Co", "consecutive_failures": 9}
+    )
+    assert captured[-1] == {"consecutive_failures": 10, "enabled": False}
+
+
+@pytest.mark.asyncio
+async def test_source_failure_threshold_zero_disables_backoff(monkeypatch):
+    from app.services import poller
+
+    monkeypatch.setattr(poller.settings, "source_failure_disable_threshold", 0)
+    sb = MagicMock()
+    await poller._record_source_failure(sb, {"id": "s-1"})
+    sb.table.assert_not_called()

--- a/apps/wyrdfold-api/tests/test_notify.py
+++ b/apps/wyrdfold-api/tests/test_notify.py
@@ -29,6 +29,7 @@ def _build_supabase_mock(
     profiles_chain.select.return_value = profiles_chain
     profiles_chain.eq.return_value = profiles_chain
     profiles_chain.is_.return_value = profiles_chain
+    profiles_chain.or_.return_value = profiles_chain
     profiles_chain.execute.return_value = _ExecuteStub(profiles)
 
     claim_chain = MagicMock()
@@ -76,6 +77,7 @@ def _build_sms_supabase_mock(
     profiles_chain.select.return_value = profiles_chain
     profiles_chain.eq.return_value = profiles_chain
     profiles_chain.is_.return_value = profiles_chain
+    profiles_chain.or_.return_value = profiles_chain
     profiles_chain.execute.return_value = _ExecuteStub(profiles)
 
     count_chain = MagicMock()

--- a/apps/wyrdfold/src/app/api/email/target-paused/route.ts
+++ b/apps/wyrdfold/src/app/api/email/target-paused/route.ts
@@ -1,0 +1,96 @@
+import { timingSafeEqual } from 'node:crypto';
+import { type NextRequest, NextResponse } from 'next/server';
+import { Resend } from 'resend';
+
+function constantTimeEqual(a: string, b: string): boolean {
+  const aBuf = Buffer.from(a, 'utf8');
+  const bBuf = Buffer.from(b, 'utf8');
+  if (aBuf.length !== bBuf.length) return false;
+  return timingSafeEqual(aBuf, bBuf);
+}
+
+interface TargetPausedPayload {
+  to: string;
+  targetLabels: string[];
+  idleDays: number;
+}
+
+function isValidPayload(body: unknown): body is TargetPausedPayload {
+  if (!body || typeof body !== 'object') return false;
+  const b = body as Partial<TargetPausedPayload>;
+  return (
+    typeof b.to === 'string' &&
+    b.to.includes('@') &&
+    Array.isArray(b.targetLabels) &&
+    typeof b.idleDays === 'number'
+  );
+}
+
+/**
+ * Server-to-server endpoint: the wyrdfold-api lifecycle sweep posts here
+ * (Bearer JOB_ALERT_SECRET) when it auto-pauses an idle user's targets.
+ * One plain transactional email via Resend — no tracking, no list.
+ */
+export async function POST(request: NextRequest) {
+  const secret = process.env['JOB_ALERT_SECRET'];
+  const authHeader = request.headers.get('authorization') ?? '';
+  const presented = authHeader.startsWith('Bearer ')
+    ? authHeader.slice('Bearer '.length)
+    : '';
+  if (!secret || !constantTimeEqual(presented, secret)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const apiKey = process.env['RESEND_API_KEY'];
+  if (!apiKey) {
+    return NextResponse.json(
+      { error: 'Email not configured' },
+      { status: 503 }
+    );
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+  if (!isValidPayload(body)) {
+    return NextResponse.json({ error: 'Invalid payload' }, { status: 400 });
+  }
+
+  const { to, targetLabels, idleDays } = body;
+  const labels = targetLabels.filter(Boolean).slice(0, 10);
+  const targetList =
+    labels.length > 0
+      ? `<ul>${labels.map(l => `<li>${escapeHtml(l)}</li>`).join('')}</ul>`
+      : '<p>your active target</p>';
+  const appUrl = process.env['NEXT_PUBLIC_SITE_URL'] ?? 'https://wyrdfold.com';
+
+  const resend = new Resend(apiKey);
+  const { data, error } = await resend.emails.send({
+    from: 'WyrdFold <notifications@wyrdfold.com>',
+    to,
+    subject: 'Your WyrdFold target was paused',
+    html: [
+      `<p>You haven't signed in for ${idleDays} days, so we paused job`,
+      ` matching for:</p>`,
+      targetList,
+      `<p>Nothing was deleted — <a href="${appUrl}/targets">log in and`,
+      ` reactivate</a> whenever you're ready to resume.</p>`,
+    ].join(''),
+  });
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 502 });
+  }
+  return NextResponse.json({ resendId: data?.id ?? null });
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;');
+}

--- a/supabase/migrations/20260611090000_idle_lifecycle_columns.sql
+++ b/supabase/migrations/20260611090000_idle_lifecycle_columns.sql
@@ -1,0 +1,26 @@
+-- Idle-account lifecycle columns (idle defer / auto-deactivate work).
+--
+-- last_seen_at backfills now() so existing users don't mass-deactivate
+-- the day this ships — the clock starts at deploy time.
+
+ALTER TABLE public.user_profiles
+  ADD COLUMN IF NOT EXISTS last_seen_at timestamptz;
+
+UPDATE public.user_profiles
+  SET last_seen_at = now()
+  WHERE last_seen_at IS NULL;
+
+COMMENT ON COLUMN public.user_profiles.last_seen_at IS
+  'Last authenticated request (throttled ~1/hour). Drives idle defer/deactivate.';
+
+ALTER TABLE public.user_targets
+  ADD COLUMN IF NOT EXISTS auto_deactivated_at timestamptz;
+
+COMMENT ON COLUMN public.user_targets.auto_deactivated_at IS
+  'Set when the idle-lifecycle sweep deactivated this link (NULL = user action).';
+
+ALTER TABLE public.sources
+  ADD COLUMN IF NOT EXISTS consecutive_failures integer NOT NULL DEFAULT 0;
+
+COMMENT ON COLUMN public.sources.consecutive_failures IS
+  'Fetch failures since last success; the poller auto-disables at threshold.';


### PR DESCRIPTION
## Summary

Follow-up to #888. The allowance caps *how fast* an abandoned account burns money, but not *whether* — active targets kept driving polling, grading, and alerts with nobody consuming them. This adds an activity-driven lifecycle plus limits on the other rogue processes exploration surfaced.

**Lifecycle (the core):**
- `user_profiles.last_seen_at` stamped on authenticated requests — throttled to 1/hour via in-process cache (single-replica, same justification as the slowapi limiter), fire-and-forget so it can never affect auth, disabled in tests. Migration backfills `now()` so nobody mass-deactivates on day one.
- **7 days idle → LLM defer**: idle payers join the `PayerBudgetGate` blocked set (same machinery as over-budget) — jobs still ingest fail-open, Phase-1/2/3 grading pauses, resumes instantly on next login.
- **30 days idle → auto-deactivate**: a sweep (piggybacks the poll cron, throttled to 6h in-process, idempotent) flips their `user_targets` inactive (`auto_deactivated_at` stamped) and sends one "target paused" email. Email failure never blocks the deactivation.

**Rogue-process limits:**
- **Paid Firecrawl sources skipped when zero targets are active** — free ATS fetchers keep the supply warm; the paid scraper only runs with a consumer.
- **Source failure backoff** — `consecutive_failures` counter, reset on success, auto-disable at 10 (`SOURCE_FAILURE_DISABLE_THRESHOLD`, 0 disables).
- **Batch reaper** — `batch_runs` stuck in `processing` >2h flip to `failed`.
- **Alert hygiene** — job alerts skip users idle past the deactivate window (NULL `last_seen_at` passes; never punish missing data).

All thresholds are settings (`IDLE_DEFER_DAYS=7`, `IDLE_DEACTIVATE_DAYS=30`, 0 disables).

### ⚠️ Pre-existing bug found (not fixed here)
`notify.py` POSTs job alerts to `/api/email/job-alert` — **that route doesn't exist anywhere in the repo**, so job-alert emails have been silently failing (dedup row claims, send 404s, no retry). The new `/api/email/target-paused` route works standalone (Resend SDK, `JOB_ALERT_SECRET`-gated, timing-safe). Worth a follow-up issue to build the job-alert route on the same pattern.

## Test plan
- [x] API: ruff + mypy clean (144 files); pytest **1262 passed** (new `test_lifecycle.py`: sweep transitions/idempotency/email-at-most-once/email-failure-tolerance, batch reaper, stamp throttle+flag+failure-swallow, gate idle blocking incl. NULL last_seen + 0-disables, paid-source skip, failure backoff incr/reset/disable)
- [x] FE: jest 469 passed; lint 0 errors (new email route is server-only)
- [ ] Apply migration `20260611090000_idle_lifecycle_columns.sql` (`pnpm db:push`)
- [ ] Ops: set `RESEND_API_KEY` + `JOB_ALERT_SECRET` in the wyrdfold Vercel env (route 503s/401s safely without them)
- [ ] Post-deploy: log in → `last_seen_at` updates; backdate a test user 8d → grading defers next cycle; 31d → sweep deactivates + one email, re-run sends nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)