### PR TITLE
feat(nav): backward View Transition morph (hero → card on browser-back)

### DIFF
--- a/apps/root/src/components/BreadCrumbs.tsx
+++ b/apps/root/src/components/BreadCrumbs.tsx
@@ -1,13 +1,38 @@
 'use client';
+import { type MouseEvent } from 'react';
 import { ChevronRight } from 'lucide-react';
 import { usePathname } from 'next/navigation';
 import Button from '@/components/Button';
+import { useViewTransitionNavigate } from '@/components/ViewTransitions';
 import type { BreadCrumbsProps } from '@/types/base';
 
-export default function BreadCrumbs({ items }: BreadCrumbsProps) {
+export default function BreadCrumbs({
+  items,
+  coverTransitionName,
+}: BreadCrumbsProps) {
   const pathname = usePathname();
+  const navigate = useViewTransitionNavigate();
 
   if (items == null) return null;
+
+  const handleCrumbClick = (
+    event: MouseEvent<HTMLAnchorElement>,
+    href: string
+  ) => {
+    // Let the browser handle modified clicks (open in new tab, etc.).
+    if (
+      event.metaKey ||
+      event.ctrlKey ||
+      event.shiftKey ||
+      event.altKey ||
+      event.button !== 0
+    ) {
+      return;
+    }
+    event.preventDefault();
+    // Morph the detail hero into the matching card on the destination list.
+    navigate(href, coverTransitionName);
+  };
 
   return (
     <nav aria-label='Breadcrumb' className='flex'>
@@ -19,7 +44,17 @@ export default function BreadCrumbs({ items }: BreadCrumbsProps) {
                 {item.label}
               </p>
             ) : (
-              <Button as='link' variant='bare' size='sm' href={item.href}>
+              <Button
+                as='link'
+                variant='bare'
+                size='sm'
+                href={item.href}
+                onClick={
+                  coverTransitionName
+                    ? event => handleCrumbClick(event, item.href)
+                    : undefined
+                }
+              >
                 {item.label}
                 <span
                   className='flex h-full items-center justify-center'

--- a/apps/root/src/components/PostBody.tsx
+++ b/apps/root/src/components/PostBody.tsx
@@ -30,7 +30,11 @@ export default function PostBody({
         <Heading variant='detail' className='lg:flex-1 lg:min-w-0'>
           {title}
         </Heading>
-        <div className='lg:flex-1 lg:min-w-0'>
+        <div
+          className='lg:flex-1 lg:min-w-0'
+          data-vt-hero={coverTransitionName ? '' : undefined}
+          data-vt-name={coverTransitionName}
+        >
           <Image
             src={cover.src}
             alt={cover.alt}

--- a/apps/root/src/components/PostBody.tsx
+++ b/apps/root/src/components/PostBody.tsx
@@ -23,7 +23,10 @@ export default function PostBody({
 
   return (
     <div className='flex flex-col gap-6'>
-      <BreadCrumbs items={breadcrumbs} />
+      <BreadCrumbs
+        items={breadcrumbs}
+        coverTransitionName={coverTransitionName}
+      />
 
       {/* Hero: title + cover image side by side on desktop */}
       <div className='flex flex-col lg:flex-row lg:items-center gap-6 lg:gap-10'>

--- a/apps/root/src/components/ViewTransitions.tsx
+++ b/apps/root/src/components/ViewTransitions.tsx
@@ -10,7 +10,14 @@ import {
 } from 'react';
 import { usePathname, useRouter } from 'next/navigation';
 
-type NavigateFn = (href: string) => void;
+/**
+ * Navigate with a View Transition. `coverName` (optional) names the element on
+ * the *destination* page that should morph in — used when the source is a
+ * detail hero and the target is the matching list card (e.g. a breadcrumb
+ * click back to the list). Forward card clicks omit it because the card has
+ * already named its own cover.
+ */
+type NavigateFn = (href: string, coverName?: string) => void;
 
 type ViewTransitionLike = { finished?: Promise<unknown> };
 type StartViewTransition = (
@@ -120,14 +127,16 @@ export function ViewTransitions({ children }: { children: ReactNode }) {
   );
 
   const navigate = useCallback<NavigateFn>(
-    href => {
+    (href, coverName) => {
       const start = getStartViewTransition();
       if (!start || prefersReducedMotion()) {
         router.push(href);
         return;
       }
-      // Forward: the card has already named its own cover; push inside the
-      // transition.
+      // When a cover name is given (e.g. a breadcrumb morphing the hero back to
+      // its list card), tag the destination card once the list renders. Forward
+      // card clicks pass nothing — the card has already named its own cover.
+      if (coverName) pendingNameRef.current = coverName;
       beginTransition(start, href);
     },
     [beginTransition, router]

--- a/apps/root/src/components/ViewTransitions.tsx
+++ b/apps/root/src/components/ViewTransitions.tsx
@@ -12,9 +12,24 @@ import { usePathname, useRouter } from 'next/navigation';
 
 type NavigateFn = (href: string) => void;
 
-type StartViewTransition = (callback: () => void | Promise<void>) => unknown;
+type ViewTransitionLike = { finished?: Promise<unknown> };
+type StartViewTransition = (
+  callback: () => void | Promise<void>
+) => ViewTransitionLike;
 
 const ViewTransitionContext = createContext<NavigateFn | null>(null);
+
+function getStartViewTransition(): StartViewTransition | undefined {
+  const fn = (
+    document as unknown as { startViewTransition?: StartViewTransition }
+  ).startViewTransition;
+  // Bind to `document`; calling the bare method throws "Illegal invocation".
+  return typeof fn === 'function' ? fn.bind(document) : undefined;
+}
+
+function prefersReducedMotion(): boolean {
+  return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+}
 
 /**
  * Returns a navigate function that wraps the App Router push in a browser
@@ -36,49 +51,119 @@ export function useViewTransitionNavigate(): NavigateFn {
 export function ViewTransitions({ children }: { children: ReactNode }) {
   const router = useRouter();
   const pathname = usePathname();
-  // Resolver for the in-flight transition's "new state is ready" promise.
-  const finishRef = useRef<(() => void) | null>(null);
 
-  // Once the new route commits, release the transition so the browser captures
-  // the new DOM and runs the morph.
+  // Resolver for the in-flight transition's "new DOM is ready" promise.
+  const finishRef = useRef<(() => void) | null>(null);
+  // Back/forward morph: the shared name to re-apply to the destination card
+  // once it renders, plus the element we applied it to (for cleanup after).
+  const pendingNameRef = useRef<string | null>(null);
+  const namedElRef = useRef<HTMLElement | null>(null);
+
+  // Once the new route commits: for a back/forward morph, tag the destination
+  // card with the shared name so it pairs with the hero we're leaving; then
+  // release the transition so the browser captures the new state.
   useEffect(() => {
-    finishRef.current?.();
+    if (!finishRef.current) return;
+    const name = pendingNameRef.current;
+    if (name) {
+      const el = document.querySelector<HTMLElement>(
+        `[data-cover-name="${CSS.escape(name)}"]`
+      );
+      if (el) {
+        el.style.viewTransitionName = name;
+        namedElRef.current = el;
+      }
+      pendingNameRef.current = null;
+    }
+    finishRef.current();
     finishRef.current = null;
   }, [pathname]);
 
-  const navigate = useCallback<NavigateFn>(
-    href => {
-      const startViewTransition = (
-        document as unknown as { startViewTransition?: StartViewTransition }
-      ).startViewTransition;
-      const prefersReduced = window.matchMedia(
-        '(prefers-reduced-motion: reduce)'
-      ).matches;
+  const beginTransition = useCallback(
+    (start: StartViewTransition, href?: string) => {
+      // Create the "new DOM is ready" promise and stash its resolver
+      // *synchronously*, before the route can re-render. For a browser
+      // traverse the App Router re-renders almost immediately, so resolving
+      // inside the (async) startViewTransition callback would race the commit
+      // effect and lose the morph.
+      let resolveReady: () => void = () => undefined;
+      const ready = new Promise<void>(resolve => {
+        resolveReady = resolve;
+      });
+      finishRef.current = resolveReady;
 
-      if (typeof startViewTransition !== 'function' || prefersReduced) {
-        router.push(href);
-        return;
-      }
+      const transition = start(() => ready);
 
-      startViewTransition.call(
-        document,
-        () =>
-          new Promise<void>(resolve => {
-            finishRef.current = resolve;
-            router.push(href);
-            // Safety net: never leave the page frozen if the route doesn't
-            // change or the commit effect never fires.
-            window.setTimeout(() => {
-              if (finishRef.current === resolve) {
-                finishRef.current = null;
-                resolve();
-              }
-            }, 800);
-          })
-      );
+      // Forward nav drives the route change; back/forward leaves it to the
+      // browser's own history navigation.
+      if (href) router.push(href);
+
+      // Safety net: never leave the page frozen if the route never changes or
+      // the commit effect doesn't fire.
+      window.setTimeout(() => {
+        if (finishRef.current === resolveReady) {
+          finishRef.current = null;
+          resolveReady();
+        }
+      }, 800);
+
+      // Once the morph finishes, drop the name we applied to the destination
+      // card so the next transition starts clean.
+      transition.finished
+        ?.then(() => {
+          namedElRef.current?.style.removeProperty('view-transition-name');
+          namedElRef.current = null;
+        })
+        .catch(() => undefined);
     },
     [router]
   );
+
+  const navigate = useCallback<NavigateFn>(
+    href => {
+      const start = getStartViewTransition();
+      if (!start || prefersReducedMotion()) {
+        router.push(href);
+        return;
+      }
+      // Forward: the card has already named its own cover; push inside the
+      // transition.
+      beginTransition(start, href);
+    },
+    [beginTransition, router]
+  );
+
+  // Backward morph: browser back/forward off a detail page morphs the hero
+  // back into the card it came from. `popstate` fires *after* the App Router
+  // has already re-rendered (the old DOM is gone), so it can't snapshot the
+  // hero. The Navigation API's `navigate` event fires *before* the re-render
+  // while the detail DOM is still present, so we hook that instead — observe
+  // only (no `intercept()`), letting Next perform the actual routing. Card
+  // clicks are `push`/`replace`; only browser back/forward is `traverse`.
+  // Chromium-only; elsewhere back/forward is a normal navigation.
+  useEffect(() => {
+    const navigation = (
+      window as unknown as { navigation?: EventTarget | undefined }
+    ).navigation;
+    if (!navigation) return;
+
+    const onNavigate = (event: Event) => {
+      if (
+        (event as { navigationType?: string }).navigationType !== 'traverse'
+      ) {
+        return;
+      }
+      const hero = document.querySelector<HTMLElement>('[data-vt-hero]');
+      const name = hero?.getAttribute('data-vt-name') ?? null;
+      const start = getStartViewTransition();
+      if (!hero || !name || !start || prefersReducedMotion()) return;
+      pendingNameRef.current = name;
+      beginTransition(start);
+    };
+
+    navigation.addEventListener('navigate', onNavigate);
+    return () => navigation.removeEventListener('navigate', onNavigate);
+  }, [beginTransition]);
 
   return (
     <ViewTransitionContext.Provider value={navigate}>

--- a/apps/root/src/components/kit/CoverImage.tsx
+++ b/apps/root/src/components/kit/CoverImage.tsx
@@ -4,13 +4,20 @@ export function CoverImage({
   src,
   alt,
   priority = false,
+  coverName,
 }: {
   src: string;
   alt: string;
   priority?: boolean;
+  /**
+   * Shared identity for the View Transition morph. Rendered as `data-cover-name`
+   * so the navigation layer can tag this cover with a matching
+   * `view-transition-name` when it morphs to/from a detail-page hero.
+   */
+  coverName?: string | undefined;
 }) {
   return (
-    <div className='relative h-36 overflow-hidden' data-cover>
+    <div className='relative h-36 overflow-hidden' data-cover-name={coverName}>
       <Image
         src={src}
         alt={alt}

--- a/apps/root/src/components/kit/PostCard.tsx
+++ b/apps/root/src/components/kit/PostCard.tsx
@@ -31,6 +31,7 @@ export function PostCard({
   analyticsType?: ContentType;
 }) {
   const navigate = useViewTransitionNavigate();
+  const coverName = `cover-${analyticsType}-${post.slug}`;
 
   const handleClick = (event: MouseEvent<HTMLAnchorElement>) => {
     analyticsHandlers[analyticsType](post.slug);
@@ -48,9 +49,9 @@ export function PostCard({
     // Name the clicked cover so it — and only it — morphs into the detail
     // hero that carries the matching `view-transition-name`.
     const cover =
-      event.currentTarget.querySelector<HTMLElement>('[data-cover]');
+      event.currentTarget.querySelector<HTMLElement>('[data-cover-name]');
     if (cover) {
-      cover.style.viewTransitionName = `cover-${analyticsType}-${post.slug}`;
+      cover.style.viewTransitionName = coverName;
     }
     navigate(post.link.href);
   };
@@ -66,6 +67,7 @@ export function PostCard({
           src={post.cover.src}
           alt={post.cover.alt}
           priority={priority}
+          coverName={coverName}
         />
         {logo && (
           <div className='absolute bottom-3 left-3'>

--- a/apps/root/src/types/base.ts
+++ b/apps/root/src/types/base.ts
@@ -16,6 +16,12 @@ export interface NavLink {
 
 export interface BreadCrumbsProps {
   items: NavLink[];
+  /**
+   * Detail pages only: when set, clicking a parent crumb morphs the detail
+   * hero into the matching list card via a View Transition. The value is the
+   * shared `view-transition-name`.
+   */
+  coverTransitionName?: string | undefined;
 }
 
 export interface SlugPageProps {


### PR DESCRIPTION
## Summary

Makes the shared-element cover→hero morph run in **both directions**, via two interactions:
1. **Browser back/forward** off a detail page morphs the hero back into the card it came from.
2. **The parent breadcrumb** ("Projects" / "Blog") on a detail page does the same on click.

## Why browser-back is non-trivial
`popstate` fires **after** the App Router has already re-rendered (verified in-browser: at `popstate` the detail DOM is gone, `heroPresent: false`), so it can't snapshot the hero. The **Navigation API** `navigate` event fires **before** the re-render while the detail DOM is still present — we observe it (no `intercept()`, Next still routes). Card clicks are `push`/`replace`; only browser back/forward is `traverse`.

The breadcrumb case is the easy one — a click we control, like the forward morph — so it just wraps the navigation in a transition and names the destination card.

## Changes
- **`ViewTransitions.tsx`**: drives `document.startViewTransition()` directly (stable React 19.2.x has no `<ViewTransition>` component). The "new DOM is ready" resolver is created **synchronously** before the route re-renders (resolving inside the async callback raced the commit and dropped the morph). `navigate(href, coverName?)` — the optional name tags the destination card so exactly one pair morphs; cleaned up after the transition. Navigation-API listener handles browser back/forward.
- **`BreadCrumbs.tsx`**: opt-in via a `coverTransitionName` prop — on detail pages the parent crumb intercepts its click and morphs; tag-page breadcrumbs (no prop) and modified clicks keep plain navigation.
- **`CoverImage` / `PostBody`**: `data-cover-name` on cards and `data-vt-hero` / `data-vt-name` on the detail hero provide the shared identity.
- **Fix**: bind `document.startViewTransition` (the bare method throws `Illegal invocation`).

## Progressive enhancement
- Browser back/forward morph is **Chromium-only** (Navigation API); elsewhere it's a normal nav. The breadcrumb morph works wherever `startViewTransition` exists (Chrome, Safari 18+). Firefox / no-API / reduced-motion all fall back to plain navigation, no regression.

## Validation
**Automated (green):** `pnpm tsc --noEmit` clean · `pnpm nx test root` **589/589** (fresh) · ESLint clean.

**In-browser, real conditions (no instrumentation):**
- Forward: card click morphs cover → hero (mid-flight screenshot captured).
- Browser-back: names both the leaving hero and the destination card during the morph and pairs them.
- Breadcrumb "Projects" click: fires `startViewTransition`, navigates to the list, names the matching card during the morph.

**Negative / edge cases (guards proven — `startViewTransition` count stays 0):**
- Modified clicks (`metaKey`) on both cards and breadcrumbs: no `preventDefault`, no transition, stay put (new-tab preserved).
- `prefers-reduced-motion: reduce`: forward, browser-back, and breadcrumb all navigate with no transition.
- No View Transitions API: plain client push, no error.

**Pending:**
- [ ] Review on the Vercel preview (Chromium for the back-button morph).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
