### PR TITLE
feat(nav): shared-element View Transition — card cover morphs into detail hero

### DIFF
--- a/apps/root/src/app/home/AppContext.tsx
+++ b/apps/root/src/app/home/AppContext.tsx
@@ -9,6 +9,7 @@ import ModalProvider from '@/state/Modal/ModalProvider';
 import ErrorBoundary from '@/components/ErrorBoundary';
 import { ScrollToTop } from '@/components/kit';
 import KeyboardShortcuts from '@/components/KeyboardShortcuts';
+import { ViewTransitions } from '@/components/ViewTransitions';
 
 const Modal = dynamic(() => import('@/components/Modal'), { ssr: false });
 const ScrollToElement = dynamic(() => import('./ScrollToElement'), {
@@ -33,6 +34,7 @@ const Providers = composeProviders([
   ThemeProvider,
   ToastProvider,
   ModalProvider,
+  ViewTransitions,
 ]);
 
 export default function AppContext({ children }: WithChildren) {

--- a/apps/root/src/components/PostBody.tsx
+++ b/apps/root/src/components/PostBody.tsx
@@ -8,6 +8,7 @@ import BreadCrumbs from './BreadCrumbs';
 export default function PostBody({
   children,
   cover,
+  coverTransitionName,
   breadcrumbs,
   title,
   date,
@@ -38,6 +39,11 @@ export default function PostBody({
             priority
             sizes='(max-width: 1024px) calc(100vw - 2rem), 480px'
             className='w-full h-auto object-cover rounded-lg'
+            style={
+              coverTransitionName
+                ? { viewTransitionName: coverTransitionName }
+                : undefined
+            }
           />
         </div>
       </div>

--- a/apps/root/src/components/PostDetailLayout.tsx
+++ b/apps/root/src/components/PostDetailLayout.tsx
@@ -11,6 +11,7 @@ export default function PostDetailLayout({
   entry,
   pagination,
   breadcrumbs,
+  coverTransitionName,
 }: PostDetailProps) {
   const Post = entry.component;
 
@@ -23,6 +24,7 @@ export default function PostDetailLayout({
       <div className='max-w-5xl mx-auto w-full px-4 sm:px-6 py-8 md:py-14'>
         <PostBody
           cover={entry.thumbnail.cover}
+          coverTransitionName={coverTransitionName}
           breadcrumbs={breadcrumbs}
           title={entry.metadata.title}
           date={entry.metadata.date}

--- a/apps/root/src/components/ViewTransitions.tsx
+++ b/apps/root/src/components/ViewTransitions.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  type ReactNode,
+} from 'react';
+import { usePathname, useRouter } from 'next/navigation';
+
+type NavigateFn = (href: string) => void;
+
+type StartViewTransition = (callback: () => void | Promise<void>) => unknown;
+
+const ViewTransitionContext = createContext<NavigateFn | null>(null);
+
+/**
+ * Returns a navigate function that wraps the App Router push in a browser
+ * View Transition, so an element sharing a `view-transition-name` across the
+ * two pages morphs between them. Falls back to a plain client push when the
+ * browser lacks the API, the user prefers reduced motion, or the provider is
+ * absent — callers never need to branch.
+ *
+ * Stable React (19.x) does not ship React's experimental `<ViewTransition>`
+ * component, and Next's `experimental.viewTransition` flag only enables that
+ * component — so we drive `document.startViewTransition()` directly instead.
+ */
+export function useViewTransitionNavigate(): NavigateFn {
+  const router = useRouter();
+  const navigate = useContext(ViewTransitionContext);
+  return navigate ?? (href => router.push(href));
+}
+
+export function ViewTransitions({ children }: { children: ReactNode }) {
+  const router = useRouter();
+  const pathname = usePathname();
+  // Resolver for the in-flight transition's "new state is ready" promise.
+  const finishRef = useRef<(() => void) | null>(null);
+
+  // Once the new route commits, release the transition so the browser captures
+  // the new DOM and runs the morph.
+  useEffect(() => {
+    finishRef.current?.();
+    finishRef.current = null;
+  }, [pathname]);
+
+  const navigate = useCallback<NavigateFn>(
+    href => {
+      const startViewTransition = (
+        document as unknown as { startViewTransition?: StartViewTransition }
+      ).startViewTransition;
+      const prefersReduced = window.matchMedia(
+        '(prefers-reduced-motion: reduce)'
+      ).matches;
+
+      if (typeof startViewTransition !== 'function' || prefersReduced) {
+        router.push(href);
+        return;
+      }
+
+      startViewTransition.call(
+        document,
+        () =>
+          new Promise<void>(resolve => {
+            finishRef.current = resolve;
+            router.push(href);
+            // Safety net: never leave the page frozen if the route doesn't
+            // change or the commit effect never fires.
+            window.setTimeout(() => {
+              if (finishRef.current === resolve) {
+                finishRef.current = null;
+                resolve();
+              }
+            }, 800);
+          })
+      );
+    },
+    [router]
+  );
+
+  return (
+    <ViewTransitionContext.Provider value={navigate}>
+      {children}
+    </ViewTransitionContext.Provider>
+  );
+}

--- a/apps/root/src/components/kit/CoverImage.tsx
+++ b/apps/root/src/components/kit/CoverImage.tsx
@@ -10,7 +10,7 @@ export function CoverImage({
   priority?: boolean;
 }) {
   return (
-    <div className='relative h-36 overflow-hidden'>
+    <div className='relative h-36 overflow-hidden' data-cover>
       <Image
         src={src}
         alt={alt}

--- a/apps/root/src/components/kit/PostCard.tsx
+++ b/apps/root/src/components/kit/PostCard.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { type MouseEvent } from 'react';
 import Link from 'next/link';
 import { ArrowUpRight, Clock } from 'lucide-react';
 import { Badge } from '@danieljoffe/shared-ui/Badge';
@@ -8,6 +9,7 @@ import { IconText } from '@danieljoffe/shared-ui/IconText';
 import { Text } from '@danieljoffe/shared-ui/Text';
 import { analytics } from '@/lib/analytics';
 import { ContentType, PostThumbnail } from '@/types/postTypes';
+import { useViewTransitionNavigate } from '@/components/ViewTransitions';
 import { CoverImage } from './CoverImage';
 import { CompanyLogo } from './CompanyLogo';
 
@@ -28,8 +30,29 @@ export function PostCard({
   priority?: boolean;
   analyticsType?: ContentType;
 }) {
-  const handleClick = () => {
+  const navigate = useViewTransitionNavigate();
+
+  const handleClick = (event: MouseEvent<HTMLAnchorElement>) => {
     analyticsHandlers[analyticsType](post.slug);
+    // Let the browser handle modified clicks (open in new tab, etc.).
+    if (
+      event.metaKey ||
+      event.ctrlKey ||
+      event.shiftKey ||
+      event.altKey ||
+      event.button !== 0
+    ) {
+      return;
+    }
+    event.preventDefault();
+    // Name the clicked cover so it — and only it — morphs into the detail
+    // hero that carries the matching `view-transition-name`.
+    const cover =
+      event.currentTarget.querySelector<HTMLElement>('[data-cover]');
+    if (cover) {
+      cover.style.viewTransitionName = `cover-${analyticsType}-${post.slug}`;
+    }
+    navigate(post.link.href);
   };
 
   return (

--- a/apps/root/src/lib/getPostDetailProps.ts
+++ b/apps/root/src/lib/getPostDetailProps.ts
@@ -11,6 +11,8 @@ export interface PostDetailProps {
   entry: ContentEntry;
   pagination: PostPaginationData;
   breadcrumbs: NavLink[];
+  /** Shared `view-transition-name` so the cover morphs from its card. */
+  coverTransitionName: string;
 }
 
 /**
@@ -32,5 +34,10 @@ export function getPostDetailProps(
     { href: `${config.basePath}/${slug}`, label: entry.thumbnail.title },
   ];
 
-  return { entry, pagination, breadcrumbs };
+  return {
+    entry,
+    pagination,
+    breadcrumbs,
+    coverTransitionName: `cover-${type}-${slug}`,
+  };
 }

--- a/apps/root/src/styles/theme.css
+++ b/apps/root/src/styles/theme.css
@@ -450,3 +450,21 @@ code[data-line-numbers-max-digits='3'] > [data-line]::before {
     transition-duration: 0.01ms !important;
   }
 }
+
+/* ─── View transitions (card cover → detail-page hero morph) ───
+ * The navigation wrapper (ViewTransitions.tsx) drives the morph and already
+ * skips it under reduced motion; this just eases the default timing and, as a
+ * safety net, neutralizes any view-transition the browser may run when motion
+ * is not wanted (pseudo-elements aren't matched by the `*` rule above). */
+::view-transition-group(*) {
+  animation-duration: 0.4s;
+  animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  ::view-transition-group(*),
+  ::view-transition-old(*),
+  ::view-transition-new(*) {
+    animation: none !important;
+  }
+}

--- a/apps/root/src/types/postTypes.ts
+++ b/apps/root/src/types/postTypes.ts
@@ -28,6 +28,8 @@ export interface PostThumbnail extends PostBase {
 export interface PostBodyProps extends WithChildren {
   breadcrumbs: NavLink[];
   cover: CoverImageMeta;
+  /** Shared `view-transition-name` so the hero morphs from its source card. */
+  coverTransitionName?: string | undefined;
   title: string;
   date: string;
   tags: string[];


### PR DESCRIPTION
## Summary

**Phase 2 #1** — the marquee piece. Clicking a project / blog / experience card now **morphs its cover image into the hero image** on the detail page, instead of a hard cut.

![morph mid-flight: the cover image floats between card and detail-page hero while the rest cross-fades]

## Why not the built-in Next flag
I tried `experimental.viewTransition: true` first and **verified empirically that it does nothing here**: with the flag on, App Router client navigations called `document.startViewTransition` **0 times**. The flag only enables React's experimental `<ViewTransition>` component, which ships in React's experimental channel — this repo is on **stable React 19.2.4**, which doesn't export it. So I reverted the flag and drive the browser View Transitions API directly with a small, dependency-free wrapper (the same approach the `next-view-transitions` library takes internally).

## How it works
- **`ViewTransitions.tsx`** (new): a provider exposing `navigate()` that wraps `router.push` in `document.startViewTransition()` and releases it once the new route commits (a `usePathname` effect), with an 800ms safety timeout. Falls back to a plain push when the API is unavailable **or the user prefers reduced motion** — callers never branch.
- **`PostCard`**: intercepts the primary click only (modifier/middle clicks still open a new tab), tags the *clicked* cover with a unique `view-transition-name`, then navigates through the wrapper. Only one element is named, so exactly one cover morphs — no busy multi-fade.
- **Detail hero** (`PostBody`) carries the matching name, computed once in `getPostDetailProps` as `cover-${type}-${slug}` and threaded through `PostDetailLayout`.
- **`theme.css`**: eases the morph timing; neutralizes view-transition pseudo-element animations under `prefers-reduced-motion` as a safety net.

## Progressive enhancement
- No `startViewTransition` support → normal client nav (no regression).
- Reduced motion → normal client nav.
- `<Link>` is preserved for prefetch, `href`, right-click, and SEO; only the left-click is intercepted.
- Forward morph (list → detail). Browser-back reverse morph is a known follow-up (needs popstate wrapping); out of scope here.

## Test plan
- [x] `pnpm tsc --noEmit` — clean
- [x] `pnpm nx test root` — 589/589 pass (fresh, cache-skipped)
- [x] Pre-commit hooks (eslint + prettier + typecheck) pass
- [x] In-browser: card click fires `startViewTransition` once; detail hero carries the matching `view-transition-name`; mid-flight capture shows the cover morphing
- [ ] Review on the Vercel preview (clean prod build; clear the dev SW if testing locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
