### PR TITLE
perf(wyrdfold-api): adaptive source cadence (cold sources poll daily)

### DIFF
--- a/apps/wyrdfold-api/app/config.py
+++ b/apps/wyrdfold-api/app/config.py
@@ -188,6 +188,12 @@ class Settings(BaseSettings):
     # Auto-disable a source after this many consecutive fetch failures
     # (0 disables the backoff).
     source_failure_disable_threshold: int = Field(default=10, ge=0)
+    # Adaptive source cadence. Sources whose ``last_candidate_at`` is
+    # older than this many days get their poll interval stretched to
+    # daily by the lifecycle sweep; sources that produce candidates
+    # again get restored to the 4-hour default. NULL last_candidate_at
+    # (pre-backfill rows) are left untouched. 0 disables the sweep step.
+    source_cold_after_days: int = Field(default=7, ge=0)
 
     @property
     def allowed_hosts_list(self) -> list[str]:

--- a/apps/wyrdfold-api/app/services/lifecycle.py
+++ b/apps/wyrdfold-api/app/services/lifecycle.py
@@ -12,7 +12,14 @@ Two cleanups, run from the poll cycle (throttled in the caller):
 2. **Batch reaper** — ``batch_runs`` stuck in ``processing`` beyond
    ``BATCH_STUCK_HOURS`` flip to ``failed`` so they stop looking alive.
 
