### PR TITLE
perf(wyrdfold-api): prompt caching for Phase-1/Phase-2 static prefixes

### DIFF
--- a/apps/wyrdfold-api/app/models/llm.py
+++ b/apps/wyrdfold-api/app/models/llm.py
@@ -23,6 +23,17 @@ TurnRole = Literal["user", "assistant"]
 class Message(BaseModel):
     role: TurnRole
     content: str
+    # Prompt-caching marker (optional, additive). When set, the first
+    # ``cache_prefix_chars`` characters of ``content`` are a STATIC
+    # prefix (stable across calls — e.g. the per-target example pools in
+    # Phase 1, or the user-profile + target context in Phase 2). Real
+    # Anthropic-shaped clients split the message into two text blocks at
+    # exactly that boundary and set ``cache_control: {"type":
+    # "ephemeral"}`` on the first; block concatenation is byte-identical
+    # to ``content``, so the prompt the model sees is unchanged. The
+    # mock client and any consumer that only reads ``content`` ignore
+    # the marker entirely.
+    cache_prefix_chars: int | None = Field(default=None, ge=1)
 
 
 class LLMUsage(BaseModel):

--- a/apps/wyrdfold-api/app/services/fit/job_fit.py
+++ b/apps/wyrdfold-api/app/services/fit/job_fit.py
@@ -205,18 +205,23 @@ Return JSON matching this extended schema:
 }"""
 
 
-def _build_user_message(
+def _split_user_message(
     *,
     payload: OptimizedPayload,
     target: JobTarget,
     job_title: str,
     jd_text: str,
-) -> str:
-    """Compose the per-call user message.
+) -> tuple[str, str]:
+    """Compose the per-call user message as ``(static_prefix, dynamic_suffix)``.
 
     Order matters for prompt caching: stable per-(user, target) context
     first, variable per-job context last. The static system prompt sits
-    above this entirely.
+    above this entirely. The split boundary feeds
+    ``Message.cache_prefix_chars`` so the profile + target block is a
+    prompt-cache breakpoint across the jobs graded in one cycle;
+    concatenating the halves yields the exact message Phase 2 has
+    always sent (the ``\\n\\n`` separator lives in the suffix so the
+    cached prefix bytes never vary with the job).
     """
     parts: list[str] = []
 
@@ -262,13 +267,28 @@ def _build_user_message(
             )
     parts.append("\n".join(target_lines))
 
-    # Job posting (last — cache-unfriendly, varies per call).
+    # Job posting (last — cache-unfriendly, varies per call). Kept out
+    # of the static prefix: it lands in the dynamic suffix below.
     jd_snippet = jd_text[:_JD_CONTEXT_CHAR_CAP]
     if len(jd_text) > _JD_CONTEXT_CHAR_CAP:
         jd_snippet += " [truncated]"
-    parts.append(f"## Job posting\n**Title:** {job_title}\n\n{jd_snippet}")
+    job_part = f"## Job posting\n**Title:** {job_title}\n\n{jd_snippet}"
 
