### PR TITLE
fix(shared-ui): fix color-contrast + heading-order, re-enable axe rules

### DIFF
--- a/libs/shared/ui/.storybook/preview.ts
+++ b/libs/shared/ui/.storybook/preview.ts
@@ -50,16 +50,7 @@ const preview: Preview = {
     a11y: {
       test: 'error',
       config: {
-        rules: [
-          { id: 'aria-hidden-body', enabled: false },
-          // TODO: re-enable once story placeholder content is fixed. Temporarily
-          // disabled so the a11y suite can be enforced in CI for every other rule
-          // (button-name, interactions, aria, etc.) right away. The remaining
-          // failures are color-contrast/heading-order in demo content only — see
-          // the follow-up that fixes those and removes these two lines.
-          { id: 'color-contrast', enabled: false },
-          { id: 'heading-order', enabled: false },
-        ],
+        rules: [{ id: 'aria-hidden-body', enabled: false }],
       },
     },
   },

--- a/libs/shared/ui/src/lib/AspectRatio.stories.tsx
+++ b/libs/shared/ui/src/lib/AspectRatio.stories.tsx
@@ -28,7 +28,7 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 const PlaceholderImage = ({ label }: { label: string }) => (
-  <div className='absolute inset-0 bg-brand-500 flex items-center justify-center text-text-inverse font-medium'>
+  <div className='absolute inset-0 bg-brand-500 flex items-center justify-center text-on-brand font-medium'>
     {label}
   </div>
 );

--- a/libs/shared/ui/src/lib/Grid.stories.tsx
+++ b/libs/shared/ui/src/lib/Grid.stories.tsx
@@ -38,7 +38,7 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 const Box = ({ children }: { children: React.ReactNode }) => (
-  <div className='bg-brand-500 text-text-inverse p-4 rounded text-center'>
+  <div className='bg-brand-500 text-on-brand p-4 rounded text-center'>
     {children}
   </div>
 );

--- a/libs/shared/ui/src/lib/PyreThemePreview.stories.tsx
+++ b/libs/shared/ui/src/lib/PyreThemePreview.stories.tsx
@@ -121,6 +121,19 @@ const meta = {
   component: PyrePreview,
   parameters: {
     layout: 'fullscreen',
+    a11y: {
+      config: {
+        // This is a kitchen-sink showcase that dumps many components onto one
+        // page, so component headings (e.g. CardTitle) follow the section h2s
+        // out of strict document order. heading-order is a false positive here;
+        // it stays enabled for every other story. (aria-hidden-body mirrors the
+        // global preview.ts config since a per-story rules array replaces it.)
+        rules: [
+          { id: 'aria-hidden-body', enabled: false },
+          { id: 'heading-order', enabled: false },
+        ],
+      },
+    },
   },
 } satisfies Meta<typeof PyrePreview>;
 export default meta;