-Idempotent by construction: both steps only transition rows, so re-runs
+3. **Adaptive source cadence** — sources whose ``last_candidate_at``
+   stamp is older than ``source_cold_after_days`` get their poll
+   interval stretched to daily (cold boards aren't worth a 4-hour
+   fetch + triage cycle); sources that produce candidates again get
+   restored to the 4-hour default. NULL stamps (rows predating the
+   column backfill) are left untouched.
+
+Idempotent by construction: all steps only transition rows, so re-runs
 (e.g. after a restart loses the throttle marker) are no-ops.
 """
 
@@ -32,18 +39,32 @@ logger = logging.getLogger(__name__)
 
 BATCH_STUCK_HOURS = 2
 
+# Adaptive cadence intervals. Cold sources poll daily; sources restored
+# after producing a candidate go back to the poller's 4-hour default.
+SOURCE_COLD_INTERVAL_MINUTES = 1440
+SOURCE_WARM_INTERVAL_MINUTES = 240
+
 
 async def run_lifecycle_sweep(supabase: Client) -> dict[str, int]:
-    """Run both cleanups; returns counts for logging/tests."""
+    """Run all cleanups; returns counts for logging/tests."""
     deactivated = await _deactivate_idle_targets(supabase)
     reaped = await _reap_stuck_batches(supabase)
-    if deactivated or reaped:
+    stretched, restored = await _adjust_source_cadence(supabase)
+    if deactivated or reaped or stretched or restored:
         logger.info(
-            "lifecycle sweep: deactivated=%d stuck_batches_failed=%d",
+            "lifecycle sweep: deactivated=%d stuck_batches_failed=%d "
+            "sources_stretched=%d sources_restored=%d",
             deactivated,
             reaped,
+            stretched,
+            restored,
         )
-    return {"deactivated": deactivated, "batches_reaped": reaped}
+    return {
+        "deactivated": deactivated,
+        "batches_reaped": reaped,
+        "sources_stretched": stretched,
+        "sources_restored": restored,
+    }
 
 
 async def _deactivate_idle_targets(supabase: Client) -> int:
@@ -119,6 +140,52 @@ async def _target_labels(supabase: Client, target_ids: list[str]) -> list[str]:
         str(r.get("label") or "")
         for r in cast(list[dict[str, Any]], resp.data or [])
     ]
+
+
+async def _adjust_source_cadence(supabase: Client) -> tuple[int, int]:
+    """Stretch cold sources to daily polling; restore productive ones.
+
+    Cold = enabled source whose ``last_candidate_at`` is older than
+    ``source_cold_after_days`` (0 disables the whole step). NULL stamps
+    are excluded by SQL comparison semantics (``NULL < cutoff`` is not
+    true), so pre-backfill rows are never touched. The restore arm only
+    rewrites rows the stretch arm previously set to the cold interval,
+    keeping any operator-tuned custom interval intact.
+
+    Returns ``(stretched, restored)`` row counts.
+    """
+    days = settings.source_cold_after_days
+    if days <= 0:
+        return 0, 0
+    cutoff = (datetime.now(UTC) - timedelta(days=days)).isoformat()
+
+    stretch_resp = await asyncio.to_thread(
+        lambda: supabase.table("sources")
+        .update({"poll_interval_minutes": SOURCE_COLD_INTERVAL_MINUTES})
+        .eq("enabled", True)
+        .lt("last_candidate_at", cutoff)
+        # Skip rows already at the cold interval; include NULL-interval
+        # rows (they currently poll at the 4h default via the poller's
+        # fallback, so they're stretchable too).
+        .or_(
+            f"poll_interval_minutes.neq.{SOURCE_COLD_INTERVAL_MINUTES},"
+            "poll_interval_minutes.is.null"
+        )
+        .execute()
+    )
+    stretched = len(cast(list[dict[str, Any]], stretch_resp.data or []))
+
+    restore_resp = await asyncio.to_thread(
+        lambda: supabase.table("sources")
+        .update({"poll_interval_minutes": SOURCE_WARM_INTERVAL_MINUTES})
+        .eq("enabled", True)
+        .gte("last_candidate_at", cutoff)
+        .eq("poll_interval_minutes", SOURCE_COLD_INTERVAL_MINUTES)
+        .execute()
+    )
+    restored = len(cast(list[dict[str, Any]], restore_resp.data or []))
+
+    return stretched, restored
 
 
 async def _reap_stuck_batches(supabase: Client) -> int:

--- a/apps/wyrdfold-api/app/services/poller.py
+++ b/apps/wyrdfold-api/app/services/poller.py
@@ -1216,15 +1216,20 @@ async def _poll_one_source(
 
         # Archive stale jobs AND update last_polled_at in parallel.
         # A successful poll also resets the failure-backoff counter.
+        mark_polled_payload: dict[str, Any] = {
+            "last_polled_at": datetime.now(UTC).isoformat(),
+            "job_count": len(jobs),
+            "consecutive_failures": 0,
+        }
+        # Adaptive cadence: a non-empty upsert batch means this source
+        # produced at least one ingestible candidate this cycle. The
+        # lifecycle sweep stretches sources whose stamp goes cold to a
+        # daily interval and restores them once they produce again.
+        if rows_to_upsert:
+            mark_polled_payload["last_candidate_at"] = datetime.now(UTC).isoformat()
         last_polled_query = (
             supabase.table("sources")
-            .update(
-                {
-                    "last_polled_at": datetime.now(UTC).isoformat(),
-                    "job_count": len(jobs),
-                    "consecutive_failures": 0,
-                }
-            )
+            .update(mark_polled_payload)
             .eq("id", source_id)
         )
 

--- a/apps/wyrdfold-api/tests/test_lifecycle.py
+++ b/apps/wyrdfold-api/tests/test_lifecycle.py
@@ -40,6 +40,13 @@ def _supabase_for_sweep(
             ]
         elif name == "batch_runs":
             t.update.return_value.eq.return_value.lt.return_value.execute.return_value.data = []
+        elif name == "sources":
+            # Adaptive-cadence arms: stretch (.lt + .or_) and restore
+            # (.gte + .eq). Both no-op by default.
+            stretch = t.update.return_value.eq.return_value.lt.return_value.or_.return_value
+            stretch.execute.return_value.data = []
+            restore = t.update.return_value.eq.return_value.gte.return_value.eq.return_value
+            restore.execute.return_value.data = []
         return t
 
     supabase.table.side_effect = table
@@ -85,6 +92,8 @@ async def test_sweep_skips_users_with_no_active_links(monkeypatch):
 @pytest.mark.asyncio
 async def test_sweep_disabled_when_threshold_zero(monkeypatch):
     monkeypatch.setattr(lifecycle.settings, "idle_deactivate_days", 0)
+    # Keep the cadence step out of this test's raw mock.
+    monkeypatch.setattr(lifecycle.settings, "source_cold_after_days", 0)
     sb = MagicMock()
     sb.table.return_value.update.return_value.eq.return_value.lt.return_value.execute.return_value.data = []
 
@@ -116,7 +125,9 @@ async def test_email_failure_does_not_block_deactivation(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_reaper_fails_stuck_processing_batches():
+async def test_reaper_fails_stuck_processing_batches(monkeypatch):
+    # Keep the cadence step out of this test's raw mock.
+    monkeypatch.setattr(lifecycle.settings, "source_cold_after_days", 0)
     sb = MagicMock()
 
     def table(name: str) -> MagicMock:
@@ -314,3 +325,80 @@ async def test_source_failure_threshold_zero_disables_backoff(monkeypatch):
     sb = MagicMock()
     await poller._record_source_failure(sb, {"id": "s-1"})
     sb.table.assert_not_called()
+
+
+# ---- _adjust_source_cadence -------------------------------------------------
+
+
+def _supabase_for_cadence(
+    *,
+    stretched_rows: list[dict[str, Any]],
+    restored_rows: list[dict[str, Any]],
+) -> tuple[MagicMock, MagicMock]:
+    """Mock just the sources table for direct `_adjust_source_cadence`
+    calls. Returns ``(supabase, sources_table)``."""
+    sources = MagicMock()
+    stretch = sources.update.return_value.eq.return_value.lt.return_value.or_.return_value
+    stretch.execute.return_value.data = stretched_rows
+    restore = sources.update.return_value.eq.return_value.gte.return_value.eq.return_value
+    restore.execute.return_value.data = restored_rows
+    supabase = MagicMock()
+    supabase.table.return_value = sources
+    return supabase, sources
+
+
+@pytest.mark.asyncio
+async def test_cadence_stretches_cold_and_restores_fresh(monkeypatch):
+    monkeypatch.setattr(lifecycle.settings, "source_cold_after_days", 7)
+    sb, sources = _supabase_for_cadence(
+        stretched_rows=[{"id": "s-cold-1"}, {"id": "s-cold-2"}],
+        restored_rows=[{"id": "s-warm-1"}],
+    )
+
+    stretched, restored = await lifecycle._adjust_source_cadence(sb)
+
+    assert (stretched, restored) == (2, 1)
+    payloads = [c.args[0] for c in sources.update.call_args_list]
+    assert {"poll_interval_minutes": lifecycle.SOURCE_COLD_INTERVAL_MINUTES} in payloads
+    assert {"poll_interval_minutes": lifecycle.SOURCE_WARM_INTERVAL_MINUTES} in payloads
+    # Stretch arm filters on a STALE stamp (lt cutoff): NULL stamps fall
+    # out of the comparison, so pre-backfill rows are untouched.
+    lt_call = sources.update.return_value.eq.return_value.lt.call_args
+    assert lt_call.args[0] == "last_candidate_at"
+    cutoff = datetime.fromisoformat(lt_call.args[1])
+    expected = datetime.now(UTC) - timedelta(days=7)
+    assert abs((cutoff - expected).total_seconds()) < 60
+    # Restore arm only rewrites rows currently at the cold interval.
+    restore_eq = sources.update.return_value.eq.return_value.gte.return_value.eq.call_args
+    assert restore_eq.args == (
+        "poll_interval_minutes",
+        lifecycle.SOURCE_COLD_INTERVAL_MINUTES,
+    )
+
+
+@pytest.mark.asyncio
+async def test_cadence_disabled_when_setting_is_zero(monkeypatch):
+    monkeypatch.setattr(lifecycle.settings, "source_cold_after_days", 0)
+    sb, _sources = _supabase_for_cadence(stretched_rows=[], restored_rows=[])
+
+    stretched, restored = await lifecycle._adjust_source_cadence(sb)
+
+    assert (stretched, restored) == (0, 0)
+    sb.table.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_sweep_reports_cadence_counts(monkeypatch):
+    """run_lifecycle_sweep surfaces the cadence counts alongside the
+    existing steps."""
+    sb = _supabase_for_sweep(idle_user_ids=[], flipped_rows_by_user={})
+    monkeypatch.setattr(
+        lifecycle,
+        "_adjust_source_cadence",
+        AsyncMock(return_value=(3, 2)),
+    )
+
+    result = await lifecycle.run_lifecycle_sweep(sb)
+
+    assert result["sources_stretched"] == 3
+    assert result["sources_restored"] == 2

--- a/apps/wyrdfold-api/tests/test_poller.py
+++ b/apps/wyrdfold-api/tests/test_poller.py
@@ -555,3 +555,88 @@ async def test_load_alert_rows_no_ids_short_circuits():
 
     assert rows == [{"title": "no id"}]
     supabase.table.assert_not_called()
+
+
+# ---- adaptive cadence: last_candidate_at stamp ------------------------------
+
+
+@pytest.mark.asyncio
+async def test_last_candidate_at_stamped_when_candidates_upserted(monkeypatch):
+    """A poll that produces at least one ingestible candidate must stamp
+    ``sources.last_candidate_at`` alongside ``last_polled_at`` so the
+    lifecycle cadence sweep can tell productive sources from cold ones."""
+    from app.config import settings as live_settings
+    from app.services import poller as poller_mod
+
+    monkeypatch.setattr(live_settings, "validate_poll_urls", False)
+
+    supabase, jobs_table, sources_table = _make_poll_supabase([])
+    jobs_table.upsert.return_value.execute.return_value.data = []
+
+    async def fetch(_token: str) -> list[StandardJob]:
+        return [
+            StandardJob(
+                external_id="c-1",
+                title="Brand New Role",
+                location_name="Remote",
+                department=None,
+                content="",
+                updated_at="2026-01-01",
+                absolute_url="https://example.com/j/1",
+            )
+        ]
+
+    target = _target_with_keywords({"brand": 3}, ["brand new role"])
+    monkeypatch.setitem(poller_mod.FETCHERS, "greenhouse", fetch)
+
+    open_gate = MagicMock()
+    open_gate.target_blocked.return_value = False
+
+    summary = await poller_mod._poll_one_source(
+        dict(_GUARD_SOURCE),
+        supabase,
+        budget_gate=open_gate,
+        active_targets=[target],
+        stage3_users=({}, {}),
+    )
+
+    assert summary["error"] is None
+    payload = sources_table.update.call_args.args[0]
+    assert "last_candidate_at" in payload
+    assert "last_polled_at" in payload
+
+
+@pytest.mark.asyncio
+async def test_no_candidates_leaves_last_candidate_at_unstamped(monkeypatch):
+    """A poll that fetched jobs but produced no ingestible candidates
+    must NOT touch the stamp — staleness is what the cadence sweep keys
+    on."""
+    from app.services import poller as poller_mod
+
+    existing = [
+        {"id": "job-1", "external_id": "gone-1", "title": "T1", "company_name": "Acme"},
+    ]
+    supabase, _jobs_table, sources_table = _make_poll_supabase(existing)
+
+    async def fetch(_token: str) -> list[StandardJob]:
+        return [
+            StandardJob(
+                external_id="c-1",
+                title="Director of CX",
+                location_name="London, United Kingdom",  # dropped at the US gate
+                department=None,
+                content="",
+                updated_at="2026-01-01",
+                absolute_url="https://example.com/j/1",
+            )
+        ]
+
+    monkeypatch.setitem(poller_mod.FETCHERS, "greenhouse", fetch)
+    monkeypatch.setattr(poller_mod, "get_active_target", lambda _sb: [])
+
+    summary = await poller_mod._poll_one_source(dict(_GUARD_SOURCE), supabase)
+
+    assert summary["error"] is None
+    payload = sources_table.update.call_args.args[0]
+    assert "last_candidate_at" not in payload
+    assert "last_polled_at" in payload

--- a/supabase/migrations/20260612090000_sources_last_candidate_at.sql
+++ b/supabase/migrations/20260612090000_sources_last_candidate_at.sql
@@ -1,0 +1,13 @@
+-- Adaptive source cadence: track when a source last produced an
+-- ingestible candidate (a non-empty upsert batch in the poller).
+--
+-- NULL means "never stamped" — rows predating this migration stay NULL
+-- until their next productive poll, and the lifecycle sweep leaves NULL
+-- rows untouched so the backfill happens organically instead of
+-- mass-stretching every source on deploy day.
+
+ALTER TABLE public.sources
+  ADD COLUMN IF NOT EXISTS last_candidate_at timestamptz;
+
+COMMENT ON COLUMN public.sources.last_candidate_at IS
+  'Last poll that upserted at least one candidate job. Drives the adaptive cadence sweep (cold sources stretch to daily polling).';


### PR DESCRIPTION
## Summary
- Migration `20260612090000_sources_last_candidate_at.sql` (idempotent `ADD COLUMN IF NOT EXISTS`): `sources.last_candidate_at timestamptz`, NULL for pre-backfill rows.
- `_poll_one_source` stamps it whenever `rows_to_upsert` is non-empty, piggybacking the existing `last_polled_at` update (no extra round-trip).
- New `source_cold_after_days` setting (default 7, `0` disables). The lifecycle sweep gains a third step: enabled sources with a stamp older than the cutoff get `poll_interval_minutes` stretched to 1440 (skipping rows already at 1440; including NULL-interval rows, which poll at the 240 default); fresh-stamped sources currently at 1440 are restored to 240, leaving operator-tuned custom intervals alone. NULL stamps are excluded by SQL comparison semantics — pre-backfill rows are untouched. Counts logged with the existing sweep line.

## Test plan
- [x] `pnpm nx run-many -t lint typecheck test -p wyrdfold-api` — ruff clean, mypy clean, 1260 passed (5 new: stamp present when candidates upserted / absent when none, sweep stretch+restore filters and counts, `0` disables, sweep result surfaces the counts)
- [ ] Apply the migration in Supabase before deploying the stamp (the UPDATE references the new column)

🤖 Generated with [Claude Code](https://claude.com/claude-code)