### PR TITLE
Fix /tools/admin redirect to deleted /tools/admin/jobs

### DIFF
--- a/apps/root-e2e/src/tools-admin.spec.ts
+++ b/apps/root-e2e/src/tools-admin.spec.ts
@@ -16,14 +16,14 @@ test.describe('tools admin login', () => {
     ).toBeVisible();
   });
 
-  test('redirects unauthenticated visitors from /tools/admin/jobs to /tools/login with next param', async ({
+  test('redirects unauthenticated visitors from /tools/admin/audit to /tools/login with next param', async ({
     page,
   }) => {
-    await page.goto('/tools/admin/jobs', { waitUntil: 'domcontentloaded' });
+    await page.goto('/tools/admin/audit', { waitUntil: 'domcontentloaded' });
 
     await expect(page).toHaveURL(/\/tools\/login\?next=/);
     expect(page.url()).toContain(
-      `next=${encodeURIComponent('/tools/admin/jobs')}`
+      `next=${encodeURIComponent('/tools/admin/audit')}`
     );
     await expect(
       page.getByRole('textbox', { name: /admin password/i })
@@ -33,7 +33,7 @@ test.describe('tools admin login', () => {
   test('shows an error alert when the wrong password is submitted', async ({
     page,
   }) => {
-    await page.goto('/tools/login?next=/tools/admin/jobs', {
+    await page.goto('/tools/login?next=/tools/admin/audit', {
       waitUntil: 'domcontentloaded',
     });
     await waitForHydration(page);
@@ -63,7 +63,7 @@ test.describe('tools admin login', () => {
       'TOOLS_ADMIN_PASSWORD env var not set; skipping happy-path login test'
     );
 
-    await page.goto('/tools/login?next=/tools/admin/jobs', {
+    await page.goto('/tools/login?next=/tools/admin/audit', {
       waitUntil: 'domcontentloaded',
     });
     await waitForHydration(page);
@@ -76,9 +76,9 @@ test.describe('tools admin login', () => {
     const submitButton = page.getByRole('button', { name: /sign in/i });
     await submitButton.click();
 
-    await expect(page).toHaveURL(/\/tools\/admin\/jobs$/, { timeout: 15000 });
+    await expect(page).toHaveURL(/\/tools\/admin\/audit$/, { timeout: 15000 });
     await expect(
-      page.getByRole('heading', { name: /job search/i })
+      page.getByRole('heading', { name: /audit admin/i })
     ).toBeVisible();
   });
 });

--- a/apps/root/src/app/tools/admin/page.tsx
+++ b/apps/root/src/app/tools/admin/page.tsx
@@ -1,5 +1,5 @@
 import { redirect } from 'next/navigation';
 
 export default function ToolsAdminIndex() {
-  redirect('/tools/admin/jobs');
+  redirect('/tools/admin/audit');
 }

--- a/apps/root/src/app/tools/login/LoginForm.spec.tsx
+++ b/apps/root/src/app/tools/login/LoginForm.spec.tsx
@@ -75,7 +75,7 @@ describe('LoginForm', () => {
   });
 
   it('redirects to sanitized next param on success', async () => {
-    mockSearchParamsGet.mockReturnValue('/tools/admin/jobs');
+    mockSearchParamsGet.mockReturnValue('/tools/admin/audit');
     (global.fetch as jest.Mock).mockResolvedValueOnce({
       ok: true,
       status: 200,
@@ -91,7 +91,7 @@ describe('LoginForm', () => {
     });
 
     await waitFor(() => {
-      expect(mockReplace).toHaveBeenCalledWith('/tools/admin/jobs');
+      expect(mockReplace).toHaveBeenCalledWith('/tools/admin/audit');
     });
   });
 


### PR DESCRIPTION
## Summary
- `/tools/admin` redirected to `/tools/admin/jobs` (removed in `bed308e2` along with the /fitted prototype) — anyone hitting the admin root got a 404. Pointed it at `/tools/admin/audit`, the only remaining admin page.
- Updated `LoginForm.spec.tsx` to use `/tools/admin/audit` for the same-origin `next` param sanitization test.
- Updated `tools-admin.spec.ts` (e2e) to use `/tools/admin/audit` and check for the "Audit Admin" heading after happy-path login.

Closes the cleanup portion of #912. The "prototype that outgrew the portfolio" case-study idea is the remaining item there.

## Test plan
- [x] `LoginForm.spec.tsx` — 8/8 pass
- [x] grep for `admin/jobs` / `/fitted` is clean
- [ ] tools-admin e2e via release validation (full / full)

🤖 Generated with [Claude Code](https://claude.com/claude-code)