### PR TITLE
Fix: homepage og:image — explicit reference for share previews

### DIFF
--- a/apps/root/src/data/metadata/home.ts
+++ b/apps/root/src/data/metadata/home.ts
@@ -32,6 +32,19 @@ export const homeMetadata: Metadata = {
     url: 'https://danieljoffe.com',
     type: 'website',
     siteName: 'Daniel Joffe',
+    // Explicit reference to the root-level app/opengraph-image.tsx — Next.js
+    // doesn't auto-merge it across the (public) route group boundary, so the
+    // homepage has been shipping with no og:image since release. Each project
+    // / experience / blog page has its own segment-level opengraph-image.tsx
+    // and gets auto-populated; the homepage is the one that needs the hint.
+    images: [
+      {
+        url: '/opengraph-image',
+        width: 1200,
+        height: 630,
+        alt: 'Daniel Joffe — Full-Stack Engineer',
+      },
+    ],
   },
   twitter: {
     title: `Daniel Joffe | Full-Stack Engineer`,
@@ -39,5 +52,6 @@ export const homeMetadata: Metadata = {
       'Full-Stack Engineer. Performance optimization, backend architecture, and accessible web applications.',
     card: 'summary_large_image',
     creator: '@danieljoffe',
+    images: ['/opengraph-image'],
   },
 };


### PR DESCRIPTION
Closes #937. Part of the Portfolio Positioning epic (#938).

## The bug
The homepage at https://danieljoffe.com/ ships with **no `og:image` or `twitter:image` meta tag**. Every share link (LinkedIn, Slack, X) shows no preview.

Verified by fetching the live HTML — only 5 `og:*` tags, none for image. Each project / experience / blog page does have one (verified `/projects/audit-tool-case-study`, `/about`, `/projects/performance-case-study` — all populate `og:image` correctly).

## Root cause
`home.ts`'s `openGraph` block overrides the root-layout `openGraph` (`rootMetadata`). Next.js's auto-merge of the root-level `apps/root/src/app/opengraph-image.tsx` doesn't propagate across the `(public)` route-group boundary into the homepage. Other pages have their own segment-level `opengraph-image.tsx` so they get auto-populated; the homepage is the only one inheriting from root.

## Fix
Explicit `images` field in `home.ts`'s `openGraph` and `twitter` blocks, referencing `/opengraph-image`. The root opengraph-image.tsx renders correctly at that URL (confirmed: returns 200 image/png, 64KB).

## Test plan
- [x] `pnpm tsc --noEmit` clean
- [x] Metadata specs — 40/40 pass
- [ ] After deploy: fetch homepage HTML, confirm `og:image` meta appears, confirm content-type is `image/png`

🤖 Generated with [Claude Code](https://claude.com/claude-code)