### PR TITLE
feat(wyrdfold): per-account LLM kill-switch (llm_enabled)

### DIFF
--- a/apps/wyrdfold-api/app/dependencies.py
+++ b/apps/wyrdfold-api/app/dependencies.py
@@ -327,14 +327,16 @@ def enforce_llm_budget(
         return
     from app.services.llm import budget
 
+    monthly_cap, llm_enabled = budget.get_llm_account(
+        supabase, user_id=user_id, default_usd=s.user_llm_monthly_budget_usd
+    )
+    budget.raise_if_llm_disabled(llm_enabled)
     budget.check_user_budget(
         supabase,
         user_id=user_id,
         daily_limit_usd=s.user_llm_daily_budget_usd,
         hourly_limit_usd=s.user_llm_hourly_budget_usd,
-        monthly_limit_usd=budget.effective_monthly_cap(
-            supabase, user_id=user_id, default_usd=s.user_llm_monthly_budget_usd
-        ),
+        monthly_limit_usd=monthly_cap,
     )
 
 

--- a/apps/wyrdfold-api/app/services/llm/budget.py
+++ b/apps/wyrdfold-api/app/services/llm/budget.py
@@ -25,25 +25,45 @@ no first-of-month reset stampede, and it matches how Claude's own usage
 limits behave."""
 
 
-def effective_monthly_cap(
+def get_llm_account(
     supabase: Client, *, user_id: str, default_usd: float
-) -> float:
-    """Resolve the user's monthly allowance: per-user override or default.
+) -> tuple[float, bool]:
+    """One profile read → (effective monthly cap, llm_enabled).
 
-    ``user_profiles.llm_monthly_budget_usd`` is the manual "add credits"
-    lever — NULL (or no profile row) means the global default applies.
+    ``llm_monthly_budget_usd`` is the manual "add credits" lever — NULL
+    (or no profile row) means the global default. ``llm_enabled`` is the
+    operator kill-switch; missing rows default to enabled.
     """
     rows = cast(
         list[dict[str, Any]],
         supabase.table("user_profiles")
-        .select("llm_monthly_budget_usd")
+        .select("llm_monthly_budget_usd,llm_enabled")
         .eq("user_id", user_id)
         .execute()
         .data
         or [],
     )
     override = rows[0].get("llm_monthly_budget_usd") if rows else None
-    return float(cast(float, override)) if override is not None else default_usd
+    enabled = bool(rows[0].get("llm_enabled", True)) if rows else True
+    cap = float(cast(float, override)) if override is not None else default_usd
+    return cap, enabled
+
+
+def effective_monthly_cap(
+    supabase: Client, *, user_id: str, default_usd: float
+) -> float:
+    """Back-compat wrapper around :func:`get_llm_account` (cap only)."""
+    cap, _ = get_llm_account(supabase, user_id=user_id, default_usd=default_usd)
+    return cap
+
+
+def raise_if_llm_disabled(enabled: bool) -> None:
+    """403 when the operator kill-switch is off for this account."""
+    if not enabled:
+        raise HTTPException(
+            status_code=403,
+            detail={"code": "llm_disabled"},
+        )
 
 
 def _raise_budget_429(scope: str, limit_usd: float, spent_usd: float) -> None:

--- a/apps/wyrdfold-api/app/services/targets/payers.py
+++ b/apps/wyrdfold-api/app/services/targets/payers.py
@@ -58,6 +58,7 @@ class PayerBudgetGate:
     payer_by_target: dict[str, str | None] = field(default_factory=dict)
     over_budget_users: frozenset[str] = frozenset()
     idle_users: frozenset[str] = frozenset()
+    disabled_users: frozenset[str] = frozenset()
 
     def payer_for(self, target_id: str) -> str | None:
         return self.payer_by_target.get(target_id)
@@ -65,20 +66,21 @@ class PayerBudgetGate:
     def target_blocked(self, target_id: str) -> bool:
         """True when this target's LLM work must be skipped this cycle.
 
-        Blocked when the payer is over budget, idle, OR unknown (orphan
-        active target, or activated after the snapshot) — never spend
-        money nobody will consume. Jobs still ingest fail-open; grading
-        resumes once the payer's window frees up / they return.
+        Blocked when the payer is over budget, idle, operator-disabled,
+        OR unknown (orphan active target, or activated after the
+        snapshot) — never spend money nobody will consume. Jobs still
+        ingest fail-open; grading resumes once the payer's window frees
+        up / they return / the operator re-enables them.
         """
         payer = self.payer_by_target.get(target_id)
