### PR TITLE
feat(shared-ui): emit per-component JS for npm subpath imports

### DIFF
--- a/libs/shared/ui/package.json
+++ b/libs/shared/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@danieljoffe/shared-ui",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "React component library and design system shared across danieljoffe.com and WyrdFold — Tailwind CSS 4, React 19, server-component-friendly.",
   "type": "module",
   "sideEffects": false,
@@ -18,17 +18,20 @@
     "./*": {
       "@danieljoffe.com/source": "./src/lib/*.tsx",
       "types": "./dist/lib/*.d.ts",
-      "default": "./src/lib/*.tsx"
+      "import": "./dist/lib/*.js",
+      "default": "./dist/lib/*.js"
     },
     "./styles/*": {
       "@danieljoffe.com/source": "./src/lib/styles/*.ts",
       "types": "./dist/lib/styles/*.d.ts",
-      "default": "./src/lib/styles/*.ts"
+      "import": "./dist/lib/styles/*.js",
+      "default": "./dist/lib/styles/*.js"
     },
     "./types": {
       "@danieljoffe.com/source": "./src/lib/types.ts",
       "types": "./dist/lib/types.d.ts",
-      "default": "./src/lib/types.ts"
+      "import": "./dist/lib/types.js",
+      "default": "./dist/lib/types.js"
     },
     "./styles/indigo-theme.css": "./src/styles/indigo-theme.css",
     "./styles/pyre-theme.css": "./src/styles/pyre-theme.css"

--- a/libs/shared/ui/vite.config.ts
+++ b/libs/shared/ui/vite.config.ts
@@ -2,8 +2,34 @@
 import { readdirSync } from 'node:fs';
 import * as path from 'path';
 import react from '@vitejs/plugin-react';
-import { defineConfig } from 'vite';
+import { defineConfig, type Plugin } from 'vite';
 import dts from 'vite-plugin-dts';
