### PR TITLE
fix(csp): clear the two production console errors

### DIFF
--- a/apps/root/src/app/layout.tsx
+++ b/apps/root/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata, Viewport } from 'next';
 import * as Sentry from '@sentry/nextjs';
 import { Inter, JetBrains_Mono } from 'next/font/google';
+import { headers } from 'next/headers';
 import { rootMetadata } from '@/data/metadata/root';
 import { WithChildren } from '@/types/base';
 import '@/styles/global.css';
@@ -38,6 +39,9 @@ export const viewport: Viewport = {
 };
 
 export default async function RootLayout({ children }: WithChildren) {
+  // Same nonce the proxy set in the CSP header, so the inline no-flash script
+  // below satisfies `strict-dynamic` instead of being blocked.
+  const nonce = (await headers()).get('x-nonce') ?? undefined;
   return (
     <html
       lang='en'
@@ -58,6 +62,7 @@ export default async function RootLayout({ children }: WithChildren) {
             first paint, only when JS is on and motion is allowed. Without this
             (no-JS / reduced-motion) content renders immediately and unhidden. */}
         <script
+          nonce={nonce}
           dangerouslySetInnerHTML={{
             __html:
               "try{if(!matchMedia('(prefers-reduced-motion: reduce)').matches){document.documentElement.classList.add('reveal-ready')}}catch(e){}",

--- a/apps/root/src/utils/constants.ts
+++ b/apps/root/src/utils/constants.ts
@@ -8,6 +8,8 @@ const GOOGLE_DOCS_URL = 'https://docs.google.com';
 const EXAMPLE_URL = 'https://example.com';
 const GOOGLE_ANALYTICS_URL = 'https://www.google-analytics.com';
 const GOOGLE_TAG_MANAGER_URL = 'https://www.googletagmanager.com';
+// GA4 Google Signals sends a beacon to google.com/g/collect (connect-src only).
+const GOOGLE_URL = 'https://www.google.com';
 const SENTRY_URL = 'https://www.sentry.io';
 const SENTRY_INGEST_URL = 'https://*.ingest.us.sentry.io';
 const SCHEMA_ORG_URL = 'https://schema.org';
@@ -41,6 +43,7 @@ export const allowedImageOrigins = [
 
 export const allowedOrigins = [
   ...allowedImageOrigins,
+  GOOGLE_URL,
   DOMAIN_URL,
   SENTRY_URL,
   SENTRY_INGEST_URL,


### PR DESCRIPTION
## Summary
First task of **Phase 3 (technical excellence)** — a clean console on an engineer's own site. Both production CSP console errors are now gone.

| Error | Cause | Fix |
|---|---|---|
| Inline script blocked by `strict-dynamic` | The root layout's no-flash `reveal-ready` script had no nonce | Read the proxy's `x-nonce` and apply it (mirrors `Head.tsx`) |
| `google.com/g/collect` blocked | GA4 Google Signals beacon not in `connect-src` | Allowlist `https://www.google.com` (connect-src only) |

The nonce miss wasn't just noise — it **silently defeated the no-flash optimization**: `reveal-ready` was only added after hydration, not before paint. Now it's set pre-paint as intended.

`https://www.google.com` was allowlisted (your call) to keep GA Google Signals/demographics while clearing the console.

## Validation
**Gate:** `pnpm tsc --noEmit` clean · `pnpm nx test root` passes · ESLint clean.

**Positive (production build, fresh isolated context — no SW cache):**
- **0 console errors** on home + a detail route (was 3).
- GA still fires (`gtag` present, `dataLayer` populated); `reveal-ready` set before paint.

**Negative / guard checks (proving the CSP wasn't weakened):**
- script-src still carries `'nonce-…' 'strict-dynamic'`, and **no `'unsafe-inline'`**.
- connect-src has **no `https:`/`*` wildcard** — only `https://www.google.com` was added.
- An **un-nonced inline `<script>` is still blocked** (strict-dynamic intact).
- A **fetch to a non-allowlisted origin (`example.org`) is still blocked** by connect-src.

> Note: a stale **service worker** can keep serving the old shell — verify in a fresh/incognito window or after unregistering the SW.

🤖 Generated with [Claude Code](https://claude.com/claude-code)