### PR TITLE
Mobile smoketest fixes: blog title, name validation, tap targets, preload

### DIFF
--- a/apps/root/src/app/api/email/contact/schema.ts
+++ b/apps/root/src/app/api/email/contact/schema.ts
@@ -95,9 +95,12 @@ export const formSchema = z.object({
     .pipe(
       z
         .string()
-        .regex(VALIDATION_PATTERNS.NAME, 'Name contains invalid characters')
+        // Length checks first so an empty/short field reports a length
+        // message instead of the regex's "invalid characters" (the regex
+        // requires ≥1 char, so it fired first on blank input).
         .min(NAME_MIN_LENGTH, minLengthMessage('Name', NAME_MIN_LENGTH))
         .max(NAME_MAX_LENGTH, maxLengthMessage('Name', NAME_MAX_LENGTH))
+        .regex(VALIDATION_PATTERNS.NAME, 'Name contains invalid characters')
     ),
   /** Email address with format and deliverability validation */
   email: z

--- a/apps/root/src/components/Footer/index.tsx
+++ b/apps/root/src/components/Footer/index.tsx
@@ -65,7 +65,7 @@ export default function Footer() {
                 rel='noopener noreferrer'
                 aria-label={label}
                 title={label.replace(/^(Send |Visit |Download )/, '')}
-                className={`p-2 rounded-lg text-text-tertiary hover:text-text-primary hover:bg-surface-tertiary transition-colors ${FOCUS_RING} ${FOCUS_RING_OFFSET}`}
+                className={`inline-flex min-h-[40px] min-w-[40px] items-center justify-center rounded-lg text-text-tertiary hover:text-text-primary hover:bg-surface-tertiary transition-colors ${FOCUS_RING} ${FOCUS_RING_OFFSET}`}
               >
                 <Icon className='h-4 w-4' />
               </a>

--- a/apps/root/src/components/kit/ListPagination.tsx
+++ b/apps/root/src/components/kit/ListPagination.tsx
@@ -41,9 +41,10 @@ function getPages(currentPage: number, totalPages: number): (number | '...')[] {
   return pages;
 }
 
+// 40px minimum tap targets (was 28px arrows / 32px numbers).
 const navItemBase =
-  'rounded-md p-1.5 text-text-secondary hover:bg-surface-tertiary transition-colors';
-const pageItemBase = 'rounded-md h-8 min-w-8 px-2 text-sm transition-colors';
+  'inline-flex h-10 w-10 items-center justify-center rounded-md text-text-secondary hover:bg-surface-tertiary transition-colors';
+const pageItemBase = 'rounded-md h-10 min-w-10 px-2 text-sm transition-colors';
 
 /**
  * Server-rendered page-number pagination using real `<Link>` elements so

--- a/apps/root/src/data/metadata/about.ts
+++ b/apps/root/src/data/metadata/about.ts
@@ -34,15 +34,8 @@ export const aboutMetadata: Metadata = {
     card: 'summary_large_image',
     creator: '@danieljoffe',
   },
-  icons: {
-    other: [
-      {
-        url: '/images/daniel-joffe-profile.webp',
-        rel: 'preload',
-        fetchPriority: 'high',
-        media: '(max-width: 768px)',
-        type: 'image/png',
-      },
-    ],
-  },
+  // Note: the profile <Image> on /about already sets `priority`, which emits
+  // a correct <link rel="preload" as="image">. A manual icons.other preload
+  // here was redundant and rendered without a valid `as` (console warning),
+  // so it was removed.
 };

--- a/apps/root/src/data/metadata/blog.ts
+++ b/apps/root/src/data/metadata/blog.ts
@@ -1,7 +1,10 @@
 import { Metadata } from 'next';
 
 export const blogRootMetadata: Metadata = {
-  title: 'Blog | Daniel Joffe - Full-Stack Engineer',
+  // Bare segment — the root layout's title.template appends
+  // " | Daniel Joffe - Full-Stack Engineer". Including the suffix here
+  // doubled it (e.g. "Blog | … | …").
+  title: 'Blog',
   description:
     "Notes from shipping code. Deep-dives on the problems I've debugged, the patterns I've extracted, and the decisions I'd make differently next time.",
   keywords: [


### PR DESCRIPTION
Batch of UI fixes found in a mobile (390×844) smoketest pass. Discovery was run by a subagent (kept screenshots out of the main context); these are the clear, low-risk items.

## Fixes
1. **Blog `<title>` doubled** — `Blog | Daniel Joffe - Full-Stack Engineer | Daniel Joffe - Full-Stack Engineer`. `blogRootMetadata.title` already included the suffix the root layout's `title.template` appends. Now bare `'Blog'`.
2. **Contact name validation copy** — an empty Name field reported *"Name contains invalid characters"*. The Zod `.regex()` (requires ≥1 char) ran before `.min()`, so blank input failed the regex first. Reordered length checks ahead of the regex → blank/short input now gets a length message.
3. **Tap targets <40px** — footer social icons (32px) and blog pagination number links/arrows (28–32px) were below the 40px minimum. Bumped to 40×40.
4. **Stray preload warning on /about** — a manual `icons.other` image preload rendered without a valid `as` (console warning) and was redundant: the profile `<Image priority>` already emits a correct `<link rel="preload" as="image">`. Removed.

## Verification
- Live: blog title single-suffixed; footer icon / pagination number / pagination arrow all measure 40×40.
- `pnpm tsc --noEmit` clean.
- 102 tests pass across metadata / contact / pagination / footer suites.

## Not included (flagged for separate verification)
- **GA blocked by CSP** (`google.com/g/collect`) — relaxing `connect-src` is a security change; want to confirm it actually drops in prod first.
- **hCaptcha `ERR_FAILED`** — almost certainly local-env (missing site key / MCP Chrome); the form works on the live site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)