### PR TITLE
chore(shared-ui): bump version to 0.2.0

### DIFF
--- a/libs/shared/ui/package.json
+++ b/libs/shared/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@danieljoffe/shared-ui",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "React component library and design system shared across danieljoffe.com and WyrdFold — Tailwind CSS 4, React 19, server-component-friendly.",
   "type": "module",
   "sideEffects": false,


### PR DESCRIPTION
Reconciles `libs/shared/ui/package.json` with the published npm release. **`@danieljoffe/shared-ui@0.2.0` is live on npm** (adds `IconText` + the `--color-on-brand` token), but the publish workflow's "Commit version bump + tag" step failed to push to protected `develop`, leaving source at 0.1.0. This catches it up.

Follow-up (separate): the publish workflow should open a PR for the bump (or run from a ref it can push) instead of pushing directly to a protected branch.