### PR TITLE
ci(preview): allow Changesets release branch as a PR source to main

### DIFF
--- a/.github/workflows/ci-preview.yml
+++ b/.github/workflows/ci-preview.yml
@@ -19,15 +19,15 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Check source branch
-        if: github.head_ref != 'develop'
+        if: github.head_ref != 'develop' && github.head_ref != 'changeset-release/main'
         env:
           HEAD_REF: ${{ github.head_ref }}
         run: |
-          echo "PRs to main must come from develop, not '${HEAD_REF}'"
+          echo "PRs to main must come from develop or the changesets release branch, not '${HEAD_REF}'"
           exit 1
       - name: Source branch OK
-        if: github.head_ref == 'develop'
-        run: echo "PR is from develop"
+        if: github.head_ref == 'develop' || github.head_ref == 'changeset-release/main'
+        run: echo "PR source branch OK ('${{ github.head_ref }}')"
 
   # Full CI already ran on merge to develop; Vercel build validates compilation.
   preview:


### PR DESCRIPTION
## Summary

The `check-source` job in `ci-preview.yml` `exit 1`s for any PR to `main` whose head isn't `develop`. That guard never accounted for the **Changesets bot's Version PR** (`changeset-release/main` → `main`), so every shared-ui release PR is **BLOCKED** on a failing `check-source` — which is exactly what stalled the **0.3.0** publish (Version PR #1007).

This whitelists `changeset-release/main` alongside `develop`:

```yaml
- name: Check source branch
  if: github.head_ref != 'develop' && github.head_ref != 'changeset-release/main'
  ...
- name: Source branch OK
  if: github.head_ref == 'develop' || github.head_ref == 'changeset-release/main'
```

## Notes

- The develop→main release flow is unchanged; this only adds the bot's release branch as a legitimate source.
- **Does not retroactively unblock #1007** (its run used the pre-fix workflow). To publish 0.3.0 now, admin-merge #1007. Once this lands on `main`, future Version PRs pass `check-source` automatically.

## Test plan
- [ ] `ci-status` green on this PR
- [ ] Next changesets Version PR passes `check-source`

🤖 Generated with [Claude Code](https://claude.com/claude-code)