### PR TITLE
ci(shared-ui): guard publish against already-published versions

### DIFF
--- a/.github/workflows/publish-shared-ui.yml
+++ b/.github/workflows/publish-shared-ui.yml
@@ -89,6 +89,21 @@ jobs:
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "Publishing version: ${VERSION}"
 
+      - name: Verify version is not already published
+        if: ${{ !inputs.dry-run }}
+        run: |
+          NAME=$(node -p "require('./libs/shared/ui/package.json').name")
+          VERSION="${{ steps.version.outputs.version }}"
+          # `npm view pkg@version version` prints the version if it exists and
+          # an empty string otherwise (exit 0 either way, since the package
+          # exists), so test for non-empty output rather than exit code.
+          PUBLISHED=$(npm view "${NAME}@${VERSION}" version 2>/dev/null || true)
+          if [ -n "${PUBLISHED}" ]; then
+            echo "::error::${NAME}@${VERSION} is already published to npm. npm forbids overwriting a version — re-run with a bumped 'version' input (e.g. 0.2.1) instead of '${VERSION}'."
+            exit 1
+          fi
+          echo "${NAME}@${VERSION} is not yet on npm — OK to publish."
+
       - name: Build
         run: pnpm nx build @danieljoffe/shared-ui
 


### PR DESCRIPTION
## Summary
- The Publish shared-ui workflow failed with `npm error You cannot publish over the previously published versions: 0.2.0` — it tried to republish a version already on npm and only discovered the collision at the late publish step (after build).
- Adds an early `Verify version is not already published` step that queries npm for the resolved version and fails fast with an actionable message ("re-run with a bumped version input") before the build runs.
- Runs only on real publishes (`!inputs.dry-run`), so `dry-run` stays a pure inspection path.

## Notes
- No code/library change — the actual fix for the failed run is to re-run the workflow with a bumped `version` input (e.g. `0.2.1`) instead of `current`/`0.2.0`. This PR just makes the failure mode obvious next time.

## Test plan
- [ ] Run **Publish shared-ui** with `version: current` (resolves to `0.2.0`) and `dry-run: false` → should fail early at the new guard step with the "already published" message.
- [ ] Run with `version: 0.2.1`, `dry-run: false` → guard passes, publishes `0.2.1`, tags `shared-ui-v0.2.1`, creates release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)