### PR TITLE
feat(wyrdfold): keep saved jobs viewable for deactivated targets

### DIFF
--- a/apps/wyrdfold-api/scripts/analyze_llm_burn.py
+++ b/apps/wyrdfold-api/scripts/analyze_llm_burn.py
@@ -1,0 +1,79 @@
+"""Read-only: where did the LLM spend go? Groups llm_costs by purpose/day/user.
+
+Run with SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY in env. Pass --since/--until
+ISO dates to bound the window (default 2026-06-04 .. 2026-06-11).
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+from collections import defaultdict
+
+from supabase import create_client
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--since", default="2026-06-04")
+    ap.add_argument("--until", default="2026-06-11")
+    args = ap.parse_args()
+
+    url = os.environ.get("SUPABASE_URL") or os.environ["NEXT_PUBLIC_SUPABASE_URL"]
+    sb = create_client(url, os.environ["SUPABASE_SERVICE_ROLE_KEY"])
+
+    rows: list[dict] = []
+    page = 0
+    while True:
+        chunk = (
+            sb.table("llm_costs")
+            .select("cost_usd,purpose,user_id,created_at,metadata")
+            .gte("created_at", args.since)
+            .lt("created_at", args.until)
+            .order("created_at")
+            .range(page * 1000, page * 1000 + 999)
+            .execute()
+            .data
+            or []
+        )
+        rows.extend(chunk)
+        if len(chunk) < 1000:
+            break
+        page += 1
+
+    total = sum(float(r.get("cost_usd") or 0) for r in rows)
+    print(f"window {args.since} .. {args.until}: {len(rows)} calls, ${total:.2f} total\n")
+
+    by_purpose: dict[str, list[float]] = defaultdict(list)
+    by_day: dict[str, float] = defaultdict(float)
+    by_user: dict[str, float] = defaultdict(float)
+    by_target: dict[str, float] = defaultdict(float)
+    for r in rows:
+        c = float(r.get("cost_usd") or 0)
+        by_purpose[r.get("purpose") or "?"].append(c)
+        by_day[str(r.get("created_at"))[:10]] += c
+        by_user[str(r.get("user_id"))] += c
+        meta = r.get("metadata") or {}
+        tid = meta.get("target_id") if isinstance(meta, dict) else None
+        if tid:
+            by_target[str(tid)] += c
+
+    print("BY PURPOSE (cost desc):")
+    for p, costs in sorted(by_purpose.items(), key=lambda kv: -sum(kv[1])):
+        print(f"  {p:35} ${sum(costs):8.2f}  calls={len(costs):6d}  avg=${sum(costs)/len(costs):.4f}")
+
+    print("\nBY DAY:")
+    for d in sorted(by_day):
+        print(f"  {d}  ${by_day[d]:8.2f}")
+
+    print("\nBY USER:")
+    for u, c in sorted(by_user.items(), key=lambda kv: -kv[1]):
+        print(f"  {u:40} ${c:8.2f}")
+
+    print("\nBY TARGET (where metadata.target_id present):")
+    for t, c in sorted(by_target.items(), key=lambda kv: -kv[1])[:10]:
+        print(f"  {t:40} ${c:8.2f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/wyrdfold/src/app/(app)/jobs/JobsList.tsx
+++ b/apps/wyrdfold/src/app/(app)/jobs/JobsList.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useRouter } from 'next/navigation';
 import { Heading } from '@danieljoffe/shared-ui/Heading';
 import { Spinner } from '@danieljoffe/shared-ui/Spinner';
 import { Text } from '@danieljoffe/shared-ui/Text';
@@ -20,6 +21,9 @@ import { useJobsUrlState } from './useJobsUrlState';
 export interface TargetTab {
   id: string;
   label: string;
+  /** Deactivated link — saved jobs stay viewable, but polling/grading
+   * is paused until the user reactivates. */
+  paused: boolean;
 }
 
 const BATCH_POLL_INTERVAL = 3000;
@@ -219,6 +223,34 @@ export default function JobsList({
   const activatingRef = useRef<Set<string>>(new Set());
   const pollRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
   const { toast } = useToast();
+  const router = useRouter();
+
+  // Paused-tab reactivation. The server re-render (router.refresh) flips
+  // the tab's ``paused`` flag and the activation pipeline takes over.
+  const [reactivating, setReactivating] = useState(false);
+  const selectedTab = initialTargets.find(t => t.id === activeTargetId);
+
+  const handleReactivate = useCallback(async () => {
+    if (!activeTargetId) return;
+    setReactivating(true);
+    try {
+      const res = await fetch(`/api/targets/${activeTargetId}/activate`, {
+        method: 'POST',
+      });
+      if (!res.ok)
+        throw new Error(await extractApiError(res, 'Reactivate failed'));
+      toast({ variant: 'success', title: 'Target reactivated' });
+      router.refresh();
+    } catch (err) {
+      toast({
+        variant: 'error',
+        title:
+          err instanceof Error ? err.message : 'Failed to reactivate target',
+      });
+    } finally {
+      setReactivating(false);
+    }
+  }, [activeTargetId, toast, router]);
 
   const targets = initialTargets;
 
@@ -640,11 +672,39 @@ export default function JobsList({
                       : 'border-transparent text-text-secondary hover:text-text-primary hover:border-border-secondary'
                   )}
                 >
-                  {target.label}
+                  {target.paused ? `${target.label} (paused)` : target.label}
                 </button>
               ))}
             </div>
           </div>
+
+          {selectedTab?.paused && (
+            <Card padding='none'>
+              <CardContent className='flex flex-col items-start gap-3 p-4 sm:flex-row sm:items-center sm:justify-between'>
+                <Text variant='caption' className='text-text-secondary'>
+                  This target is paused — showing saved jobs; new roles
+                  aren&apos;t being fetched or scored. Reactivate to resume
+                  matching.
+                </Text>
+                <Button
+                  name='jobs-reactivate-target'
+                  variant='outline'
+                  size='sm'
+                  onClick={handleReactivate}
+                  disabled={reactivating}
+                >
+                  {reactivating ? (
+                    <>
+                      <Spinner size='sm' aria-label='Reactivating' />
+                      <span>Reactivating...</span>
+                    </>
+                  ) : (
+                    <span>Reactivate</span>
+                  )}
+                </Button>
+              </CardContent>
+            </Card>
+          )}
 
           {activeTargetId && activationStatus === 'deriving' && (
             <div className='flex items-center gap-2 text-sm text-text-secondary'>

--- a/apps/wyrdfold/src/app/(app)/jobs/__tests__/JobsList.spec.tsx
+++ b/apps/wyrdfold/src/app/(app)/jobs/__tests__/JobsList.spec.tsx
@@ -221,8 +221,8 @@ describe('JobsList — empty targets state', () => {
 
 describe('JobsList — with targets', () => {
   const TARGETS: TargetTab[] = [
-    { id: 't1', label: 'Frontend' },
-    { id: 't2', label: 'Backend' },
+    { id: 't1', label: 'Frontend', paused: false },
+    { id: 't2', label: 'Backend', paused: false },
   ];
 
   it('renders the page heading and a target filter group with "All Jobs" + targets', () => {
@@ -250,6 +250,38 @@ describe('JobsList — with targets', () => {
     expect(
       screen.getByRole('button', { name: /backend/i })
     ).toBeInTheDocument();
+  });
+
+  it('marks paused targets in the tab strip and shows the paused banner with a working Reactivate', async () => {
+    const user = userEvent.setup();
+    const PAUSED: TargetTab[] = [
+      { id: 't1', label: 'Frontend', paused: false },
+      { id: 't2', label: 'Backend', paused: true },
+    ];
+    const fetchSpy = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ activation_status: 'ready', jobs_count: 0 }),
+    });
+    global.fetch = fetchSpy as unknown as typeof fetch;
+
+    render(<JobsList targetId='t2' initialTargets={PAUSED} />);
+
+    expect(
+      screen.getByRole('button', { name: /backend \(paused\)/i })
+    ).toBeInTheDocument();
+    expect(screen.getByText(/this target is paused/i)).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /^reactivate$/i }));
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith('/api/targets/t2/activate', {
+        method: 'POST',
+      });
+    });
+  });
+
+  it('shows no paused banner on active targets', () => {
+    render(<JobsList targetId='t1' initialTargets={TARGETS} />);
+    expect(screen.queryByText(/this target is paused/i)).toBeNull();
   });
 
   it('renders the loading skeleton state via JobsListView', () => {

--- a/apps/wyrdfold/src/app/(app)/jobs/page.tsx
+++ b/apps/wyrdfold/src/app/(app)/jobs/page.tsx
@@ -36,13 +36,17 @@ export default async function FittedJobsPage({
   const targetsRes = await fetchJsonFromWyrdfoldAPI<{
     targets: UserTargetWithSummary[];
   }>('/targets/mine');
-  const initialTargets: TargetTab[] = (targetsRes?.targets ?? [])
-    .filter(t => t.user_target.is_active)
-    .map(t => ({ id: t.target.id, label: t.target.label }));
+  // Deactivated targets stay visible as paused tabs — their saved jobs
+  // remain browsable (DB reads are free); only polling/grading stops.
+  const initialTargets: TargetTab[] = (targetsRes?.targets ?? []).map(t => ({
+    id: t.target.id,
+    label: t.target.label,
+    paused: !t.user_target.is_active,
+  }));
 
-  // If the URL points to a target this user doesn't have active, drop the
-  // filter rather than rendering an empty list. Server-side redirect avoids
-  // a render → effect → client redirect waterfall.
+  // If the URL points to a target this user isn't linked to at all, drop
+  // the filter rather than rendering an empty list. Server-side redirect
+  // avoids a render → effect → client redirect waterfall.
   if (targetId && !initialTargets.some(t => t.id === targetId)) {
     redirect('/jobs');
   }

--- a/apps/wyrdfold/src/app/(app)/targets/TargetCard.tsx
+++ b/apps/wyrdfold/src/app/(app)/targets/TargetCard.tsx
@@ -73,8 +73,10 @@ export default function TargetCard({
       label: 'View jobs',
       icon: <Briefcase className='size-4' aria-hidden />,
       onClick: () => onViewJobs(target.id),
-      // No jobs to view until the target is active *and* its profile exists.
-      disabled: !isActive || deriving,
+      // Saved jobs stay viewable even when the target is deactivated
+      // (the jobs page shows a paused banner). Only block while the
+      // profile is still deriving — nothing exists to show yet.
+      disabled: deriving,
     },
     {
       label: isActive ? 'Deactivate' : 'Activate',

--- a/apps/wyrdfold/src/app/(app)/targets/__tests__/TargetCard.spec.tsx
+++ b/apps/wyrdfold/src/app/(app)/targets/__tests__/TargetCard.spec.tsx
@@ -201,6 +201,31 @@ describe('TargetCard', () => {
     expect(onActivate).not.toHaveBeenCalled();
   });
 
+  it('keeps "View jobs" enabled on a deactivated target (saved jobs stay viewable)', async () => {
+    const user = userEvent.setup();
+    const onViewJobs = jest.fn();
+    const { container } = render(
+      <TargetCard
+        target={makeTarget({ is_active: false })}
+        fitScore={null}
+        fitScoreReasoning={null}
+        isActive={false}
+        onActivate={noop}
+        onDeactivate={noop}
+        onDelete={noop}
+        onViewJobs={onViewJobs}
+      />
+    );
+    const trigger = container.querySelector(
+      '[aria-haspopup="menu"]'
+    ) as HTMLElement;
+    await user.click(trigger);
+    const viewJobs = screen.getByRole('menuitem', { name: /view jobs/i });
+    expect(viewJobs).not.toHaveAttribute('aria-disabled', 'true');
+    await user.click(viewJobs);
+    expect(onViewJobs).toHaveBeenCalledWith('t-1');
+  });
+
   it('surfaces a failure state when derivation errored', () => {
     render(
       <TargetCard


### PR DESCRIPTION
## Summary

Deactivating a target used to hide its jobs completely — tab filtered out of /jobs, `?target=` server-redirected away, TargetCard "View jobs" disabled. But saved jobs are free DB reads; only polling/grading should stop. FE-only change (the API never gated on active status):

- Deactivated targets show as **"(paused)" tabs**; selecting one renders a banner — *"This target is paused — showing saved jobs; new roles aren't being fetched or scored"* — with an inline **Reactivate** button (existing `/activate` endpoint + `router.refresh()`)
- `/jobs?target=X` now only redirects when the user **isn't linked to X at all** (was: redirect when inactive)
- TargetCard **"View jobs" enabled** for inactive targets (still disabled while `deriving` — nothing to show yet)
- **Full interaction retained** on saved jobs (analyze/tailor/status) — per product decision, the #888 budget gates bound any LLM spend

Also includes the read-only `scripts/analyze_llm_burn.py` used to attribute the June 5–7 OpenRouter burn ($93.71 of $117.23 = Phase-1 title triage re-grading known titles; context for the upcoming pipeline-cost discussion).

## Test plan
- [x] FE: jest **472 passed** (new: paused tab label + banner + Reactivate POST wiring; no banner on active tabs; View jobs enabled+fires on inactive target); lint 0 errors
- [x] API untouched (script only)
- [ ] Preview: deactivated target's tab visible with banner; Reactivate flips it live; active targets unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)