### PR TITLE
chore: format mermaid MDX + add Prettier CI gate

### DIFF
--- a/.github/workflows/ci-fast.yml
+++ b/.github/workflows/ci-fast.yml
@@ -30,6 +30,9 @@ jobs:
 
       - uses: ./.github/actions/setup-workspace
 
+      - name: Format check (Prettier)
+        run: pnpm format:check
+
       - name: Lint, typecheck, test, build affected
         run: pnpm nx affected -t lint typecheck test build --nxBail
         env:

--- a/apps/root/src/data/content/projects/api-performance-case-study.mdx
+++ b/apps/root/src/data/content/projects/api-performance-case-study.mdx
@@ -61,11 +61,11 @@ Lighthouse and axe-core now run in parallel via `asyncio.gather` with `return_ex
   Axe["axe-core<br/>(Playwright page)"]
   Gather["asyncio.gather → grade"]
 
-  Queue --> Pool
-  Pool --> LH
-  Pool --> Axe
-  LH --> Gather
-  Axe --> Gather
+Queue --> Pool
+Pool --> LH
+Pool --> Axe
+LH --> Gather
+Axe --> Gather
 `}
 />
 

--- a/apps/root/src/data/content/projects/audit-tool-case-study.mdx
+++ b/apps/root/src/data/content/projects/audit-tool-case-study.mdx
@@ -58,11 +58,11 @@ Three pieces cooperate through Supabase. The browser only ever talks to Next.js;
   FastAPI["FastAPI (Railway)<br/>queue, browser pool<br/>Lighthouse + axe, grade"]
   DB[("Supabase<br/>scans, scan_issues, leads")]
 
-  Browser -->|"POST /api/audit/scan"| Next
-  Next -.->|"poll /api/audit/status"| Browser
-  Next -->|"x-api-key"| FastAPI
-  Next -->|"service-role"| DB
-  FastAPI -->|"service-role"| DB
+Browser -->|"POST /api/audit/scan"| Next
+Next -.->|"poll /api/audit/status"| Browser
+Next -->|"x-api-key"| FastAPI
+Next -->|"service-role"| DB
+FastAPI -->|"service-role"| DB
 `}
 />
 

--- a/apps/root/src/data/content/projects/job-pipeline-case-study.mdx
+++ b/apps/root/src/data/content/projects/job-pipeline-case-study.mdx
@@ -70,12 +70,12 @@ The pipeline has three services cooperating through Supabase:
   Proxy["Next.js proxy routes<br/>/api/jobs/* (verifies admin cookie)"]
   Dashboard["/tools/admin/jobs<br/>dashboard"]
 
-  ATS --> FastAPI
-  Cron -->|"x-api-key"| FastAPI
-  FastAPI -->|"writes"| DB
-  Proxy -->|"JWT bearer"| FastAPI
-  DB -->|"reads"| Proxy
-  Proxy --> Dashboard
+ATS --> FastAPI
+Cron -->|"x-api-key"| FastAPI
+FastAPI -->|"writes"| DB
+Proxy -->|"JWT bearer"| FastAPI
+DB -->|"reads"| Proxy
+Proxy --> Dashboard
 `}
 />
 

--- a/apps/root/src/data/content/projects/shared-ui-case-study.mdx
+++ b/apps/root/src/data/content/projects/shared-ui-case-study.mdx
@@ -134,8 +134,8 @@ The portfolio renders almost every heading, section wrapper, and button through 
   Pkg["Published npm package<br/>per-component ESM + .d.ts"]
   Wyrdfold["WyrdFold<br/>(separate repo, installs package)"]
 
-  Source --> Cond --> Portfolio
-  Source --> Vite --> Pkg --> Wyrdfold
+Source --> Cond --> Portfolio
+Source --> Vite --> Pkg --> Wyrdfold
 `}
 />
 


### PR DESCRIPTION
## Why
The 4 Mermaid case-study MDX files (`api-performance`, `audit-tool`, `job-pipeline`, `shared-ui`, added in #962) were committed **non-Prettier-compliant** — the lines inside the `<Mermaid chart={`…`} />` template literal were indented, but Prettier's canonical form strips that indentation. Result: any `pnpm format` / lint-staged / agent action that ran Prettier silently re-dirtied the working tree with phantom whitespace diffs.

Root cause confirmed by reproduction: the build's content scripts (`generate-search-index`, `validate-content`) leave MDX untouched; `prettier --check` flagged exactly these 4 files. The de-indent is cosmetic — Mermaid ignores leading whitespace, so rendering and VR baselines are unaffected.

## What
- **Reformat** the 4 files with Prettier so the committed source matches Prettier's canonical form (no more phantom diffs).
- **Add a `pnpm format:check` step** to the `fast` CI job (`ci-fast.yml`). The repo had **no** Prettier gate in CI — it relied solely on pre-commit lint-staged, which can be bypassed (e.g. commits made in agent worktrees, which is how the unformatted file landed). Now unformatted files fail CI instead of silently merging.

Repo is fully Prettier-compliant after this (`prettier --check .` passes).