### PR TITLE
fix(shared-ui): add visible focus indicator to dismiss/close buttons

### DIFF
--- a/libs/shared/ui/src/lib/styles/formStyles.ts
+++ b/libs/shared/ui/src/lib/styles/formStyles.ts
@@ -83,4 +83,4 @@ export const FOCUS_RING_PEER = [
 
 /** Hover treatment for icon-only dismiss/close buttons (Alert, Modal, Toast). */
 export const DISMISS_BUTTON =
-  'text-text-tertiary hover:text-text-primary transition-colors';
+  'rounded-md text-text-tertiary transition-colors hover:text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2 focus-visible:ring-offset-surface';


### PR DESCRIPTION
## Summary
- `DISMISS_BUTTON` (used by Alert/Modal/Toast close buttons) had only a hover color change and no focus indicator. Keyboard users saw nothing on focus — fails **WCAG 2.4.7**.
- Add the kit's standard `focus-visible` ring (`ring-2 ring-brand-500 ring-offset-2 ring-offset-surface`) plus `rounded-md` so the ring renders cleanly around the icon-only button.

Closes #974

## Test plan
- [ ] CI green
- [ ] Tab to the close button on an Alert/Modal/Toast story → a visible brand ring appears
- [ ] Hover behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)