### PR TITLE
docs(shared-ui): document Button className prop in Storybook args

### DIFF
--- a/libs/shared/ui/src/lib/Button.stories.tsx
+++ b/libs/shared/ui/src/lib/Button.stories.tsx
@@ -48,6 +48,11 @@ const meta = {
       description: 'Button content',
       control: 'text',
     },
+    className: {
+      description:
+        'Additional CSS classes merged onto the button (escape hatch for one-off styling)',
+      control: 'text',
+    },
   },
 } satisfies Meta<typeof Button>;
 


### PR DESCRIPTION
## Summary
- Add a `className` argType to `Button.stories.tsx` so the styling escape hatch appears in the Controls/args table (previously accepted but undocumented).

Closes #973

## Test plan
- [ ] CI green
- [ ] Storybook → Forms/Button → Controls shows a `className` row with description

🤖 Generated with [Claude Code](https://claude.com/claude-code)