### PR TITLE
Home: "Currently building" section linking to WyrdFold

### DIFF
--- a/apps/root/src/app/(public)/page.tsx
+++ b/apps/root/src/app/(public)/page.tsx
@@ -7,6 +7,7 @@ import {
   ArrowUpRight,
   Zap,
   Layers,
+  Sparkles,
 } from 'lucide-react';
 import { CTACard } from '@danieljoffe/shared-ui/CTACard';
 // import { GridBg } from '@danieljoffe/shared-ui/GridBg';
@@ -71,6 +72,54 @@ export default function Index() {
 
           <HeroActions />
         </div>
+      </Section>
+
+      {/* ══════════════════════════════════
+          CURRENTLY BUILDING — single product. A list would go stale; one
+          card with a live-status indicator signals momentum without
+          maintenance cost.
+          ══════════════════════════════════ */}
+      <Section padding='none'>
+        <SectionLabel
+          icon={<Sparkles className='h-3.5 w-3.5' />}
+          label='Currently building'
+        />
+        <a
+          href='https://wyrdfold.com'
+          target='_blank'
+          rel='noopener noreferrer'
+          className={cn(
+            cardBase,
+            'group block p-5 hover:border-border-secondary transition-colors'
+          )}
+        >
+          <div className='flex items-start justify-between gap-4'>
+            <div className='space-y-2'>
+              <div className='flex flex-wrap items-center gap-2'>
+                <Heading variant='cardTitle' as='p'>
+                  WyrdFold
+                </Heading>
+                <span className='inline-flex items-center gap-1.5 rounded-full bg-emerald-500/10 px-2 py-0.5 text-xs font-medium text-emerald-600 dark:text-emerald-400'>
+                  <span
+                    className='h-1.5 w-1.5 rounded-full bg-emerald-500'
+                    aria-hidden='true'
+                  />
+                  Live
+                </span>
+              </div>
+              <Text variant='body'>
+                AI-powered job-search product I built and run solo. Resume
+                tailoring, job ingestion, match scoring &mdash; with the
+                production LLM pipelines (versioned prompts, shadow runs, async
+                observability) behind them.
+              </Text>
+            </div>
+            <ArrowUpRight
+              className='h-5 w-5 text-text-tertiary group-hover:text-text-primary transition-colors shrink-0 mt-1'
+              aria-hidden='true'
+            />
+          </div>
+        </a>
       </Section>
 
       {/* ══════════════════════════════════


### PR DESCRIPTION
Closes #929. Part of the Portfolio Positioning epic (#938).

## Summary
Adds a single-card "Currently building" section directly below the hero. Links to wyrdfold.com (external) until the WyrdFold case study (#926) ships and gives it an in-portfolio destination.

The card shows:
- Product name + live status indicator (green dot + "Live")
- One paragraph naming the actual scope: "resume tailoring, job ingestion, match scoring — with the production LLM pipelines (versioned prompts, shadow runs, async observability) behind them"

Deliberately one product, not a list — a multi-product list would go stale every time the focus shifts.

## Test plan
- [x] `pnpm tsc --noEmit` clean
- [x] Homepage spec — 8/8 pass
- [ ] VR snapshot refresh on next release window

🤖 Generated with [Claude Code](https://claude.com/claude-code)