### PR TITLE
fix(root): responsiveness + UX fixes across the app

### DIFF
--- a/apps/root/src/app/(public)/about/Contact/Form.tsx
+++ b/apps/root/src/app/(public)/about/Contact/Form.tsx
@@ -68,6 +68,7 @@ export default function Form() {
     formState: { errors, isSubmitting },
     setError,
     setValue,
+    clearErrors,
   } = useForm<ContactFormData>({
     resolver: zodResolver(formSchema),
   });
@@ -158,6 +159,9 @@ export default function Form() {
 
   const onVerify = (token: string) => {
     setValue('hcaptcha', token);
+    // Clear the captcha error as soon as it's solved so the assertive error
+    // summary doesn't linger until the next submit attempt.
+    clearErrors('hcaptcha');
   };
 
   return (

--- a/apps/root/src/app/api/email/contact/schema.ts
+++ b/apps/root/src/app/api/email/contact/schema.ts
@@ -133,6 +133,14 @@ export const formSchema = z.object({
           'Please remove links from your message'
         )
     ),
-  /** hCaptcha token for bot protection */
-  hcaptcha: z.string().min(1, 'Please verify you are human'),
+  /**
+   * hCaptcha token for bot protection. The `error` param makes the
+   * invalid-type case (token still `undefined` before the captcha is solved)
+   * report a friendly message instead of zod's raw
+   * "Invalid input: expected string, received undefined", which otherwise
+   * surfaces in the form's assertive error summary.
+   */
+  hcaptcha: z
+    .string({ error: 'Please complete the captcha verification.' })
+    .min(1, 'Please complete the captcha verification.'),
 });

--- a/apps/root/src/components/BlogSearchAndList.tsx
+++ b/apps/root/src/components/BlogSearchAndList.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useDeferredValue, useMemo, useState } from 'react';
+import { useDeferredValue, useEffect, useMemo, useState } from 'react';
 import { Search } from 'lucide-react';
 import { Input } from '@danieljoffe/shared-ui/Input';
 import { Text } from '@danieljoffe/shared-ui/Text';