-    return "\n\n".join(parts)
+    return "\n\n".join(parts), f"\n\n{job_part}"
+
+
+def _build_user_message(
+    *,
+    payload: OptimizedPayload,
+    target: JobTarget,
+    job_title: str,
+    jd_text: str,
+) -> str:
+    """Full user message — concatenation of the cache-split halves."""
+    static_prefix, dynamic_suffix = _split_user_message(
+        payload=payload, target=target, job_title=job_title, jd_text=jd_text
+    )
+    return static_prefix + dynamic_suffix
 
 
 async def derive_job_fit(
@@ -299,9 +319,10 @@ async def derive_job_fit(
     Callers should pass ``settings.logistics_extraction_enabled`` so
     the global flag controls the behaviour.
     """
-    user_message = _build_user_message(
+    static_prefix, dynamic_suffix = _split_user_message(
         payload=payload, target=target, job_title=job_title, jd_text=jd_text
     )
+    user_message = static_prefix + dynamic_suffix
 
     system_prompt = (
         _SYSTEM_PROMPT + _LOGISTICS_PROMPT_ADDENDUM
@@ -313,7 +334,16 @@ async def derive_job_fit(
         llm,
         model=model,
         system=system_prompt,
-        messages=[Message(role="user", content=user_message)],
+        # ``cache_prefix_chars`` marks the per-(user, target) context as
+        # a prompt-cache breakpoint — the second cacheable prefix after
+        # the system prompt. Bytes-identical split, see Message model.
+        messages=[
+            Message(
+                role="user",
+                content=user_message,
+                cache_prefix_chars=len(static_prefix),
+            )
+        ],
         schema=JobFitResult,
         purpose=purpose,
         # 1024 (was 512) to give Sonnet headroom for the evidence-first

--- a/apps/wyrdfold-api/app/services/llm/anthropic_client.py
+++ b/apps/wyrdfold-api/app/services/llm/anthropic_client.py
@@ -13,6 +13,12 @@ cacheable prefix of **4096 tokens for Opus 4.7 / 4.6 / Haiku 4.5** and
 no-ops (no error, just `cache_creation_input_tokens: 0`). Our current
 system prompts land below 4096 tokens, so caching will activate once
 prompts grow — this is intentional plumbing, not an immediate cost win.
+
+`Message.cache_prefix_chars` adds a second, message-level breakpoint:
+the static per-target/per-user prefix of a user message is split into
+its own text block with `cache_control` (see `_api_message_content`).
+Combined with the cached system block, the whole static prompt prefix
+(system + target context) counts toward the cacheable minimum.
 """
 
 from __future__ import annotations
@@ -38,6 +44,37 @@ from app.services.llm.errors import (
     translate_api_status_error,
 )
 from app.services.llm.pricing import calculate_cost
+
+
+def _api_message_content(message: Message) -> Any:
+    """Serialize one Message for the API, honouring the cache marker.
+
+    No marker → plain string content (unchanged legacy shape). With
+    ``cache_prefix_chars`` set, the content is split into two text
+    blocks at exactly that character boundary with ``cache_control:
+    ephemeral`` on the first — Anthropic's documented incremental-
+    caching pattern. Block concatenation is byte-identical to
+    ``message.content``, so this is a cache marker, not a prompt
+    change. A marker at/past the end of the content caches the whole
+    message as a single block.
+    """
+    n = message.cache_prefix_chars
+    if not n:
+        return message.content
+    cached_block = {
+        "type": "text",
+        "text": message.content[:n],
+        "cache_control": {"type": "ephemeral"},
+    }
+    if n >= len(message.content):
+        return [cached_block]
+    return [cached_block, {"type": "text", "text": message.content[n:]}]
+
+
+def _api_messages(messages: list[Message]) -> list[dict[str, Any]]:
+    return [
+        {"role": m.role, "content": _api_message_content(m)} for m in messages
+    ]
 
 
 class AnthropicLLMClient:
@@ -114,9 +151,7 @@ class AnthropicLLMClient:
         else:
             system_param = system or ""
 
-        api_messages = [
-            {"role": m.role, "content": m.content} for m in messages
-        ]
+        api_messages = _api_messages(messages)
 
         start = time.perf_counter()
         try:
@@ -195,7 +230,7 @@ class AnthropicLLMClient:
         else:
             system_param = system or ""
 
-        api_messages = [{"role": m.role, "content": m.content} for m in messages]
+        api_messages = _api_messages(messages)
 
         tool: dict[str, Any] = {
             "name": tool_name,
@@ -286,9 +321,7 @@ class AnthropicLLMClient:
         else:
             system_param = system or ""
 
-        api_messages = [
-            {"role": m.role, "content": m.content} for m in messages
-        ]
+        api_messages = _api_messages(messages)
 
         start = time.perf_counter()
         # SDK raises APIStatusError on the initial HTTP handshake (which

--- a/apps/wyrdfold-api/app/services/relevance/title_triage.py
+++ b/apps/wyrdfold-api/app/services/relevance/title_triage.py
@@ -164,37 +164,48 @@ class TitleTriageResponse(BaseModel):
     verdicts: list[TitleVerdict] = Field(default_factory=list)
 
 
-def _build_user_message(target: JobTarget, titles: list[str]) -> str:
-    """Compose the per-call user message: target context + numbered batch.
+def _split_user_message(target: JobTarget, titles: list[str]) -> tuple[str, str]:
+    """Compose the per-call user message as ``(static_prefix, dynamic_suffix)``.
 
     Target context (label + example pools) sits at the top so it's a
     natural prompt-cache prefix when grading multiple batches for the
-    same target in one poll cycle.
+    same target in one poll cycle. The split boundary feeds
+    ``Message.cache_prefix_chars`` — the prefix depends only on the
+    target, the suffix carries the per-batch titles. Concatenating the
+    two halves yields the exact message Phase 1 has always sent (the
+    boundary newline lives in the suffix so the cached prefix bytes
+    never vary with the batch).
     """
-    lines: list[str] = [f"Target role: {target.label}"]
+    static_lines: list[str] = [f"Target role: {target.label}"]
 
     if target.example_promising_titles:
-        lines.append("")
-        lines.append("Examples of PROMISING titles for this target:")
+        static_lines.append("")
+        static_lines.append("Examples of PROMISING titles for this target:")
         for ex in target.example_promising_titles:
-            lines.append(f"- {ex}")
+            static_lines.append(f"- {ex}")
 
     if target.example_unpromising_titles:
-        lines.append("")
-        lines.append("Examples of UNPROMISING titles:")
+        static_lines.append("")
+        static_lines.append("Examples of UNPROMISING titles:")
         for ex in target.example_unpromising_titles:
-            lines.append(f"- {ex}")
+            static_lines.append(f"- {ex}")
 
-    lines.append("")
-    lines.append(
+    dynamic_lines: list[str] = [""]
+    dynamic_lines.append(
         f"Grade the following {len(titles)} candidate titles. Return one "
         "verdict per id."
     )
-    lines.append("")
+    dynamic_lines.append("")
     for idx, title in enumerate(titles, start=1):
-        lines.append(f"{idx}. {title}")
+        dynamic_lines.append(f"{idx}. {title}")
 
-    return "\n".join(lines)
+    return "\n".join(static_lines), "\n" + "\n".join(dynamic_lines)
+
+
+def _build_user_message(target: JobTarget, titles: list[str]) -> str:
+    """Full user message — concatenation of the cache-split halves."""
+    static_prefix, dynamic_suffix = _split_user_message(target, titles)
+    return static_prefix + dynamic_suffix
 
 
 async def triage_titles(
@@ -233,14 +244,25 @@ async def triage_titles(
             f"PHASE1_BATCH_SIZE={PHASE1_BATCH_SIZE}. Chunk the input."
         )
 
-    user_message = _build_user_message(target, titles)
+    static_prefix, dynamic_suffix = _split_user_message(target, titles)
+    user_message = static_prefix + dynamic_suffix
 
     try:
         parsed, result = await complete_json(
             llm,
             model=model,
             system=_SYSTEM_PROMPT,
-            messages=[Message(role="user", content=user_message)],
+            # ``cache_prefix_chars`` marks the per-target context (label
+            # + example pools) as a prompt-cache breakpoint — the second
+            # cacheable prefix after the system prompt. Bytes-identical
+            # split, see Message model.
+            messages=[
+                Message(
+                    role="user",
+                    content=user_message,
+                    cache_prefix_chars=len(static_prefix),
+                )
+            ],
             schema=TitleTriageResponse,
             purpose=purpose,
             # Output is ~250 verdicts x~30 tokens each = ~7500 tokens.

--- a/apps/wyrdfold-api/tests/test_fit_job_fit.py
+++ b/apps/wyrdfold-api/tests/test_fit_job_fit.py
@@ -208,3 +208,56 @@ class TestBuildUserMessage:
         )
         assert "[truncated]" not in msg
         assert "Short JD body." in msg
+
+
+# ---- prompt-cache marker ----------------------------------------------------
+
+
+class TestCacheMarker:
+    @pytest.mark.asyncio
+    async def test_marker_covers_profile_and_target_but_not_jd(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``cache_prefix_chars`` must span the per-(user, target) static
+        block and exclude the per-job posting context."""
+        from unittest.mock import MagicMock
+
+        from app.services.fit import job_fit as job_fit_mod
+        from app.services.fit.job_fit import derive_job_fit
+
+        captured: dict[str, object] = {}
+
+        async def fake_complete_json(*_args: object, **kwargs: object) -> object:
+            captured.update(kwargs)
+            return MagicMock(), MagicMock()
+
+        monkeypatch.setattr(job_fit_mod, "complete_json", fake_complete_json)
+
+        await derive_job_fit(
+            MagicMock(),
+            payload=_payload(),
+            target=_target(),
+            job_title="Staff Web Engineer",
+            jd_text="We need React and TypeScript experience.",
+        )
+
+        messages = captured["messages"]
+        assert isinstance(messages, list) and len(messages) == 1
+        msg = messages[0]
+        n = msg.cache_prefix_chars
+        assert n is not None
+        prefix, suffix = msg.content[:n], msg.content[n:]
+        # Profile + target context cached...
+        assert "## User profile" in prefix
+        assert "## Target: Staff Frontend Engineer" in prefix
+        # ...job posting not.
+        assert "## Job posting" not in prefix
+        assert "## Job posting" in suffix
+        assert "Staff Web Engineer" in suffix
+        # Split, not rewrite.
+        assert prefix + suffix == _build_user_message(
+            payload=_payload(),
+            target=_target(),
+            job_title="Staff Web Engineer",
+            jd_text="We need React and TypeScript experience.",
+        )

--- a/apps/wyrdfold-api/tests/test_llm_anthropic.py
+++ b/apps/wyrdfold-api/tests/test_llm_anthropic.py
@@ -356,3 +356,86 @@ async def test_usage_without_cache_fields_defaults_to_zero() -> None:
     )
     assert result.usage.cache_read_input_tokens == 0
     assert result.usage.cache_creation_input_tokens == 0
+
+
+# ---- message-level cache markers (cache_prefix_chars) -----------------------
+
+
+async def test_cache_prefix_chars_splits_message_into_two_blocks() -> None:
+    """The marker splits content at exactly the byte boundary: block 0
+    carries cache_control, block 1 is the remainder, and concatenation
+    is identical to the original content (marker, not a prompt change)."""
+    client, create_mock = _client_with_mocked_sdk(_fake_response())
+    content = "STATIC target context\nDYNAMIC batch of titles"
+    prefix_len = len("STATIC target context")
+    await client.complete(
+        model="claude-haiku-4-5",
+        system="sys",
+        messages=[
+            Message(role="user", content=content, cache_prefix_chars=prefix_len)
+        ],
+        purpose="test",
+    )
+    (msg,) = create_mock.call_args.kwargs["messages"]
+    blocks = msg["content"]
+    assert isinstance(blocks, list)
+    assert len(blocks) == 2
+    assert blocks[0] == {
+        "type": "text",
+        "text": "STATIC target context",
+        "cache_control": {"type": "ephemeral"},
+    }
+    assert blocks[1] == {"type": "text", "text": "\nDYNAMIC batch of titles"}
+    assert blocks[0]["text"] + blocks[1]["text"] == content
+
+
+async def test_no_cache_prefix_keeps_plain_string_content() -> None:
+    client, create_mock = _client_with_mocked_sdk(_fake_response())
+    await client.complete(
+        model="claude-haiku-4-5",
+        system="sys",
+        messages=[Message(role="user", content="plain")],
+        purpose="test",
+    )
+    (msg,) = create_mock.call_args.kwargs["messages"]
+    assert msg["content"] == "plain"
+
+
+async def test_cache_prefix_covering_whole_message_uses_single_block() -> None:
+    client, create_mock = _client_with_mocked_sdk(_fake_response())
+    await client.complete(
+        model="claude-haiku-4-5",
+        system="sys",
+        messages=[Message(role="user", content="all static", cache_prefix_chars=999)],
+        purpose="test",
+    )
+    (msg,) = create_mock.call_args.kwargs["messages"]
+    assert msg["content"] == [
+        {
+            "type": "text",
+            "text": "all static",
+            "cache_control": {"type": "ephemeral"},
+        }
+    ]
+
+
+async def test_cache_prefix_chars_applies_to_tool_use_path() -> None:
+    client = AnthropicLLMClient(api_key="test-key")
+    create_mock = AsyncMock(
+        return_value=_fake_tool_use_response(
+            tool_name="grade", tool_input={"ok": True}
+        )
+    )
+    client._client.messages.create = create_mock  # type: ignore[method-assign]
+    await client.complete_tool_use(
+        model="claude-sonnet-4-6",
+        system="sys",
+        messages=[Message(role="user", content="AB", cache_prefix_chars=1)],
+        tool_name="grade",
+        tool_description="d",
+        tool_input_schema={"type": "object"},
+        purpose="test",
+    )
+    (msg,) = create_mock.call_args.kwargs["messages"]
+    assert msg["content"][0]["cache_control"] == {"type": "ephemeral"}
+    assert msg["content"][0]["text"] + msg["content"][1]["text"] == "AB"

--- a/apps/wyrdfold-api/tests/test_relevance_title_triage.py
+++ b/apps/wyrdfold-api/tests/test_relevance_title_triage.py
@@ -243,3 +243,77 @@ class TestTriageTitles:
 # pattern matters once we add an integration test that drives the real
 # LLM client mock.
 _ = AsyncMock  # keep the import live for follow-up
+
+
+# ---- prompt-cache marker ----------------------------------------------------
+
+
+class TestCacheMarker:
+    @pytest.mark.asyncio
+    async def test_marker_covers_target_context_but_not_batch(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``cache_prefix_chars`` must span exactly the per-target static
+        block (label + example pools) and exclude the per-batch titles."""
+        from app.services.relevance import title_triage as triage_mod
+
+        captured: dict[str, object] = {}
+
+        async def fake_complete_json(*_args: object, **kwargs: object) -> object:
+            captured.update(kwargs)
+            return TitleTriageResponse(verdicts=[]), MagicMock()
+
+        monkeypatch.setattr(triage_mod, "complete_json", fake_complete_json)
+
+        target = _target(
+            promising=["Senior FE Engineer"], unpromising=["Sales Lead"]
+        )
+        await triage_titles(
+            MagicMock(), target=target, titles=["Title One", "Title Two"]
+        )
+
+        messages = captured["messages"]
+        assert isinstance(messages, list) and len(messages) == 1
+        msg = messages[0]
+        n = msg.cache_prefix_chars
+        assert n is not None
+        prefix, suffix = msg.content[:n], msg.content[n:]
+        # Static target context lives entirely in the cached prefix...
+        assert "Staff Frontend Engineer" in prefix
+        assert "Senior FE Engineer" in prefix
+        assert "Sales Lead" in prefix
+        # ...and the dynamic batch entirely in the suffix.
+        assert "Title One" not in prefix
+        assert "Title One" in suffix
+        assert "Title Two" in suffix
+        # Marker is a split, not a rewrite: halves reassemble the exact
+        # message the prompt has always sent.
+        assert prefix + suffix == _build_user_message(
+            target, ["Title One", "Title Two"]
+        )
+
+    @pytest.mark.asyncio
+    async def test_cached_prefix_is_stable_across_batches(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Different batches for the same target must produce a byte-
+        identical cached prefix, or every call is a cache miss."""
+        from app.services.relevance import title_triage as triage_mod
+
+        prefixes: list[str] = []
+
+        async def fake_complete_json(*_args: object, **kwargs: object) -> object:
+            (msg,) = kwargs["messages"]
+            prefixes.append(msg.content[: msg.cache_prefix_chars])
+            return TitleTriageResponse(verdicts=[]), MagicMock()
+
+        monkeypatch.setattr(triage_mod, "complete_json", fake_complete_json)
+
+        target = _target(promising=["Senior FE Engineer"])
+        await triage_titles(MagicMock(), target=target, titles=["Batch One Title"])
+        await triage_titles(
+            MagicMock(), target=target, titles=["Other", "Different", "Batch"]
+        )
+
+        assert len(prefixes) == 2
+        assert prefixes[0] == prefixes[1]


### PR DESCRIPTION
## Summary
- New optional `Message.cache_prefix_chars` marker (additive): the first N chars of a user message are a static prefix. `AnthropicLLMClient` (and the OpenRouter subclass, which inherits the serialization) splits the message into two text blocks at exactly that boundary and sets `cache_control: {"type": "ephemeral"}` on the first — Anthropic's documented incremental-caching pattern. Block concatenation is byte-identical to the original content: **markers only, no prompt content reordered or reworded**, so outputs are unchanged and no shadow-run is required per project policy. Mock client and all other consumers ignore the marker.
- Phase 1 (`title_triage`): the per-target context (label + example pools) is now the cached prefix; the numbered batch is the dynamic suffix. `_build_user_message` output is unchanged (delegates to the new `_split_user_message`).
- Phase 2 (`job_fit`): the user-profile + target context block is the cached prefix; the per-job posting stays dynamic. Same delegation pattern.
- Combined with the already-cached system blocks, the full static prefix (system + target/profile context) now counts toward Anthropic's cacheable minimum (4096 tokens Haiku, 2048 Sonnet) — below it caching silently no-ops, so the marker is safe either way.

## Test plan
- [x] `pnpm nx run-many -t lint typecheck test -p wyrdfold-api` — ruff clean, mypy clean, 1262 passed (7 new: client serializes the two-block split byte-exactly on `complete` and `complete_tool_use`, plain-string when unmarked, whole-message marker → single block; triage marker spans target context but not titles and is byte-stable across batches; job_fit marker spans profile+target but not the JD)

🤖 Generated with [Claude Code](https://claude.com/claude-code)