+
+// Rollup strips module-level `"use client"`/`"use server"` directives under
+// preserveModules, which makes the per-component dist files crash Next.js
+// Server Component builds (the file uses client hooks but no longer declares
+// the boundary). Capture each module's directive before transforms run, then
+// re-emit it at the top of the matching emitted chunk.
+const DIRECTIVE_RE =
+  /^(?:\s*(?:\/\/[^\n]*|\/\*[\s\S]*?\*\/))*\s*(['"])use (client|server)\1/;
+function preserveDirectives(): Plugin {
+  const directives = new Map<string, string>();
+  return {
+    name: 'preserve-use-directives',
+    enforce: 'pre',
+    transform(code, id) {
+      const match = DIRECTIVE_RE.exec(code);
+      if (match) directives.set(id, `'use ${match[2]}';`);
+      return null;
+    },
+    renderChunk(code, chunk) {
+      const id = chunk.facadeModuleId;
+      const directive = id ? directives.get(id) : undefined;
+      if (!directive) return null;
+      return { code: `${directive}\n${code}`, map: null };
+    },
+  };
+}
 
 // Build one ES module per source file (preserveModules) so consumers can deep-
 // import subpaths from node_modules, e.g. `@danieljoffe/shared-ui/Text` →
@@ -35,6 +61,7 @@ export default defineConfig(() => ({
   root: __dirname,
   cacheDir: '../../../node_modules/.vite/libs/shared/ui',
   plugins: [
+    preserveDirectives(),
     react(),
     dts({
       entryRoot: 'src',

--- a/libs/shared/ui/vite.config.ts
+++ b/libs/shared/ui/vite.config.ts
@@ -1,8 +1,35 @@
 /// <reference types='vitest' />
+import { readdirSync } from 'node:fs';
 import * as path from 'path';
 import react from '@vitejs/plugin-react';
 import { defineConfig } from 'vite';
 import dts from 'vite-plugin-dts';
+
+// Build one ES module per source file (preserveModules) so consumers can deep-
+// import subpaths from node_modules, e.g. `@danieljoffe/shared-ui/Text` →
+// `dist/lib/Text.js`. The published package previously shipped only a single
+// bundled `dist/index.js`, so the `./*` exports subpaths resolved to raw
+// `src/lib/*.tsx` (workspace-only, via the `@danieljoffe.com/source` condition)
+// and broke when consumed from npm. Multi-entry + preserveModules makes the JS
+// layout mirror the per-component `.d.ts` files vite-plugin-dts already emits.
+const SKIP = /\.(spec|stories|test)\.(ts|tsx)$|\.d\.ts$/;
+function collect(dir: string): string[] {
+  const out: string[] = [];
+  for (const e of readdirSync(path.resolve(__dirname, dir), {
+    withFileTypes: true,
+  })) {
+    const rel = `${dir}/${e.name}`;
+    if (e.isDirectory()) out.push(...collect(rel));
+    else if (/\.(ts|tsx)$/.test(e.name) && !SKIP.test(e.name)) out.push(rel);
+  }
+  return out;
+}
+const entry = Object.fromEntries(
+  ['src/index.ts', ...collect('src/lib')].map(f => [
+    f.replace(/^src\//, '').replace(/\.(ts|tsx)$/, ''),
+    path.resolve(__dirname, f),
+  ])
+);
 
 export default defineConfig(() => ({
   root: __dirname,
@@ -14,10 +41,6 @@ export default defineConfig(() => ({
       tsconfigPath: path.join(__dirname, 'tsconfig.lib.json'),
     }),
   ],
-  // Uncomment this if you are using workers.
-  // worker: {
-  //  plugins: [ nxViteTsPaths() ],
-  // },
   // Configuration for building your library.
   // See: https://vitejs.dev/guide/build.html#library-mode
   build: {
@@ -28,17 +51,29 @@ export default defineConfig(() => ({
       transformMixedEsModules: true,
     },
     lib: {
-      // Could also be a dictionary or array of multiple entry points.
-      entry: 'src/index.ts',
-      name: '@danieljoffe/shared-ui',
-      fileName: 'index',
-      // Change this to the formats you want to support.
-      // Don't forget to update your package.json as well.
+      // Multiple entry points — one per component/util/style module — so each
+      // is independently importable from the published package.
+      entry,
       formats: ['es' as const],
     },
     rollupOptions: {
-      // External packages that should not be bundled into your library.
-      external: ['react', 'react-dom', 'react/jsx-runtime'],
+      // Peer/runtime deps consumers install themselves — keep them out of the
+      // build so they aren't duplicated across the per-module chunks.
+      external: [
+        'react',
+        'react-dom',
+        'react/jsx-runtime',
+        'clsx',
+        'tailwind-merge',
+        /^lucide-react/,
+      ],
+      output: {
+        // Mirror the src tree into dist (dist/index.js, dist/lib/Text.js, …)
+        // so output JS aligns 1:1 with the emitted .d.ts files.
+        preserveModules: true,
+        preserveModulesRoot: 'src',
+        entryFileNames: '[name].js',
+      },
     },
   },
 }));


### PR DESCRIPTION
## Summary

Makes `@danieljoffe/shared-ui` consumable via deep subpath imports
(`@danieljoffe/shared-ui/Text`) from **npm/node_modules**, not just inside the
workspace. This is **Phase 1** of extracting wyrdfold into its own repo (where
it must depend on the published package), but it's self-contained and ships
independently.

### Problem
The published tarball shipped only a bundled `dist/index.js` + per-component
`.d.ts` — **no per-component `.js`**. The `./*` exports subpath `default`
pointed at raw `./src/lib/*.tsx`, which only resolves in-repo via the
`@danieljoffe.com/source` condition (`tsconfig.base.json` + `next.config.mjs`).
Consumed from node_modules, every deep import would fail.

### Change
- **`vite.config.ts`**: multi-entry + Rollup `preserveModules` → build emits
  `dist/lib/*.js` mirroring the `.d.ts` layout. Externalize
  `lucide-react`/`clsx`/`tailwind-merge` so they aren't duplicated per module.
- **`package.json`**: `./*`, `./styles/*`, `./types` subpath `import`/`default`
  now point at `dist/lib/*.js`. The `@danieljoffe.com/source` condition is
  **unchanged**, so in-repo consumers (`apps/root`, `apps/wyrdfold`) keep
  resolving source — non-breaking. Version `0.0.1` → `0.1.0`.

## Verification
- `npm pack` + clean `npm i` in a throwaway project resolves `/Text`, `/Card`,
  `/styles/formStyles`, and the barrel **without** the custom condition (52
  per-component JS files in the tarball).
- `pnpm tsc --noEmit` ✓ · `@danieljoffe/shared-ui` 754 tests ✓ · `root` 1024 tests ✓.

## After merge (manual)
Run the **publish-shared-ui** workflow (`dry-run=true` first to inspect the file
list, then `dry-run=false`) to publish `0.1.0`. Pass `version=current` since the
bump is already in `package.json`.

## Test plan
- [ ] CI green (incl. `shared-ui-package-check` / `size-limit`)
- [ ] Publish `0.1.0`; confirm `npm view @danieljoffe/shared-ui@0.1.0` then a deep import resolves from a fresh install

🤖 Generated with [Claude Code](https://claude.com/claude-code)