### PR TITLE
fix(shared-ui): give Heading 'detail' a distinct rank below 'hero' (#979)

### DIFF
--- a/apps/root/src/data/content/blog/shared-ui-design-system.mdx
+++ b/apps/root/src/data/content/blog/shared-ui-design-system.mdx
@@ -63,7 +63,7 @@ The fix was simple: move every variant into shared-ui.
 ```tsx
 const variantStyles: Record<HeadingVariant, string> = {
   hero: 'text-4xl sm:text-5xl font-bold tracking-tight leading-[1.1]',
-  detail: 'text-3xl sm:text-4xl lg:text-5xl font-bold tracking-tight',
+  detail: 'text-3xl sm:text-4xl font-bold tracking-tight',
   subtitle: 'text-2xl font-bold tracking-tight',
   section: 'text-2xl sm:text-3xl font-bold tracking-tight',
   cardTitle: 'text-sm font-semibold',

--- a/libs/shared/ui/src/lib/Heading.tsx
+++ b/libs/shared/ui/src/lib/Heading.tsx
@@ -27,8 +27,7 @@ export interface HeadingProps extends Omit<
 
 const variantStyles: Record<HeadingVariant, string> = {
   hero: 'text-4xl sm:text-5xl font-bold text-text-primary tracking-tight leading-[1.1]',
-  detail:
-    'text-3xl sm:text-4xl lg:text-5xl font-bold text-text-primary tracking-tight',
+  detail: 'text-3xl sm:text-4xl font-bold text-text-primary tracking-tight',
   subtitle: 'text-2xl font-bold text-text-primary tracking-tight',
   section: 'text-2xl sm:text-3xl font-bold text-text-primary tracking-tight',
   cardTitle: 'text-sm font-semibold text-text-primary',


### PR DESCRIPTION
## Summary
`detail` ramped `text-3xl sm:text-4xl lg:text-5xl`, tying `hero` at **48px** on desktop and muddying the hierarchy. Capped it at **36px** (`text-3xl sm:text-4xl`) so it reads as a clear rank below `hero` — which is **unchanged** (all ~9 hero usages and its documented `36→48` scale stay intact).

`detail` (Heading) is used in exactly one place — the **blog post title** in `PostBody`, which sits in a `lg:flex-1 lg:min-w-0` column beside the cover image. At 36px it balances better against the image and can't overflow (`min-w-0`).

Also updated the reproduced `detail:` class string in `shared-ui-design-system.mdx` so the published post stays accurate.

Closes #979

## Verification
- Code-reviewed `PostBody` layout: change is a strict size reduction inside a `min-w-0` flex column — no overflow/reflow risk. (Full dev-server visual check not run; can confirm in-browser on request.)

## Test plan
- [ ] CI green
- [ ] Blog post title renders at 36px on desktop, balanced beside the cover image
- [ ] Index/marketing page heroes unchanged (still 48px)

🤖 Generated with [Claude Code](https://claude.com/claude-code)