### PR TITLE
fix(storybook): resolve @/ alias under Vite 8 for root storybook build

### DIFF
--- a/apps/root/.storybook/main.ts
+++ b/apps/root/.storybook/main.ts
@@ -1,6 +1,8 @@
-import { dirname } from 'node:path';
+import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { StorybookConfig } from '@storybook/nextjs-vite';
+
+const storybookDir = dirname(fileURLToPath(import.meta.url));
 
 const config: StorybookConfig = {
   stories: ['../**/*.@(stories.@(js|jsx|ts|tsx|mdx))'],
@@ -12,6 +14,16 @@ const config: StorybookConfig = {
   staticDirs: ['../public'],
   docs: {
     defaultName: 'autodocs',
+  },
+  // Vite 8 (Rolldown) no longer resolves the Next.js "@/" path alias on its
+  // own, so register it explicitly for the Storybook build/preview.
+  viteFinal: async viteConfig => {
+    const { mergeConfig } = await import('vite');
+    return mergeConfig(viteConfig, {
+      resolve: {
+        alias: { '@': join(storybookDir, '../src') },
+      },
+    });
   },
 };
 


### PR DESCRIPTION
Vite 8 (Rolldown) no longer auto-resolves the Next.js `@/` path alias, so root's Storybook build failed in the `full / full` CI job on the release PR (#1031):

```
Error: [vite]: Rolldown failed to resolve import "@/styles/global.css"
```

Fix: register the `@` → `src` alias explicitly in `apps/root/.storybook/main.ts` via `viteFinal`. Verified locally — `nx build-storybook root` now succeeds (exit 0).

Unblocks the `develop`→`main` release (#1031).

🤖 Generated with [Claude Code](https://claude.com/claude-code)