### PR TITLE
Fix: production server-side self-fetches hit the Deployment Protection wall

### DIFF
--- a/apps/root/src/lib/__tests__/getOrigin.spec.ts
+++ b/apps/root/src/lib/__tests__/getOrigin.spec.ts
@@ -1,0 +1,52 @@
+import { DOMAIN_URL } from '@/utils/constants';
+import { getOrigin } from '../getOrigin';
+
+const mockHeadersGet = jest.fn();
+jest.mock('next/headers', () => ({
+  headers: () => Promise.resolve({ get: mockHeadersGet }),
+}));
+
+describe('getOrigin', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env = { ...originalEnv };
+    delete process.env.VERCEL_ENV;
+    delete process.env.VERCEL_URL;
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it('returns DOMAIN_URL on Vercel production, even when VERCEL_URL is set', async () => {
+    // VERCEL_URL is the *.vercel.app deployment URL behind Deployment
+    // Protection — using it for self-fetches returns the auth wall.
+    process.env.VERCEL_ENV = 'production';
+    process.env.VERCEL_URL = 'danieljoffe-com-abc123.vercel.app';
+
+    await expect(getOrigin()).resolves.toBe(DOMAIN_URL);
+  });
+
+  it('returns the VERCEL_URL deployment origin on previews', async () => {
+    process.env.VERCEL_ENV = 'preview';
+    process.env.VERCEL_URL = 'danieljoffe-com-abc123.vercel.app';
+
+    await expect(getOrigin()).resolves.toBe(
+      'https://danieljoffe-com-abc123.vercel.app'
+    );
+  });
+
+  it('falls back to the host header in development', async () => {
+    mockHeadersGet.mockReturnValue('localhost:3000');
+
+    await expect(getOrigin()).resolves.toBe('http://localhost:3000');
+  });
+
+  it('uses https for non-localhost hosts', async () => {
+    mockHeadersGet.mockReturnValue('example.test');
+
+    await expect(getOrigin()).resolves.toBe('https://example.test');
+  });
+});

--- a/apps/root/src/lib/getOrigin.ts
+++ b/apps/root/src/lib/getOrigin.ts
@@ -7,6 +7,13 @@ import { DOMAIN_URL } from '@/utils/constants';
  * in development for localhost support.
  */
 export async function getOrigin(): Promise<string> {
+  // VERCEL_URL is the *.vercel.app deployment URL, which sits behind
+  // Deployment Protection — self-fetches through it hit the auth wall
+  // instead of the API. Production must use the public domain.
+  if (process.env.VERCEL_ENV === 'production') {
+    return DOMAIN_URL;
+  }
+
   if (process.env.VERCEL_URL) {
     return `https://${process.env.VERCEL_URL}`;
   }


### PR DESCRIPTION
## Summary
- `getOrigin()` returned `https://${VERCEL_URL}` whenever `VERCEL_URL` was set — which is always, on Vercel. That's the `*.vercel.app` deployment URL, which sits behind Deployment Protection.
- Result: the `/audit/insights` page's server-side API fetches received the auth wall instead of JSON, failed silently through the `catch → null` fallback, and **production has been rendering all-zero insights** (0 sites audited, no charts).
- Fix: check `VERCEL_ENV === 'production'` first and return the public domain (`DOMAIN_URL`), keeping the `VERCEL_URL` branch for previews. This matches the function's own doc comment, which the old branch order contradicted.
- Adds `getOrigin.spec.ts` covering production-on-Vercel, preview, and dev host-header branches.

## Test plan
- [x] New unit tests pass (4/4)
- [x] Typecheck clean (pre-commit hook)
- [ ] After release to production: `/audit/insights` renders real aggregate data (verified manually — direct API calls already return `totalScans: 26`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)