-        return (
-            payer is None
-            or payer in self.over_budget_users
-            or payer in self.idle_users
-        )
+        return payer is None or self.user_blocked(payer)
 
     def user_blocked(self, user_id: str) -> bool:
-        return user_id in self.over_budget_users or user_id in self.idle_users
+        return (
+            user_id in self.over_budget_users
+            or user_id in self.idle_users
+            or user_id in self.disabled_users
+        )
 
 
 def build_budget_gate(
@@ -100,15 +102,18 @@ def build_budget_gate(
 
     overrides: dict[str, float | None] = {}
     last_seen: dict[str, str | None] = {}
+    disabled: set[str] = set()
     resp = (
         supabase.table("user_profiles")
-        .select("user_id,llm_monthly_budget_usd,last_seen_at")
+        .select("user_id,llm_monthly_budget_usd,last_seen_at,llm_enabled")
         .in_("user_id", distinct)
         .execute()
     )
     for row in cast(list[dict[str, Any]], resp.data or []):
         overrides[row["user_id"]] = row.get("llm_monthly_budget_usd")
         last_seen[row["user_id"]] = row.get("last_seen_at")
+        if row.get("llm_enabled", True) is False:
+            disabled.add(row["user_id"])
 
     now = datetime.now(UTC)
     since = now - timedelta(days=MONTHLY_WINDOW_DAYS)
@@ -121,6 +126,9 @@ def build_budget_gate(
         else None
     )
     for uid in distinct:
+        if uid in disabled:
+            # Operator kill-switch — skip idle/spend checks entirely.
+            continue
         if idle_cutoff is not None:
             seen_raw = last_seen.get(uid)
             if seen_raw is not None:
@@ -142,4 +150,5 @@ def build_budget_gate(
         payer_by_target=payers,
         over_budget_users=frozenset(over),
         idle_users=frozenset(idle),
+        disabled_users=frozenset(disabled),
     )

--- a/apps/wyrdfold-api/tests/test_dependencies.py
+++ b/apps/wyrdfold-api/tests/test_dependencies.py
@@ -376,12 +376,12 @@ def test_enforce_llm_budget_jwt_user_invokes_check(monkeypatch):
         )
 
     monkeypatch.setattr(budget_mod, "check_user_budget", _spy)
-    # The dep resolves the monthly cap (user_profiles override ?? default)
-    # before the check — stub it so no Supabase round-trip happens.
+    # The dep resolves (cap, llm_enabled) from user_profiles before the
+    # check — stub it so no Supabase round-trip happens.
     monkeypatch.setattr(
         budget_mod,
-        "effective_monthly_cap",
-        lambda supabase, *, user_id, default_usd: default_usd,
+        "get_llm_account",
+        lambda supabase, *, user_id, default_usd: (default_usd, True),
     )
     enforce_llm_budget(
         user_id=USER_SUB,
@@ -409,13 +409,34 @@ def test_enforce_llm_budget_monthly_honors_profile_override(monkeypatch):
     monkeypatch.setattr(budget_mod, "check_user_budget", _spy)
     monkeypatch.setattr(
         budget_mod,
-        "effective_monthly_cap",
-        lambda supabase, *, user_id, default_usd: 25.0,
+        "get_llm_account",
+        lambda supabase, *, user_id, default_usd: (25.0, True),
     )
     enforce_llm_budget(
         user_id=USER_SUB, supabase=MagicMock(), s=_budget_settings(monthly=5.0)
     )
     assert captured["monthly_limit_usd"] == 25.0
+
+
+def test_enforce_llm_budget_disabled_account_403s(monkeypatch):
+    """The operator kill-switch blocks before any spend math runs."""
+    from app.services.llm import budget as budget_mod
+
+    monkeypatch.setattr(
+        budget_mod,
+        "get_llm_account",
+        lambda supabase, *, user_id, default_usd: (default_usd, False),
+    )
+    check_spy = MagicMock()
+    monkeypatch.setattr(budget_mod, "check_user_budget", check_spy)
+
+    with pytest.raises(HTTPException) as exc:
+        enforce_llm_budget(
+            user_id=USER_SUB, supabase=MagicMock(), s=_budget_settings()
+        )
+    assert exc.value.status_code == 403
+    assert exc.value.detail["code"] == "llm_disabled"
+    check_spy.assert_not_called()
 
 
 def test_enforce_llm_budget_propagates_429(monkeypatch):

--- a/apps/wyrdfold-api/tests/test_llm_cost_caps.py
+++ b/apps/wyrdfold-api/tests/test_llm_cost_caps.py
@@ -264,6 +264,38 @@ def test_build_gate_zero_cap_disables_gating(monkeypatch):
     assert spend_called is False  # 0 cap short-circuits the spend query
 
 
+def test_build_gate_blocks_operator_disabled_user(monkeypatch):
+    """llm_enabled=false (the operator kill-switch) blocks the payer's
+    background work without touching spend/idle checks."""
+    import app.services.targets.payers as payers_mod
+
+    monkeypatch.setattr(
+        payers_mod,
+        "resolve_target_payers",
+        lambda sb, ids: {"t-off": "u-off", "t-on": "u-on"},
+    )
+    sb = MagicMock()
+    sb.table.return_value.select.return_value.in_.return_value.execute.return_value.data = [
+        {"user_id": "u-off", "llm_monthly_budget_usd": None, "llm_enabled": False},
+        {"user_id": "u-on", "llm_monthly_budget_usd": None, "llm_enabled": True},
+    ]
+    monkeypatch.setattr(payers_mod.settings, "user_llm_monthly_budget_usd", 5.0)
+    monkeypatch.setattr(payers_mod.settings, "idle_defer_days", 0)
+    spend_calls: list[str] = []
+
+    def _spend(sb, user_id, since):
+        spend_calls.append(user_id)
+        return 0.0
+
+    monkeypatch.setattr(payers_mod.cost_log, "total_spend", _spend)
+
+    gate = build_budget_gate(sb, ["t-off", "t-on"])
+    assert gate.target_blocked("t-off") is True
+    assert gate.user_blocked("u-off") is True
+    assert gate.target_blocked("t-on") is False
+    assert spend_calls == ["u-on"]  # disabled user skips the spend query
+
+
 def test_build_gate_override_raises_cap(monkeypatch):
     """A user_profiles override above the spend keeps the payer unblocked."""
     import app.services.targets.payers as payers_mod

--- a/apps/wyrdfold/src/lib/extractApiError.ts
+++ b/apps/wyrdfold/src/lib/extractApiError.ts
@@ -94,6 +94,15 @@ export async function extractApiError(
     detail &&
     typeof detail === 'object' &&
     'code' in detail &&
+    (detail as { code: unknown }).code === 'llm_disabled'
+  ) {
+    return 'AI features are currently disabled for your account.';
+  }
+
+  if (
+    detail &&
+    typeof detail === 'object' &&
+    'code' in detail &&
     (detail as { code: unknown }).code === 'analysis_daily_limit'
   ) {
     const d = detail as { limit?: number };

--- a/supabase/migrations/20260611120000_user_profiles_llm_enabled.sql
+++ b/supabase/migrations/20260611120000_user_profiles_llm_enabled.sql
@@ -1,0 +1,12 @@
+-- Operator kill-switch for per-account LLM spend.
+--
+-- FALSE blocks all of a user's LLM work: user-triggered endpoints 429
+-- and the poller defers their targets' background grading (jobs still
+-- ingest). Distinct from the budget override, where 0 means "window
+-- disabled" (unlimited), not blocked.
+
+ALTER TABLE public.user_profiles
+  ADD COLUMN IF NOT EXISTS llm_enabled boolean NOT NULL DEFAULT true;
+
+COMMENT ON COLUMN public.user_profiles.llm_enabled IS
+  'Operator kill-switch: FALSE blocks all LLM spend for this account (429 + poller defer).';


### PR DESCRIPTION
## Summary

Operator ran out of OpenRouter credits ($150, June 5–6, pre-#888 caps). This adds the manual lever to disable LLM spend per account while topping up, keeping a single test account live.

- **`user_profiles.llm_enabled boolean NOT NULL DEFAULT true`** — operator-flipped via SQL (no UI)
- `false` → user-triggered LLM endpoints **403 `{code: "llm_disabled"}`** before any spend math; the poller's `PayerBudgetGate` blocks the account's background grading (same defer semantics as over-budget/idle — jobs still ingest, grading pauses, re-enable resumes instantly)
- One profile read serves both the cap override and the flag (`get_llm_account`); `effective_monthly_cap` kept as a compat wrapper for the usage endpoint
- FE: clear copy for the 403 ("AI features are currently disabled for your account")
- Note: this is intentionally distinct from the budget override, where `0` means *unlimited* (window disabled), not blocked

## Test plan
- [x] API: ruff + mypy clean; pytest 1265 passed (new: 403 fires before budget math; gate blocks disabled payer and skips their spend query; existing cap/idle tests untouched)
- [x] FE: 469 passed
- [ ] Apply migration (`pnpm db:push`)
- [ ] Operator: flip flags (SQL below), verify a disabled account 403s and Mel's works

🤖 Generated with [Claude Code](https://claude.com/claude-code)