### PR TITLE
UX review: FTE-align /about copy + surface full-stack/AI proof

### DIFF
--- a/apps/root/src/app/(public)/about/page.tsx
+++ b/apps/root/src/app/(public)/about/page.tsx
@@ -104,8 +104,7 @@ export default function About() {
             I&apos;ve been doing this for over a decade, across startups (Winc,
             FightCamp), enterprise (Internet Brands), and specialized
             environments (The Library Corporation). The common thread: every
-            engagement left the team faster and more autonomous than I found
-            them.
+            role left the team faster and more autonomous than I found them.
           </Text>
           <Text variant='bodyLg'>
             Below is the full picture: the tools I use, the companies I&apos;ve
@@ -295,8 +294,8 @@ export default function About() {
           heading="Let's figure out if I'm the right fit."
           description={
             <>
-              Tell me about your project. I respond within 24 hours, and
-              I&apos;ll be upfront about whether I can actually help.
+              Tell me about the role or the team. I respond within 24 hours, and
+              I&apos;ll be straight about whether it&apos;s a fit.
             </>
           }
         >

--- a/apps/root/src/app/(public)/page.tsx
+++ b/apps/root/src/app/(public)/page.tsx
@@ -120,6 +120,16 @@ export default function Index() {
             />
           </div>
         </a>
+        <Button
+          as='link'
+          href='/blog/operating-llm-pipelines-in-production'
+          variant='ghost'
+          size='sm'
+          className='mt-3'
+        >
+          How I operate the LLM pipelines
+          <ArrowUpRight className='h-4 w-4' />
+        </Button>
       </Section>
 
       {/* ══════════════════════════════════

--- a/apps/root/src/data/about.ts
+++ b/apps/root/src/data/about.ts
@@ -23,8 +23,17 @@ export const expertiseCategories = [
   {
     label: 'Backend',
     description:
-      'Enough backend depth to own the full stack: auth, APIs, cloud infrastructure.',
-    skills: ['Node.js', 'Express', 'REST APIs', 'S3', 'AWS Cognito', 'OAuth'],
+      'Full backend and data ownership: Python/FastAPI and Node services, Postgres, auth, and production LLM pipelines.',
+    skills: [
+      'Python',
+      'FastAPI',
+      'Node.js',
+      'PostgreSQL',
+      'Supabase',
+      'REST APIs',
+      'LLM Pipelines',
+      'AWS Cognito',
+    ],
   },
   {
     label: 'Tools',


### PR DESCRIPTION
From the recruiter-persona UX smoketest ("Maya Chen, in-house Senior Technical Recruiter" — verdict: **advance to a screen**, with 3 friction points). This addresses all three.

## Changes
- **MED — /about read freelancer, not FTE.** Contact card said "Tell me about your **project**… whether I can actually help"; the intro said "every **engagement**". Both contradicted the homepage's "Open to full-time roles." Reframed to role/team/fit language.
- **LOW — /about Backend chips omitted the headline stack.** Listed Node/Express/REST/S3/Cognito but not the Python/FastAPI/Postgres/AI the hero + resume lead with. Added Python, FastAPI, PostgreSQL, Supabase, LLM Pipelines; tightened the hedged "enough backend depth" description.
- **HIGH (partial) — AI/LLM claim had no on-site receipts.** The hero/WyrdFold card promised LLM pipelines, but a recruiter had to leave to wyrdfold.com to verify. Added an on-site link from the Currently-building card to the "Operating LLM Pipelines in Production" post. The full WyrdFold case study (with product screenshots) remains **#926**.

## Verification
- `pnpm tsc --noEmit` clean; eslint clean on changed files
- 33 page/about tests pass
- Rendered checks: home shows the LLM-ops link; /about shows the FTE copy + FastAPI/LLM chips

🤖 Generated with [Claude Code](https://claude.com/claude-code)