### PR TITLE
fix(wyrdfold-api): discovery crashed on non-JSON 200 from ATS probes

### DIFF
--- a/apps/wyrdfold-api/app/services/ats_detect.py
+++ b/apps/wyrdfold-api/app/services/ats_detect.py
@@ -86,11 +86,11 @@ async def _probe_workday(
             url,
             json={"appliedFacets": {}, "limit": 1, "offset": 0, "searchText": ""},
         )
-    except httpx.HTTPError:
+        if resp.status_code != 200:
+            return None
+        data = resp.json()
+    except (httpx.HTTPError, ValueError):
         return None
-    if resp.status_code != 200:
-        return None
-    data = resp.json()
     if not isinstance(data, dict):
         return None
     total = data.get("total")
@@ -142,11 +142,15 @@ async def _probe_greenhouse(slug: str, client: httpx.AsyncClient) -> DetectResul
     url = f"{GREENHOUSE_BASE}/{slug}/jobs"
     try:
         resp = await client.get(url)
-    except httpx.HTTPError:
+        if resp.status_code != 200:
+            return None
+        data = resp.json()
+    except (httpx.HTTPError, ValueError):
+        # ValueError covers a 200 with a non-JSON body (rate-limit HTML,
+        # Cloudflare interstitial, a marketing page sharing the host).
         return None
-    if resp.status_code != 200:
+    if not isinstance(data, dict):
         return None
-    data = resp.json()
     jobs = data.get("jobs")
     if not isinstance(jobs, list):
         return None
@@ -160,7 +164,7 @@ async def _probe_greenhouse(slug: str, client: httpx.AsyncClient) -> DetectResul
             meta = meta_resp.json()
             if isinstance(meta, dict):
                 company_name = meta.get("name") or slug
