### PR TITLE
fix(vercel): stop excluding apps/root from CLI deploys

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -28,8 +28,10 @@ playwright-report-json
 .claude
 .git
 
-# Other apps in the monorepo — deployed separately; upload-only ballast.
-apps/root
+# Other apps/projects in the monorepo not part of this build — upload-only
+# ballast. NOTE: do NOT list apps/root here — it is the danieljoffe-com deploy
+# target, and CLI deploys (`vercel --prod`) honor .vercelignore (git deploys
+# do not). Excluding it makes the production build fail (missing app source).
 apps/root-e2e
 apps/audit-api
 apps/audit-scan-service


### PR DESCRIPTION
The repo's `.vercelignore` (leftover from when wyrdfold lived in this monorepo) excluded `apps/root` as "ballast". Git deploys ignore `.vercelignore`, but **CLI deploys (`vercel --prod`) honor it** — so the manual production deploy of `danieljoffe-com` failed because the app source was missing:

```
postinstall: Directory not found: /vercel/path0/apps/root/src/data/content/blog
ELIFECYCLE Command failed with exit code 1 (pnpm install)
```

Removes `apps/root` from the exclusion list (keeps the genuinely-unused `apps/root-e2e` / audit apps excluded) and documents why it must stay out, so future CLI deploys of the site work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)