### PR TITLE
Audit teardown phase A: hide user surfaces, 308 to case study

### DIFF
--- a/apps/root/next.config.mjs
+++ b/apps/root/next.config.mjs
@@ -261,6 +261,20 @@ const nextConfig = {
         destination: '/about',
         permanent: true,
       },
+      // Audit tool archived after the case study shipped — point any
+      // remaining inbound link (form, results, insights, per-violation,
+      // compare) at the case study. Excludes /api/audit/* so the admin
+      // dashboard keeps working until Phase C removes those routes.
+      {
+        source: '/audit',
+        destination: '/projects/audit-tool-case-study',
+        permanent: true,
+      },
+      {
+        source: '/audit/:path*',
+        destination: '/projects/audit-tool-case-study',
+        permanent: true,
+      },
     ];
   },
 

--- a/apps/root/src/app/__tests__/sitemap.spec.ts
+++ b/apps/root/src/app/__tests__/sitemap.spec.ts
@@ -3,8 +3,6 @@ import sitemap from '../sitemap';
 jest.mock('@/utils/constants', () => ({
   DOMAIN_URL: 'https://danieljoffe.com',
   ABOUT_LINK: { href: '/about' },
-  AUDIT_LINK: { href: '/audit' },
-  AUDIT_INSIGHTS_LINK: { href: '/audit/insights' },
   BLOG_LINK: { href: '/blog' },
   BLOG_TAGS_LINK: { href: '/blog/tags' },
   EXPERIENCE_LINK: { href: '/experience' },
@@ -47,7 +45,8 @@ describe('sitemap', () => {
     expect(urls).toContain('https://danieljoffe.com/projects');
     expect(urls).toContain('https://danieljoffe.com/experience');
     expect(urls).toContain('https://danieljoffe.com/blog');
-    expect(urls).toContain('https://danieljoffe.com/audit');
+    expect(urls).not.toContain('https://danieljoffe.com/audit');
+    expect(urls).not.toContain('https://danieljoffe.com/audit/insights');
   });
 
   it('includes dynamic experience routes', () => {

--- a/apps/root/src/app/sitemap.ts
+++ b/apps/root/src/app/sitemap.ts
@@ -2,8 +2,6 @@ import { MetadataRoute } from 'next';
 import {
   DOMAIN_URL,
   ABOUT_LINK,
-  AUDIT_LINK,
-  AUDIT_INSIGHTS_LINK,
   BLOG_LINK,
   BLOG_TAGS_LINK,
   EXPERIENCE_LINK,
@@ -51,18 +49,6 @@ export default function sitemap(): MetadataRoute.Sitemap {
       lastModified: BUILD_DATE,
       changeFrequency: 'weekly' as const,
       priority: 0.8,
-    },
-    {
-      url: `${DOMAIN_URL}${AUDIT_LINK.href}`,
-      lastModified: BUILD_DATE,
-      changeFrequency: 'weekly' as const,
-      priority: 0.9,
-    },
-    {
-      url: `${DOMAIN_URL}${AUDIT_INSIGHTS_LINK.href}`,
-      lastModified: BUILD_DATE,
-      changeFrequency: 'weekly' as const,
-      priority: 0.7,
     },
   ];
 

--- a/apps/root/src/components/Footer/index.tsx
+++ b/apps/root/src/components/Footer/index.tsx
@@ -9,7 +9,6 @@ import { profileData } from '@/data/profileData';
 import {
   FULL_NAME,
   NAV_LINKS,
-  AUDIT_LINK,
   STORYBOOK_URL,
   RESUME_URL,
 } from '@/utils/constants';
@@ -87,14 +86,6 @@ export default function Footer() {
                 </Link>
               </li>
             ))}
-            <li>
-              <Link
-                href={AUDIT_LINK.href}
-                className={`text-sm text-text-secondary hover:text-text-primary transition-colors ${FOCUS_RING} ${FOCUS_RING_OFFSET} rounded-sm`}
-              >
-                {AUDIT_LINK.label}
-              </Link>
-            </li>
           </ul>
         </nav>
 

--- a/apps/root/src/components/Nav/Links.tsx
+++ b/apps/root/src/components/Nav/Links.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { cn } from '@/lib/cn';
 import { analytics } from '@/lib/analytics';
-import { AUDIT_LINK, NAV_LINKS } from '@/utils/constants';
+import { NAV_LINKS } from '@/utils/constants';
 
 export default function NavLinks({
   pathname,
@@ -55,16 +55,6 @@ export default function NavLinks({
           </li>
         ))}
       </ul>
-      <Link
-        href={AUDIT_LINK.href}
-        onClick={(e: React.MouseEvent) =>
-          handleLinkClick(e, AUDIT_LINK.label, AUDIT_LINK.href)
-        }
-        aria-current={pathname === AUDIT_LINK.href ? 'page' : undefined}
-        className='inline-flex items-center px-3 py-1.5 rounded-lg bg-brand-600 text-white text-sm font-medium hover:bg-brand-700 transition-colors md:ml-2'
-      >
-        {AUDIT_LINK.label}
-      </Link>
     </div>
   );
 }

--- a/apps/root/src/components/Nav/MobileNav.tsx
+++ b/apps/root/src/components/Nav/MobileNav.tsx
@@ -21,7 +21,6 @@ import {
   HOME_LINK,
   PRIMARY_NAV_LINKS,
   MORE_NAV_LINKS,
-  AUDIT_LINK,
 } from '@/utils/constants';
 import { useFocusTrap } from '@/hooks/useFocusTrap';
 import DarkModeToggle from './DarkModeToggle';
@@ -32,13 +31,10 @@ const primaryIcons: Record<string, typeof Briefcase> = {
   '/about': User,
 };
 
-const moreSheetLinks = [
-  ...MORE_NAV_LINKS.map(link => ({
-    ...link,
-    icon: link.href === '/about' ? User : BookOpen,
-  })),
-  { ...AUDIT_LINK, icon: Briefcase },
-];
+const moreSheetLinks = MORE_NAV_LINKS.map(link => ({
+  ...link,
+  icon: link.href === '/about' ? User : BookOpen,
+}));
 
 export default function MobileNav({ pathname }: { pathname: string }) {
   const [sheetOpen, setSheetOpen] = useState(false);
@@ -88,9 +84,7 @@ export default function MobileNav({ pathname }: { pathname: string }) {
     [router]
   );
 
-  const isMoreActive =
-    MORE_NAV_LINKS.some(l => pathname === l.href) ||
-    pathname === AUDIT_LINK.href;
+  const isMoreActive = MORE_NAV_LINKS.some(l => pathname === l.href);
 
   const isHome = pathname === '/';
 

--- a/apps/root/src/components/Nav/TabletUpNav.spec.tsx
+++ b/apps/root/src/components/Nav/TabletUpNav.spec.tsx
@@ -53,14 +53,14 @@ jest.mock('@/lib/analytics', () => ({
 }));
 
 describe('TabletUpNav', () => {
-  test('renders logo, primary links, More dropdown, Free Audit CTA, search, and theme toggle', () => {
+  test('renders logo, primary links, More dropdown, search, and theme toggle', () => {
     render(<TabletUpNav pathname='/' />);
     expect(screen.getByAltText('Home')).toBeInTheDocument();
     expect(screen.getByText('Projects')).toBeInTheDocument();
     expect(screen.getByText('Experience')).toBeInTheDocument();
     expect(screen.getByText('About')).toBeInTheDocument();
     expect(screen.getByText('More')).toBeInTheDocument();
-    expect(screen.getByText('Free Audit')).toBeInTheDocument();
+    expect(screen.queryByText('Free Audit')).not.toBeInTheDocument();
     expect(screen.getByTestId('search-trigger')).toBeInTheDocument();
     expect(screen.getByTestId('dark-mode-toggle')).toBeInTheDocument();
   });

--- a/apps/root/src/components/Nav/TabletUpNav.tsx
+++ b/apps/root/src/components/Nav/TabletUpNav.tsx
@@ -10,7 +10,6 @@ import { analytics } from '@/lib/analytics';
 import {
   PRIMARY_NAV_LINKS,
   MORE_NAV_LINKS,
-  AUDIT_LINK,
   HOME_LINK,
 } from '@/utils/constants';
 import SearchTrigger from './SearchTrigger';
@@ -83,14 +82,6 @@ export default function TabletUpNav({ pathname }: { pathname: string }) {
       </nav>
 
       <div className='ml-auto flex items-center gap-1'>
-        <Link
-          href={AUDIT_LINK.href}
-          onClick={() => analytics.navClick(AUDIT_LINK.label)}
-          aria-current={pathname === AUDIT_LINK.href ? 'page' : undefined}
-          className='inline-flex items-center px-3 py-1.5 rounded-lg bg-brand-600 text-white text-sm font-medium hover:bg-brand-700 transition-colors'
-        >
-          {AUDIT_LINK.label}
-        </Link>
         <SearchTrigger />
         <DarkModeToggle />
       </div>

--- a/apps/root/src/components/Nav/__tests__/MobileNav.spec.tsx
+++ b/apps/root/src/components/Nav/__tests__/MobileNav.spec.tsx
@@ -31,7 +31,6 @@ jest.mock('@/utils/constants', () => ({
     { href: '/experience', label: 'Experience' },
   ],
   MORE_NAV_LINKS: [{ href: '/blog', label: 'Blog' }],
-  AUDIT_LINK: { href: '/audit', label: 'Audit' },
 }));
 
 jest.mock('../DarkModeToggle', () => {
@@ -79,14 +78,14 @@ describe('MobileNav', () => {
     ).not.toHaveAttribute('aria-hidden', 'true');
   });
 
-  it('shows more sheet links (Blog, Audit)', () => {
+  it('shows more sheet links (Blog only)', () => {
     render(<MobileNav pathname='/' />);
 
     fireEvent.click(screen.getByRole('button', { name: /open more menu/i }));
 
     // Sheet links render as buttons with link labels
     expect(screen.getByText('Blog')).toBeInTheDocument();
-    expect(screen.getByText('Audit')).toBeInTheDocument();
+    expect(screen.queryByText('Audit')).not.toBeInTheDocument();
   });
 
   it('closes sheet on Escape key', () => {

--- a/apps/root/src/data/structuredData/audit.ts
+++ b/apps/root/src/data/structuredData/audit.ts
@@ -1,4 +1,4 @@
-import { DOMAIN_URL, AUDIT_LINK } from '@/utils/constants';
+import { DOMAIN_URL } from '@/utils/constants';
 
 export const auditFaqStructuredData = Object.freeze({
   '@context': 'https://schema.org',
@@ -29,5 +29,5 @@ export const auditFaqStructuredData = Object.freeze({
       },
     },
   ],
-  url: `${DOMAIN_URL}${AUDIT_LINK.href}`,
+  url: `${DOMAIN_URL}/audit`,
 });

--- a/apps/root/src/lib/__tests__/searchIndex.spec.ts
+++ b/apps/root/src/lib/__tests__/searchIndex.spec.ts
@@ -37,8 +37,8 @@ describe('buildSearchIndex', () => {
 
   it('includes generated entries and static page entries', () => {
     const index = buildSearchIndex();
-    // 2 generated + 2 static pages
-    expect(index).toHaveLength(4);
+    // 2 generated + 1 static page
+    expect(index).toHaveLength(3);
   });
 
   it('each entry has required fields', () => {
@@ -56,14 +56,12 @@ describe('buildSearchIndex', () => {
     }
   });
 
-  it('includes static page entries for about and audit', () => {
+  it('includes static page entry for about', () => {
     const index = buildSearchIndex();
     const pages = index.filter(e => e.type === 'page');
-    expect(pages).toHaveLength(2);
+    expect(pages).toHaveLength(1);
 
-    const slugs = pages.map(p => p.slug);
-    expect(slugs).toContain('about');
-    expect(slugs).toContain('audit');
+    expect(pages[0].slug).toBe('about');
   });
 
   it('has body text for generated content entries', () => {

--- a/apps/root/src/lib/searchIndex.ts
+++ b/apps/root/src/lib/searchIndex.ts
@@ -30,20 +30,6 @@ const staticEntries: SearchEntry[] = [
     date: null,
     author: 'Daniel Joffe',
   },
-  {
-    id: 'page:audit',
-    slug: 'audit',
-    type: 'page',
-    title: 'Audit',
-    excerpt:
-      'Service for auditing web applications and providing actionable feedback',
-    tags: [],
-    category: 'page',
-    body: '',
-    url: '/audit',
-    date: null,
-    author: 'Daniel Joffe',
-  },
 ];
 
 export function buildSearchIndex(): SearchEntry[] {

--- a/apps/root/src/utils/constants.ts
+++ b/apps/root/src/utils/constants.ts
@@ -115,11 +115,6 @@ export const PROJECTS_TAGS_LINK: NavLink = {
   href: '/projects/tags',
   label: 'Tags',
 };
-export const AUDIT_LINK: NavLink = { href: '/audit', label: 'Free Audit' };
-export const AUDIT_INSIGHTS_LINK: NavLink = {
-  href: '/audit/insights',
-  label: 'Audit Insights',
-};
 
 // ============================================================================
 // CONTENT LISTING CONSTANTS


### PR DESCRIPTION
First of four phases for #909 workstream 2 (audit app teardown). Each phase is a separate, reversible PR.

| | What | Risk |
|---|---|---|
| **A (this)** | Hide `/audit*` from nav, sitemap, search index; 308 → case study. Backend + routes still exist | Low; reverts cleanly |
| B | Delete `/audit/*` public pages + components, update e2e | Medium |
| C | Delete `/tools/admin/audit` + `/api/audit/*` | Medium |
| D | Delete `apps/audit-api`, `libs/shared/audit`; coordinate Railway stop | High |
| E | Drop `scans`, `scan_issues`, `leads*` tables on legacy Supabase | Low, sequenced after wyrdfold cutover |

## Summary
- Remove the Free Audit CTA from `TabletUpNav`, `MobileNav` More sheet, `Links`, and `Footer`
- Drop `AUDIT_LINK` / `AUDIT_INSIGHTS_LINK` constants, their sitemap + searchIndex entries; inline the literal URL in `structuredData/audit.ts`
- Permanent 308 redirects for `/audit`, `/audit/*` (form, results, insights, violations, compare) → `/projects/audit-tool-case-study`
- `/api/audit/*` left alone — admin dashboard at `/tools/admin/audit` still uses them until phase C

## Test plan
- [x] `pnpm tsc --noEmit` clean
- [x] Full unit suite: 977/977 pass
- [x] Dev-server smoke: `/audit`, `/audit/insights`, `/audit/r/abc`, `/audit/insights/violations/lcp` all 308 → case study; `/api/audit/insights/summary` returns 403 (auth gate, not redirected); homepage has no Free Audit link; sitemap has zero audit entries
- [ ] Visual regression snapshots will need a refresh (Free Audit button gone from nav) — handled via `update-snapshots` workflow before next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)