### PR TITLE
perf(wyrdfold-api): free gates before LLM triage + Phase 2 on activation path

### DIFF
--- a/apps/wyrdfold-api/app/services/poller.py
+++ b/apps/wyrdfold-api/app/services/poller.py
@@ -333,6 +333,24 @@ def _is_us_location(location: str | None) -> bool:
     return not _NON_US_RE.search(location.lower())
 
 
+def _passes_free_gates(job: StandardJob, active_targets: list[JobTarget]) -> bool:
+    """The zero-cost ingestion gates, conjunction form.
+
+    Same semantics as the per-job loop in ``_poll_one_source`` — title
+    prematch (including the excluded-admits-for-audit rule and the
+    empty-``search_keywords`` fallback inside
+    ``_title_matches_any_target``; skipped entirely when no targets are
+    active) AND the US-location pass. Used to pre-filter the Phase 1
+    triage candidate set so the LLM only ever sees titles that could
+    actually be ingested: a job these gates reject is dropped in the
+    per-job loop regardless of its verdict, so classifying it is pure
+    spend.
+    """
+    if active_targets and not _title_matches_any_target(job.title, active_targets):
+        return False
+    return _is_us_location(job.location_name)
+
+
 def _content_dedupe_key(
     company: str | None, title: str | None
 ) -> tuple[str, str]:
