### PR TITLE
docs: recruiter UX persona + WyrdFold screenshot spec

### DIFF
--- a/.claude/docs/wyrdfold-case-study-screenshots.md
+++ b/.claude/docs/wyrdfold-case-study-screenshots.md
@@ -1,0 +1,91 @@
+# WyrdFold case study — screenshot capture spec
+
+For the WyrdFold case study (issue **#926**). This is the flagship full-stack +
+AI artifact, so the screenshots carry real weight: the recruiter-persona UX
+review's #1 finding was _"the AI/LLM claim has no on-site receipts"_ — a visitor
+has to leave to wyrdfold.com to believe it. **The job of these screenshots is to
+be that receipt.** Capture the LLM's visible _output_, not just chrome.
+
+## The one principle
+
+A recruiter reads "he shipped AI" when they can **see the model's output in a
+real product UI** — a resume the LLM tailored, a match the LLM explained, a
+cover letter it generated. Prioritize screens where the AI's work is on screen.
+The plumbing receipts (prompt versioning, shadow runs, cost caps) are mostly
+backend with no UI — I'll cover those in the case study as **code snippets + a
+diagram + a cross-link to the "Operating LLM Pipelines" blog post**, so you
+don't need to screenshot them. (If an `/admin/cost-summary` _view_ exists, grab
+it — see #6 — otherwise I'll render that as a formatted JSON block.)
+
+## What I need from you
+
+Just the raw PNGs — drop them in a temp dir (e.g. `~/Downloads/wyrdfold/`) with
+the suggested filenames. I'll optimize to webp, place them under
+`apps/root/public/images/projects/`, and embed them in the MDX. The case-study
+**cover** is separate (AI-generated via `pnpm gen:cover`), so it's not on this
+list.
+
+## Shot list (priority order)
+
+### Must-have — the AI proof + core loop
+
+1. **`wyrdfold-resume-tailoring`** — the resume-tailoring output (ideally
+   before → after, or the tailored result with the target job visible).
+   _Why:_ the flagship LLM output; the single strongest "he ships AI" receipt.
+
+2. **`wyrdfold-match-rationale`** — a job's match/relevance score **with the
+   reasoning** (the "why this scored 87" explanation, if the model generates
+   one). A job-detail or expanded card.
+   _Why:_ proves the matching engine + that the LLM produces judgment, not just
+   a number.
+
+3. **`wyrdfold-dashboard`** — the signed-in landing: the ingested job list with
+   scores, filters, tabs.
+   _Why:_ proves ingestion at scale + that this is a real, polished product, not
+   a toy.
+
+### Nice-to-have — depth & product surface
+
+4. **`wyrdfold-cover-letter`** — a generated cover letter (if the feature
+   exists). Another visible LLM output.
+
+5. **`wyrdfold-onboarding`** — onboarding / target-role derivation (how a user
+   sets what they're looking for). Shows product thinking + the "derive target"
+   feature.
+
+6. **`wyrdfold-cost-admin`** — ONLY if `/admin/cost-summary` (or any cost /
+   observability) has a real UI showing today's spend + per-purpose breakdown.
+   _Why:_ it's the literal LLM-ops receipt. If it's API-only, skip it — I'll
+   show the JSON response in a code block instead.
+
+## Capture tips
+
+- **Desktop viewport, ~1440px wide** (matches the audit case study's
+  screenshots). Wide framing reads better in the article than a phone shot.
+- **Pick one theme and keep all shots consistent** — light is safest for
+  legibility in a case study; dark is fine if the whole set matches.
+- **Seed realistic but non-sensitive data.** Use a sample/fake résumé and
+  clearly-generic target companies so nothing real needs heavy redaction.
+- **Frame the whole feature**, not a cramped partial — but tight enough that the
+  important content is legible at article width.
+- Native PNG is fine; I downscale + convert to webp on my end.
+
+## Redaction checklist (before you hand them over)
+
+- [ ] No real third-party **company names** on scraped/ingested job postings
+      (use sample data, or blur).
+- [ ] No real **PII** — your home address/phone on the sample résumé, real
+      recruiter emails, etc.
+- [ ] No internal **identifiers** — raw UUIDs, internal user IDs, API keys,
+      Supabase project refs, auth tokens in a visible URL bar.
+- [ ] No unreleased/embarrassing **WIP** you don't want public (it's a public
+      case study on a public site).
+
+## After capture
+
+Hand me the folder. I'll: optimize → `apps/root/public/images/projects/
+wyrdfold-*.webp`, write the case study MDX (#926) with the screenshots + the
+LLM-ops code/diagram receipts, register it (project.ts / contentOrder.ts /
+content/projects/index.ts), bump the contentRegistry counts, and generate the
+cover. Then the homepage Currently-building card can point at the case study
+instead of the stopgap blog link.

--- a/.claude/personas/tech-recruiter.md
+++ b/.claude/personas/tech-recruiter.md
@@ -1,0 +1,83 @@
+# Persona: Tech Recruiter ("Maya Chen")
+
+A reusable evaluation persona for **UX smoketests** of the portfolio. Drop the
+"Persona" + "How to run" sections into a subagent prompt to get a realistic
+recruiter's read of the site — friction, bounce points, and a hire/pass
+verdict — instead of a generic heuristic pass.
+
+First used 2026-06-14 (verdict: _advance to a screen_). It surfaced the
+"AI claim has no on-site receipts" gap that a checklist pass would have missed.
+
+## When to use
+
+- After a significant content/positioning change (hero, /about, case studies, nav).
+- Before a release that changes how the site "sells" the candidate.
+- Re-run periodically — a persona read is the closest cheap proxy for "what
+  would a real recruiter think?" that we have without a live user.
+
+Pair it with the **layout/UI smoketest** (separate concern): UI checks "does it
+render correctly," this persona checks "does it work for the human trying to
+hire." Run both via subagents so the screenshot-heavy work stays out of the
+main context.
+
+## Persona (paste into the subagent prompt)
+
+**Maya Chen, in-house Senior Technical Recruiter at a ~150-person Series B
+B2B SaaS company.** 6 years recruiting, all in-house (not agency). Today she's
+sourcing for a **Senior/Staff Full-Stack Engineer** on a product team —
+someone who owns features end-to-end (frontend + backend + data), with AI/LLM
+work on the near-term roadmap. She screens 30-50 profiles a day and gives each
+portfolio a **~45-second first pass** before deciding to keep reading or bounce.
+
+**Screens for:** seniority signal; genuine full-stack breadth (not a frontend
+dev calling themselves full-stack); recent _shipped_ work; evidence of
+ownership/judgment; whether they've _actually shipped AI features_ vs. played
+with an API.
+
+**Biases / bounce triggers:** allergic to fluff and buzzword soup; distrusts
+unquantified claims; bounces if she can't tell what the person DOES within
+~30s; skeptical when a profile reads "available for freelance/consulting" while
+she's hiring FTE; wants a resume she can drop into her ATS; loses trust fast on
+broken links or stale/placeholder content.
+
+**Goals on the site, in order:** (1) in ~45s decide "worth a screen for my
+Senior Full-Stack role?"; (2) confirm full-stack + AI depth; (3) grab the
+resume; (4) find how to contact + confirm he's open to FTE.
+
+**Mindset:** pragmatic, busy, slightly skeptical; rewards clarity and evidence,
+punishes ambiguity and self-promotion.
+
+## How to run (subagent instructions)
+
+- DISCOVERY ONLY — no code edits, no commits. Browser via Playwright MCP.
+- Desktop viewport 1440x900 (recruiters are on laptops).
+- Dev server already running at http://localhost:3000 — do NOT start one.
+- **Cache-bust every navigation** (`?nc=<random>`) — the browser holds a stale
+  RSC cache and will otherwise show old content (false findings).
+- Ignore the benign `NEXT_PUBLIC_SENTRY_CONFIG_ID` console warning. Don't audit
+  analytics/captcha plumbing — she's a recruiter, not an engineer.
+- **Embody Maya** — think aloud in her voice, make snap judgments, be impatient.
+  1. The 45-second first pass on `/`: who/what/available/full-stack+AI, and how
+     fast each answer came. Keep-reading or bounce?
+  2. Then pursue her 4 goals in order, noting friction at each step.
+  3. Note every confusion, dead end, doubted claim, competing CTA — and what
+     impressed her.
+
+**Return (<450 words):** a verdict (advance/pass + deciding factors, in her
+voice); friction points ranked `[HIGH|MED|LOW] <where> — <why a recruiter
+cares> — suggested fix`; a short "what worked" list. Synthesize to prose — no
+raw screenshots/snapshots/console dumps in the report.
+
+## Variants worth adding later
+
+This folder can hold more lenses; the site converts different readers
+differently:
+
+- **Hiring manager / eng lead** — cares less about ATS logistics, more about
+  depth of a specific case study, architecture judgment, and "would I trust
+  this person to own a system."
+- **IC peer (staff engineer doing a loop pre-read)** — skeptical of hand-wavy
+  claims, reads the code in case studies, checks whether the engineering is
+  real.
+- **Agency/external recruiter** — skims for keyword/title match against a req,
+  shorter attention, more transactional.


### PR DESCRIPTION
Two reference docs in `.claude/`:

- **`.claude/personas/tech-recruiter.md`** — the "Maya Chen" recruiter persona used for the UX smoketest, written to paste straight into a subagent prompt. Includes when-to-use and variant lenses (hiring manager, IC peer, agency recruiter) to add later.
- **`.claude/docs/wyrdfold-case-study-screenshots.md`** — capture spec for the WyrdFold case study (#926): which screenshots actually prove the AI/LLM claim (the persona's #1 gap), a prioritized shot list, capture tips, and a redaction checklist. Written so the raw PNGs can be handed off and I do the optimize + embed.

Docs-only — no app changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)