@@ -49,6 +49,15 @@ export function BlogSearchAndList({
   const [query, setQuery] = useState('');
   const [activeTag, setActiveTag] = useState<string | null>(null);
   const deferredQuery = useDeferredValue(query);
+
+  // Reset scroll to the top of the list on pagination. The App Router doesn't
+  // reliably scroll to top across the /blog ↔ /blog/page/N navigation, so a
+  // visitor clicking "Next" from the bottom of the list would otherwise land
+  // mid-page. Keyed on currentPage, so it does NOT fire while searching or
+  // tag-filtering (those don't change the page).
+  useEffect(() => {
+    window.scrollTo({ top: 0, behavior: 'instant' });
+  }, [currentPage]);
 
   const hrefFor = (page: number): string =>
     page <= 1 ? basePath : `${basePath}/page/${page}`;

--- a/apps/root/src/components/CommandPalette.tsx
+++ b/apps/root/src/components/CommandPalette.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { Command } from 'cmdk';
 import { Search, FileText, Briefcase, BookOpen, Globe } from 'lucide-react';
@@ -28,6 +28,38 @@ export default function CommandPalette() {
   const [open, setOpen] = useState(false);
   const [search, setSearch] = useState('');
   const router = useRouter();
+
+  // Remember what opened the palette so focus can return there on close
+  // (Escape / backdrop / ⌘K). The trigger must be captured synchronously at
+  // open time — before the palette's input autofocuses and becomes
+  // activeElement — so we capture in openPalette() rather than a post-open
+  // effect. On select we navigate away, so the restore is skipped.
+  const triggerRef = useRef<HTMLElement | null>(null);
+  const selectedRef = useRef(false);
+  const openRef = useRef(false);
+
+  useEffect(() => {
+    openRef.current = open;
+  }, [open]);
+
+  const openPalette = useCallback(() => {
+    triggerRef.current = document.activeElement as HTMLElement | null;
+    selectedRef.current = false;
+    setOpen(true);
+  }, []);
+
+  // Restore focus to whatever opened the palette once it closes. Deferred to
+  // the next frame so it runs after cmdk's teardown / the input-removal focus
+  // reset (which otherwise leaves focus on <body>).
+  useEffect(() => {
+    if (open || selectedRef.current || !triggerRef.current?.isConnected) return;
+    const el = triggerRef.current;
+    triggerRef.current = null;
+    const id = requestAnimationFrame(() => {
+      if (el.isConnected) el.focus();
+    });
+    return () => cancelAnimationFrame(id);
+  }, [open]);
 
   const { engine, entries } = useMemo(() => {
     try {
@@ -71,7 +103,8 @@ export default function CommandPalette() {
     const handler = (e: KeyboardEvent) => {
       if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
         e.preventDefault();
-        setOpen(prev => !prev);
+        if (openRef.current) setOpen(false);
+        else openPalette();
       }
       if (e.key === 'Escape') {
         setOpen(false);
@@ -79,14 +112,14 @@ export default function CommandPalette() {
     };
     document.addEventListener('keydown', handler);
     return () => document.removeEventListener('keydown', handler);
-  }, []);
+  }, [openPalette]);
 
   // Allow external triggers (e.g. nav search button) to open the palette
   useEffect(() => {
-    const handler = () => setOpen(true);
+    const handler = () => openPalette();
     document.addEventListener('open-command-palette', handler);
     return () => document.removeEventListener('open-command-palette', handler);
-  }, []);
+  }, [openPalette]);
 
   // Lock body scroll when open
   useEffect(() => {
@@ -100,6 +133,7 @@ export default function CommandPalette() {
 
   const handleSelect = useCallback(
     (url: string) => {
+      selectedRef.current = true;
       setOpen(false);
       router.push(url);
     },

--- a/apps/root/src/data/metadata/about.ts
+++ b/apps/root/src/data/metadata/about.ts
@@ -1,7 +1,9 @@
 import { Metadata } from 'next';
 
 export const aboutMetadata: Metadata = {
-  title: 'About Daniel Joffe | Full-Stack Engineer & Technical Leader',
+  // Page name only — the root metadata title template appends
+  // "| Daniel Joffe - Full-Stack Engineer". The previous full string doubled it.
+  title: 'About',
   description:
     '10+ years building performant web applications. Specializing in React, Vue, TypeScript, and performance optimization.',
   keywords: [

--- a/apps/root/src/data/metadata/experience.ts
+++ b/apps/root/src/data/metadata/experience.ts
@@ -2,7 +2,9 @@ import { Metadata } from 'next';
 import { DOMAIN_URL, FULL_NAME, EXPERIENCE_LINK } from '@/utils/constants';
 
 export const experienceRootMetadata: Metadata = {
-  title: `Experience | ${FULL_NAME} - Full-Stack Engineer`,
+  // Page name only — the root metadata title template appends the
+  // "| Daniel Joffe - Full-Stack Engineer" suffix (was doubled here).
+  title: 'Experience',
   description:
     'Five companies, ten years. Every engagement left the team faster and more autonomous than I found them.',
   keywords: [

--- a/apps/root/src/data/metadata/project.ts
+++ b/apps/root/src/data/metadata/project.ts
@@ -1,7 +1,9 @@
 import { Metadata } from 'next';
 
 export const projectRootMetadata: Metadata = {
-  title: 'Projects | Daniel Joffe - Full-Stack Engineer',
+  // Page name only — the root metadata title template appends
+  // "| Daniel Joffe - Full-Stack Engineer". Including the suffix here doubled it.
+  title: 'Projects',
   description:
     'Case studies from the field. Every study has the challenge, the approach, and the measurable outcome.',
   keywords: [


### PR DESCRIPTION
## What

A browser sweep of every interactive action in the portfolio app (desktop + mobile, in the spirit of #1015). The app is in good shape overall — nav, theme cycle, mobile More bottom-sheet, ⌘K command palette, blog search/filter, TOC + scroll-spy, links/CTAs, external-link safety, and the 404 are all solid. Five concrete defects fixed:

| # | Fix | File(s) |
|---|---|---|
| 1 | **Command palette lost focus on close** — Esc/backdrop/⌘K left focus on `<body>` instead of the trigger (WCAG 2.4.3). Capture the opener synchronously in `openPalette()` (before the input autofocuses) and restore on close, deferred a frame past cmdk's teardown. Skipped on select (navigates). | `CommandPalette.tsx` |
| 2 | **Doubled `<title>`** on `/projects`, `/experience`, `/about` — titles already included the `\| Daniel Joffe - Full-Stack Engineer` suffix that the root template re-appends. Use the page name only (like `/blog`). | `metadata/{project,experience,about}.ts` |
| 3 | **Blog pagination didn't reset scroll** — `/blog` → `/blog/page/2` landed mid-page. Scroll to top on `currentPage` change (not on search/filter). | `BlogSearchAndList.tsx` |
| 4 | **Contact form leaked raw zod text** — empty submit showed `"Invalid input: expected string, received undefined"` (unset hcaptcha) in the assertive summary. Friendly invalid-type message on the hcaptcha field. | `contact/schema.ts` |
| 5 | **Contact summary lingered** — `clearErrors('hcaptcha')` on solve so it doesn't persist. | `Contact/Form.tsx` |

## Verification
All five confirmed in a browser against a **clean production build**. ✅ command palette focus returns to trigger · ✅ single titles · ✅ pagination lands at scrollY 0 (was ~2109) · ✅ friendly captcha message.

⚠️ **Note for verifiers:** this app's PWA service worker serves **stale JS chunks** after a rebuild — clear the SW + caches (or use a fresh profile) when testing, or you'll see old behavior. (That cost me a few cycles here.)

`pnpm tsc` clean · eslint clean · **770/770 root unit tests pass**.

## Out of scope (flagged, not fixed)
Audit-only notes from the sweep: no copy-button on code blocks; sub-44px tap targets on `/projects` filter chips; skip-link target lacks `tabindex`; scroll-spy has no `aria-current`. And two CSP issues seen in console: GA4 `/g/collect` blocked by `connect-src`, and hCaptcha `js.hcaptcha.com` not in `script-src` (worth confirming it doesn't block real prod submissions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)