### PR TITLE
fix(shared-ui): preserve dark-mode AA + fix light error for indigo status

### DIFF
--- a/libs/shared/ui/src/styles/indigo-theme.css
+++ b/libs/shared/ui/src/styles/indigo-theme.css
@@ -69,7 +69,7 @@
   --color-success-light: #ecfdf5;
   --color-warning: #b45309;
   --color-warning-light: #fffbeb;
-  --color-error: #ef4444;
+  --color-error: #cb2424;
   --color-error-light: #fef2f2;
   --color-info: #2563eb;
   --color-info-light: #eff6ff;
@@ -91,6 +91,12 @@
   --color-text-tertiary: #8494a7;
   --color-text-inverse: #0f1117;
   --color-text-brand: oklch(0.65 0.19 250);
+
+  /* Status base colors kept bright for the dark surface. Light mode
+     darkens warning/error for AA on white; dark mode needs the
+     opposite (bright on near-black), so override them back here. */
+  --color-warning: #f59e0b;
+  --color-error: #ef4444;
 
   --color-success-light: #052e16;
   --color-warning-light: #451a03;


### PR DESCRIPTION
## Summary
Follow-up to #983. Two issues with indigo's status colors:

1. **Dark-mode regression** — #983 darkened `:root` `--color-warning` to `#b45309` for light-mode AA, but indigo's `.dark` block doesn't override base status colors, so **dark-mode** warning inherited `#b45309` → only **3.76:1** on the dark surface (was 8.79:1). Fixed by adding `.dark` overrides that keep warning/error bright on near-black, the way Pyre already does.
2. **Light error** (your go-ahead) — `:root` `--color-error: #ef4444` was **3.76:1** on white (fails AA). Darkened to `#cb2424` → **5.50:1** on white, **5.03:1** on the error-light tint. Dark keeps `#ef4444` (5.01:1).

Contrast (recomputed):
| | light | dark |
|---|---|---|
| warning | #b45309 = 5.02 | #f59e0b = 8.79 |
| error | #cb2424 = 5.50 | #ef4444 = 5.01 |

Refs #975. (Dark error-on-tint is ~4.29 — addressed by the #978 tint lift.)

## Test plan
- [ ] CI green
- [ ] Light: warning/error text legible on white & tint
- [ ] Dark: warning/error text still bright/legible (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)