### PR TITLE
chore(shared-ui): consolidate Storybook sections + fix CI Playwright timeout

### DIFF
--- a/.github/workflows/ci-fast.yml
+++ b/.github/workflows/ci-fast.yml
@@ -53,8 +53,15 @@ jobs:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ steps.pw-version.outputs.version }}
 
+      # No `--with-deps`: that runs `apt-get install` for system libraries, which
+      # hangs/crawls on the GitHub runner (it was taking 16+ min and timing the
+      # job out). ubuntu-latest already ships the libraries headless Chromium
+      # needs, so install only the browser binary (seconds, then cached above).
+      # timeout-minutes guards against a future hang failing fast instead of
+      # eating the whole 20-min job budget.
       - name: Install Playwright browsers (Chromium)
-        run: pnpm exec playwright install --with-deps chromium
+        timeout-minutes: 5
+        run: pnpm exec playwright install chromium
 
       - name: Storybook a11y + interaction tests (affected)
         run: pnpm nx affected -t test-storybook --nxBail

--- a/libs/shared/ui/src/lib/Dropdown.mdx
+++ b/libs/shared/ui/src/lib/Dropdown.mdx
@@ -1,7 +1,7 @@
 import { Meta } from '@storybook/addon-docs/blocks';
 import { Dropdown } from './Dropdown';
 
-<Meta title='Navigation/Dropdown/Guide' />
+<Meta title='Overlay/Dropdown/Guide' />
 
 <style>
   {`

--- a/libs/shared/ui/src/lib/Modal.mdx
+++ b/libs/shared/ui/src/lib/Modal.mdx
@@ -2,7 +2,7 @@ import { Meta } from '@storybook/addon-docs/blocks';
 import { Modal } from './Modal';
 import { Button } from './Button';
 
-<Meta title='Overlays/Modal/Guide' />
+<Meta title='Overlay/Modal/Guide' />
 
 <style>
   {`

--- a/libs/shared/ui/src/lib/Tabs.mdx
+++ b/libs/shared/ui/src/lib/Tabs.mdx
@@ -1,7 +1,7 @@
 import { Meta } from '@storybook/addon-docs/blocks';
 import { Tabs } from './Tabs';
 
-<Meta title='Navigation/Tabs/Guide' />
+<Meta title='Data Display/Tabs/Guide' />
 
 <style>
   {`


### PR DESCRIPTION
Two Storybook-pipeline fixes (bundled because the CI fix is what lets this PR's own checks pass).

## 1. Consolidate Storybook sidebar sections
Three "Guide" MDX pages sat in a different sidebar section than their component's stories, splitting the component across two sections (and creating a near-duplicate **`Overlays`** vs **`Overlay`** group):

| Guide | Before | After |
|---|---|---|
| Modal | `Overlays/Modal/Guide` | `Overlay/Modal/Guide` |
| Dropdown | `Navigation/Dropdown/Guide` | `Overlay/Dropdown/Guide` |
| Tabs | `Navigation/Tabs/Guide` | `Data Display/Tabs/Guide` |

Now every component appears once, under the same section as its stories, and the duplicate `Overlays` group is gone. *(There was no actual `Layouts`/`Layout` split — that was the `Overlay`/`Overlays` duplicate.)*

## 2. Fix `fast / checks` timeout (Playwright install)
The **"Install Playwright browsers (Chromium)"** step was running **16+ min and getting cancelled** at the job's 20-min timeout — failing every shared-ui-affected PR (incl. #1019). Cause: `--with-deps` runs `apt-get` for system libs, which hangs/crawls on the runner. `ubuntu-latest` already ships the libs headless Chromium needs, so we now install **only the browser binary** (`playwright install chromium`, seconds + cached) with a 5-min step timeout as a guard.

*This PR's own `fast / checks` run validates the fix end-to-end* — the MDX change makes shared-ui affected, so `test-storybook` actually launches the browser and runs the a11y suite after the (now fast) install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)