--- a/libs/shared/ui/src/lib/Stack.stories.tsx
+++ b/libs/shared/ui/src/lib/Stack.stories.tsx
@@ -72,7 +72,7 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 const Box = ({ children }: { children: React.ReactNode }) => (
-  <div className='bg-brand-500 text-text-inverse p-4 rounded'>{children}</div>
+  <div className='bg-brand-500 text-on-brand p-4 rounded'>{children}</div>
 );
 
 export const Vertical: Story = {
@@ -157,15 +157,9 @@ export const AsUnorderedList: Story = {
     className: 'list-none',
     children: (
       <>
-        <li className='bg-brand-500 text-text-inverse p-3 rounded'>
-          First item
-        </li>
-        <li className='bg-brand-500 text-text-inverse p-3 rounded'>
-          Second item
-        </li>
-        <li className='bg-brand-500 text-text-inverse p-3 rounded'>
-          Third item
-        </li>
+        <li className='bg-brand-500 text-on-brand p-3 rounded'>First item</li>
+        <li className='bg-brand-500 text-on-brand p-3 rounded'>Second item</li>
+        <li className='bg-brand-500 text-on-brand p-3 rounded'>Third item</li>
       </>
     ),
   },
@@ -180,13 +174,11 @@ export const AsOrderedList: Story = {
     className: 'list-none',
     children: (
       <>
-        <li className='bg-brand-500 text-text-inverse p-3 rounded'>
-          Step 1: Plan
-        </li>
-        <li className='bg-brand-500 text-text-inverse p-3 rounded'>
+        <li className='bg-brand-500 text-on-brand p-3 rounded'>Step 1: Plan</li>
+        <li className='bg-brand-500 text-on-brand p-3 rounded'>
           Step 2: Build
         </li>
-        <li className='bg-brand-500 text-text-inverse p-3 rounded'>
+        <li className='bg-brand-500 text-on-brand p-3 rounded'>
           Step 3: Deploy
         </li>
       </>
@@ -203,16 +195,28 @@ export const AsNav: Story = {
     align: 'center',
     children: (
       <>
-        <a href='#' className='text-brand-500 hover:underline'>
+        <a
+          href='#'
+          className='text-brand-600 dark:text-brand-400 hover:underline'
+        >
           Home
         </a>
-        <a href='#' className='text-brand-500 hover:underline'>
+        <a
+          href='#'
+          className='text-brand-600 dark:text-brand-400 hover:underline'
+        >
           About
         </a>
-        <a href='#' className='text-brand-500 hover:underline'>
+        <a
+          href='#'
+          className='text-brand-600 dark:text-brand-400 hover:underline'
+        >
           Projects
         </a>
-        <a href='#' className='text-brand-500 hover:underline'>
+        <a
+          href='#'
+          className='text-brand-600 dark:text-brand-400 hover:underline'
+        >
           Contact
         </a>
       </>

--- a/libs/shared/ui/src/lib/Tabs.spec.tsx
+++ b/libs/shared/ui/src/lib/Tabs.spec.tsx
@@ -55,7 +55,7 @@ describe('Tabs', () => {
     const tab1Button = screen.getByText('Tab 1');
     const tab2Button = screen.getByText('Tab 2');
 
-    expect(tab1Button).toHaveClass('border-brand-500', 'text-brand-500');
+    expect(tab1Button).toHaveClass('border-brand-500', 'text-brand-600');
     expect(tab2Button).toHaveClass('border-transparent');
   });
 
@@ -68,7 +68,7 @@ describe('Tabs', () => {
     const tab2Button = screen.getByText('Tab 2');
 
     expect(tab1Button).toHaveClass('border-transparent');
-    expect(tab2Button).toHaveClass('border-brand-500', 'text-brand-500');
+    expect(tab2Button).toHaveClass('border-brand-500', 'text-brand-600');
   });
 
   it('renders nothing with empty tabs array', () => {

--- a/libs/shared/ui/src/lib/Tabs.tsx
+++ b/libs/shared/ui/src/lib/Tabs.tsx
@@ -121,7 +121,7 @@ export function Tabs({
                   ? cn(
                       'border-b-2',
                       activeTab === tab.id
-                        ? 'border-brand-500 text-brand-500'
+                        ? 'border-brand-500 text-brand-600 dark:text-brand-400'
                         : 'border-transparent text-text-secondary hover:text-text-primary hover:border-border-secondary'
                     )
                   : cn(

--- a/libs/shared/ui/src/styles/indigo-theme.css
+++ b/libs/shared/ui/src/styles/indigo-theme.css
@@ -98,7 +98,8 @@
      darkens warning/error for AA on white; dark mode needs the
      opposite (bright on near-black), so override them back here. */
   --color-warning: oklch(0.7686 0.1647 70.08);
-  --color-error: oklch(0.6368 0.2078 25.33);
+  /* Lightened from 0.6368 so error text clears AA (4.5:1) on dark surfaces. */
+  --color-error: oklch(0.68 0.2078 25.33);
   --color-success: oklch(0.6959 0.1491 162.48);
   --color-info: oklch(0.66 0.1697 264.92);
 

--- a/libs/shared/ui/src/styles/pyre-theme.css
+++ b/libs/shared/ui/src/styles/pyre-theme.css
@@ -154,7 +154,8 @@
   --color-success-light: oklch(0.25 0.05 145);
   --color-warning: oklch(0.78 0.18 70);
   --color-warning-light: oklch(0.3 0.055 72);
-  --color-error: oklch(0.65 0.22 25);
+  /* Lightened from 0.65 so error text clears AA (4.5:1) on dark surfaces. */
+  --color-error: oklch(0.68 0.22 25);
   --color-error-light: oklch(0.21 0.055 25);
   --color-info: oklch(0.7 0.2 230);
   --color-info-light: oklch(0.25 0.05 230);


### PR DESCRIPTION
## Why

Follow-up to #1016 (which wired the Storybook a11y suite into CI with `color-contrast` + `heading-order` temporarily disabled). This fixes every remaining failure and **re-enables both rules** — so contrast/heading regressions are now fully gated.

## Fixes

**Story placeholder content**
- Grid / Stack / AspectRatio demo boxes used `text-text-inverse` on `bg-brand-500` (dark-on-blue, ~3.8:1). Switched to **`text-on-brand`** (the token `Button`/`Badge` already use), which is contrast-safe per theme. *(This was the bulk — ~22 failures.)*
- Stack "As Navigation" demo links: `text-brand-500` → `text-brand-600 dark:text-brand-400`.

**Components / theme — real a11y bugs in all consumers**
- **Tabs** active tab (underline variant) used `text-brand-500` = 3.8:1 on dark. Now `text-brand-600 dark:text-brand-400` — clears AA in light + dark, keeps the brand colour and brand underline. *(Verified visually in dark mode.)*
- **Dark `--color-error`** (indigo + pyre) was ~4.44:1 for small error text on dark surfaces (StatsCard change, Badge/Alert error) — just under AA. Lightened to clear 4.5:1. *(Verified StatsCard "-5.2%" still reads as a clear red.)*

**heading-order**
- The Pyre/Indigo theme previews are kitchen-sink showcases that stack component headings (`CardTitle`, …) under section `h2`s, so strict document order can't hold. Disabled `heading-order` for **that one story only** — it stays enforced everywhere else.

## Verification
- ✅ **308/308** Storybook a11y/interaction tests pass with `color-contrast` + `heading-order` enabled.
- ✅ Visually confirmed Tabs active tab + StatsCard error in dark mode.
- ✅ `tsc` + eslint clean. (CI runs the now-gated `test-storybook` step.)

⚠️ **Design note:** this nudges the dark-mode error colour slightly lighter across the design system (all error text on dark) and changes the active-tab/brand-link shade per theme. Both are a11y improvements, but flagging the visual ripple for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)