### PR TITLE
Drop stale Free Audit nav e2e test (Phase A residue)

### DIFF
--- a/apps/root-e2e/src/navigation.spec.ts
+++ b/apps/root-e2e/src/navigation.spec.ts
@@ -86,18 +86,6 @@ test.describe('desktop navigation', () => {
       menu.locator('[role="menuitem"]', { hasText: 'Blog' })
     ).toBeVisible();
   });
-
-  test('free Audit CTA is visible', async ({ page }) => {
-    await page.goto('/', { waitUntil: 'domcontentloaded' });
-    await waitForHydration(page);
-
-    await expect(page.locator('nav[aria-label="Primary"]')).toBeVisible();
-
-    const auditLink = page
-      .locator('nav[aria-label="Main navigation"]')
-      .locator('a[href="/audit"]', { hasText: 'Free Audit' });
-    await expect(auditLink).toBeVisible();
-  });
 });
 
 test.describe('mobile navigation', () => {


### PR DESCRIPTION
Audit teardown Phase A (#923) removed the Free Audit CTA from TabletUpNav, but left this nav spec asserting it's still visible. The release full suite ([#946](https://github.com/danieljoffe/danieljoffe.com/pull/946)) fails three times on `'a[href="/audit"]'` with no matches after the link was removed.

Drop the test. The `/audit` → `/projects/audit-tool-case-study` redirect is already covered by the `next.config.mjs` redirects table.

## Test plan
- [x] Grep confirms no other e2e refs to `Free Audit` or `a[href="/audit"]`
- [ ] `full / full` passes on the release PR after this lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)