### PR TITLE
fix(shared-ui): de-mud dark warning/error status tints (#978)

### DIFF
--- a/.changeset/dark-status-tint-contrast.md
+++ b/.changeset/dark-status-tint-contrast.md
@@ -1,0 +1,10 @@
+---
+'@danieljoffe/shared-ui': patch
+---
+
+Dark-mode `warning`/`error` status tints (Badge, Alert, Toast) are less muddy
+and lift the error text off the WCAG AA floor. `--color-error-light` moves to
+`oklch(0.21 0.055 25)` (text-on-tint contrast 4.53 → 5.00) and
+`--color-warning-light` to `oklch(0.3 0.055 72)`; both keep their hue but drop
+chroma to read as cleaner tinted surfaces. Also re-syncs the Storybook preview
+tokens, which had drifted from the published theme.

--- a/libs/shared/ui/src/styles/pyre-storybook-preview.css
+++ b/libs/shared/ui/src/styles/pyre-storybook-preview.css
@@ -44,9 +44,9 @@
   --color-success: oklch(0.72 0.2 145);
   --color-success-light: oklch(0.25 0.05 145);
   --color-warning: oklch(0.78 0.18 70);
-  --color-warning-light: oklch(0.28 0.05 70);
+  --color-warning-light: oklch(0.3 0.055 72);
   --color-error: oklch(0.65 0.22 25);
-  --color-error-light: oklch(0.25 0.05 25);
+  --color-error-light: oklch(0.21 0.055 25);
   --color-info: oklch(0.7 0.2 230);
   --color-info-light: oklch(0.25 0.05 230);
 }

--- a/libs/shared/ui/src/styles/pyre-theme.css
+++ b/libs/shared/ui/src/styles/pyre-theme.css
@@ -153,9 +153,9 @@
   --color-success: oklch(0.72 0.2 145);
   --color-success-light: oklch(0.25 0.05 145);
   --color-warning: oklch(0.78 0.18 70);
-  --color-warning-light: oklch(0.32 0.08 70);
+  --color-warning-light: oklch(0.3 0.055 72);
   --color-error: oklch(0.65 0.22 25);
-  --color-error-light: oklch(0.24 0.1 25);
+  --color-error-light: oklch(0.21 0.055 25);
   --color-info: oklch(0.7 0.2 230);
   --color-info-light: oklch(0.25 0.05 230);
 }


### PR DESCRIPTION
Closes #978 (finding #2) and resolves finding #1 as stale.

## Summary

Dark-mode `warning`/`error` status tints (Badge, Alert, Toast) were muddy brown/maroon, and the error tint left its text **at the WCAG AA floor**. This drops chroma to clean up the tints and darkens the error surface to lift its contrast margin. Both pass AA. Also re-syncs the Storybook preview tokens, which had **drifted** from the published theme.

| Token (`.dark`) | Before | After | text-on-tint contrast |
|---|---|---|---|
| `--color-warning-light` | `oklch(0.32 0.08 70)` (theme) / `0.28 0.05 70` (preview) | `oklch(0.3 0.055 72)` | 6.23 → **6.66** ✓ AA |
| `--color-error-light` | `oklch(0.24 0.1 25)` (theme) / `0.25 0.05 25` (preview) | `oklch(0.21 0.055 25)` | 4.53 → **5.00** ✓ AA |

Contrast = status **text on its tinted surface** (the binding constraint for Badge/Alert), computed via oklch→linear-sRGB→WCAG. The status *text* tokens are unchanged.

## Finding #1 (Badge "Brand" dark = "near-white solid pill") — stale

`Badge.tsx` is unchanged since the issue was filed; the `brand` dark variant is already `dark:bg-brand-950` (`oklch(0.2 0.08 127)`) — a dark tinted pill with light `brand-300` text, i.e. the tinted pattern the finding said it was breaking. It does not collide with `brand-solid` (`brand-600`). Recommend confirming via the Chromatic snapshot and closing finding #1 as not-reproducible.

## Visual review

Eyeball the **Chromatic** check on this PR for the dark Badge/Alert/Toast warning+error swatches and the Badge "Brand" dark pill — that's the visual sign-off.

## Test plan
- [x] WCAG AA verified for both tints (text-on-tint ≥ 4.5; error margin lifted off the floor)
- [x] `pnpm nx build shared-ui` — clean
- [x] `pnpm nx test shared-ui` — 49 suites / 771 tests pass
- [x] Changeset added (patch — published `pyre-theme.css`)
- [ ] Chromatic visual diff reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)