### PR TITLE
Footer: credit shared-ui ("Built with my own UI library")

### DIFF
--- a/apps/root/src/components/Footer/__tests__/index.spec.tsx
+++ b/apps/root/src/components/Footer/__tests__/index.spec.tsx
@@ -56,20 +56,22 @@ describe('Footer', () => {
     expect(nav).toBeInTheDocument();
   });
 
-  it('renders the Storybook design system link', () => {
+  it('renders the Storybook design system link with shared-ui attribution', () => {
     render(<Footer />);
     const link = screen.getByRole('link', {
-      name: /browse the design system.*ui\.danieljoffe\.com/i,
+      name: /built with my own ui library.*@danieljoffe\/shared-ui/i,
     });
     expect(link).toBeInTheDocument();
     expect(link).toHaveAttribute('href', 'https://ui.danieljoffe.com');
     expect(link).toHaveAttribute('target', '_blank');
   });
 
-  it('renders the design system link text', () => {
+  it('renders the shared-ui attribution text', () => {
     render(<Footer />);
-    expect(screen.getByText('Browse the design system')).toBeInTheDocument();
-    expect(screen.getByText('ui.danieljoffe.com')).toBeInTheDocument();
+    expect(
+      screen.getByText('Built with my own UI library')
+    ).toBeInTheDocument();
+    expect(screen.getByText('@danieljoffe/shared-ui')).toBeInTheDocument();
   });
 
   it('has no accessibility violations', async () => {

--- a/apps/root/src/components/Footer/index.tsx
+++ b/apps/root/src/components/Footer/index.tsx
@@ -110,14 +110,14 @@ export default function Footer() {
             className={`flex items-center gap-1 rounded-sm ${FOCUS_RING} ${FOCUS_RING_OFFSET}`}
           >
             <Text variant='meta' as='span'>
-              Browse the design system
+              Built with my own UI library
             </Text>
             <Text
               variant='meta'
               as='span'
               className='inline-flex items-center gap-1 text-text-secondary hover:underline'
             >
-              ui.danieljoffe.com
+              @danieljoffe/shared-ui
               <ChevronRight className='h-3 w-3' />
             </Text>
           </a>


### PR DESCRIPTION
Closes #931. Part of the Portfolio Positioning epic (#938).

## Summary
Footer Storybook link copy changes from "Browse the design system — ui.danieljoffe.com" → "Built with my own UI library — @danieljoffe/shared-ui". Same anchor, same href, no layout change.

The portfolio already imports the library across every page (Heading, Section, Text, Dropdown, CTACard, etc.) — this just makes the ownership visible on the site itself, which it wasn't before.

## Test plan
- [x] Footer spec — 8/8 pass (assertions updated for new copy)
- [x] `pnpm tsc --noEmit` clean
- [ ] VR snapshot refresh on the next release window (footer copy diff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)