### PR TITLE
fix(og): add blog listing OG image + render profile photo in avatar ring

### DIFF
--- a/apps/root/src/app/(public)/blog/opengraph-image.tsx
+++ b/apps/root/src/app/(public)/blog/opengraph-image.tsx
@@ -1,0 +1,110 @@
+import { ImageResponse } from 'next/og';
+import { getOgFonts, getProfileImageBase64 } from '@/lib/og';
+
+export const alt = 'Daniel Joffe - Blog';
+export const size = { width: 1200, height: 630 };
+export const contentType = 'image/png';
+
+export default async function OgImage() {
+  const [fonts, profileSrc] = await Promise.all([
+    getOgFonts(),
+    getProfileImageBase64(),
+  ]);
+
+  return new ImageResponse(
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        width: '100%',
+        height: '100%',
+        background: 'linear-gradient(135deg, #1c1917 0%, #0d7377 100%)',
+        padding: '60px',
+      }}
+    >
+      <picture>
+        <img
+          src={profileSrc}
+          alt=''
+          width={120}
+          height={120}
+          style={{
+            borderRadius: '50%',
+            border: '4px solid rgba(255,255,255,0.2)',
+          }}
+        />
+      </picture>
+
+      <span
+        style={{
+          fontFamily: 'Inter',
+          fontSize: '14px',
+          fontWeight: 500,
+          color: '#5eead4',
+          textTransform: 'uppercase',
+          letterSpacing: '2px',
+          marginTop: '24px',
+        }}
+      >
+        Blog
+      </span>
+
+      <span
+        style={{
+          fontFamily: 'Inter',
+          fontSize: '56px',
+          fontWeight: 700,
+          color: '#ffffff',
+          lineHeight: 1.1,
+          marginTop: '8px',
+          textAlign: 'center',
+        }}
+      >
+        Notes from Shipping Code
+      </span>
+
+      <span
+        style={{
+          fontFamily: 'Inter',
+          fontSize: '22px',
+          fontWeight: 400,
+          color: 'rgba(255,255,255,0.75)',
+          marginTop: '16px',
+          textAlign: 'center',
+          maxWidth: '800px',
+        }}
+      >
+        Deep-dives on the problems I&apos;ve debugged, the patterns I&apos;ve
+        extracted, and the decisions I&apos;d make differently next time
+      </span>
+
+      <div
+        style={{
+          display: 'flex',
+          width: '120px',
+          height: '2px',
+          background: '#0d9488',
+          marginTop: '28px',
+          marginBottom: '28px',
+        }}
+      />
+
+      <span
+        style={{
+          fontFamily: 'Inter',
+          fontSize: '18px',
+          fontWeight: 500,
+          color: '#5eead4',
+        }}
+      >
+        danieljoffe.com
+      </span>
+    </div>,
+    {
+      ...size,
+      fonts,
+    }
+  );
+}

--- a/apps/root/src/lib/og.ts
+++ b/apps/root/src/lib/og.ts
@@ -49,19 +49,29 @@ export async function getOgFonts() {
   ];
 }
 
