### PR TITLE
Audit case study: retirement notice for /audit redirects

### DIFF
--- a/apps/root/mdx-components.tsx
+++ b/apps/root/mdx-components.tsx
@@ -1,6 +1,7 @@
 import type { MDXComponents } from 'mdx/types';
 import type { ComponentPropsWithoutRef } from 'react';
 import { Heading } from '@danieljoffe/shared-ui/Heading';
+import { Alert } from '@danieljoffe/shared-ui/Alert';
 import { InteractiveDemo, MetricsDashboard } from '@/components/kit';
 
 function slugify(text: string): string {
@@ -125,6 +126,7 @@ export function useMDXComponents(components: MDXComponents): MDXComponents {
         />
       </picture>
     ),
+    Alert,
     InteractiveDemo,
     MetricsDashboard,
     ...components,

--- a/apps/root/src/data/content/projects/audit-tool-case-study.mdx
+++ b/apps/root/src/data/content/projects/audit-tool-case-study.mdx
@@ -24,6 +24,12 @@ export const metadata = {
   },
 };
 
+<Alert variant='info' title='This tool has been retired'>
+  Landed here from `/audit`? The free audit tool is no longer live — this is the
+  case study of how I built it and why I shut it down. The honest postmortem is
+  at the end.
+</Alert>
+
 ## Overview
 
 **Project:** Free public website audit tool: paste a URL, get a graded performance, accessibility, and SEO report in about 30 seconds


### PR DESCRIPTION
Addresses the redirect dead-end flagged in the UX review: someone clicks an old `/audit` link expecting the live tool and lands at the top of the case study with no context.

## Change
- Adds an info `Alert` at the top of the audit case study: explains the tool was retired, that this is the build write-up, and points to the postmortem at the end.
- Wires the shared-ui `<Alert>` into the MDX component map (`mdx-components.tsx`) so it's reusable for future content notices.

## Verification
- `pnpm tsc --noEmit` clean
- `validate-content` passes (65/65)
- Notice confirmed rendering server-side at `/projects/audit-tool-case-study`
- 22 mdx/contentRegistry tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)