### PR TITLE
fix(shared-ui): Storybook theme + form-input statefulness

### DIFF
--- a/libs/shared/ui/.storybook/preview-head.html
+++ b/libs/shared/ui/.storybook/preview-head.html
@@ -27,10 +27,11 @@
     // Set initial dark class (matches preview.ts defaultTheme: 'dark')
     apply();
 
-    // Guard against anything that clears the class during init.
-    // Once the channel listener is active, the observer only acts
-    // as a safety net — both the decorator and the listener set
-    // the same value so there is no conflict.
+    // Guard the INITIAL paint only: if something clears the class before the
+    // decorator's useEffect fires, re-assert it. This runs for a short window
+    // then disconnects (below) so it never fights *runtime* theme changes made
+    // by the components under test — e.g. the ThemeProvider / ThemeToggle demos
+    // toggle the `dark` class themselves and must stay visible.
     var observer = new MutationObserver(function () {
       if (currentTheme === DARK && !html.classList.contains(DARK)) {
         observer.disconnect();
@@ -43,7 +44,15 @@
     });
     observer.observe(html, { attributes: true, attributeFilter: ['class'] });
 
-    // Poll for the Storybook channel (it's created after this script).
+    // The guard is only needed during initial load. After that the decorator
+    // and the toolbar listener own the class, so stop observing — otherwise
+    // runtime theme changes from components get reverted.
+    setTimeout(function () {
+      observer.disconnect();
+    }, 1000);
+
+    // Poll for the Storybook channel (it's created after this script) to keep
+    // MDX docs pages (where decorators don't run) in sync with the toolbar.
     var timer = setInterval(function () {
       var ch = window.__STORYBOOK_ADDONS_CHANNEL__;
       if (!ch) return;

--- a/libs/shared/ui/src/lib/Checkbox.stories.tsx
+++ b/libs/shared/ui/src/lib/Checkbox.stories.tsx
@@ -1,7 +1,8 @@
 import { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useArgs } from 'storybook/preview-api';
 import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
-import { Checkbox } from './Checkbox';
+import { Checkbox, type CheckboxProps } from './Checkbox';
 
 const meta = {
   title: 'Forms/Checkbox',
@@ -20,6 +21,21 @@ const meta = {
       description: 'Disables the checkbox',
       control: 'boolean',
     },
+  },
+  // Drive `checked` from clicks so stories are interactive AND the check icon
+  // shows (it renders off the `checked` prop, not native :checked state).
+  render: function Render(args) {
+    const [, updateArgs] = useArgs<CheckboxProps>();
+    return (
+      <Checkbox
+        {...args}
+        checked={args.checked ?? false}
+        onChange={e => {
+          updateArgs({ checked: e.target.checked });
+          args.onChange?.(e);
+        }}
+      />
+    );
   },
 } satisfies Meta<typeof Checkbox>;
 

--- a/libs/shared/ui/src/lib/Switch.stories.tsx
+++ b/libs/shared/ui/src/lib/Switch.stories.tsx
@@ -1,7 +1,8 @@
 import { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useArgs } from 'storybook/preview-api';
 import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
-import { Switch } from './Switch';
+import { Switch, type SwitchProps } from './Switch';
 
 const meta = {
   title: 'Forms/Switch',
@@ -24,6 +25,20 @@ const meta = {
       description: 'Callback when switch state changes',
       action: 'onChange executed!',
     },
+  },
+  // Keep the `checked` arg in sync with clicks so every story is interactive
+  // (Switch is controlled-only). Without this the thumb never moves.
+  render: function Render(args) {
+    const [, updateArgs] = useArgs<SwitchProps>();
+    return (
+      <Switch
+        {...args}
+        onChange={value => {
+          updateArgs({ checked: value });
+          args.onChange?.(value);
+        }}
+      />
+    );
   },
 } satisfies Meta<typeof Switch>;
 


### PR DESCRIPTION
Makes interactive components in the shared-ui Storybook actually respond to user input. Two related statefulness bugs:

## 1. Theme section (`Theme/ThemeToggle`, `Theme/ThemeProvider`)
- Clicking Light/Dark/System updated React state (`aria-pressed`, `localStorage`, displayed values) but the visible theme never changed.
- **Cause:** the `MutationObserver` in `.storybook/preview-head.html` — intended only as an initial-load guard — ran for the whole session and re-asserted `dark` on `<html>` whenever a component cleared it.
- **Fix:** disconnect the observer after a 1s init window. Initial-paint guard preserved; runtime theme changes from components now stick.

## 2. Forms `Switch` & `Checkbox`
- `Switch` is controlled-only; every non-`Controlled` story passed a fixed `checked` + no-op `onChange: fn()`, so the thumb never moved.
- `Checkbox` had the same issue on controlled stories, and its check icon renders off the `checked` prop (not native `:checked`), so uncontrolled stories showed a filled box with no checkmark.
- **Fix:** meta-level `useArgs` render on both so the controlling prop stays in sync with interaction. Every story now responds to clicks and the Controls panel reflects state. No component/API changes.

## Scope & verification
- Files: `.storybook/preview-head.html`, `Switch.stories.tsx`, `Checkbox.stories.tsx`. No published-package source changes → no changeset.
- An audit subagent drove every interactive component live; only Theme + the two controlled inputs were affected (Tabs, Dropdown, Modal, Tooltip, Select, Input, Textarea, Sidebar, Toast, Pagination all already worked).
- Verified after fix in a running Storybook: Theme toggles flip + persist; Switch thumb moves (`translate-x-6`) and `aria-checked` toggles; Checkbox toggles, shows the checkmark when checked, and reverts.
- `pnpm tsc --noEmit` ✅

## Test plan
- [ ] Theme/ThemeToggle + ThemeProvider: clicking changes the visible theme
- [ ] Forms/Switch (Default): clicking flicks the switch on/off
- [ ] Forms/Checkbox (Default): clicking toggles and shows/hides the checkmark
- [ ] Storybook play-function tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)