### PR TITLE
fix(shared-ui): dark Badge brand tint + de-muddy Pyre status tints (#978)

### DIFF
--- a/libs/shared/ui/src/lib/Badge.tsx
+++ b/libs/shared/ui/src/lib/Badge.tsx
@@ -33,7 +33,7 @@ const variantStyles: Record<BadgeVariant, string> = {
   warning: semanticBadge('warning'),
   error: semanticBadge('error'),
   info: semanticBadge('info'),
-  brand: 'bg-brand-50 text-brand-700',
+  brand: 'bg-brand-50 text-brand-700 dark:bg-brand-950 dark:text-brand-300',
   'brand-solid': 'bg-brand-600 text-on-brand',
 };
 

--- a/libs/shared/ui/src/styles/pyre-theme.css
+++ b/libs/shared/ui/src/styles/pyre-theme.css
@@ -151,9 +151,9 @@
   --color-success: oklch(0.72 0.2 145);
   --color-success-light: oklch(0.25 0.05 145);
   --color-warning: oklch(0.78 0.18 70);
-  --color-warning-light: oklch(0.28 0.05 70);
+  --color-warning-light: oklch(0.32 0.08 70);
   --color-error: oklch(0.65 0.22 25);
-  --color-error-light: oklch(0.25 0.05 25);
+  --color-error-light: oklch(0.24 0.1 25);
   --color-info: oklch(0.7 0.2 230);
   --color-info-light: oklch(0.25 0.05 230);
 }


### PR DESCRIPTION
## Summary
Two dark-mode palette fixes from the smoketest (#978), per your chosen options:

- **Badge "brand" (dark)** — was `bg-brand-50 text-brand-700`; `brand-50` doesn't flip between themes, so dark mode showed a glaring near-white pill colliding with "brand-solid". Added `dark:bg-brand-950 dark:text-brand-300` → a proper dark chartreuse tint (9.4:1). *(Option A.)*
- **Pyre dark status tints** — were muddy (low chroma). De-muddied **chroma-forward**: `warning-light 0.28/0.05 → 0.32/0.08`, `error-light 0.25/0.05 → 0.24/0.10`.

⚠️ Note on the error tint: it's **lightness-constrained** — the current 0.25/0.05 was already only 4.53:1 for the error text, so I couldn't raise lightness (your visual mockup's 0.30 dropped text to 3.91, failing AA). Went chroma-only instead: richer red, text stays AA (warning 6.2:1, error 4.7:1).

**Indigo** dark tints get the same treatment in the upcoming oklch-standardization PR (after #986 lands), to avoid colliding with #986's open indigo changes.

Refs #978

## Test plan
- [ ] CI green
- [ ] Dark: "brand" badge is a dark chartreuse tint, distinct from "brand-solid"
- [ ] Dark: warning/error tints read clearly amber/red; text legible

🤖 Generated with [Claude Code](https://claude.com/claude-code)