### PR TITLE
fix(shared-ui): add --color-border-strong for form field outlines (WCAG 1.4.11)

### DIFF
--- a/libs/shared/ui/src/lib/styles/formStyles.ts
+++ b/libs/shared/ui/src/lib/styles/formStyles.ts
@@ -20,7 +20,7 @@ export const REQUIRED_MARK = 'text-error ml-1';
  * Does NOT include padding — that varies per component (Input has size prop).
  */
 export const BASE_FIELD = [
-  'w-full bg-surface border border-border rounded-md',
+  'w-full bg-surface border border-border-strong rounded-md',
   'text-text-primary',
   'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500',
   'focus-visible:border-transparent transition-all',

--- a/libs/shared/ui/src/styles/indigo-theme.css
+++ b/libs/shared/ui/src/styles/indigo-theme.css
@@ -51,6 +51,7 @@
   /* Semantic Colors - Border */
   --color-border: #e5e7eb;
   --color-border-secondary: #d1d5db;
+  --color-border-strong: #8b909c;
   --color-border-focus: oklch(0.54 0.19 250);
 
   /* Semantic Colors - Text */
@@ -85,6 +86,7 @@
 
   --color-border: #2a2d3a;
   --color-border-secondary: #3a3d4a;
+  --color-border-strong: #5e6270;
 
   --color-text-primary: #f1f5f9;
   --color-text-secondary: #94a3b8;

--- a/libs/shared/ui/src/styles/pyre-storybook-preview.css
+++ b/libs/shared/ui/src/styles/pyre-storybook-preview.css
@@ -31,6 +31,7 @@
 
   --color-border: oklch(0.22 0.01 270);
   --color-border-secondary: oklch(0.3 0.01 270);
+  --color-border-strong: oklch(0.48 0.01 270);
   --color-border-focus: oklch(0.67 0.28 127);
 
   --color-text-primary: oklch(0.96 0.01 90);

--- a/libs/shared/ui/src/styles/pyre-theme.css
+++ b/libs/shared/ui/src/styles/pyre-theme.css
@@ -81,6 +81,7 @@
   /* Semantic Colors — Border (light mode) */
   --color-border: oklch(0.9 0.005 270);
   --color-border-secondary: oklch(0.82 0.005 270);
+  --color-border-strong: oklch(0.66 0.01 270);
   --color-border-focus: oklch(0.55 0.28 127);
 
   /* Semantic Colors — Text (light mode, near-black hue 270) */
@@ -138,6 +139,7 @@
   /* Border */
   --color-border: oklch(0.22 0.01 270);
   --color-border-secondary: oklch(0.3 0.01 270);
+  --color-border-strong: oklch(0.48 0.01 270);
   --color-border-focus: oklch(0.67 0.28 127);
 
   /* Text — near-white */


### PR DESCRIPTION
## Summary
Adds a 3:1-contrast `--color-border-strong` token and applies it to `BASE_FIELD`, so Input/Select/Textarea outlines meet **WCAG 1.4.11** (current `--color-border` is only ~1.2–1.7:1 against the surface). Decorative borders and dividers keep the subtle `--color-border` — this is the targeted "functional outlines only" approach.

**Values**
| theme | light | dark |
|---|---|---|
| pyre | `oklch(0.66 0.01 270)` 3.02:1 | `oklch(0.48 0.01 270)` 3.15:1 |
| indigo | `#8b909c` 3.20:1 | `#5e6270` 3.11:1 |

**Bonus fix:** `--color-border-strong` was already referenced by **Switch** (`bg-border-strong`, the unchecked track) and **Button** (`hover:outline-border-strong`) but never defined — those dangling utilities were no-ops and now resolve to a real color.

Closes #977

## Test plan
- [ ] CI green
- [ ] Input/Select/Textarea outlines clearly visible in light & dark
- [ ] Switch unchecked track now shows a gray fill
- [ ] Decorative card/divider borders unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)