-    except httpx.HTTPError:
+    except (httpx.HTTPError, ValueError):
         pass
 
     return DetectResult(
@@ -175,11 +179,11 @@ async def _probe_lever(slug: str, client: httpx.AsyncClient) -> DetectResult | N
     url = f"{LEVER_BASE}/{slug}?mode=json&limit=1"
     try:
         resp = await client.get(url)
-    except httpx.HTTPError:
+        if resp.status_code != 200:
+            return None
+        data = resp.json()
+    except (httpx.HTTPError, ValueError):
         return None
-    if resp.status_code != 200:
-        return None
-    data = resp.json()
     if not isinstance(data, list) or len(data) == 0:
         return None
     # Lever doesn't expose board-level company name; use slug title-cased
@@ -195,11 +199,13 @@ async def _probe_ashby(slug: str, client: httpx.AsyncClient) -> DetectResult | N
     url = f"{ASHBY_BASE}/{slug}"
     try:
         resp = await client.get(url)
-    except httpx.HTTPError:
+        if resp.status_code != 200:
+            return None
+        data = resp.json()
+    except (httpx.HTTPError, ValueError):
         return None
-    if resp.status_code != 200:
+    if not isinstance(data, dict):
         return None
-    data = resp.json()
     jobs = data.get("jobs", [])
     if not isinstance(jobs, list):
         return None
@@ -217,11 +223,13 @@ async def _probe_smartrecruiters(
     url = f"{SMARTRECRUITERS_BASE}/{slug}/postings?limit=1"
     try:
         resp = await client.get(url)
-    except httpx.HTTPError:
+        if resp.status_code != 200:
+            return None
+        data = resp.json()
+    except (httpx.HTTPError, ValueError):
         return None
-    if resp.status_code != 200:
+    if not isinstance(data, dict):
         return None
-    data = resp.json()
     content = data.get("content", [])
     if not isinstance(content, list) or len(content) == 0:
         return None

--- a/apps/wyrdfold-api/app/services/source_discovery.py
+++ b/apps/wyrdfold-api/app/services/source_discovery.py
@@ -470,8 +470,16 @@ async def run_discovery_for_target(
             continue
 
         # detect_ats has its own httpx client — it manages probe
-        # cadence + provider fallback internally.
-        detect = await detect_ats(hit.url)
+        # cadence + provider fallback internally. Guard it anyway: a single
+        # malformed URL or an unexpected probe error must never abort the
+        # whole target's run (the bulk endpoint would record it as a generic
+        # "discovery failed" and zero out every later URL). Treat any raise
+        # as unclassified — log, count, and move to the next hit.
+        try:
+            detect = await detect_ats(hit.url)
+        except Exception as exc:
+            logger.warning("detect_ats raised for %s: %s", hit.url, exc)
+            detect = None
         if detect is None:
             unclassified += 1
             _log_discovery(

--- a/apps/wyrdfold-api/scripts/debug_discovery_run.py
+++ b/apps/wyrdfold-api/scripts/debug_discovery_run.py
@@ -1,0 +1,64 @@
+"""Run source discovery for a single target locally with a full traceback.
+
+The bulk ``/discovery/run`` endpoint swallows per-target exceptions into a
+generic ``"<id>: discovery failed"`` string. This script bypasses that so the
+real exception + traceback surfaces on the console.
+
+Usage:
+    cd apps/wyrdfold-api
+    PYTHONPATH=. uv run python scripts/debug_discovery_run.py <target_id>
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import traceback
+
+from app.config import settings
+from app.services.source_discovery import run_discovery_for_target
+from app.services.targets import crud
+from app.supabase_pool import get_supabase_pool, init_supabase
+
+
+async def _run(target_id: str) -> None:
+    init_supabase()
+    sb = get_supabase_pool()
+    if sb is None:
+        raise SystemExit("Supabase not configured — check .env / SUPABASE_URL")
+
+    print("# config")
+    print(f"  brave_search_api_key set: {bool(settings.brave_search_api_key)}")
+    print(f"  query_cap_per_run:        {settings.discovery_query_cap_per_run}")
+    print(f"  results_per_query:        {settings.discovery_results_per_query}")
+
+    target = crud.get(sb, target_id)
+    if target is None:
+        raise SystemExit(f"No target row for id={target_id!r}")
+
+    print("\n# target")
+    print(f"  id:            {target.id}")
+    print(f"  is_active:     {target.is_active}")
+    kws = target.search_keywords or []
+    print(f"  search_keywords ({len(kws)}): {kws[:20]}")
+
+    print("\n# running discovery …")
+    try:
+        stats = await run_discovery_for_target(sb, target)
+    except Exception:
+        print("\n!!! discovery raised:")
+        traceback.print_exc()
+        raise SystemExit(1) from None
+
+    print("\n# stats")
+    print(f"  {stats}")
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        raise SystemExit("usage: debug_discovery_run.py <target_id>")
+    asyncio.run(_run(sys.argv[1]))
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/wyrdfold-api/tests/test_ats_detect.py
+++ b/apps/wyrdfold-api/tests/test_ats_detect.py
@@ -143,6 +143,27 @@ async def test_detect_greenhouse_name_fetch_failure_falls_back_to_slug():
 
 
 @pytest.mark.asyncio
+async def test_detect_greenhouse_non_json_200_returns_none():
+    """Regression: a 200 response with a non-JSON body (rate-limit HTML,
+    Cloudflare interstitial) made ``resp.json()`` raise ``ValueError``, which
+    propagated out of ``detect_ats`` and aborted the entire discovery run for
+    the target. It must return None instead."""
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json.side_effect = ValueError("Expecting value: line 1 column 1")
+
+    mock_client = AsyncMock()
+    mock_client.get.return_value = resp
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("app.services.ats_detect.httpx.AsyncClient", return_value=mock_client):
+        result = await detect_ats("https://boards.greenhouse.io/acme")
+
+    assert result is None
+
+
+@pytest.mark.asyncio
 async def test_detect_lever_from_url():
     mock_client = AsyncMock()
     mock_client.get.return_value = _make_http_response(200, [{"id": "1", "text": "Engineer"}])

--- a/apps/wyrdfold-api/tests/test_source_discovery.py
+++ b/apps/wyrdfold-api/tests/test_source_discovery.py
@@ -544,3 +544,49 @@ async def test_discovery_fires_brave_queries_concurrently(monkeypatch):
         f"expected concurrent Brave queries, peak in-flight was {peak} "
         "— is the semaphore wired up?"
     )
+
+
+@pytest.mark.asyncio
+async def test_discovery_survives_detect_ats_raise(monkeypatch):
+    """A single URL whose probe raises must not abort the whole target.
+
+    Regression: ``detect_ats`` was called unguarded, so one bad URL (e.g. a
+    200 with a non-JSON body that made ``resp.json()`` raise) bubbled out of
+    ``run_discovery_for_target`` and the bulk endpoint recorded a generic
+    "discovery failed", zeroing out every later URL. The raise must be
+    swallowed and counted as unclassified instead.
+    """
+    from app.config import settings as live_settings
+
+    monkeypatch.setattr(live_settings, "brave_search_api_key", "test-key")
+    monkeypatch.setattr(live_settings, "discovery_query_cap_per_run", 1)
+
+    supabase = _make_supabase(existing_tokens=[])
+    # Two distinct boards: the first probe raises, the second classifies
+    # cleanly — proving the run continues past the failure and still inserts.
+    fake_brave = AsyncMock(
+        return_value=[
+            "https://boards.greenhouse.io/boom",
+            "https://boards.greenhouse.io/good",
+        ]
+    )
+
+    async def flaky_detect(url: str) -> DetectResult:
+        if "boom" in url:
+            raise ValueError("simulated non-JSON 200 body")
+        return DetectResult(
+            provider="greenhouse",
+            board_token="good",
+            company_name="Good Co",
+            job_count=3,
+        )
+
+    with (
+        patch("app.services.source_discovery._brave_search", fake_brave),
+        patch("app.services.source_discovery.detect_ats", side_effect=flaky_detect),
+    ):
+        stats = await run_discovery_for_target(supabase, _make_target())
+
+    assert stats.unclassified == 1
+    assert stats.inserted == 1
+    assert stats.urls_examined == 2


### PR DESCRIPTION
## Summary
- Source discovery threw a generic `"discovery failed"` for any target whose Brave results included a URL returning HTTP 200 with a **non-JSON body** (rate-limit HTML, Cloudflare interstitial, a marketing page sharing an ATS host). All five ATS probers called `resp.json()` right after the status check, unguarded — `JSONDecodeError` is a `ValueError`, not an `httpx.HTTPError`, so the probers' `except` missed it. The raise propagated out of `detect_ats` and, because the call site was also unguarded, **aborted the entire target's run**, zeroing every later insert.
- `ats_detect.py`: wrap `resp.json()` in the try, catch `(httpx.HTTPError, ValueError)`, and guard `.get()` access with `isinstance(data, dict)` across all five probers.
- `source_discovery.py`: wrap the `detect_ats` call so any single-URL failure is logged + counted unclassified and skipped — no one URL can ever abort a whole target's discovery again.
- `scripts/debug_discovery_run.py`: operator tool to run one target's discovery locally with a full traceback (the bulk endpoint swallows them).

## Why this matters (#845)
This was the sourcing-coverage collapse #845 diagnosed. Validated against real Brave + Supabase via `railway run` for Mel's Director-of-CX target:

| metric | before | after |
| --- | --- | --- |
| inserted | 0 (crash) | **366** new CX-relevant boards |
| previously-fatal URLs | aborted run | 123 safely unclassified |

The 366 new sources are auto-enabled; the poller picks them up next cycle.

## Test plan
- [x] `ruff check` + `mypy` clean on edited files
- [x] `pytest tests/test_ats_detect.py tests/test_source_discovery.py` — 44 pass, incl. 2 new regression tests (non-JSON 200 → None; discovery survives a `detect_ats` raise)
- [x] End-to-end: `railway run -- … debug_discovery_run.py <cx-target>` → 366 inserts, exit 0, no traceback
- [ ] After deploy: confirm the `/discovery/run` cron completes without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)