### PR TITLE
fix(shared-ui): make Modal docs previews readable + guard process.env

### DIFF
--- a/libs/shared/ui/src/lib/Modal.stories.tsx
+++ b/libs/shared/ui/src/lib/Modal.stories.tsx
@@ -54,6 +54,17 @@ const meta = {
       description: 'Optional footer content (typically action buttons)',
     },
   },
+  parameters: {
+    // Modal renders a `position: fixed inset-0` overlay. In the inline autodocs
+    // preview the fixed panel is out of flow, so the preview block collapses to
+    // a ~32px sliver and the modal is unreadable. Rendering each story in a
+    // sized iframe gives the overlay a real viewport, so it renders centered and
+    // fully visible — exactly like production. (Canvas view and interaction
+    // tests are unaffected; this only changes Docs rendering.)
+    docs: {
+      story: { inline: false, height: '460px' },
+    },
+  },
 } satisfies Meta<typeof Modal>;
 
 export default meta;
@@ -145,6 +156,13 @@ export const ExtraLarge: Story = {
 };
 
 export const ScrollableContent: Story = {
+  // Long-form content — give the docs preview iframe extra height so more of
+  // the tall modal is visible.
+  parameters: {
+    docs: {
+      story: { height: '640px' },
+    },
+  },
   args: {
     isOpen: true,
     title: 'Scrollable Content',

--- a/libs/shared/ui/src/lib/utils/ErrorBoundary.tsx
+++ b/libs/shared/ui/src/lib/utils/ErrorBoundary.tsx
@@ -27,7 +27,10 @@ export class ErrorBoundary extends Component<
   }
 
   override componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
-    if (process.env['NODE_ENV'] === 'development') {
+    if (
+      typeof process !== 'undefined' &&
+      process.env['NODE_ENV'] === 'development'
+    ) {
       console.error('[ErrorBoundary] Render error:', error, errorInfo);
     }
     this.props.onError?.(error, errorInfo);

--- a/libs/shared/ui/src/lib/utils/ModalErrorBoundary.tsx
+++ b/libs/shared/ui/src/lib/utils/ModalErrorBoundary.tsx
@@ -27,7 +27,10 @@ export class ModalErrorBoundary extends Component<
   }
 
   override componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
-    if (process.env['NODE_ENV'] === 'development') {
+    if (
+      typeof process !== 'undefined' &&
+      process.env['NODE_ENV'] === 'development'
+    ) {
       console.error('[Modal] Render error:', error, errorInfo);
     }
     // Ensure body scroll is restored on error

--- a/libs/shared/ui/src/lib/utils/validateProps.ts
+++ b/libs/shared/ui/src/lib/utils/validateProps.ts
@@ -11,7 +11,10 @@ export function validateProps<T extends Record<string, unknown>>(
   const error = validate(props);
 
   if (error) {
-    if (process.env['NODE_ENV'] === 'development') {
+    if (
+      typeof process !== 'undefined' &&
+      process.env['NODE_ENV'] === 'development'
+    ) {
       console.error(`[${componentName}] Invalid props: ${error}`);
     }
     return { ...defaults, ...props } as T;


### PR DESCRIPTION
## What

Two related Storybook/shared-ui fixes found while auditing component preview usability.

### 1. Modal docs previews collapsed to a ~32px sliver
`Modal` renders a `position: fixed inset-0` overlay. In the **inline** autodocs preview the fixed panel is out of flow, so the `.docs-story` block collapsed to ~32px and **every** Modal story preview was unreadable (only the bottom edge of the header peeked in; title/body/footer cut off).

**Fix:** render the Modal stories in a sized docs **iframe** so the overlay gets a real viewport and renders centered + fully visible:
- meta: `parameters.docs.story = { inline: false, height: '460px' }`
- `ScrollableContent` override: `height: '640px'`

No change to `Modal.tsx` — production behavior is correct; this only affects Docs rendering. Canvas view and interaction/a11y tests are unaffected.

### 2. `process is not defined` in the browser test runner
`process.env['NODE_ENV']` was referenced unguarded in `ModalErrorBoundary`, `ErrorBoundary`, and `validateProps`. `process` is undefined in the Vitest browser runner, so any story exercising an error-boundary catch (e.g. `ModalErrorBoundary › With Fallback`, `ErrorBoundary` throw stories) failed with `process is not defined`. Guarded with `typeof process !== 'undefined'`; Next.js still strips `NODE_ENV` at build.

## Verification
- ✅ Audited all 47 shared-ui components in a running Storybook — Modal was the only too-small-preview defect.
- ✅ Confirmed in the live Storybook: all 11 Modal previews now render in iframes (10×460px, ScrollableContent 640px); Default modal fully visible.
- ✅ `pnpm tsc --noEmit` clean.
- ✅ Vitest: the `process.env` fixes reduce failures (39 → 35). The remaining ~35 are **pre-existing** a11y color-contrast violations in unrelated components (AspectRatio, Grid, Stack, Tabs, Sidebar…), reproduce on a clean `develop` tree, and appear local/environmental — out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)