### PR TITLE
release: .vercelignore CLI-deploy fix

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -28,8 +28,10 @@ playwright-report-json
 .claude
 .git
 
-# Other apps in the monorepo — deployed separately; upload-only ballast.
-apps/root
+# Other apps/projects in the monorepo not part of this build — upload-only
+# ballast. NOTE: do NOT list apps/root here — it is the danieljoffe-com deploy
+# target, and CLI deploys (`vercel --prod`) honor .vercelignore (git deploys
+# do not). Excluding it makes the production build fail (missing app source).
 apps/root-e2e
 apps/audit-api
 apps/audit-scan-service


### PR DESCRIPTION
Promotes `develop` → `main`.

## Ships
- **#1033** — `.vercelignore` no longer excludes `apps/root`, so CLI (`vercel --prod`) deploys of danieljoffe-com build correctly. Tooling-only; no change to the live site's behavior.

## Note
First release since the **Ignored Build Step** was corrected — merging this should **auto-deploy production** (validates that the deploy pipeline is healthy again, no manual `vercel --prod` needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)