### PR TITLE
fix(shared-ui): a11y bugs + dead showcase interactions (Sidebar/Breadcrumb/Pagination/Alert)

### DIFF
--- a/libs/shared/ui/src/lib/Alert.stories.tsx
+++ b/libs/shared/ui/src/lib/Alert.stories.tsx
@@ -1,6 +1,8 @@
+import { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { expect, fn, userEvent, within } from 'storybook/test';
-import { Alert } from './Alert';
+import { Alert, type AlertProps } from './Alert';
+import { Button } from './Button';
 
 const meta = {
   title: 'Feedback/Alert',
@@ -40,6 +42,25 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
+// Alert is controlled-dismiss (`onDismiss` callback, no internal visibility
+// state). Wire `onDismiss` to local state so the dismiss button actually removes
+// the alert in the showcase, with a trigger to bring it back.
+function DismissibleAlert(args: AlertProps) {
+  const [visible, setVisible] = useState(true);
+  if (!visible) {
+    return <Button onClick={() => setVisible(true)}>Show alert</Button>;
+  }
+  return (
+    <Alert
+      {...args}
+      onDismiss={() => {
+        setVisible(false);
+        args.onDismiss?.();
+      }}
+    />
+  );
+}
+
 export const Default: Story = {
   args: {
     children: 'This is an alert message.',
@@ -55,6 +76,7 @@ export const Dismissible: Story = {
     title: 'Dismissible Alert',
     dismissible: true,
   },
+  render: DismissibleAlert,
 };
 
 export const Success: Story = {
@@ -73,6 +95,7 @@ export const Error: Story = {
     title: 'Error',
     dismissible: true,
   },
+  render: DismissibleAlert,
 };
 
 export const DismissInteraction: Story = {

--- a/libs/shared/ui/src/lib/Breadcrumb.tsx
+++ b/libs/shared/ui/src/lib/Breadcrumb.tsx
@@ -15,16 +15,25 @@ export interface BreadcrumbProps {
 
 export function Breadcrumb({ items, className }: BreadcrumbProps) {
   return (
-    <nav className={cn('flex items-center gap-1 text-sm', className)}>
+    <nav
+      aria-label='Breadcrumb'
+      className={cn('flex items-center gap-1 text-sm', className)}
+    >
       {items.map((item, i) => {
         const isLast = i === items.length - 1;
         return (
           <div key={i} className='flex items-center gap-1'>
             {i > 0 && (
-              <ChevronRight className='h-3.5 w-3.5 text-text-tertiary' />
+              <ChevronRight
+                aria-hidden='true'
+                className='h-3.5 w-3.5 text-text-tertiary'
+              />
             )}
             {isLast ? (
-              <span className='font-medium text-text-primary flex items-center gap-1.5'>
+              <span
+                aria-current='page'
+                className='font-medium text-text-primary flex items-center gap-1.5'
+              >
                 {item.icon}
                 {item.label}
               </span>

--- a/libs/shared/ui/src/lib/Pagination.stories.tsx
+++ b/libs/shared/ui/src/lib/Pagination.stories.tsx
@@ -1,7 +1,8 @@
 import { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useArgs } from 'storybook/preview-api';
 import { expect, fn, userEvent, within } from 'storybook/test';
-import { Pagination } from './Pagination';
+import { Pagination, type PaginationProps } from './Pagination';
 
 const meta = {
   title: 'Navigation/Pagination',
@@ -14,20 +15,40 @@ type Story = StoryObj<typeof meta>;
 
 const noop = () => {};
 
+// Pagination is controlled (`currentPage` + `onPageChange`). Wire it through
+// `useArgs` so the showcase stories actually paginate when clicked, instead of
+// `onPageChange` being a no-op against a frozen `currentPage`.
+function InteractivePagination(args: PaginationProps) {
+  const [, updateArgs] = useArgs<PaginationProps>();
+  return (
+    <Pagination
+      {...args}
+      onPageChange={page => {
+        updateArgs({ currentPage: page });
+        args.onPageChange?.(page);
+      }}
+    />
+  );
+}
+
 export const Default: Story = {
   args: { currentPage: 1, totalPages: 10, onPageChange: noop },
+  render: InteractivePagination,
 };
 
 export const MiddlePage: Story = {
   args: { currentPage: 5, totalPages: 10, onPageChange: noop },
+  render: InteractivePagination,
 };
 
 export const FewPages: Story = {
   args: { currentPage: 2, totalPages: 3, onPageChange: noop },
+  render: InteractivePagination,
 };
 
 export const ManyPages: Story = {
   args: { currentPage: 10, totalPages: 50, onPageChange: noop },
+  render: InteractivePagination,
 };
 
 export const Interactive: Story = {

--- a/libs/shared/ui/src/lib/Sidebar.stories.tsx
+++ b/libs/shared/ui/src/lib/Sidebar.stories.tsx
@@ -1,7 +1,8 @@
 import { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useArgs } from 'storybook/preview-api';
 import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
-import { Sidebar } from './Sidebar';
+import { Sidebar, type SidebarProps } from './Sidebar';
 
 const meta = {
   title: 'Navigation/Sidebar',
@@ -72,11 +73,28 @@ const iconItems = [
   },
 ];
 
+// Sidebar is controlled via `activeId` + `onSelect`. Wire it through `useArgs`
+// so selecting an item actually moves the active highlight in the showcase,
+// instead of `onSelect` being a no-op against a frozen `activeId`.
+function InteractiveSidebar(args: SidebarProps) {
+  const [, updateArgs] = useArgs<SidebarProps>();
+  return (
+    <Sidebar
+      {...args}
+      onSelect={id => {
+        updateArgs({ activeId: id });
+        args.onSelect?.(id);
+      }}
+    />
+  );
+}
+
 export const Default: Story = {
   args: {
     items: sampleItems,
     activeId: 'dashboard',
   },
+  render: InteractiveSidebar,
 };
 
 export const WithHeaderFooter: Story = {
@@ -84,8 +102,9 @@ export const WithHeaderFooter: Story = {
     items: sampleItems,
     activeId: 'dashboard',
     header: <span className='font-semibold text-sm'>My App</span>,
-    footer: <span className='text-xs text-gray-500'>v1.0.0</span>,
+    footer: <span className='text-xs text-text-secondary'>v1.0.0</span>,
   },
+  render: InteractiveSidebar,
 };
 
 export const Collapsed: Story = {
@@ -100,6 +119,7 @@ export const WithIcons: Story = {
     items: iconItems,
     activeId: 'home',
   },
+  render: InteractiveSidebar,
 };
 
 export const Interactive: Story = {

--- a/libs/shared/ui/src/lib/Sidebar.tsx
+++ b/libs/shared/ui/src/lib/Sidebar.tsx
@@ -50,6 +50,10 @@ function SidebarItemComponent({
           if (hasChildren) setExpanded(!expanded);
           onSelect?.(item.id);
         }}
+        // Collapsed items render icon-only, so give them an accessible name.
+        aria-label={collapsed ? item.label : undefined}
+        aria-current={isActive ? 'page' : undefined}
+        aria-expanded={hasChildren ? expanded : undefined}
         className={cn(
           'w-full justify-start',
           depth > 0 && 'ml-6 w-[calc(100%-1.5rem)]',
@@ -63,12 +67,16 @@ function SidebarItemComponent({
           <>
             <span className='flex-1 text-left truncate'>{item.label}</span>
             {item.badge !== undefined && (
-              <span className='text-xs px-1.5 py-0.5 rounded-full bg-surface-tertiary text-text-tertiary'>
+              <span
+                aria-hidden='true'
+                className='text-xs px-1.5 py-0.5 rounded-full bg-surface-tertiary text-text-tertiary'
+              >
                 {item.badge}
               </span>
             )}
             {hasChildren && (
               <ChevronDown
+                aria-hidden='true'
                 className={cn(
                   'h-4 w-4 text-text-tertiary transition-transform duration-200 motion-reduce:transition-none',
                   expanded && 'rotate-180'


### PR DESCRIPTION
## What

A thorough functional sweep of every interactive component in the shared-ui Storybook (driven in a real browser, grounded against source). It surfaced the same two classes of bug as the recent Modal work, plus a CI gap that explains why they shipped silently.

### 🔴 Dead-in-showcase (controlled prop + no-op callback — like the Modal close button)
State-wired the affected showcase stories so interactions actually work (matching the Switch/Modal `useArgs` convention):
- **Pagination** — `Default`/`MiddlePage`/`FewPages`/`ManyPages`: clicking a page/next/prev was a no-op (`onPageChange: noop`, frozen `currentPage`). Now paginates. *(Verified: clicking page 2 moved `aria-current` 1→2.)*
- **Sidebar** — `Default`/`WithHeaderFooter`/`WithIcons`: selecting an item didn't move the highlight (static `activeId`). Now it does. *(Verified: Settings became active.)*
- **Alert** — `Dismissible`/`Error`: the dismiss button fired a no-op spy and never removed the alert. Now removes it, with a trigger to bring it back. *(Verified: alert removed → "Show alert" appears.)*

### 🟠 Genuine component a11y bugs (affect real consumers)
- **Sidebar.tsx** — collapsed items rendered icon-only with **no accessible name** (axe `button-name` failure). Added `aria-label`; plus `aria-current` on the active item, `aria-expanded` on parent toggles, and `aria-hidden` on the decorative badge/chevron (the badge was also polluting the button's accessible name).
- **Breadcrumb.tsx** — added `nav aria-label="Breadcrumb"`, `aria-current="page"` on the current item, and `aria-hidden` on the chevron separators.

Also fixed the `WithHeaderFooter` story footer contrast (`text-gray-500` → `text-text-secondary`, was 3.9:1 on dark).

## ⚠️ CI gap worth noting (separate)
The shared-ui story **a11y/interaction suite (vitest browser) is not run in CI** — `ci-fast.yml` runs `nx test` which maps to **jest** (the `.spec.tsx` unit tests). The vitest browser suite (which catches `button-name`, color-contrast, dead interactions) is a separate target with no browser install in CI. That's why these a11y failures shipped green. Recommend wiring it into CI in a follow-up. There are also ~32 remaining **color-contrast** failures across other stories (hardcoded grays) — a separate cleanup.

## Verification
- ✅ In-browser: every fix confirmed (page moves, active highlight moves, alert dismiss+reopen, collapsed buttons named, breadcrumb aria).
- ✅ shared-ui vitest story suite: **39 → 32 failures** (3 Sidebar fixed, **no regressions**).
- ✅ **771/771 jest unit specs pass** (what CI runs); full `tsc` clean; eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)