### PR TITLE
feat(shared-ui): introduce --color-on-brand token, drop hardcoded text-white

### DIFF
--- a/apps/root/src/components/Button.tsx
+++ b/apps/root/src/components/Button.tsx
@@ -60,7 +60,7 @@ const baseButtonStyles =
 
 const variantButtonStyles: Record<string, string> = {
   primary:
-    'hover:shadow-lg/12.5 bg-brand-500 text-white hover:bg-brand-600 active:bg-brand-700',
+    'hover:shadow-lg/12.5 bg-brand-500 text-on-brand hover:bg-brand-600 active:bg-brand-700',
   secondary:
     'hover:shadow-lg/12.5 bg-surface-elevated text-text-primary hover:bg-surface border border-border',
   ghost:

--- a/apps/root/src/components/kit/InteractiveDemo.tsx
+++ b/apps/root/src/components/kit/InteractiveDemo.tsx
@@ -149,7 +149,7 @@ export function InteractiveDemo({
               href={fullUrl}
               target='_blank'
               rel='noopener noreferrer'
-              className='inline-flex items-center gap-1.5 rounded-md bg-brand-500 px-3 py-1.5 text-xs font-medium text-white hover:bg-brand-600 transition-colors'
+              className='inline-flex items-center gap-1.5 rounded-md bg-brand-500 px-3 py-1.5 text-xs font-medium text-on-brand hover:bg-brand-600 transition-colors'
             >
               Open in Storybook
               <ExternalLink className='h-3 w-3' />

--- a/apps/root/src/components/kit/ListPagination.tsx
+++ b/apps/root/src/components/kit/ListPagination.tsx
@@ -107,7 +107,7 @@ export function ListPagination({
             aria-current='page'
             className={cn(
               pageItemBase,
-              'bg-brand-600 text-white font-medium inline-flex items-center justify-center'
+              'bg-brand-600 text-on-brand font-medium inline-flex items-center justify-center'
             )}
           >
             {page}

--- a/apps/root/src/styles/theme.css
+++ b/apps/root/src/styles/theme.css
@@ -59,6 +59,10 @@
   --color-text-tertiary: #6b6b6b;
   --color-text-inverse: #ffffff;
   --color-text-brand: oklch(0.5 0.19 250);
+  /* Foreground color that reads on top of brand-500/600/700 backgrounds.
+     Indigo's brand-500 (oklch 0.54 0.19 250) is dark enough that white
+     reads cleanly. Themes with luminous brands override this token. */
+  --color-on-brand: oklch(1 0 0);
 
   /* Semantic Colors - Status */
   --color-success: #10b981;

--- a/libs/shared/ui/src/lib/Badge.spec.tsx
+++ b/libs/shared/ui/src/lib/Badge.spec.tsx
@@ -51,7 +51,7 @@ describe('Badge', () => {
     render(<Badge variant='brand-solid'>Solid</Badge>);
     const badge = screen.getByText('Solid');
     expect(badge).toHaveClass('bg-brand-600');
-    expect(badge).toHaveClass('text-white');
+    expect(badge).toHaveClass('text-on-brand');
   });
 
   it('applies custom className', () => {

--- a/libs/shared/ui/src/lib/Badge.tsx
+++ b/libs/shared/ui/src/lib/Badge.tsx
@@ -34,7 +34,7 @@ const variantStyles: Record<BadgeVariant, string> = {
   error: semanticBadge('error'),
   info: semanticBadge('info'),
   brand: 'bg-brand-50 text-brand-700',
-  'brand-solid': 'bg-brand-600 text-white',
+  'brand-solid': 'bg-brand-600 text-on-brand',
 };
 
 const sizeStyles: Record<ComponentSize, string> = {

--- a/libs/shared/ui/src/lib/Button.tsx
+++ b/libs/shared/ui/src/lib/Button.tsx
@@ -42,10 +42,10 @@ export const variantButtonStyles: Record<ButtonVariant, string> = {
   bare: '',
   primary: `${
     regularButton
-    // ``text-text-on-brand`` (themed) instead of hardcoded ``text-white``.
+    // ``text-on-brand`` (themed) instead of hardcoded ``text-white``.
     // Pyre's chartreuse brand-500 with white text was 2.76:1 (below AA);
     // the token resolves to near-black on pyre and white on indigo.
-  } bg-brand-500 text-text-on-brand hover:bg-brand-600 active:bg-brand-700`,
+  } bg-brand-500 text-on-brand hover:bg-brand-600 active:bg-brand-700`,
   secondary: `${
     regularButton
   } bg-surface-elevated text-text-primary hover:bg-surface border border-border`,

--- a/libs/shared/ui/src/lib/Pagination.tsx
+++ b/libs/shared/ui/src/lib/Pagination.tsx
@@ -109,7 +109,7 @@ export function Pagination({
               FOCUS_RING_OFFSET,
               pageButtonSizeStyles[size],
               page === currentPage
-                ? 'bg-brand-600 text-white font-medium'
+                ? 'bg-brand-600 text-on-brand font-medium'
                 : 'text-text-secondary hover:bg-surface-tertiary'
             )}
           >

--- a/libs/shared/ui/src/styles/indigo-theme.css
+++ b/libs/shared/ui/src/styles/indigo-theme.css
@@ -59,9 +59,10 @@
   --color-text-tertiary: #6b6b6b;
   --color-text-inverse: #ffffff;
   --color-text-brand: oklch(0.5 0.19 250);
-  /* Tokenized text color paired with brand-500 bg. Indigo's brand-500
-     (oklch 0.54 0.19 250) is dark enough that white reads cleanly. */
-  --color-text-on-brand: #ffffff;
+  /* Foreground color paired with brand-500/600/700 backgrounds. Indigo's
+     brand-500 (oklch 0.54 0.19 250) is dark enough that white reads cleanly.
+     Luminous palettes (e.g. Pyre's chartreuse) override this to near-black. */
+  --color-on-brand: oklch(1 0 0);
 
   /* Semantic Colors - Status */
   --color-success: #10b981;

--- a/libs/shared/ui/src/styles/pyre-storybook-preview.css
+++ b/libs/shared/ui/src/styles/pyre-storybook-preview.css
@@ -38,6 +38,7 @@
   --color-text-tertiary: oklch(0.6 0.02 90);
   --color-text-inverse: oklch(0.1 0.01 270);
   --color-text-brand: oklch(0.78 0.22 127);
+  --color-on-brand: oklch(0.15 0.02 127);
 
   --color-success: oklch(0.72 0.2 145);
   --color-success-light: oklch(0.25 0.05 145);

--- a/libs/shared/ui/src/styles/pyre-theme.css
+++ b/libs/shared/ui/src/styles/pyre-theme.css
@@ -89,10 +89,10 @@
   --color-text-tertiary: oklch(0.55 0.02 270);
   --color-text-inverse: oklch(0.98 0.005 270);
   --color-text-brand: oklch(0.4 0.22 127);
-  /* Brand-500 chartreuse over a near-black foreground clears WCAG
-     AA in both modes (foreground is the dark token; surface is
-     bright). */
-  --color-text-on-brand: oklch(0.15 0.02 127);
+  /* Foreground paired with brand-500/600/700 backgrounds. Brand-500
+     chartreuse over a near-black foreground clears WCAG AA in both modes
+     (foreground is the dark token; surface is bright). */
+  --color-on-brand: oklch(0.15 0.02 127);
 
   /* Semantic Colors — Status (light mode: mid-lightness hues
      readable on near-white surfaces) */


### PR DESCRIPTION
## Summary

Resolves #565.

Introduces a semantic `--color-on-brand` foreground token and removes hardcoded `text-white` (and the interim `text-text-on-brand`) on brand-colored backgrounds, so luminous palettes no longer need a brittle `.text-white` CSS shim.

- Added `--color-on-brand` under `@theme` in `libs/shared/ui/src/styles/indigo-theme.css` (`oklch(1 0 0)` / white), `pyre-theme.css` (`oklch(0.15 0.02 127)` / near-black), the `.pyre` Storybook scope in `pyre-storybook-preview.css`, and the root app `apps/root/src/styles/theme.css` (white). Tailwind 4 now exposes `text-on-brand`.
- Swapped the foreground class on every brand-background surface to `text-on-brand`.
- Updated `Badge.spec.tsx` assertion from `text-white` → `text-on-brand`.

### Components / files with hardcoded foreground replaced
- `libs/shared/ui/src/lib/Button.tsx` (was `text-text-on-brand`)
- `libs/shared/ui/src/lib/Pagination.tsx` (was `text-white`)
- `libs/shared/ui/src/lib/Badge.tsx` — `brand-solid` variant (was `text-white`)
- `apps/root/src/components/Button.tsx` (was `text-white`)
- `apps/root/src/components/kit/ListPagination.tsx` (was `text-white`)
- `apps/root/src/components/kit/InteractiveDemo.tsx` (was `text-white`)

### Notes / deviations from the issue
- The codebase had already partially landed this work under a different token name: `--color-text-on-brand` existed in both shared-ui themes and `Button.tsx` already consumed `text-text-on-brand`. This PR renames that to the issue's requested `--color-on-brand` and migrates all consumers, so the token name is now consistent.
- No `wyrdfold-theme.css` / `.text-white` shim exists in this repo anymore (WyrdFold was extracted to its own repo), so there was nothing to delete — the shim removal criterion is satisfied by absence.
- `CTACard.stories.tsx` still uses `text-white` on `bg-brand-600`, but those are story-only decoration markup (a fake CTA span), not shipped components — left as-is.

### Verification
- `pnpm nx test @danieljoffe/shared-ui` — 754 passed
- `pnpm nx build @danieljoffe/shared-ui` — built clean
- `pnpm tsc --noEmit` — clean

### VR / Storybook baselines
Rendered colors are unchanged for the default indigo theme (white on dark indigo brand) and for Pyre (near-black on chartreuse), so no visual shift is expected. **Baselines were NOT regenerated** — if Chromatic/Playwright VR flags any diff, please regenerate via the usual `workflow_dispatch` path rather than blocking on it.

## Test plan
- [ ] CI: lint, typecheck, unit, build, e2e green
- [ ] Chromatic: confirm Button/Badge/Pagination stories render identically (no unexpected diff)
- [ ] Manual: indigo Button/Badge/Pagination on `apps/root` look pixel-identical to before

🤖 Generated with [Claude Code](https://claude.com/claude-code)