### PR TITLE
ci: auto-deploy Vercel preview on PRs to develop

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,0 +1,46 @@
+name: Deploy Preview
+
+# Auto-deploys a Vercel preview for the root app on every PR to develop and
+# posts the URL as a PR comment. PRs to main are handled by ci-preview.yml.
+#
+# The root project's Vercel Git-integration build is disabled (dashboard
+# "Ignored Build Step"), so feature-branch previews would otherwise never
+# build. This workflow drives the preview from CI using the same vercel-deploy
+# action production uses, so previews are generated automatically.
+
+on:
+  pull_request:
+    branches: [develop]
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: preview-develop-${{ github.head_ref }}
+  cancel-in-progress: true
+
+jobs:
+  preview:
+    name: Vercel Preview
+    # Skip drafts; the ready_for_review trigger runs it once the PR is opened.
+    if: ${{ github.event.pull_request.draft != true }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: ./.github/actions/vercel-deploy
+        id: deploy
+        with:
+          vercel-token: ${{ secrets.VERCEL_TOKEN }}
+          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
+          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
+
+      - uses: ./.github/actions/preview-comment
+        with:
+          label: Preview deployed
+          url: ${{ steps.deploy.outputs.url }}
+          marker: '<!-- vercel-preview-url -->'
+          github-token: ${{ github.token }}


### PR DESCRIPTION
## Problem

The root project's Vercel **Git-integration build is disabled** via the dashboard *Settings → Git → Ignored Build Step* (you see `Vercel – danieljoffe-com … Canceled by Ignored Build Step` on PRs). That's why feature PRs never get a working preview — only the shared-ui/Storybook project (`ui-danieljoffe-com`) does.

The skip lives in **Vercel project settings**, not the repo, so it can't be flipped in a PR directly. But the repo already drives deploys through GitHub Actions (`./.github/actions/vercel-deploy`), and `ci-preview.yml` already auto-deploys a preview + comments the URL — just **only for PRs to `main`**. Feature PRs target `develop`, so they're never covered.

## Fix

Add `.github/workflows/deploy-preview.yml` that runs the same proven preview job on **PRs to `develop`**:
- Builds and deploys a Vercel **preview** of the root app with the existing `vercel-deploy` action (reusing `VERCEL_TOKEN` / `VERCEL_ORG_ID` / `VERCEL_PROJECT_ID`).
- Posts/updates the preview URL as a PR comment via `preview-comment`.
- Non-draft PRs only; `cancel-in-progress` supersedes stale builds on new pushes.

No dashboard change needed, no new secrets. PRs to `main` stay on `ci-preview.yml`; a PR has one base, so there's no double-deploy.

## Notes
- This activates for **subsequent** PRs (GitHub runs the version of a workflow that exists when the PR's event fires).
- Alternative, if you'd rather use Vercel-native previews: change the dashboard *Ignored Build Step* to build on preview deployments. Pick **one** mechanism — don't enable both, or every PR gets two previews.
- Workflow-only change, so `ci.yml` classifies it as docs-only and the heavy CI jobs skip (`ci-status` still gates green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)