### PR TITLE
ci(release): publish shared-ui via OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,8 +12,15 @@
 #      it runs `pnpm release` (build + `changeset publish`), publishing to npm
 #      and creating git tags + GitHub Releases.
 #
+# Publishing auth: OIDC Trusted Publishing (no NPM_TOKEN).
+#   The package's npm settings must list this repo + this workflow
+#   (.github/workflows/release.yml) and the `npm-publish` environment as a
+#   trusted publisher. The job exchanges the GitHub OIDC token (id-token:
+#   write) for short-lived npm credentials at publish time — nothing stored,
+#   nothing to expire. Requires pnpm >= 10.14 (OIDC support; pinned via
+#   packageManager) and Node >= 24. Provenance is attached automatically.
+#
 # Required repo secrets:
-#   NPM_TOKEN     — npm automation token with publish rights, no 2FA-on-publish.
 #   RELEASE_TOKEN — (recommended) a PAT or GitHub App token. The default
 #                   GITHUB_TOKEN cannot trigger the required status checks on
 #                   the bot's Version Packages PR, leaving it unmergeable.
@@ -31,7 +38,7 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 permissions:
   contents: write # create tags + GitHub Releases, push the version branch
   pull-requests: write # open/update the Version Packages PR
-  id-token: write # npm provenance
+  id-token: write # OIDC trusted publishing + provenance
 
 jobs:
   release:
@@ -57,5 +64,3 @@ jobs:
           commit: 'chore(release): version packages'
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN || github.token }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@danieljoffe.com/source",
   "version": "0.0.0",
   "license": "MIT",
-  "packageManager": "pnpm@10.12.1",
+  "packageManager": "pnpm@10.34.3",
   "engines": {
     "node": "24.x"
   },


### PR DESCRIPTION
## Summary

Moves `@danieljoffe/shared-ui` publishing off the long-lived `NPM_TOKEN` to **OIDC Trusted Publishing** — short-lived, per-run credentials, nothing stored, nothing to expire (this is what just took down the 0.3.0 publish when the token lapsed).

- **Drop `NPM_TOKEN` / `NODE_AUTH_TOKEN`** from the changesets publish step so npm uses OIDC. `id-token: write` and the `npm-publish` environment were already present.
- **Bump `packageManager` `pnpm@10.12.1` → `pnpm@10.34.3`.** This is the load-bearing part: changesets publishes via `pnpm publish`, and **pnpm only gained OIDC support in 10.14** (released 2025-07-31, the npm OIDC GA date). 10.12.1 (2025-06-08) predates it, so it would silently fall back to token auth and 404 again. 10.34.3 is the latest 10.x; **pnpm 11 is intentionally avoided** (known OIDC 404 regression, pnpm/pnpm#11513).
- Frozen-lockfile install verified unchanged by the bump (no lockfile churn).

## Requires (your side, npm)
The package's npm trusted-publisher config must point at **this repo + `.github/workflows/release.yml` + the `npm-publish` environment** (you set this up choosing Option B).

## How 0.3.0 actually publishes
`release.yml` runs on push to `main`, and the 0.3.0 version bump is already on `main` (#1007). So: merge this → cut a `develop→main` release → that push triggers `release.yml` with OIDC → **0.3.0 publishes**. After it's confirmed working you can delete the `NPM_TOKEN` secret and set npm Publishing access to "disallow tokens".

## Test plan
- [ ] `ci-status` green
- [ ] After reaching main: Release run publishes 0.3.0 via OIDC (npm flips 0.2.1 → 0.3.0, tag + GitHub release created)

🤖 Generated with [Claude Code](https://claude.com/claude-code)