### PR TITLE
Case study: Publishing @danieljoffe/shared-ui

### DIFF
--- a/apps/root/src/data/__tests__/contentRegistry.spec.ts
+++ b/apps/root/src/data/__tests__/contentRegistry.spec.ts
@@ -12,7 +12,7 @@ describe('contentRegistry', () => {
   describe('getContentByType', () => {
     it('returns all project entries in order', () => {
       const projects = getContentByType('project');
-      expect(projects.length).toBe(13);
+      expect(projects.length).toBe(14);
       expect(projects[0].type).toBe('project');
       expect(projects[0].slug).toBe('ui-components-v1');
     });
@@ -72,7 +72,7 @@ describe('contentRegistry', () => {
       const slugs = getContentSlugs('project');
       expect(slugs).toContain('ui-components-v1');
       expect(slugs).toContain('ui-components-v2');
-      expect(slugs.length).toBe(13);
+      expect(slugs.length).toBe(14);
     });
 
     it('returns experience slugs', () => {
@@ -104,14 +104,14 @@ describe('contentRegistry', () => {
   describe('getContentPagination', () => {
     it('returns circular pagination for first project', () => {
       const pagination = getContentPagination('project', 'ui-components-v1');
-      expect(pagination.prev.slug).toBe('audit-tool-case-study'); // wraps to last
+      expect(pagination.prev.slug).toBe('shared-ui-case-study'); // wraps to last
       expect(pagination.next.slug).toBe('cms-tooling-case-study'); // second project
     });
 
     it('returns circular pagination for last project', () => {
       const pagination = getContentPagination(
         'project',
-        'audit-tool-case-study'
+        'shared-ui-case-study'
       );
       expect(pagination.next.slug).toBe('ui-components-v1'); // wraps to first
     });
@@ -145,7 +145,7 @@ describe('contentRegistry', () => {
   describe('getAllContent', () => {
     it('returns all entries (projects + experience)', () => {
       const all = getAllContent();
-      expect(all.length).toBe(64); // 13 projects + 5 experiences + 46 blogs
+      expect(all.length).toBe(65); // 14 projects + 5 experiences + 46 blogs
     });
 
     it('contains entries of all types', () => {

--- a/apps/root/src/data/content/projects/index.ts
+++ b/apps/root/src/data/content/projects/index.ts
@@ -36,6 +36,9 @@ import ApiPerformanceCaseStudy, {
 import AuditToolCaseStudy, {
   metadata as auditToolMeta,
 } from './audit-tool-case-study.mdx';
+import SharedUiCaseStudy, {
+  metadata as sharedUiCaseStudyMeta,
+} from './shared-ui-case-study.mdx';
 
 export const projectMdxComponents: Record<AllowedProjectSlugs, ComponentType> =
   {
@@ -52,6 +55,7 @@ export const projectMdxComponents: Record<AllowedProjectSlugs, ComponentType> =
     'job-pipeline-case-study': JobPipelineCaseStudy,
     'api-performance-case-study': ApiPerformanceCaseStudy,
     'audit-tool-case-study': AuditToolCaseStudy,
+    'shared-ui-case-study': SharedUiCaseStudy,
   };
 
 export const projectMdxMetadata: Record<AllowedProjectSlugs, PostMetadata> = {
@@ -68,4 +72,5 @@ export const projectMdxMetadata: Record<AllowedProjectSlugs, PostMetadata> = {
   'job-pipeline-case-study': jobPipelineMeta,
   'api-performance-case-study': apiPerfMeta,
   'audit-tool-case-study': auditToolMeta,
+  'shared-ui-case-study': sharedUiCaseStudyMeta,
 };

--- a/apps/root/src/data/content/projects/shared-ui-case-study.mdx
+++ b/apps/root/src/data/content/projects/shared-ui-case-study.mdx
@@ -1,0 +1,134 @@
+export const metadata = {
+  title: 'Publishing a React Component Library: @danieljoffe/shared-ui',
+  date: '2026-06-13',
+  excerpt:
+    "Extracting a workspace component library into a published npm package: Vite + preserveModules, and the 'use client' directive Rollup keeps stripping.",
+  author: 'Daniel Joffe',
+  category: 'Design Systems',
+  tags: ['React', 'TypeScript', 'Storybook', 'Component Library', 'Monorepo'],
+  slug: 'shared-ui-case-study',
+  type: 'project',
+  role: 'Solo Developer',
+  duration: 'April - June 2026',
+  // TODO: generate the cover via scripts/optimize-covers.ts before shipping
+  cover: {
+    alt: 'A wall of indexed library card drawers with brass handles',
+    src: '/images/covers/shared-ui-case-study.webp',
+  },
+  featured: false,
+};
+
+## Overview
+
+**Project:** `@danieljoffe/shared-ui` — a React 19 + Tailwind 4 component library published to npm and used across this portfolio, WyrdFold, and a public Storybook at [ui.danieljoffe.com](https://ui.danieljoffe.com).
+
+**Role:** Solo developer
+
+**Why it exists:** I had two products (the portfolio and WyrdFold) wanting the same Heading, Section, Button, Dropdown, Alert, Card. The Internet Brands case study covers the _first_ time I built a component library — for one application, on one team. This is the case study for the _second_ time: extracting components from one Nx workspace, publishing them as an npm package, and having a different product (WyrdFold, a different repo) consume them.
+
+## The interesting problem isn't the components
+
+The components were already there. What made the extraction non-trivial was the build pipeline.
+
+The first attempt — a single bundled `dist/index.js` — worked locally but broke as soon as another product tried to deep-import a subpath like `@danieljoffe/shared-ui/Text`. The package's `exports` field declared a `./*` subpath that resolved to per-component TypeScript sources during local development (`@danieljoffe.com/source` condition for source-level imports inside the workspace), but the published artifact only had one bundled file. So `import { Text } from '@danieljoffe/shared-ui/Text'` resolved to nothing on npm consumers.
+
+The fix is multi-entry output with Rollup's `preserveModules`:
+
+```ts
+// libs/shared/ui/vite.config.ts
+import { defineConfig } from 'vite';
+import { readdirSync } from 'node:fs';
+
+const entries = readdirSync('./src/lib')
+  .filter(name => /\.tsx?$/.test(name) && !/\.(spec|stories)\./.test(name))
+  .map(name => `src/lib/${name}`);
+
+export default defineConfig({
+  build: {
+    lib: { entry: ['src/index.ts', ...entries], formats: ['es'] },
+    rollupOptions: {
+      output: { preserveModules: true, preserveModulesRoot: 'src' },
+    },
+  },
+});
+```
+
+Now the emitted JS layout matches the per-component `.d.ts` files that `vite-plugin-dts` was already producing: every component becomes its own importable subpath, deep-imports work, and tree-shaking falls out for free.
+
+## The "use client" directive Rollup keeps stripping
+
+This was the second non-trivial problem. Some components in the library are client-only — they use `useState`, `useRef`, or event handlers — and the file starts with `'use client'` so Next.js Server Components know to treat them as a client boundary.
+
+Rollup's `preserveModules` mode strips module-level string directives during the transform pipeline. The emitted chunk is functionally identical, but the directive is gone, and Next.js builds it as a server component. The runtime explodes the first time the component reads from `useState`.
+
+The fix is a tiny Vite plugin that captures the directive before transforms run and re-emits it on the matching output chunk:
+
+```ts
+const DIRECTIVE_RE =
+  /^(?:\s*(?:\/\/[^\n]*|\/\*[\s\S]*?\*\/))*\s*(['"])use (client|server)\1/;
+
+function preserveDirectives(): Plugin {
+  const directives = new Map<string, string>();
+  return {
+    name: 'preserve-use-directives',
+    enforce: 'pre',
+    transform(code, id) {
+      const match = DIRECTIVE_RE.exec(code);
+      if (match) directives.set(id, `'use ${match[2]}';`);
+      return null;
+    },
+    renderChunk(code, chunk) {
+      const id = chunk.facadeModuleId;
+      const directive = id ? directives.get(id) : undefined;
+      if (!directive) return null;
+      return { code: `${directive}\n${code}`, map: null };
+    },
+  };
+}
+```
+
+About 20 lines. Reading the directive in the `transform` hook captures it from the original source, before Rollup has a chance to strip it. The `renderChunk` hook re-emits the directive at the top of the matching output chunk. Now both `'use client'` and `'use server'` survive `preserveModules`, and Next.js can correctly identify client component boundaries across the package.
+
+## React 19 changes the ref pattern
+
+The library targets React 19, which makes one API decision easier than the previous decade. `forwardRef` is on the way out — components can accept `ref` as a regular prop:
+
+```tsx
+interface ButtonProps extends ComponentPropsWithoutRef<'button'> {
+  ref?: Ref<HTMLButtonElement>;
+  variant?: 'primary' | 'secondary' | 'ghost';
+}
+
+export function Button({
+  ref,
+  className,
+  variant = 'primary',
+  ...rest
+}: ButtonProps) {
+  return (
+    <button
+      ref={ref}
+      className={cn(buttonStyles({ variant }), className)}
+      {...rest}
+    />
+  );
+}
+```
+
+Components that don't use hooks or state work in both server and client contexts without `'use client'` boundaries. The package's runtime cost on a server-component-heavy page is close to zero.
+
+## Tokens via Tailwind 4
+
+Tailwind 4's `@theme` block + `oklch()` color space means the design system tokens live in CSS, not a JS object. Consumers pick up the tokens through Tailwind's own pipeline — there's no separate token export, no JSON file, no theme provider. A consumer that already uses Tailwind 4 inherits the design system by importing the package's `theme.css`.
+
+## What ships across products
+
+The portfolio renders almost every heading, section wrapper, and button through `shared-ui`. WyrdFold's dashboards consume the same Card, Alert, and Dropdown. The published Storybook is the third consumer — it imports from the same source via the `@danieljoffe.com/source` condition, so development hot-reloads stay instant inside the monorepo while the published artifact stays stable for outside consumers.
+
+## What this case study leaves out
+
+The components themselves — patterns for Dropdown, Toast, Tooltip, focus management — are covered in [Building a Design System (v1)](/projects/ui-components-v1) and [Expanding the Design System (v2)](/projects/ui-components-v2). This is the case study about turning those components into a package other products can install.
+
+## Takeaway
+
+The interesting engineering wasn't picking React components or color tokens. It was making a workspace package usable from outside the workspace: getting the file layout right, getting the directives to survive the build, and finding the 20-line plugin that fixes the thing Rollup quietly broke. The components are the easy part. The publishing pipeline is where shared design systems live or die.

--- a/apps/root/src/data/contentOrder.ts
+++ b/apps/root/src/data/contentOrder.ts
@@ -49,6 +49,7 @@ export const projectHistory: AllowedProjectSlugs[] = [
   projectSlugs.csJobPipeline, // 2026-04-15 — Portfolio (Apr 2026)
   projectSlugs.csApiPerformance, // 2026-04-21 — Portfolio (Apr 2026)
   projectSlugs.csAuditTool, // 2026-06-11 — Portfolio (Feb-Apr 2026)
+  projectSlugs.csSharedUi, // 2026-06-13 — @danieljoffe/shared-ui (Apr-Jun 2026)
 ];
 
 /**

--- a/apps/root/src/data/project.ts
+++ b/apps/root/src/data/project.ts
@@ -12,6 +12,7 @@ export const projectSlugs = {
   csJobPipeline: 'job-pipeline-case-study',
   csApiPerformance: 'api-performance-case-study',
   csAuditTool: 'audit-tool-case-study',
+  csSharedUi: 'shared-ui-case-study',
 } as const;
 
 export const projectPageSlugs = [...Object.values(projectSlugs)];


### PR DESCRIPTION
Closes #930. Part of the Portfolio Positioning epic (#938).

## Summary
New project case study under `apps/root/src/data/content/projects/shared-ui-case-study.mdx`. Title: "Publishing a React Component Library: @danieljoffe/shared-ui".

Scoped to the **extraction + publishing engineering**, not the components themselves — those are covered in [ui-components-v1](/projects/ui-components-v1) and [ui-components-v2](/projects/ui-components-v2). This case study covers what's currently missing: the build pipeline that lets two products (the portfolio and WyrdFold) install the same package.

Concrete depth:
- Multi-entry + Rollup `preserveModules` so `@danieljoffe/shared-ui/Text` deep-imports work
- A ~20-line Vite plugin that re-emits `'use client'` / `'use server'` directives Rollup strips during `preserveModules` (annotated with the actual code from `libs/shared/ui/vite.config.ts`)
- React 19 ref-as-prop pattern (no `forwardRef`)
- Tailwind 4 `@theme` tokens

Registered in `data/project.ts`, `data/contentOrder.ts`, `data/content/projects/index.ts`. Cover image TODO (placeholder path; validate-content passes).

## Test plan
- [x] `pnpm tsc --noEmit` clean
- [x] `scripts/validate-content.ts` passes (65/65, only pre-existing unrelated warning)
- [x] `contentRegistry.spec.ts` — 18/18 pass (counts bumped: 14 projects, last-project pagination wrap)
- [ ] Cover image generation (follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)