### PR TITLE
perf(wyrdfold-api): Phase-2 seniority pre-gate + fix stale backfill (#902)

### DIFF
--- a/apps/wyrdfold-api/app/config.py
+++ b/apps/wyrdfold-api/app/config.py
@@ -185,6 +185,17 @@ class Settings(BaseSettings):
     # allowance; 20/day ≈ $2/month/target).
     phase2_daily_cap: int = Field(default=20, ge=0)
 
+    # Phase 2 seniority pre-gate (#902). When True, candidates whose title is
+    # clearly below the target's ``seniority_hint`` are dropped before Phase 2
+    # spends a Sonnet grade on them (shadow-measured: ~32% of grades skipped
+    # for a director target, 94% of them genuine waste). Only gates targets
+    # hinted director-or-above; ambiguous titles always pass. Ships False so
+    # the skip volume can be validated per-target before enforcing.
+    phase2_seniority_gate_enabled: bool = False
+    # Allowed rungs below the hint (1 = a Manager still grades for a Director
+    # target — the stretch case — but a Coordinator does not).
+    phase2_seniority_gate_tolerance: int = Field(default=1, ge=0, le=6)
+
     # Idle-account lifecycle. last_seen_at is stamped on authenticated
     # requests (throttled in-process); the poller defers a payer's LLM
     # work after idle_defer_days unseen and the lifecycle sweep

--- a/apps/wyrdfold-api/app/services/fit/phase2_runner.py
+++ b/apps/wyrdfold-api/app/services/fit/phase2_runner.py
@@ -35,10 +35,12 @@ from typing import Any, cast
 
 from supabase import Client
 
+from app.config import settings
 from app.models.experience import OptimizedPayload
 from app.models.targets import JobTarget
 from app.services.fit.daily_cap import DEFAULT_DAILY_CAP, phase2_quota_remaining
 from app.services.fit.score_persistence import score_with_phase2_and_persist
+from app.services.fit.seniority_gate import passes_seniority_gate
 from app.services.llm.client import LLMClient
 from app.services.scoring import strip_html
 
@@ -174,6 +176,36 @@ async def run_phase2_for_jobs(
     ]
     if not candidates:
         return 0
+
+    # Cheap seniority pre-gate (#902): Phase 1's promising verdict is
+    # domain-oriented and permissive, so it forwards many roles whose
+    # *seniority* is well below the target's — Phase 2 then spends a real grade
+    # to discover the mismatch. Drop clearly-below-level titles first. Flag-off
+    # by default; shadow-measured via scripts/shadow_seniority_gate.py before
+    # enforcing (per the prompt/scoring-change rollout rule).
+    if settings.phase2_seniority_gate_enabled and target.seniority_hint:
+        kept = [
+            jid
+            for jid in candidates
+            if passes_seniority_gate(
+                job_by_id[jid].get("title") or "",
+                target.seniority_hint,
+                tolerance=settings.phase2_seniority_gate_tolerance,
+            )
+        ]
+        skipped = len(candidates) - len(kept)
+        if skipped:
+            logger.info(
+                "Phase 2 seniority gate: skipped %d/%d below-level candidate(s) "
+                "for target %s (hint=%s)",
+                skipped,
+                len(candidates),
+                target.id,
+                target.seniority_hint,
+            )
+        candidates = kept
+        if not candidates:
+            return 0
 
     # Order candidates so the Phase 2 daily cap goes to the highest-leverage
     # jobs first:

--- a/apps/wyrdfold-api/app/services/fit/seniority_gate.py
+++ b/apps/wyrdfold-api/app/services/fit/seniority_gate.py
@@ -1,0 +1,91 @@
+"""Cheap title-seniority pre-gate for Phase 2 (#902).
+
+Phase 1's binary ``promising`` verdict is domain-oriented and deliberately
+permissive ("lean-promising"), so it forwards many roles whose *seniority* is
+well below the target's — a "Customer Success Manager" for a *Director*-level
+target. Phase 2 (Sonnet) then spends a real grade discovering the obvious
+mismatch. This module is a near-free string gate that drops clearly-below-level
+titles *before* Phase 2, complementing — not replacing — the Phase 1 verdict.
+
+Pure + dependency-free so it's trivially testable and safe to call in the hot
+path. Conservative by design: it only rejects titles whose seniority is
+*explicitly* below the bar, and passes anything ambiguous (no level token) so a
+real role with an unusual title is never silently dropped.
+"""
+
+from __future__ import annotations
+
+import re
+
+from app.models.targets import SeniorityHint
+
+# The canonical seniority ladder (mirrors models.targets.SeniorityHint).
+_RANK: dict[str, int] = {
+    "ic": 0,
+    "senior": 1,
+    "staff": 2,
+    "manager": 3,
+    "director": 4,
+    "vp": 5,
+    "c_level": 6,
+}
+
+# Title tokens → the rank they imply. Checked high-to-low; first match wins, so
+# "Senior Director" reads as director, not senior. Word-boundaried to avoid
+# matching inside other words (e.g. "management" must not trip "manager").
+_TITLE_PATTERNS: tuple[tuple[int, re.Pattern[str]], ...] = (
+    (6, re.compile(r"\b(chief|c[xeofmt]o|c-level|chief officer)\b", re.I)),
+    (5, re.compile(r"\b(vp|svp|evp|vice[\s-]?president)\b", re.I)),
+    (4, re.compile(r"\b(director|head\s+of|global\s+head|group\s+head)\b", re.I)),
+    (3, re.compile(r"\b(manager|mgr)\b", re.I)),
+    (1, re.compile(r"\b(senior|sr\.?|staff|principal|lead)\b", re.I)),
+    (
+        0,
+        re.compile(
+            r"\b(coordinator|specialist|associate|analyst|representative|"
+            r"rep|agent|intern|assistant|clerk|trainee|apprentice)\b",
+            re.I,
+        ),
+    ),
+)
+
+
+def detect_title_rank(title: str) -> int | None:
+    """Best-guess seniority rank from a job title, or None if no level token.
+
+    None means "no explicit seniority signal" — the gate treats that as a pass
+    so unusual titles are never dropped on a guess.
+    """
+    for rank, pattern in _TITLE_PATTERNS:
+        if pattern.search(title):
+            return rank
+    return None
+
+
+def passes_seniority_gate(
+    title: str,
+    seniority_hint: SeniorityHint | None,
+    *,
+    tolerance: int = 1,
+) -> bool:
+    """True if ``title`` is senior enough to be worth a Phase 2 grade.
+
+    Only gates targets whose hint is *director or above* — below that the bar is
+    low enough that pre-filtering would mostly cause false drops, so it's a
+    pass-through. ``tolerance`` allows roles up to N rungs below the hint (1 by
+    default, so a *Manager* still grades for a *Director* target — the stretch
+    case worth a look — but a *Coordinator* does not). Ambiguous titles (no
+    level token) always pass.
+    """
+    if seniority_hint is None:
+        return True
+    hint_rank = _RANK[seniority_hint]
+    if hint_rank < _RANK["director"]:
+        return True
+    title_rank = detect_title_rank(title)
+    if title_rank is None:
+        return True
+    return title_rank >= hint_rank - tolerance
+
+
+__all__ = ["detect_title_rank", "passes_seniority_gate"]

--- a/apps/wyrdfold-api/scripts/backfill_phase2_fit.py
+++ b/apps/wyrdfold-api/scripts/backfill_phase2_fit.py
@@ -146,7 +146,9 @@ async def backfill(
                 1
                 for j in jobs
                 if j["id"] in state
-                and _needs_phase2(*state[j["id"]], target.profile_version)
+                # state tuples carry phase1_confidence as a 4th field for
+                # ordering; _needs_phase2 only gates on the first three.
+                and _needs_phase2(*state[j["id"]][:3], target.profile_version)
             )
             logger.info(
                 "%s — %d promising, %d need Phase 2 (dry-run)",

--- a/apps/wyrdfold-api/scripts/debug_cx_scoring.py
+++ b/apps/wyrdfold-api/scripts/debug_cx_scoring.py
@@ -1,0 +1,105 @@
+"""Why do CX-relevant director roles score low for Mel's target?
+
+For each job whose title matches a CX keyword, print scoring_status + score +
+axis_scores so we can tell a *graded-low* job (Phase-2 ran, scorer disagrees)
+from an *ungraded* one (still keyword-scored, Phase-2 backlog/starvation).
+
+Usage:
+    cd apps/wyrdfold-api
+    PYTHONPATH=. railway run -- uv run python scripts/debug_cx_scoring.py
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from typing import Any, cast
+
+from app.supabase_pool import get_supabase_pool, init_supabase
+
+MEL_TARGET_ID = "4195d651-2009-4c43-bc6b-beec4d3fca0b"
+CX_TOKENS = (
+    "customer experience",
+    "customer success",
+    "customer support",
+    "customer service",
+    "customer operations",
+    "cx",
+    "client success",
+    "onboarding",
+)
+
+
+def main() -> None:
+    init_supabase()
+    sb = get_supabase_pool()
+    if sb is None:
+        raise RuntimeError("Supabase not configured")
+
+    scores = cast(
+        list[dict[str, Any]],
+        (
+            sb.table("scores")
+            .select("job_posting_id, score, scoring_status, axis_scores")
+            .eq("target_id", MEL_TARGET_ID)
+            .eq("excluded", False)
+            .order("score", desc=True)
+            .execute()
+        ).data
+        or [],
+    )
+
+    by_status: Counter[str] = Counter(s.get("scoring_status") or "?" for s in scores)
+    print(f"# all excluded=False scores: {len(scores)}")
+    print(f"# scoring_status breakdown: {dict(by_status)}\n")
+
+    ids = [s["job_posting_id"] for s in scores]
+    jobs: dict[str, dict[str, Any]] = {}
+    for i in range(0, len(ids), 200):
+        jr = (
+            sb.table("jobs")
+            .select("id, title, company_name, status")
+            .in_("id", ids[i : i + 200])
+            .execute()
+        )
+        for row in cast(list[dict[str, Any]], jr.data or []):
+            jobs[row["id"]] = row
+
+    cx = []
+    for s in scores:
+        job = jobs.get(s["job_posting_id"])
+        if not job:
+            continue
+        title = (job.get("title") or "").lower()
+        if any(tok in title for tok in CX_TOKENS):
+            cx.append({**s, **job})
+
+    graded = [c for c in cx if c.get("scoring_status") == "complete"]
+    ungraded = [c for c in cx if c.get("scoring_status") != "complete"]
+    print(
+        f"# CX-title matches: {len(cx)}  "
+        f"(complete/graded={len(graded)}, ungraded={len(ungraded)})\n"
+    )
+
+    print(f"{'score':>5}  {'status':<9}  {'jobstat':<8}  {'title':<50}  {'company':<20}")
+    print("-" * 100)
+    for c in cx[:40]:
+        print(
+            f"{c.get('score', '?'):>5}  "
+            f"{(c.get('scoring_status') or '?'):<9}  "
+            f"{(c.get('status') or '?'):<8}  "
+            f"{(c.get('title') or '').strip()[:48]:<50}  "
+            f"{(c.get('company_name') or '').strip()[:18]:<20}"
+        )
+
+    print("\n# axis_scores for the graded CX roles (the real LLM verdicts):")
+    for c in graded[:15]:
+        print(
+            f"  score={c.get('score')}  {(c.get('title') or '').strip()[:50]}  "
+            f"axes={c.get('axis_scores')}"
+        )
+    if not graded:
+        print("  (none Phase-2 graded — every CX role is showing a keyword score)")
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/wyrdfold-api/scripts/debug_phase1_conf_vs_fit.py
+++ b/apps/wyrdfold-api/scripts/debug_phase1_conf_vs_fit.py
@@ -1,0 +1,94 @@
+"""Does Phase-1 confidence predict the Phase-2 fit score?
+
+If a confidence cutoff before Phase-2 is to save money WITHOUT dropping good
+roles, low confidence must correlate with low fit. This cross-tabs
+phase1_confidence vs the final Phase-2 score for every graded (complete) row
+on a target, and reports how many *wasted* grades (fit < FLOOR) a given
+confidence cutoff would actually have avoided — and how many *good* roles
+(fit >= GOOD) it would have wrongly dropped.
+
+Usage:
+    cd apps/wyrdfold-api
+    PYTHONPATH=. railway run -- uv run python scripts/debug_phase1_conf_vs_fit.py
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+from app.supabase_pool import get_supabase_pool, init_supabase
+
+MEL_TARGET_ID = "4195d651-2009-4c43-bc6b-beec4d3fca0b"
+WASTE_FLOOR = 20   # fit < this == Phase-2 spent on a role that'll never surface
+GOOD = 45          # fit >= this == a role we definitely wanted to grade
+
+
+def _bucket(v: int, edges: tuple[int, ...]) -> str:
+    lo = 0
+    for e in edges:
+        if v < e:
+            return f"{lo}-{e - 1}"
+        lo = e
+    return f"{lo}+"
+
+
+def main() -> None:
+    init_supabase()
+    sb = get_supabase_pool()
+    if sb is None:
+        raise RuntimeError("Supabase not configured")
+
+    rows: list[dict[str, Any]] = []
+    page = 0
+    while True:
+        resp = (
+            sb.table("scores")
+            .select("score, phase1_confidence")
+            .eq("target_id", MEL_TARGET_ID)
+            .eq("scoring_status", "complete")
+            .range(page * 1000, page * 1000 + 999)
+            .execute()
+        )
+        chunk = cast(list[dict[str, Any]], resp.data or [])
+        rows.extend(chunk)
+        if len(chunk) < 1000:
+            break
+        page += 1
+
+    graded = [r for r in rows if r.get("score") is not None]
+    with_conf = [r for r in graded if r.get("phase1_confidence") is not None]
+    print(f"# graded (complete) rows: {len(graded)}")
+    print(f"# of those WITH phase1_confidence: {len(with_conf)}")
+    if not with_conf:
+        print("  (no confidence data — these graded before the confidence prompt)")
+        return
+
+    conf_edges = (40, 60, 75, 90)
+    fit_edges = (20, 35, 50)
+    grid: dict[str, dict[str, int]] = {}
+    for r in with_conf:
+        cb = _bucket(int(r["phase1_confidence"]), conf_edges)
+        fb = _bucket(int(r["score"]), fit_edges)
+        grid.setdefault(cb, {}).setdefault(fb, 0)
+        grid[cb][fb] += 1
+
+    fit_labels = ["0-19", "20-34", "35-49", "50+"]
+    print("\n# rows: phase1_confidence (down) x phase2 fit_score (across)")
+    print(f"{'conf':<8} " + "  ".join(f"{f:>7}" for f in fit_labels) + "    total")
+    for cb in sorted(grid):
+        row = grid[cb]
+        cells = [row.get(f, 0) for f in fit_labels]
+        print(f"{cb:<8} " + "  ".join(f"{c:>7}" for c in cells) + f"    {sum(cells)}")
+
+    # What a confidence cutoff would actually do.
+    print(f"\n# confidence-cutoff impact (waste = fit<{WASTE_FLOOR}, good = fit>={GOOD})")
+    print(f"{'cutoff':>7}  {'rows_dropped':>12}  {'waste_avoided':>13}  {'good_lost':>9}")
+    for cut in (40, 50, 60, 70, 80):
+        dropped = [r for r in with_conf if int(r["phase1_confidence"]) < cut]
+        waste_avoided = sum(1 for r in dropped if int(r["score"]) < WASTE_FLOOR)
+        good_lost = sum(1 for r in dropped if int(r["score"]) >= GOOD)
+        print(f"{cut:>7}  {len(dropped):>12}  {waste_avoided:>13}  {good_lost:>9}")
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/wyrdfold-api/scripts/shadow_seniority_gate.py
+++ b/apps/wyrdfold-api/scripts/shadow_seniority_gate.py
@@ -1,0 +1,94 @@
+"""Shadow-measure the Phase-2 seniority pre-gate (#902).
+
+Applies ``passes_seniority_gate`` retrospectively to every already-graded
+(complete) row on a target and reports, per tolerance:
+  - grades the gate WOULD have skipped (the Phase-2 spend it saves),
+  - of those, how many were WASTE (fit < WASTE_FLOOR) vs GOOD (fit >= GOOD).
+A good gate skips lots of waste and almost no good roles. Read-only.
+
+Usage:
+    cd apps/wyrdfold-api
+    PYTHONPATH=. railway run -- uv run python scripts/shadow_seniority_gate.py
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+from app.services.fit.seniority_gate import detect_title_rank, passes_seniority_gate
+from app.supabase_pool import get_supabase_pool, init_supabase
+
+MEL_TARGET_ID = "4195d651-2009-4c43-bc6b-beec4d3fca0b"
+SENIORITY_HINT = "director"
+WASTE_FLOOR = 20
+GOOD = 45
+
+
+def main() -> None:
+    init_supabase()
+    sb = get_supabase_pool()
+    if sb is None:
+        raise RuntimeError("Supabase not configured")
+
+    scores: list[dict[str, Any]] = []
+    page = 0
+    while True:
+        resp = (
+            sb.table("scores")
+            .select("job_posting_id, score")
+            .eq("target_id", MEL_TARGET_ID)
+            .eq("scoring_status", "complete")
+            .range(page * 1000, page * 1000 + 999)
+            .execute()
+        )
+        chunk = cast(list[dict[str, Any]], resp.data or [])
+        scores.extend(chunk)
+        if len(chunk) < 1000:
+            break
+        page += 1
+    scores = [s for s in scores if s.get("score") is not None]
+
+    ids = [s["job_posting_id"] for s in scores]
+    titles: dict[str, str] = {}
+    for i in range(0, len(ids), 200):
+        jr = (
+            sb.table("jobs")
+            .select("id, title")
+            .in_("id", ids[i : i + 200])
+            .execute()
+        )
+        for row in cast(list[dict[str, Any]], jr.data or []):
+            titles[row["id"]] = row.get("title") or ""
+
+    rows = [
+        {"title": titles.get(s["job_posting_id"], ""), "score": int(s["score"])}
+        for s in scores
+        if s["job_posting_id"] in titles
+    ]
+    total = len(rows)
+    waste = [r for r in rows if r["score"] < WASTE_FLOOR]
+    good = [r for r in rows if r["score"] >= GOOD]
+    print(f"# graded rows: {total}  (waste fit<{WASTE_FLOOR}: {len(waste)}, "
+          f"good fit>={GOOD}: {len(good)})\n")
+
+    print(f"{'tol':>3}  {'skipped':>7}  {'waste_saved':>11}  {'good_lost':>9}  "
+          f"{'precision':>9}")
+    for tol in (0, 1, 2):
+        skipped = [
+            r for r in rows
+            if not passes_seniority_gate(r["title"], SENIORITY_HINT, tolerance=tol)
+        ]
+        ws = sum(1 for r in skipped if r["score"] < WASTE_FLOOR)
+        gl = sum(1 for r in skipped if r["score"] >= GOOD)
+        prec = f"{ws / len(skipped) * 100:.0f}%" if skipped else "—"
+        print(f"{tol:>3}  {len(skipped):>7}  {ws:>11}  {gl:>9}  {prec:>9}")
+
+    print("\n# sample of WASTE titles (fit<20) with detected rank "
+          "[director=4, manager=3, ic/senior=1, sub=0, None=ambiguous]:")
+    for r in waste[:25]:
+        print(f"  fit={r['score']:>2}  rank={detect_title_rank(r['title'])}  "
+              f"{r['title'][:60]}")
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/wyrdfold-api/tests/test_phase2_runner.py
+++ b/apps/wyrdfold-api/tests/test_phase2_runner.py
@@ -330,3 +330,64 @@ async def test_confidence_ties_break_by_first_seen_at_desc(
     )
     assert n == 1
     assert graded == ["j-new"]
+
+
+# ---- seniority pre-gate (#902) --------------------------------------------
+
+
+def _director_target() -> JobTarget:
+    t = _target(1)
+    t.seniority_hint = "director"
+    return t
+
+
+def _gate_rows(ids: list[str]) -> list[dict[str, Any]]:
+    return [
+        {"job_posting_id": jid, "promising": True, "scoring_status": "stage2",
+         "scored_profile_version": 1, "phase1_confidence": 90}
+        for jid in ids
+    ]
+
+
+@pytest.mark.asyncio
+async def test_seniority_gate_skips_below_level_when_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    graded = _patch_grader(monkeypatch)
+    _patch_quota(monkeypatch, 100)
+    monkeypatch.setattr(f"{_RUNNER}.settings.phase2_seniority_gate_enabled", True)
+    monkeypatch.setattr(f"{_RUNNER}.settings.phase2_seniority_gate_tolerance", 1)
+    rows = _gate_rows(["j-dir", "j-mgr", "j-coord", "j-eng"])
+    jobs = [
+        {"id": "j-dir", "title": "Director of CX Operations", "description_html": ""},
+        {"id": "j-mgr", "title": "Customer Success Manager", "description_html": ""},
+        {"id": "j-coord", "title": "CX Coordinator", "description_html": ""},
+        {"id": "j-eng", "title": "Senior Sales Engineer", "description_html": ""},
+    ]
+    n = await run_phase2_for_jobs(
+        _supabase(rows), MagicMock(), target=_director_target(),
+        payload=_payload(), jobs=jobs,
+    )
+    # Director + (tolerance=1) Manager grade; Coordinator + senior-IC dropped.
+    assert n == 2
+    assert set(graded) == {"j-dir", "j-mgr"}
+
+
+@pytest.mark.asyncio
+async def test_seniority_gate_noop_when_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Flag off (default) → every promising candidate still grades."""
+    graded = _patch_grader(monkeypatch)
+    _patch_quota(monkeypatch, 100)
+    rows = _gate_rows(["j-dir", "j-coord"])
+    jobs = [
+        {"id": "j-dir", "title": "Director of CX", "description_html": ""},
+        {"id": "j-coord", "title": "CX Coordinator", "description_html": ""},
+    ]
+    n = await run_phase2_for_jobs(
+        _supabase(rows), MagicMock(), target=_director_target(),
+        payload=_payload(), jobs=jobs,
+    )
+    assert n == 2
+    assert set(graded) == {"j-dir", "j-coord"}

--- a/apps/wyrdfold-api/tests/test_seniority_gate.py
+++ b/apps/wyrdfold-api/tests/test_seniority_gate.py
@@ -1,0 +1,78 @@
+"""Tests for the Phase-2 seniority pre-gate (#902)."""
+
+from __future__ import annotations
+
+from app.services.fit.seniority_gate import detect_title_rank, passes_seniority_gate
+
+
+class TestDetectTitleRank:
+    def test_director(self) -> None:
+        assert detect_title_rank("Director of CX Operations") == 4
+        assert detect_title_rank("Head of Customer Experience") == 4
+
+    def test_director_wins_over_senior(self) -> None:
+        # High-to-low scan: "Senior Director" reads as director, not senior.
+        assert detect_title_rank("Senior Director, Customer Success") == 4
+
+    def test_vp_and_clevel(self) -> None:
+        assert detect_title_rank("VP, Customer Operations") == 5
+        assert detect_title_rank("Vice President of Support") == 5
+        assert detect_title_rank("Chief Customer Officer") == 6
+
+    def test_manager(self) -> None:
+        assert detect_title_rank("Customer Success Manager") == 3
+
+    def test_management_does_not_trip_manager(self) -> None:
+        # Word-boundaried: "Management" must not match "manager".
+        assert detect_title_rank("Director, Product Management") == 4
+
+    def test_sub_level(self) -> None:
+        assert detect_title_rank("Customer Experience Coordinator") == 0
+        assert detect_title_rank("Support Specialist") == 0
+
+    def test_senior_ic(self) -> None:
+        assert detect_title_rank("Senior Machine Learning Engineer") == 1
+
+    def test_ambiguous_is_none(self) -> None:
+        assert detect_title_rank("Customer Experience") is None
+        assert detect_title_rank("Solutions Architect") is None
+
+
+class TestPassesSeniorityGate:
+    def test_none_hint_passes_everything(self) -> None:
+        assert passes_seniority_gate("Support Coordinator", None) is True
+
+    def test_below_director_hint_is_passthrough(self) -> None:
+        # Only director+ targets are gated; a manager target keeps everything.
+        assert passes_seniority_gate("Support Coordinator", "manager") is True
+
+    def test_director_hint_keeps_director_and_above(self) -> None:
+        assert passes_seniority_gate("Director of CX", "director") is True
+        assert passes_seniority_gate("VP, Customer Ops", "director") is True
+        assert passes_seniority_gate("Chief Customer Officer", "director") is True
+
+    def test_director_hint_default_tolerance_keeps_manager(self) -> None:
+        # tolerance=1 → a Manager is the stretch case worth a grade.
+        assert passes_seniority_gate("Customer Success Manager", "director") is True
+
+    def test_director_hint_drops_sub_level(self) -> None:
+        assert passes_seniority_gate("CX Coordinator", "director") is False
+        assert passes_seniority_gate("Senior Sales Engineer", "director") is False
+
+    def test_director_hint_passes_ambiguous(self) -> None:
+        # No level token → never dropped on a guess.
+        assert passes_seniority_gate("Customer Experience", "director") is True
+
+    def test_tolerance_zero_drops_manager(self) -> None:
+        assert (
+            passes_seniority_gate("Customer Success Manager", "director", tolerance=0)
+            is False
+        )
+        assert (
+            passes_seniority_gate("Director of CX", "director", tolerance=0) is True
+        )
+
+    def test_offdomain_director_still_passes(self) -> None:
+        # Documented blind spot: the gate is seniority-only, so a wrong-domain
+        # director (e.g. eng/product) passes — domain filtering is separate.
+        assert passes_seniority_gate("Head of Solutions Engineering", "director") is True


### PR DESCRIPTION
## Summary
Follow-up to #845/#902. Phase 1's `promising` verdict is domain-oriented and deliberately permissive, so it forwards roles whose *seniority* is well below the target's — Phase 2 (Sonnet) then spends a real grade discovering the mismatch. On Mel's director target, **82% of graded rows score fit < 20**.

Adds a near-free **title-seniority pre-gate** before Phase 2, **flag-gated (off by default)** and shadow-validated per our scoring-change rollout rule.

- `seniority_gate.py` — pure, tested `passes_seniority_gate(title, hint, tolerance)`.
- `phase2_runner.py` — filters candidates through the gate when `phase2_seniority_gate_enabled`; logs skip volume.
- `config.py` — `phase2_seniority_gate_enabled` (default `False`), `phase2_seniority_gate_tolerance` (default `1`).
- Fixes `backfill_phase2_fit.py`, which crashed on every run (`_needs_phase2` got 5 args after `_fetch_phase2_state` grew a 4th field; the runner slices `[:3]`, the script didn't).
- Shadow/diagnostic scripts referenced by #902.

## Shadow-measure (retrospective, `scripts/shadow_seniority_gate.py`)
| tolerance | grades skipped | waste saved (fit<20) | good lost (fit≥45) | precision |
|---|---|---|---|---|
| 0 | 1,322 | 1,078 | 16 | 82% |
| **1 (default)** | **529** | **496** | **3** | **94%** |

→ ~32% Phase-2 saving at 94% precision.

## Why a confidence cutoff was rejected
`phase1_confidence` is saturated at 90+ (345/351 rows) and is *verdict certainty, not relevance* — a threshold at 80 drops 3 rows total. Full data in #902.

## Known blind spot (next work, not this PR)
The gate is seniority-only, so off-domain directors (`Director, Product Management`, `Head of Solutions Engineering`) still pass. The larger lever is **Phase-1 domain precision** — tracked in #902.

## Test plan
- [x] `ruff` + `mypy` clean
- [x] `pytest tests/test_seniority_gate.py tests/test_phase2_runner.py` — 31 pass (incl. gate-on/off integration + pure-function cases)
- [ ] Enable `phase2_seniority_gate_enabled` in DEV for Mel's target, confirm skip-log volume matches the shadow numbers before flipping in prod

> Note: independent of the in-flight Supabase migration work — no `supabase/` files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)