### PR TITLE
fix(shared-ui): dedup Storybook story-tree categories

### DIFF
--- a/libs/shared/ui/src/lib/FormFieldError.stories.tsx
+++ b/libs/shared/ui/src/lib/FormFieldError.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { FormFieldError } from './FormFieldError';
 
 const meta = {
-  title: 'Form/FormFieldError',
+  title: 'Forms/FormFieldError',
   component: FormFieldError,
   tags: ['autodocs'],
 } satisfies Meta<typeof FormFieldError>;

--- a/libs/shared/ui/src/lib/StructuredData.stories.tsx
+++ b/libs/shared/ui/src/lib/StructuredData.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { StructuredData } from './StructuredData';
 
 const meta = {
-  title: 'Utility/StructuredData',
+  title: 'Utils/StructuredData',
   component: StructuredData,
   tags: ['autodocs'],
   parameters: {


### PR DESCRIPTION
## Summary
- Canonicalize duplicate Storybook sidebar roots: `Form` → `Forms` (`FormFieldError`), `Utility` → `Utils` (`StructuredData`).
- Pure Storybook `title` change — no runtime or visual change to components.

Closes #972

## Test plan
- [ ] CI green (lint/typecheck/test/build)
- [ ] Storybook sidebar shows single `Forms` and `Utils` roots (no stray `Form`/`Utility`)
- [ ] Chromatic: story IDs change with the title rename — accept the relocated stories as baselines

🤖 Generated with [Claude Code](https://claude.com/claude-code)