### PR TITLE
fix(shared-ui): make Modal scrollable and dismissible

### DIFF
--- a/libs/shared/ui/src/lib/Modal.stories.tsx
+++ b/libs/shared/ui/src/lib/Modal.stories.tsx
@@ -1,8 +1,9 @@
 import { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useArgs } from 'storybook/preview-api';
 import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
 import { Button } from './Button';
-import { Modal } from './Modal';
+import { Modal, type ModalProps } from './Modal';
 
 const meta = {
   title: 'Overlay/Modal',
@@ -64,6 +65,24 @@ const meta = {
     docs: {
       story: { inline: false, height: '460px' },
     },
+  },
+  // Interactive showcase: wire `isOpen` through `useArgs` so the close button,
+  // backdrop, and Escape actually dismiss the modal (and a trigger re-opens it),
+  // instead of `onClose` being a no-op spy against a hardcoded `isOpen: true`.
+  render: function Render(args) {
+    const [, updateArgs] = useArgs<ModalProps>();
+    return (
+      <>
+        <Button onClick={() => updateArgs({ isOpen: true })}>Open modal</Button>
+        <Modal
+          {...args}
+          onClose={() => {
+            updateArgs({ isOpen: false });
+            args.onClose?.();
+          }}
+        />
+      </>
+    );
   },
 } satisfies Meta<typeof Modal>;
 

--- a/libs/shared/ui/src/lib/Modal.tsx
+++ b/libs/shared/ui/src/lib/Modal.tsx
@@ -148,14 +148,14 @@ export function Modal({
         aria-labelledby={title ? titleId : undefined}
         aria-label={title ? undefined : 'Dialog'}
         className={cn(
-          'relative w-full rounded-lg shadow-2xl',
+          'relative flex max-h-[calc(100dvh-2rem)] w-full flex-col overflow-hidden rounded-lg shadow-2xl',
           sizeStyles[size],
           variantStyles[variant],
           className
         )}
       >
         {title && (
-          <div className='flex items-center justify-between p-4 sm:p-6 border-b border-border'>
+          <div className='flex shrink-0 items-center justify-between p-4 sm:p-6 border-b border-border'>
             <Heading variant='component' id={titleId}>
               {title}
             </Heading>
@@ -181,9 +181,12 @@ export function Modal({
             <X className='size-5' aria-hidden='true' />
           </Button>
         )}
-        <div className='p-4 sm:p-6'>{children}</div>
+        {/* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex -- focusable scroll region so keyboard users can scroll overflowing content (axe scrollable-region-focusable / WCAG 2.1.1) */}
+        <div className='min-h-0 flex-1 overflow-y-auto p-4 sm:p-6' tabIndex={0}>
+          {children}
+        </div>
         {footer && (
-          <div className='flex items-center justify-end gap-3 p-4 sm:p-6 border-t border-border'>
+          <div className='flex shrink-0 items-center justify-end gap-3 p-4 sm:p-6 border-t border-border'>
             {footer}
           </div>
         )}


### PR DESCRIPTION
## What

Two Modal issues found while reviewing it in Storybook.

### 1. Long modals didn't scroll — content *and* close button went off-screen
The dialog panel had no height cap or internal scroll. A modal taller than the viewport (e.g. `ScrollableContent`) overflowed off-screen: the body was unreadable **and** the header/close button were clipped *above* the viewport with no way to scroll to them.

Measured before (700px viewport): dialog 897px tall, `top: -148`, close button `visibleInViewport: false`, overlay `scrollTop` stuck at 0.

**Fix (`Modal.tsx`):**
- panel → `flex flex-col max-h-[calc(100dvh-2rem)] overflow-hidden`
- header/footer → `shrink-0` (stay pinned)
- body → `min-h-0 flex-1 overflow-y-auto` + `tabIndex={0}` (keyboard-scrollable; satisfies axe `scrollable-region-focusable` / WCAG 2.1.1)

Short modals keep their natural height (verified: Default modal stays 157px, no stretch, no scrollbar).

### 2. Close button / Escape / backdrop appeared "broken" in the showcase
The static stories hardcoded `isOpen: true` with `onClose: fn()` (a no-op spy), so dismissing did nothing visible.

**Fix (`Modal.stories.tsx`):** wire the stories through `useArgs` (matching `Switch`/`Checkbox`) so `onClose` flips `isOpen`, with a trigger button to re-open. Play-function assertions on the `onClose` spy still pass.

## Verification (thorough, in a live Storybook)
- ✅ ScrollableContent @700px: dialog now fits (top 16/bottom 684), close button visible, body scrollable (scrolled 0→229), `tabIndex=0`.
- ✅ Close button, **Escape**, **backdrop click** all dismiss; trigger re-opens.
- ✅ Default (short) modal: natural height, no scrollbar, clean rounded corners.
- ✅ Autodocs previews still render (iframes 460px / 640px), scrollable body works in docs too.
- ✅ 0 console errors.
- ✅ `pnpm vitest Modal` → 12/12 pass (incl. a11y); full `pnpm tsc` clean; eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)