### PR TITLE
fix(wyrdfold): job alerts and resume reuse silently never fired

### DIFF
--- a/apps/wyrdfold-api/app/routers/tailor.py
+++ b/apps/wyrdfold-api/app/routers/tailor.py
@@ -83,6 +83,48 @@ router = APIRouter(
     dependencies=[Depends(verify_api_key_or_jwt)],
 )
 
+
+def _resolve_target_for_posting(
+    supabase: Client, *, user_id: str | None, job_posting_id: str
+) -> str | None:
+    """Resolve which target a posting belongs to, via ``scores``.
+
+    ``jobs.target_id`` is a vestigial column the poller never writes —
+    the job ↔ target link lives in ``scores`` (same resolution as
+    ``routers/jobs.py``). JWT callers are scoped to their own targets via
+    ``user_targets`` and get their best-scoring one when several match;
+    API-key (operator) callers resolve across all targets.
+    """
+    target_ids: list[str] | None = None
+    if user_id is not None:
+        ut_resp = (
+            supabase.table("user_targets")
+            .select("target_id")
+            .eq("user_id", user_id)
+            .execute()
+        )
+        target_ids = [
+            cast(dict[str, Any], r)["target_id"]
+            for r in (ut_resp.data or [])
+            if isinstance(r, dict) and r.get("target_id")
+        ]
+        if not target_ids:
+            return None
+
+    score_query = (
+        supabase.table("scores")
+        .select("target_id")
+        .eq("job_posting_id", job_posting_id)
+    )
+    if target_ids is not None:
+        score_query = score_query.in_("target_id", target_ids)
+    rows = (
+        score_query.order("score", desc=True).limit(1).execute().data or []
+    )
+    if not rows:
+        return None
+    return cast(str, cast(dict[str, Any], rows[0])["target_id"])
+
 @router.post(
     "/resume",
     responses={422: {"model": TailorLintFailureResponse | GapGateFailureResponse}},
@@ -120,51 +162,47 @@ async def create_tailored_resume(
 
     # Reuse check (#504): skip pipeline if a similar resume exists in the target
     if not body.force_fresh and body.job_posting_id:
-        jp_resp = (
-            supabase.table("jobs")
-            .select("target_id")
-            .eq("id", body.job_posting_id)
-            .execute()
+        target_id = _resolve_target_for_posting(
+            supabase, user_id=user_id, job_posting_id=body.job_posting_id
         )
-        if jp_resp.data:
-            target_id = cast(dict[str, Any], jp_resp.data[0]).get("target_id")
-            if target_id:
-                target_resp = (
-                    supabase.table("targets")
-                    .select("scoring_profile")
-                    .eq("id", target_id)
-                    .execute()
-                )
-                if target_resp.data:
-                    from app.models.targets import ScoringProfile
+        if target_id:
+            target_resp = (
+                supabase.table("targets")
+                .select("scoring_profile")
+                .eq("id", target_id)
+                .execute()
+            )
+            if target_resp.data:
+                from app.models.targets import ScoringProfile
 
-                    target_row = cast(dict[str, Any], target_resp.data[0])
-                    profile = ScoringProfile.model_validate(
-                        target_row["scoring_profile"]
+                target_row = cast(dict[str, Any], target_resp.data[0])
+                profile = ScoringProfile.model_validate(
+                    target_row["scoring_profile"]
+                )
+                keywords = extract_profile_keywords(profile)
+                if keywords:
+                    reusable = find_reusable_resume(
+                        supabase,
+                        target_id=target_id,
+                        job_description=body.job_description,
+                        profile_keywords=keywords,
+                        user_id=user_id,
                     )
-                    keywords = extract_profile_keywords(profile)
-                    if keywords:
-                        reusable = find_reusable_resume(
+                    if reusable is not None:
+                        cloned = clone_resume_for_job(
                             supabase,
-                            target_id=target_id,
+                            source=reusable,
+                            job_posting_id=body.job_posting_id,
                             job_description=body.job_description,
-                            profile_keywords=keywords,
+                            user_id=user_id,
                         )
-                        if reusable is not None:
-                            cloned = clone_resume_for_job(
-                                supabase,
-                                source=reusable,
-                                job_posting_id=body.job_posting_id,
-                                job_description=body.job_description,
-                                user_id=user_id,
-                            )
-                            persistence.mark_job_resume_draft(
-                                supabase, body.job_posting_id
-                            )
-                            return TailorResponse(
-                                record=cloned,
-                                lint_warnings=[],
-                            )
+                        persistence.mark_job_resume_draft(
+                            supabase, body.job_posting_id
+                        )
+                        return TailorResponse(
+                            record=cloned,
+                            lint_warnings=[],
+                        )
 
     prefs_row = preferences.get(supabase, user_id=user_id)
     prefs_payload = prefs_row.payload if prefs_row else None
@@ -701,13 +739,13 @@ async def create_batch_resumes(
             detail="no optimized doc — derive one via POST /experience/derive first",
         )
 
-    # Verify all job posting IDs exist and fetch their descriptions + target_id.
+    # Verify all job posting IDs exist and fetch their descriptions.
     # Single .in_() round-trip; .in_() does not guarantee row order, so re-map
-    # by id to preserve the input ordering (downstream uses postings[0] for the
-    # common target_id and processes jobs in request order).
+    # by id to preserve the input ordering (downstream processes jobs in
+    # request order).
     resp = (
         supabase.table("jobs")
-        .select("id, title, description_html, target_id")
+        .select("id, title, description_html")
         .in_("id", body.job_posting_ids)
         .execute()
     )
@@ -726,8 +764,16 @@ async def create_batch_resumes(
             warnings.append(f"no_description:{jid}")
         postings.append(row)
 
-    # Derive common target_id from first posting (all batch jobs share a target)
-    target_id: str | None = postings[0].get("target_id") if postings else None
+    # Derive the common target from the first posting (all batch jobs share
+    # a target). Resolved via ``scores`` — ``jobs.target_id`` is vestigial
+    # and always NULL, which silently disabled batch reuse.
+    target_id: str | None = (
+        _resolve_target_for_posting(
+            supabase, user_id=user_id, job_posting_id=body.job_posting_ids[0]
+        )
+        if body.job_posting_ids
+        else None
+    )
 
     prefs_row = preferences.get(supabase, user_id=user_id)
     prefs_payload = prefs_row.payload if prefs_row else None

--- a/apps/wyrdfold-api/app/services/batch.py
+++ b/apps/wyrdfold-api/app/services/batch.py
@@ -172,6 +172,7 @@ async def process_batch(
                     target_id=target_id,
                     job_description=description_html,
                     profile_keywords=scoring_keywords,
+                    user_id=user_id,
                 )
                 if reusable is not None:
                     cloned = clone_resume_for_job(

--- a/apps/wyrdfold-api/app/services/poller.py
+++ b/apps/wyrdfold-api/app/services/poller.py
@@ -459,6 +459,34 @@ async def _batch_fetch_job_scores(
     }
 
 
+async def _load_alert_rows(
+    supabase: Client, new_rows: list[dict[str, Any]]
+) -> list[dict[str, Any]]:
+    """Re-read newly-inserted job rows with their post-scoring state.
+
+    The upsert response rows carry ``score = 0`` (the column default) —
+    the scoring stages write final scores to the DB afterwards without
+    mutating those in-memory dicts. Alert thresholds compare against
+    ``score``, so dispatching with the stale rows means no alert can
+    ever clear the bar. Falls back to the stale rows on a read failure
+    (alerts then skip this cycle, matching the old behavior, but the
+    failure is logged instead of silent).
+    """
+    new_ids = [r["id"] for r in new_rows if r.get("id")]
+    if not new_ids:
+        return new_rows
+    try:
+        resp = await asyncio.to_thread(
+            supabase.table("jobs").select("*").in_("id", new_ids).execute
+        )
+        refreshed = cast(list[dict[str, Any]], resp.data or [])
+        if refreshed:
+            return refreshed
+    except Exception:
+        logger.exception("Alert-row refresh failed — dispatching stale rows")
+    return new_rows
+
+
 async def _run_llm_scoring_for_row(
     supabase: Client,
     row_data: dict[str, Any],
@@ -1228,14 +1256,19 @@ async def _poll_one_source(
 
         # Fire email + SMS alerts for newly-inserted high-scoring jobs.
         if new_rows:
+            # ``new_rows`` was captured from the upsert response BEFORE any
+            # scoring ran, so ``score`` there is the column default 0 — which
+            # failed every alert threshold and meant no alert ever fired.
+            # Re-read the rows now that the stages have written final scores.
+            alert_rows = await _load_alert_rows(supabase, new_rows)
             try:
-                await notify.send_alerts_for_new_jobs(supabase, new_rows)
+                await notify.send_alerts_for_new_jobs(supabase, alert_rows)
             except Exception:
                 logger.exception(
                     "Email alert dispatch raised for %s", company_name
                 )
             try:
-                await notify.send_sms_alerts_for_new_jobs(supabase, new_rows)
+                await notify.send_sms_alerts_for_new_jobs(supabase, alert_rows)
             except Exception:
                 logger.exception(
                     "SMS alert dispatch raised for %s", company_name

--- a/apps/wyrdfold-api/app/services/tailor/reuse.py
+++ b/apps/wyrdfold-api/app/services/tailor/reuse.py
@@ -58,45 +58,82 @@ def jd_similarity(
     return len(hits_a & hits_b) / len(union)
 
 
+# How many of the caller's most recent resumes we consider for reuse.
+# Pulled first (cheap, user-scoped) and then filtered to the target via
+# ``scores`` membership — keeps the ``.in_()`` list bounded regardless of
+# how many postings the target has accumulated.
+_RECENT_RESUMES_WINDOW = 50
+_MAX_CANDIDATES = 10
+
+
 def find_reusable_resume(
     supabase: Client,
     *,
     target_id: str,
     job_description: str,
     profile_keywords: set[str],
+    user_id: str | None = None,
 ) -> TailoredResumeRecord | None:
     """Find an existing resume in the same target similar enough to reuse.
 
-    Queries documents for jobs sharing the same target_id.
+    The job ↔ target link lives in the ``scores`` table — ``jobs.target_id``
+    is a vestigial column the poller never populates, so the previous
+    implementation (``jobs.eq("target_id", …)``) always returned an empty
+    id list and reuse silently never fired (same root cause as the #676
+    ownership fixes). We now pull the caller's recent resumes and keep the
+    ones whose posting carries a ``scores`` row for this target.
+
+    Scoped to ``user_id`` so one user's resume is never cloned into
+    another user's documents (``user_id=None`` matches operator-created
+    rows, mirroring the batch-service convention).
+
     Returns the best match above SIMILARITY_THRESHOLD, or None.
     """
-    # Get job_posting_ids in this target
-    jp_resp = (
-        supabase.table("jobs")
-        .select("id")
-        .eq("target_id", target_id)
-        .execute()
-    )
-    jp_ids = [cast(dict[str, Any], r)["id"] for r in (jp_resp.data or [])]
-    if not jp_ids:
-        return None
-
-    # Get recent resumes for those job postings
-    resp = (
+    docs_query = (
         supabase.table("documents")
         .select("*")
-        .in_("job_posting_id", jp_ids)
         .eq("document_type", "resume")
         .order("created_at", desc=True)
-        .limit(10)
+        .limit(_RECENT_RESUMES_WINDOW)
+    )
+    docs_query = (
+        docs_query.is_("user_id", "null")
+        if user_id is None
+        else docs_query.eq("user_id", user_id)
+    )
+    rows = cast(list[dict[str, Any]], docs_query.execute().data or [])
+    posting_ids = list(
+        {
+            cast(str, r.get("job_posting_id"))
+            for r in rows
+            if r.get("job_posting_id")
+        }
+    )
+    if not posting_ids:
+        return None
+
+    scores_resp = (
+        supabase.table("scores")
+        .select("job_posting_id")
+        .eq("target_id", target_id)
+        .in_("job_posting_id", posting_ids)
         .execute()
     )
-    rows = cast(list[dict[str, Any]], resp.data or [])
+    in_target = {
+        cast(dict[str, Any], r)["job_posting_id"]
+        for r in (scores_resp.data or [])
+    }
+    if not in_target:
+        return None
+
+    candidates = [
+        r for r in rows if r.get("job_posting_id") in in_target
+    ][:_MAX_CANDIDATES]
 
     best_record: TailoredResumeRecord | None = None
     best_sim = 0.0
 
-    for row in rows:
+    for row in candidates:
         jd_snapshot = row.get("jd_snapshot", "")
         sim = jd_similarity(job_description, jd_snapshot, profile_keywords)
         if sim >= SIMILARITY_THRESHOLD and sim > best_sim:

--- a/apps/wyrdfold-api/tests/test_poller.py
+++ b/apps/wyrdfold-api/tests/test_poller.py
@@ -505,3 +505,53 @@ async def test_phase1_triage_skips_known_external_ids(monkeypatch):
     # one fails the title prematch), so nothing was scored this cycle.
     assert summary["new"] == 0
     assert summary["updated"] == 0
+
+
+# ---- alert-row refresh ------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_load_alert_rows_returns_post_scoring_state():
+    """Regression: alerts dispatched with the upsert-time rows, where
+    ``score`` is the column default 0 — so no alert ever cleared the
+    threshold. The refresh must return the DB rows written by scoring."""
+    from app.services.poller import _load_alert_rows
+
+    stale = [{"id": "job-1", "title": "T1", "score": 0}]
+    refreshed_row = {"id": "job-1", "title": "T1", "score": 88}
+
+    supabase = MagicMock()
+    supabase.table.return_value.select.return_value.in_.return_value.execute.return_value.data = [
+        refreshed_row
+    ]
+
+    rows = await _load_alert_rows(supabase, stale)
+
+    assert rows == [refreshed_row]
+    supabase.table.return_value.select.return_value.in_.assert_called_once_with(
+        "id", ["job-1"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_load_alert_rows_falls_back_to_stale_rows_on_error():
+    from app.services.poller import _load_alert_rows
+
+    stale = [{"id": "job-1", "score": 0}]
+    supabase = MagicMock()
+    supabase.table.side_effect = RuntimeError("db down")
+
+    rows = await _load_alert_rows(supabase, stale)
+
+    assert rows == stale
+
+
+@pytest.mark.asyncio
+async def test_load_alert_rows_no_ids_short_circuits():
+    from app.services.poller import _load_alert_rows
+
+    supabase = MagicMock()
+    rows = await _load_alert_rows(supabase, [{"title": "no id"}])
+
+    assert rows == [{"title": "no id"}]
+    supabase.table.assert_not_called()

--- a/apps/wyrdfold-api/tests/test_reuse.py
+++ b/apps/wyrdfold-api/tests/test_reuse.py
@@ -130,34 +130,41 @@ def test_jd_similarity_high_overlap() -> None:
 
 
 # ---- find_reusable_resume ----
+#
+# The lookup pivots through ``scores`` (the real job ↔ target link) —
+# ``jobs.target_id`` is vestigial and always NULL, which is exactly the
+# regression that silently disabled reuse before. The mocks below mirror
+# the new chain: recent user-scoped documents first, then a scores
+# membership check for the target.
 
 
-def test_find_reusable_resume_no_jobs_in_target() -> None:
-    supabase = MagicMock()
-    supabase.table.return_value.select.return_value.eq.return_value.execute.return_value.data = []
-
-    result = find_reusable_resume(
-        supabase,
-        target_id="target-1",
-        job_description="some jd",
-        profile_keywords={"react", "typescript"},
+def _reuse_supabase(
+    doc_rows: list[dict],
+    score_rows: list[dict],
+) -> MagicMock:
+    docs_mock = MagicMock()
+    docs_chain = (
+        docs_mock.select.return_value.eq.return_value.order.return_value.limit.return_value
     )
-    assert result is None
+    # ``user_id=None`` path uses .is_("user_id", "null"); a real user uses .eq.
+    docs_chain.is_.return_value.execute.return_value.data = doc_rows
+    docs_chain.eq.return_value.execute.return_value.data = doc_rows
+
+    scores_mock = MagicMock()
+    scores_mock.select.return_value.eq.return_value.in_.return_value.execute.return_value.data = (
+        score_rows
+    )
+
+    supabase = MagicMock()
+    supabase.table.side_effect = lambda name: {
+        "documents": docs_mock,
+        "scores": scores_mock,
+    }[name]
+    return supabase
 
 
 def test_find_reusable_resume_no_resumes() -> None:
-    supabase = MagicMock()
-
-    # First call: jobs query returns IDs
-    jp_mock = MagicMock()
-    jp_mock.select.return_value.eq.return_value.execute.return_value.data = [{"id": "jp-1"}]
-
-    # Second call: documents query returns empty
-    tr_mock = MagicMock()
-    tr_chain = tr_mock.select.return_value.in_.return_value.eq.return_value.order.return_value
-    tr_chain.limit.return_value.execute.return_value.data = []
-
-    supabase.table.side_effect = lambda name: jp_mock if name == "jobs" else tr_mock
+    supabase = _reuse_supabase(doc_rows=[], score_rows=[])
 
     result = find_reusable_resume(
         supabase,
@@ -168,21 +175,30 @@ def test_find_reusable_resume_no_resumes() -> None:
     assert result is None
 
 
+def test_find_reusable_resume_posting_not_in_target() -> None:
+    """A recent resume whose posting has no scores row for this target
+    must not be reused."""
+    resume_row = _record(
+        jd_snapshot="React TypeScript GraphQL Node.js developer"
+    ).model_dump(mode="json")
+    supabase = _reuse_supabase(doc_rows=[resume_row], score_rows=[])
+
+    result = find_reusable_resume(
+        supabase,
+        target_id="target-1",
+        job_description="React TypeScript GraphQL Node.js developer needed",
+        profile_keywords={"react", "typescript", "graphql", "node.js"},
+    )
+    assert result is None
+
+
 def test_find_reusable_resume_below_threshold() -> None:
-    supabase = MagicMock()
-
-    jp_mock = MagicMock()
-    jp_mock.select.return_value.eq.return_value.execute.return_value.data = [{"id": "jp-1"}]
-
-    # Resume with very different JD
     resume_row = _record(jd_snapshot="Looking for a Python Django developer").model_dump(
         mode="json"
     )
-    tr_mock = MagicMock()
-    tr_chain = tr_mock.select.return_value.in_.return_value.eq.return_value.order.return_value
-    tr_chain.limit.return_value.execute.return_value.data = [resume_row]
-
-    supabase.table.side_effect = lambda name: jp_mock if name == "jobs" else tr_mock
+    supabase = _reuse_supabase(
+        doc_rows=[resume_row], score_rows=[{"job_posting_id": "jp-1"}]
+    )
 
     result = find_reusable_resume(
         supabase,
@@ -194,20 +210,12 @@ def test_find_reusable_resume_below_threshold() -> None:
 
 
 def test_find_reusable_resume_above_threshold() -> None:
-    supabase = MagicMock()
-
-    jp_mock = MagicMock()
-    jp_mock.select.return_value.eq.return_value.execute.return_value.data = [{"id": "jp-1"}]
-
-    # Resume with very similar JD (all same keywords)
     resume_row = _record(
         jd_snapshot="Senior React TypeScript developer with GraphQL and Node.js"
     ).model_dump(mode="json")
-    tr_mock = MagicMock()
-    tr_chain = tr_mock.select.return_value.in_.return_value.eq.return_value.order.return_value
-    tr_chain.limit.return_value.execute.return_value.data = [resume_row]
-
-    supabase.table.side_effect = lambda name: jp_mock if name == "jobs" else tr_mock
+    supabase = _reuse_supabase(
+        doc_rows=[resume_row], score_rows=[{"job_posting_id": "jp-1"}]
+    )
 
     kws = {"react", "typescript", "graphql", "node.js"}
     result = find_reusable_resume(
@@ -218,6 +226,9 @@ def test_find_reusable_resume_above_threshold() -> None:
     )
     assert result is not None
     assert result.id == "rec-1"
+    # Regression guard: the lookup must never touch the vestigial
+    # ``jobs.target_id`` column.
+    assert all(c.args[0] != "jobs" for c in supabase.table.call_args_list)
 
 
 # ---- clone_resume_for_job ----


### PR DESCRIPTION
## Summary
Both fixes from the API audit's HIGH bucket — same defect class (reader depends on state the writer never populates):

### Job alerts have never fired
`_poll_one_source` dispatched `notify.send_alerts_for_new_jobs` / `send_sms_alerts_for_new_jobs` with the rows from the **upsert response**, captured before any scoring stage ran — `score` there is the column default `0`. The email (≥70) and SMS (≥85) gates therefore failed for every job, every cycle: zero alerts, ever. The poller now re-reads the newly-inserted rows after scoring completes (`_load_alert_rows`) and dispatches with live scores. A refresh failure logs and falls back to the stale rows (old behavior, but observable).

### Resume reuse (#504) silently disabled
`find_reusable_resume` listed the target's postings via `jobs.target_id` — a vestigial column the poller never writes (the job↔target link lives in `scores`; same root cause as the #676 ownership fixes). The id list was always empty, so the zero-cost clone path never fired and **every** tailor request paid the full LLM pipeline. Now:
- The lookup pivots through `scores`, with the `.in_()` list bounded by a recent-resumes window (50) instead of all postings in the target.
- It's scoped to the caller's `user_id` — previously (had it worked) one user's resume could be cloned into another user's documents on a shared target.
- Both router call sites resolve the posting's target through `scores` via a shared `_resolve_target_for_posting` helper (JWT callers scoped to their own `user_targets`, best-scoring target wins; the batch path derives its common target the same way).

## Test plan
- [x] Full wyrdfold-api suite: **1240 passed**; ruff + mypy clean
- [x] New: `_load_alert_rows` returns post-scoring rows / falls back on error / short-circuits without ids
- [x] Reuse tests rewritten for the scores pivot, including a regression guard that the lookup never touches `jobs.target_id` and a posting-not-in-target case

🤖 Generated with [Claude Code](https://claude.com/claude-code)