### PR TITLE
fix(root): service-worker stale chunks + a11y polish + code-block copy

### DIFF
--- a/apps/root/mdx-components.tsx
+++ b/apps/root/mdx-components.tsx
@@ -2,7 +2,12 @@ import type { MDXComponents } from 'mdx/types';
 import type { ComponentPropsWithoutRef } from 'react';
 import { Heading } from '@danieljoffe/shared-ui/Heading';
 import { Alert } from '@danieljoffe/shared-ui/Alert';
-import { InteractiveDemo, Mermaid, MetricsDashboard } from '@/components/kit';
+import {
+  CopyCodeButton,
+  InteractiveDemo,
+  Mermaid,
+  MetricsDashboard,
+} from '@/components/kit';
 
 function slugify(text: string): string {
   return text
@@ -91,10 +96,13 @@ export function useMDXComponents(components: MDXComponents): MDXComponents {
     // rehype-pretty-code wraps code blocks in <figure data-rehype-pretty-code-figure>
     // so bare <pre> only appears for non-highlighted blocks
     pre: props => (
-      <pre
-        className='p-4 bg-surface-secondary rounded-lg border border-border overflow-x-auto text-sm leading-relaxed mb-4 [&>code]:p-0 [&>code]:bg-transparent [&>code]:text-sm [&>code]:rounded-none'
-        {...props}
-      />
+      <div className='group relative'>
+        <pre
+          className='p-4 bg-surface-secondary rounded-lg border border-border overflow-x-auto text-sm leading-relaxed mb-4 [&>code]:p-0 [&>code]:bg-transparent [&>code]:text-sm [&>code]:rounded-none'
+          {...props}
+        />
+        <CopyCodeButton />
+      </div>
     ),
     hr: () => <hr className='border-border my-8' />,
     table: props => (

--- a/apps/root/next.config.mjs
+++ b/apps/root/next.config.mjs
@@ -170,6 +170,18 @@ const nextConfig = {
           },
         ],
       },
+      // Service worker - never HTTP-cache the script itself, so a redeployed
+      // sw.js (e.g. a new CACHE_VERSION or strategy change) is picked up on the
+      // next visit instead of being pinned to a stale copy.
+      {
+        source: '/sw.js',
+        headers: [
+          {
+            key: 'Cache-Control',
+            value: 'no-cache, no-store, must-revalidate',
+          },
+        ],
+      },
       // Static images - immutable, 1 year
       {
         source: '/images/:path*',

--- a/apps/root/public/sw.js
+++ b/apps/root/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_VERSION = 'v3';
+const CACHE_VERSION = 'v4';
 const STATIC_CACHE = `danieljoffe-static-${CACHE_VERSION}`;
 const DYNAMIC_CACHE = `danieljoffe-dynamic-${CACHE_VERSION}`;
 const IMAGE_CACHE = `danieljoffe-images-${CACHE_VERSION}`;
@@ -89,14 +89,19 @@ function getCacheStrategy(request) {
     return { strategy: 'network-only' };
   }
 
-  // HTML pages - stale-while-revalidate
+  // HTML pages - network-first.
+  // Must NOT be stale-while-revalidate: the cached HTML pins content-hashed
+  // chunk URLs from the build it was captured on, so after a deploy SWR would
+  // serve the old app shell referencing old/now-missing chunks (stale or broken
+  // app). Network-first always serves fresh HTML (with current chunk refs) when
+  // online and only falls back to the cache when offline.
   if (
     request.mode === 'navigate' ||
     request.headers.get('accept')?.includes('text/html')
   ) {
     return {
       cache: DYNAMIC_CACHE,
-      strategy: 'stale-while-revalidate',
+      strategy: 'network-first',
       limit: DYNAMIC_CACHE_LIMIT,
     };
   }

--- a/apps/root/src/components/PostDetailLayout.tsx
+++ b/apps/root/src/components/PostDetailLayout.tsx
@@ -15,7 +15,11 @@ export default function PostDetailLayout({
   const Post = entry.component;
 
   return (
-    <main id='main-content' className='w-full flex flex-col justify-center'>
+    <main
+      id='main-content'
+      tabIndex={-1}
+      className='w-full flex flex-col justify-center'
+    >
       <div className='max-w-5xl mx-auto w-full px-4 sm:px-6 py-8 md:py-14'>
         <PostBody
           cover={entry.thumbnail.cover}

--- a/apps/root/src/components/kit/CopyCodeButton.tsx
+++ b/apps/root/src/components/kit/CopyCodeButton.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { useState } from 'react';
+import { Check, Copy } from 'lucide-react';
+import { cn } from '@/lib/cn';
+
+/**
+ * Copy-to-clipboard button for MDX code blocks. Rendered inside the relative
+ * wrapper around each `<pre>` (see mdx-components `pre`); on click it reads the
+ * sibling `<code>` text content and copies it. Hidden until the block is
+ * hovered or the button is focused, so it stays out of the way for readers but
+ * is reachable by keyboard.
+ */
+export function CopyCodeButton() {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async (e: React.MouseEvent<HTMLButtonElement>) => {
+    const code =
+      e.currentTarget.parentElement?.querySelector('code')?.textContent ?? '';
+    if (!code) return;
+    try {
+      await navigator.clipboard.writeText(code);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Clipboard unavailable (e.g. insecure context) — fail silently.
+    }
+  };
+
+  return (
+    <button
+      type='button'
+      onClick={handleCopy}
+      aria-label={copied ? 'Code copied' : 'Copy code'}
+      className={cn(
+        'absolute right-2 top-2 inline-flex items-center justify-center rounded-md',
+        'border border-border bg-surface/80 p-1.5 text-text-secondary backdrop-blur',
+        'opacity-0 transition-opacity hover:text-text-primary',
+        'group-hover:opacity-100 focus-visible:opacity-100',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500',
+        'focus-visible:ring-offset-2 focus-visible:ring-offset-surface'
+      )}
+    >
+      {copied ? (
+        <Check className='h-4 w-4 text-success' aria-hidden='true' />
+      ) : (
+        <Copy className='h-4 w-4' aria-hidden='true' />
+      )}
+    </button>
+  );
+}

--- a/apps/root/src/components/kit/TableOfContents.tsx
+++ b/apps/root/src/components/kit/TableOfContents.tsx
@@ -102,6 +102,7 @@ function TocList({
           <button
             type='button'
             onClick={() => onSelect(id)}
+            aria-current={activeId === id ? 'location' : undefined}
             className={cn(
               'text-left text-xs leading-relaxed py-0.5 transition-colors',
               'cursor-pointer hover:text-text-primary w-full',

--- a/apps/root/src/components/kit/index.ts
+++ b/apps/root/src/components/kit/index.ts
@@ -1,3 +1,4 @@
+export { CopyCodeButton } from './CopyCodeButton';
 export { InteractiveDemo } from './InteractiveDemo';
 export { Mermaid } from './Mermaid';
 export { MetricsDashboard } from './MetricsDashboard';

--- a/libs/shared/ui/src/lib/PageLayout.tsx
+++ b/libs/shared/ui/src/lib/PageLayout.tsx
@@ -26,6 +26,9 @@ export function PageLayout({
     <PageContainer
       as='main'
       id='main-content'
+      // Focus target for the "Skip to main content" link — without a tabindex
+      // the browser can't move focus here when the skip link is activated.
+      tabIndex={-1}
       size={wide ? 'lg' : 'sm'}
       className={cn('py-16 lg:py-24 space-y-24', className)}
       {...rest}


### PR DESCRIPTION
Follow-up to the UX audit — investigates the stale-chunk gotcha and the out-of-scope notes.

## 🔴 Service worker: stale chunks after deploy (the headline)
**Root cause:** the SW served HTML navigations with `stale-while-revalidate`, so after a deploy it handed back the previously-cached HTML — which pins the **content-hashed chunk URLs from the build it was captured on**. The result is the old app shell referencing old/now-missing chunks (exactly the "fix looked broken until I cleared the SW" symptom).

**Fix** (`public/sw.js` + `next.config.mjs`):
- Navigations → **`network-first`** (always fresh HTML with current chunk refs when online; cache only as an offline fallback). JS/CSS were already `network-only`, so this closes the loop.
- Bump `CACHE_VERSION` v3 → v4, so existing clients evict the stale HTML cache on `activate`.
- Serve `/sw.js` with `no-cache` so a redeployed worker is picked up promptly.

*Verified:* the served `sw.js` is v4 + network-first. (The full deploy-staleness loop is best confirmed on the Vercel preview — the SW lifecycle is flaky to drive in a headless harness, but network-first cannot serve stale HTML online by construction.)

## 🟡 A11y
- **Skip link:** `#main-content` (PageLayout's `<main>`, and PostDetailLayout's) had no `tabindex`, so "Skip to main content" couldn't move focus there. Added `tabIndex={-1}`. *Verified: Enter on the skip link now focuses `<main>`.*
- **Scroll-spy:** the active TOC item now exposes `aria-current="location"` (was visual-only). *Verified.*

## ✨ Feature
- **Code-block copy buttons** in MDX posts (`CopyCodeButton`) — shown on hover/focus, with a "copied" confirmation. *Verified: one button per block, copies the correct code, shows the copied state.*

## Investigated → intentionally not changed
- **hCaptcha `script-src`**: moot under the CSP's `'strict-dynamic'` (host allowlists are ignored; the agent's `ERR_FAILED` was the localhost sandbox).
- **GA `connect-src`**: core GA is already allowed via `allowedImageOrigins`; only the secondary `www.google.com` Signals beacon is blocked, which is a reasonable tight-CSP posture.
- **Tap targets**: the `/projects` filter chips already meet **WCAG 2.5.8 AA (24px)**; 44px is AAA and would disrupt the layout.

`tsc` + eslint clean · 770/770 root unit tests · PageLayout a11y suite 2/2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)