@@ -791,11 +809,19 @@ async def _poll_one_source(
         # admitted on a previous cycle; re-triaging them re-paid the LLM
         # cost for the same titles on every poll. Known jobs simply have
         # no verdict entry, which the fail-open gate treats as admit.
+        #
+        # Only FREE-GATE SURVIVORS are triaged. The per-job loop below
+        # drops title-prematch misses and non-US locations regardless of
+        # their Phase 1 verdict, so paying Haiku to classify them was
+        # pure waste (the bulk of the June 5-7 triage bill). Non-survivors
+        # simply have no verdict entry — fail-open admit at the Phase 1
+        # gate, then dropped at the free gates exactly as before.
         phase1_verdicts: dict[str, dict[int, TitleVerdict]] = {}
         triage_candidates = [
             (idx, job)
             for idx, job in enumerate(jobs)
             if job.external_id not in known_external_ids
+            and _passes_free_gates(job, active_targets)
         ]
         if settings.phase1_triage_enabled and active_targets and triage_candidates:
             llm = get_default_llm_client()
@@ -875,24 +901,30 @@ async def _poll_one_source(
         phase1_idx_by_external_id: dict[str, int] = {}
         # Pre-DB drop counters for #845 funnel diagnostics. Order
         # matches the gate order below — first miss wins, mutually
-        # exclusive. Emitted as a single `poll_funnel` log line at end
-        # of cycle so an operator can grep one source's funnel without
-        # a DB pass.
+        # exclusive. The FREE gates run before the Phase 1 check now
+        # (mirroring the triage-candidate pre-filter above), so
+        # ``dropped_phase1`` counts only free-gate survivors the LLM
+        # actually rejected; free-gate misses land in their own
+        # counters whether or not Phase 1 ever saw them. Emitted as a
+        # single `poll_funnel` log line at end of cycle so an operator
+        # can grep one source's funnel without a DB pass.
         dropped_phase1 = 0
         dropped_title_prematch = 0
         dropped_non_us = 0
         for idx, job in enumerate(jobs):
-            # Phase 1 IDs are 1-based; the per-target verdict-check
-            # below uses the same idx + 1 convention.
-            if not _any_target_admits(idx + 1):
-                dropped_phase1 += 1
-                continue
             # Filter by target relevance instead of static keyword list
             if active_targets and not _title_matches_any_target(job.title, active_targets):
                 dropped_title_prematch += 1
                 continue
             if not _is_us_location(job.location_name):
                 dropped_non_us += 1
+                continue
+            # Phase 1 IDs are 1-based; the per-target verdict-check
+            # below uses the same idx + 1 convention. Non-survivors
+            # never reach this line, so their missing verdicts can't
+            # fail-open anything into the upsert.
+            if not _any_target_admits(idx + 1):
+                dropped_phase1 += 1
                 continue
 
             salary = job.salary_text or extract_salary_from_text(strip_html(job.content))
@@ -1596,10 +1628,23 @@ async def _poll_one_source_for_target(
         # ``phase1_verdicts`` collapses to a single dict. Skipped when
         # the payer is over their monthly allowance (or unattributable):
         # empty verdicts → fail-open ingest, grading defers.
+        #
+        # Only FREE-GATE SURVIVORS are triaged (mirrors
+        # ``_poll_one_source``): the per-job loop below drops keyword
+        # misses and non-US locations regardless of verdict, so paying
+        # the LLM to classify them was pure waste. Verdicts stay keyed
+        # by ORIGINAL 1-based job index via the candidate mapping;
+        # non-survivors have no entry (fail-open, then free-gate drop).
         target_verdicts: dict[int, TitleVerdict] = {}
-        if settings.phase1_triage_enabled and jobs and not payer_over_budget:
+        triage_candidates = [
+            (idx, job)
+            for idx, job in enumerate(jobs)
+            if _title_matches_target(job.title, target.search_keywords)
+            and _is_us_location(job.location_name)
+        ]
+        if settings.phase1_triage_enabled and triage_candidates and not payer_over_budget:
             llm = get_default_llm_client()
-            titles = [job.title for job in jobs]
+            titles = [job.title for _, job in triage_candidates]
             for start in range(0, len(titles), PHASE1_BATCH_SIZE):
                 batch = titles[start : start + PHASE1_BATCH_SIZE]
                 verdicts, result = await triage_titles(
@@ -1623,22 +1668,30 @@ async def _poll_one_source_for_target(
                             "Failed to record Phase 1 cost for target %s",
                             target.id,
                         )
+                # Shift batch-local ids (1-based within the triage
+                # subset) back to global 1-based job indices via the
+                # candidate mapping.
                 for batch_idx, verdict in verdicts.items():
-                    target_verdicts[start + batch_idx] = verdict
+                    subset_pos = start + batch_idx - 1  # 0-based
+                    if 0 <= subset_pos < len(triage_candidates):
+                        global_idx = triage_candidates[subset_pos][0] + 1
+                        target_verdicts[global_idx] = verdict
 
         rows_to_upsert: list[dict[str, Any]] = []
         phase1_idx_by_external_id: dict[str, int] = {}
         for idx, job in enumerate(jobs):
+            # Free gates first — Phase 1 only ever saw their survivors,
+            # so a non-survivor's missing verdict can't fail-open here.
+            if not _title_matches_target(job.title, target.search_keywords):
+                continue
+            if not _is_us_location(job.location_name):
+                continue
             # Phase 1 ids are 1-based. Fail-open when no verdict (gate
             # disabled or LLM dropped the entry).
             if target_verdicts:
                 v = target_verdicts.get(idx + 1)
                 if v is not None and not v.promising:
                     continue
-            if not _title_matches_target(job.title, target.search_keywords):
-                continue
-            if not _is_us_location(job.location_name):
-                continue
 
             salary = job.salary_text or extract_salary_from_text(strip_html(job.content))
 
@@ -1768,6 +1821,43 @@ async def _poll_one_source_for_target(
                     target.id,
                     payer_user_id,
                 )
+            elif settings.phase2_enabled and primary_by_user:
+                # ---- Phase 2: LLM job-fit grading (#6) ----
+                # Mirrors ``_poll_one_source``: the Haiku-batched
+                # scorecard with the promising gate, re-grade contract
+                # and per-target daily cap — NOT the legacy full-JD
+                # Sonnet call ($0.038/job) below, which previously ran
+                # unconditionally on this activation path. Legacy stays
+                # only as the flag-off fallback.
+                llm = get_default_llm_client()
+                cycle_rows = [
+                    cast(dict[str, Any], r) for r in upsert_resp.data or []
+                ]
+                for uid in primary_by_user:
+                    try:
+                        await run_phase2_for_jobs(
+                            supabase,
+                            llm,
+                            target=target,
+                            payload=user_optimized[uid].payload,
+                            jobs=cycle_rows,
+                            user_id=payer_user_id,
+                        )
+                    except Exception:
+                        logger.exception(
+                            "Phase 2 grading failed for user %s / target %s",
+                            uid,
+                            target.id,
+                        )
+                if s2_ids:
+                    try:
+                        await asyncio.to_thread(
+                            batch_update_global_scores, supabase, s2_ids
+                        )
+                    except Exception:
+                        logger.exception(
+                            "Global score update failed after Phase 2"
+                        )
             elif primary_by_user:
                 llm = get_default_llm_client()
                 llm_sem = asyncio.Semaphore(LLM_CONCURRENCY)

--- a/apps/wyrdfold-api/tests/test_poller.py
+++ b/apps/wyrdfold-api/tests/test_poller.py
@@ -475,7 +475,11 @@ async def test_phase1_triage_skips_known_external_ids(monkeypatch):
             ),
         ]
 
-    target = _target_with_keywords({"react": 3}, ["totally unrelated keyword"])
+    # The NEW title must pass the free gates (which now run before
+    # triage), while the KNOWN one must not — so the only reason the
+    # new job reaches triage and the known one doesn't is the
+    # known-external-id skip under test.
+    target = _target_with_keywords({"brand": 3}, ["brand new role"])
     # Triage rejects the (only) submitted title. Id 1 = first title in the
     # submitted subset, which must be the NEW job.
     fake_triage = AsyncMock(
@@ -555,3 +559,297 @@ async def test_load_alert_rows_no_ids_short_circuits():
 
     assert rows == [{"title": "no id"}]
     supabase.table.assert_not_called()
+
+
+# ---- free gates run before Phase 1 triage (cost ordering) -------------------
+
+
+def _job(external_id: str, title: str, location: str) -> StandardJob:
+    return StandardJob(
+        external_id=external_id,
+        title=title,
+        location_name=location,
+        department=None,
+        content="",
+        updated_at="2026-01-01",
+        absolute_url=f"https://example.com/j/{external_id}",
+    )
+
+
+@pytest.mark.asyncio
+async def test_phase1_triage_only_sees_free_gate_survivors(monkeypatch):
+    """Titles the FREE gates reject (title prematch, non-US location)
+    must never be sent to the Phase 1 LLM — classifying them is pure
+    spend since the per-job loop drops them regardless of verdict."""
+    from unittest.mock import AsyncMock
+
+    from app.config import settings as live_settings
+    from app.services import poller as poller_mod
+
+    monkeypatch.setattr(live_settings, "phase1_triage_enabled", True)
+    monkeypatch.setattr(live_settings, "validate_poll_urls", False)
+
+    supabase, jobs_table, _sources_table = _make_poll_supabase([])
+    jobs_table.upsert.return_value.execute.return_value.data = []
+
+    async def fetch(_token: str) -> list[StandardJob]:
+        return [
+            _job("n1", "Marketing Specialist", "Remote"),  # prematch miss
+            _job("n2", "Director of Customer Experience", "London, United Kingdom"),
+            _job("n3", "Director of Customer Experience", "Remote"),  # survivor
+        ]
+
+    target = _target_with_keywords(
+        {"Zendesk": 3}, ["director of customer experience"]
+    )
+    fake_triage = AsyncMock(return_value=({}, None))
+
+    monkeypatch.setitem(poller_mod.FETCHERS, "greenhouse", fetch)
+    monkeypatch.setattr(poller_mod, "get_default_llm_client", lambda: MagicMock())
+    monkeypatch.setattr(poller_mod, "triage_titles", fake_triage)
+
+    open_gate = MagicMock()
+    open_gate.target_blocked.return_value = False
+
+    summary = await poller_mod._poll_one_source(
+        dict(_GUARD_SOURCE),
+        supabase,
+        budget_gate=open_gate,
+        active_targets=[target],
+        stage3_users=({}, {}),
+    )
+
+    assert summary["polled"] is True
+    assert summary["error"] is None
+    # Exactly one triage call, carrying ONLY the survivor's title.
+    assert fake_triage.await_count == 1
+    assert fake_triage.await_args.kwargs["titles"] == [
+        "Director of Customer Experience"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_phase1_verdicts_keyed_by_original_indices_after_free_gates(monkeypatch):
+    """Verdicts come back keyed by position WITHIN the triaged subset;
+    they must be remapped to the jobs' ORIGINAL 1-based indices so the
+    per-job loop and Stage 2 lookups keep working."""
+    from unittest.mock import AsyncMock
+
+    from app.config import settings as live_settings
+    from app.services import poller as poller_mod
+    from app.services.relevance.title_triage import TitleVerdict
+
+    monkeypatch.setattr(live_settings, "phase1_triage_enabled", True)
+    monkeypatch.setattr(live_settings, "validate_poll_urls", False)
+
+    supabase, jobs_table, _sources_table = _make_poll_supabase([])
+    jobs_table.upsert.return_value.execute.return_value.data = []
+
+    async def fetch(_token: str) -> list[StandardJob]:
+        return [
+            # idx 0: free-gate reject (non-US) — never triaged.
+            _job("x0", "Director of Customer Experience", "Berlin, Germany"),
+            # idx 1: survivor — subset position 1, rejected by the LLM.
+            _job("s1", "Director of Customer Experience", "Remote"),
+            # idx 2: survivor — subset position 2, admitted.
+            _job("s2", "Head of CX", "Remote"),
+        ]
+
+    target = _target_with_keywords(
+        {"Zendesk": 3}, ["director of customer experience", "head of cx"]
+    )
+    fake_triage = AsyncMock(
+        return_value=(
+            {
+                1: TitleVerdict(id=1, promising=False),
+                2: TitleVerdict(id=2, promising=True),
+            },
+            None,
+        )
+    )
+
+    monkeypatch.setitem(poller_mod.FETCHERS, "greenhouse", fetch)
+    monkeypatch.setattr(poller_mod, "get_default_llm_client", lambda: MagicMock())
+    monkeypatch.setattr(poller_mod, "triage_titles", fake_triage)
+
+    open_gate = MagicMock()
+    open_gate.target_blocked.return_value = False
+
+    summary = await poller_mod._poll_one_source(
+        dict(_GUARD_SOURCE),
+        supabase,
+        budget_gate=open_gate,
+        active_targets=[target],
+        stage3_users=({}, {}),
+    )
+
+    assert summary["error"] is None
+    # Only the LLM-admitted survivor reaches the upsert: subset id 1
+    # mapped back to original idx 2 (s1, dropped) and subset id 2 to
+    # original idx 3 (s2, admitted). A naive subset-as-global keying
+    # would have dropped s2 instead.
+    upserted = jobs_table.upsert.call_args.args[0]
+    assert [r["external_id"] for r in upserted] == ["s2"]
+
+
+# ---- targeted path: free gates before triage + Phase 2 ----------------------
+
+
+def _make_targeted_poll_supabase() -> tuple[MagicMock, MagicMock, MagicMock]:
+    """Mock Supabase for ``_poll_one_source_for_target`` runs.
+
+    ``jobs.upsert`` returns no rows by default (override per test) and
+    the ``user_targets`` junction is empty (no stage-3 users).
+    """
+    jobs_table = MagicMock()
+    jobs_table.upsert.return_value.execute.return_value.data = []
+    sources_table = MagicMock()
+    user_targets_table = MagicMock()
+    (
+        user_targets_table.select.return_value.eq.return_value.in_.return_value
+        .execute.return_value.data
+    ) = []
+    supabase = MagicMock()
+    supabase.table.side_effect = lambda name: {
+        "jobs": jobs_table,
+        "sources": sources_table,
+        "user_targets": user_targets_table,
+    }[name]
+    return supabase, jobs_table, user_targets_table
+
+
+@pytest.mark.asyncio
+async def test_targeted_triage_only_sees_free_gate_survivors(monkeypatch):
+    """``_poll_one_source_for_target`` mirrors the shared path: keyword
+    misses and non-US locations are dropped for free BEFORE the Phase 1
+    LLM call, and verdicts stay keyed by original indices."""
+    from unittest.mock import AsyncMock
+
+    from app.config import settings as live_settings
+    from app.services import poller as poller_mod
+
+    monkeypatch.setattr(live_settings, "phase1_triage_enabled", True)
+    monkeypatch.setattr(live_settings, "validate_poll_urls", False)
+
+    supabase, _jobs_table, _user_targets = _make_targeted_poll_supabase()
+
+    async def fetch(_token: str) -> list[StandardJob]:
+        return [
+            _job("k1", "Office Manager", "Remote"),  # keyword miss
+            _job("k2", "Staff Frontend Engineer", "Berlin, Germany"),  # non-US
+            _job("k3", "Staff Frontend Engineer", "Remote"),  # survivor
+        ]
+
+    target = _full_target(is_active=True, search_keywords=["frontend engineer"])
+    fake_triage = AsyncMock(return_value=({}, None))
+
+    monkeypatch.setitem(poller_mod.FETCHERS, "greenhouse", fetch)
+    monkeypatch.setattr(poller_mod, "get_default_llm_client", lambda: MagicMock())
+    monkeypatch.setattr(poller_mod, "triage_titles", fake_triage)
+
+    summary = await poller_mod._poll_one_source_for_target(
+        dict(_GUARD_SOURCE), supabase, target, payer_user_id="payer-1"
+    )
+
+    assert summary["polled"] is True
+    assert summary["error"] is None
+    assert fake_triage.await_count == 1
+    assert fake_triage.await_args.kwargs["titles"] == ["Staff Frontend Engineer"]
+
+
+def _upserted_row() -> dict:
+    return {
+        "id": "j1",
+        "external_id": "k3",
+        "title": "Staff Frontend Engineer",
+        "description_html": "",
+        "created_at": "2026-01-01T00:00:00Z",
+        "updated_at": "2026-01-01T00:00:01Z",
+    }
+
+
+def _wire_targeted_stage3(monkeypatch, *, phase2_enabled: bool):
+    """Common harness for the targeted Stage-3 flag tests. Returns
+    ``(supabase, fake_phase2, fake_legacy, target)``."""
+    from unittest.mock import AsyncMock
+
+    from app.config import settings as live_settings
+    from app.services import poller as poller_mod
+
+    monkeypatch.setattr(live_settings, "phase1_triage_enabled", False)
+    monkeypatch.setattr(live_settings, "phase2_enabled", phase2_enabled)
+    monkeypatch.setattr(live_settings, "validate_poll_urls", False)
+
+    supabase, jobs_table, user_targets = _make_targeted_poll_supabase()
+    jobs_table.upsert.return_value.execute.return_value.data = [_upserted_row()]
+    # Legacy Stage 3's pre-fetch of stage-2 scores.
+    (
+        jobs_table.select.return_value.in_.return_value.execute.return_value.data
+    ) = []
+    (
+        user_targets.select.return_value.eq.return_value.in_.return_value
+        .execute.return_value.data
+    ) = [{"target_id": "t-1", "user_id": "u1"}]
+
+    async def fetch(_token: str) -> list[StandardJob]:
+        return [_job("k3", "Staff Frontend Engineer", "Remote")]
+
+    target = _full_target(is_active=True, search_keywords=["frontend engineer"])
+    doc = MagicMock()
+    doc.payload = {"profile": "stub"}
+
+    fake_phase2 = AsyncMock(return_value=1)
+    fake_legacy = AsyncMock()
+
+    monkeypatch.setitem(poller_mod.FETCHERS, "greenhouse", fetch)
+    monkeypatch.setattr(poller_mod, "get_default_llm_client", lambda: MagicMock())
+    monkeypatch.setattr(poller_mod, "get_latest_optimized", lambda _sb, _uid: doc)
+    monkeypatch.setattr(poller_mod, "target_title_score_and_upsert", MagicMock())
+    monkeypatch.setattr(poller_mod, "target_score_and_upsert", MagicMock())
+    monkeypatch.setattr(poller_mod, "batch_update_global_scores", MagicMock())
+    monkeypatch.setattr(poller_mod, "run_phase2_for_jobs", fake_phase2)
+    monkeypatch.setattr(poller_mod, "_run_llm_scoring_for_row", fake_legacy)
+
+    return supabase, fake_phase2, fake_legacy, target
+
+
+@pytest.mark.asyncio
+async def test_targeted_stage3_uses_phase2_when_flag_on(monkeypatch):
+    """The activation path must stop defaulting to the legacy Sonnet
+    full-JD call ($0.038/job): with ``phase2_enabled`` it runs the same
+    capped ``run_phase2_for_jobs`` grading as ``_poll_one_source``."""
+    from app.services import poller as poller_mod
+
+    supabase, fake_phase2, fake_legacy, target = _wire_targeted_stage3(
+        monkeypatch, phase2_enabled=True
+    )
+
+    summary = await poller_mod._poll_one_source_for_target(
+        dict(_GUARD_SOURCE), supabase, target, payer_user_id="payer-1"
+    )
+
+    assert summary["error"] is None
+    assert fake_phase2.await_count == 1
+    kwargs = fake_phase2.await_args.kwargs
+    assert kwargs["target"] is target
+    assert kwargs["user_id"] == "payer-1"
+    assert [j["id"] for j in kwargs["jobs"]] == ["j1"]
+    fake_legacy.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_targeted_stage3_legacy_fallback_when_flag_off(monkeypatch):
+    """Flag off → the legacy Stage 3 path runs unchanged."""
+    from app.services import poller as poller_mod
+
+    supabase, fake_phase2, fake_legacy, target = _wire_targeted_stage3(
+        monkeypatch, phase2_enabled=False
+    )
+
+    summary = await poller_mod._poll_one_source_for_target(
+        dict(_GUARD_SOURCE), supabase, target, payer_user_id="payer-1"
+    )
+
+    assert summary["error"] is None
+    assert fake_legacy.await_count == 1
+    fake_phase2.assert_not_awaited()


### PR DESCRIPTION
## Summary
- **Free gates before Phase 1** (both `_poll_one_source` and `_poll_one_source_for_target`): the US-location and title-prematch gates now pre-filter the triage candidate set, so Haiku only ever sees titles that could actually ingest. Previously every fetched title was classified and then often dropped for free anyway — the bulk of the $93.71 June 5-7 triage bill. Verdicts are remapped from subset positions back to ORIGINAL 1-based job indices via the candidate mapping, so `_any_target_admits`, `phase1_idx_by_external_id`, Stage-2 verdict lookups and fail-open semantics (missing verdict for a survivor = admit) are unchanged. Composes with #889's known-external-id skip. New `_passes_free_gates` helper replicates the loop's exact semantics, including the excluded-admits-for-audit rule and the empty-`search_keywords` fallback.
- **Funnel counters**: per-job loop now checks free gates first, so `dropped_phase1` counts only survivors the LLM actually rejected; free-gate misses land in `dropped_title_prematch`/`dropped_non_us` (comment updated).
- **Kill legacy Stage-3 on the activation path**: `_poll_one_source_for_target` unconditionally ran `_run_llm_scoring_for_row` (legacy Sonnet full-JD, $0.038/call). It now mirrors `_poll_one_source`: `run_phase2_for_jobs` (promising gate, per-target daily cap, progressive batching, charged to the existing `payer_user_id`) when `phase2_enabled`, legacy only as the flag-off fallback.

## Test plan
- [x] `pnpm nx run-many -t lint typecheck test -p wyrdfold-api` — ruff clean, mypy clean, 1260 passed (6 new: survivors-only triage on both paths, original-index verdict mapping, targeted Phase-2 flag on/off; updated the #889 known-skip test so its new title passes the free gates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)