### PR TITLE
Fix: "Live" badge contrast WCAG AA

### DIFF
--- a/apps/root/src/app/(public)/page.tsx
+++ b/apps/root/src/app/(public)/page.tsx
@@ -99,9 +99,9 @@ export default function Index() {
                 <Heading variant='cardTitle' as='p'>
                   WyrdFold
                 </Heading>
-                <span className='inline-flex items-center gap-1.5 rounded-full bg-emerald-500/10 px-2 py-0.5 text-xs font-medium text-emerald-600 dark:text-emerald-400'>
+                <span className='inline-flex items-center gap-1.5 rounded-full bg-emerald-500/15 px-2 py-0.5 text-xs font-medium text-emerald-800 dark:text-emerald-300'>
                   <span
-                    className='h-1.5 w-1.5 rounded-full bg-emerald-500'
+                    className='h-1.5 w-1.5 rounded-full bg-emerald-600'
                     aria-hidden='true'
                   />
                   Live


### PR DESCRIPTION
Caught by the full e2e axe sweep on the release PR ([#946](https://github.com/danieljoffe/danieljoffe.com/pull/946)). The "Live" badge on the Currently Building section hits 3.19:1 contrast (`#009966` on `#e0f4ee`) — needs ≥4.5:1 for WCAG AA small text.

Bump:
- Light text: `emerald-600` → `emerald-800`
- Dark text: `emerald-400` → `emerald-300`
- Background tint: `/10` → `/15`
- Dot: `emerald-500` → `emerald-600`

Both modes pass after this. Unblocks the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)