-export async function getProfileImageBase64(): Promise<string> {
-  if (!_profilePromise) _profilePromise = loadProfileImage();
-  const buffer = await _profilePromise;
-  // The source asset is WebP, but Satori/resvg (used by next/og) only supports
-  // PNG/JPEG/GIF — so we must convert before encoding, otherwise the <img>
-  // silently fails to render and only the empty avatar ring shows.
-  // sharp is a Next.js transitive dep with no direct type declarations here.
+// 1x1 transparent PNG. Fallback so a failed avatar read/convert degrades to an
+// empty ring rather than throwing and 500-ing the entire OG image.
+const TRANSPARENT_PNG =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
 
-  const sharp = require('sharp') as (input: Buffer) => {
-    png: () => { toBuffer: () => Promise<Buffer> };
-  };
-  const png = await sharp(buffer).png().toBuffer();
-  return `data:image/png;base64,${png.toString('base64')}`;
+export async function getProfileImageBase64(): Promise<string> {
+  try {
+    if (!_profilePromise) _profilePromise = loadProfileImage();
+    const buffer = await _profilePromise;
+    // The source asset is WebP, but Satori/resvg (used by next/og) only supports
+    // PNG/JPEG/GIF — so we must convert before encoding, otherwise the <img>
+    // silently fails to render and only the empty avatar ring shows.
+    // sharp is a Next.js transitive dep with no direct type declarations here.
+
+    const sharp = require('sharp') as (input: Buffer) => {
+      png: () => { toBuffer: () => Promise<Buffer> };
+    };
+    const png = await sharp(buffer).png().toBuffer();
+    return `data:image/png;base64,${png.toString('base64')}`;
+  } catch {
+    _profilePromise = null; // don't cache a failed read
+    return TRANSPARENT_PNG;
+  }
 }
 
 /**

--- a/apps/root/src/lib/og.ts
+++ b/apps/root/src/lib/og.ts
@@ -52,7 +52,16 @@ export async function getOgFonts() {
 export async function getProfileImageBase64(): Promise<string> {
   if (!_profilePromise) _profilePromise = loadProfileImage();
   const buffer = await _profilePromise;
-  return `data:image/png;base64,${buffer.toString('base64')}`;
+  // The source asset is WebP, but Satori/resvg (used by next/og) only supports
+  // PNG/JPEG/GIF — so we must convert before encoding, otherwise the <img>
+  // silently fails to render and only the empty avatar ring shows.
+  // sharp is a Next.js transitive dep with no direct type declarations here.
+
+  const sharp = require('sharp') as (input: Buffer) => {
+    png: () => { toBuffer: () => Promise<Buffer> };
+  };
+  const png = await sharp(buffer).png().toBuffer();
+  return `data:image/png;base64,${png.toString('base64')}`;
 }
 
 /**


### PR DESCRIPTION
## Summary

Two OG-image fixes from the production OG audit (#937, epic #938).

### Fix 1 — `/blog` listing had no OG image
The blog index advertised `og:image: null` while every sibling route had one. Added `apps/root/src/app/(public)/blog/opengraph-image.tsx`, mirroring the experience/projects listing templates (same gradient, avatar ring, label/title/subtitle lockup, divider, and `danieljoffe.com` footer). Label "Blog", title "Notes from Shipping Code", subtitle drawn from the page's existing `og:description`. The build now prerenders `/blog/opengraph-image` as a static route, so `/blog` resolves an `og:image`.

### Fix 2 — empty avatar ring on every OG template (chose: embed the asset)
Root cause: `getProfileImageBase64()` in `apps/root/src/lib/og.ts` read the source bytes of `public/images/daniel-joffe-profile.webp` (a real WebP, VP8 800x800) but labelled the data URL `image/png`. Satori/resvg (used by `next/og`) does **not** support WebP, so the `<img>` silently failed and only the ring's border rendered — reading as a broken avatar.

A suitable asset exists (the profile photo), so I embedded it rather than removing the ring. Fix converts WebP→PNG via `sharp` before base64-encoding — the exact pattern already used by the neighbouring `getCoverImageBase64()` helper. Because all six existing templates + the new blog one share this single helper, the fix lands everywhere at once. Verified the conversion yields a valid 800x800 PNG.

## Scope / constraints
- Touched only OG rendering (`lib/og.ts` helper + new blog OG route). No page restyling, no unrelated metadata changes.
- `shared-ui` untouched — all OG code stays in the root app.
- OG images are **not** in the VR screenshot set, so no baseline regen is expected.

## Test plan
- [x] `pnpm tsc --noEmit` — passes
- [x] `pnpm nx lint root` — passes
- [x] `pnpm nx build root` — passes; `/blog/opengraph-image` present + prerendered
- [x] `pnpm nx test root` — 982 passed
- [ ] Spot-check rendered OG images on the Vercel preview (blog listing + homepage avatar)

Refs #937, #938

🤖 Generated with [Claude Code](https://claude.com/claude-code)