### PR TITLE
perf(search): defer the 288KB command-palette index to first open

### DIFF
--- a/apps/root/src/components/CommandPalette.tsx
+++ b/apps/root/src/components/CommandPalette.tsx
@@ -13,9 +13,22 @@ import { Command } from 'cmdk';
 import { Search, FileText, Briefcase, BookOpen, Globe } from 'lucide-react';
 import { Text } from '@danieljoffe/shared-ui/Text';
 import { cn } from '@/lib/cn';
-import { buildSearchIndex, type SearchEntry } from '@/lib/searchIndex';
+import { type SearchEntry } from '@/lib/searchIndex';
 import { Z_INDEX } from '@/utils/constants';
-import { createSearchEngine, searchWithHighlights } from '@/lib/search';
+
+// MiniSearch + the ~288KB content index are only needed once the palette
+// opens, so they're dynamically imported on first open (a separate chunk)
+// instead of shipping in the bundle that loads on every page.
+type SearchEngine = ReturnType<
+  (typeof import('@/lib/search'))['createSearchEngine']
+>;
+type SearchHighlightsFn =
+  (typeof import('@/lib/search'))['searchWithHighlights'];
+type SearchData = {
+  entries: SearchEntry[];
+  engine: SearchEngine;
+  searchWithHighlights: SearchHighlightsFn;
+};
 
 const TYPE_ICONS: Record<SearchEntry['type'], typeof Search> = {
   project: FileText,
@@ -70,22 +83,34 @@ export default function CommandPalette() {
     return () => cancelAnimationFrame(id);
   }, [open]);
 
-  const { engine, entries } = useMemo(() => {
-    try {
-      const entries = buildSearchIndex();
-      const engine = createSearchEngine(entries);
+  const [searchData, setSearchData] = useState<SearchData | null>(null);
 
-      return { engine, entries };
-    } catch (error) {
-      console.error('Failed to build search index:', error);
-      return { engine: null, entries: [] };
-    }
-  }, []);
+  // Build the index the first time the palette opens, loading MiniSearch and
+  // the content index as a separate chunk so they stay off every page's load.
+  useEffect(() => {
+    if (!open || searchData) return;
+    let cancelled = false;
+    void Promise.all([import('@/lib/searchIndex'), import('@/lib/search')])
+      .then(([idx, searchMod]) => {
+        if (cancelled) return;
+        const entries = idx.buildSearchIndex();
+        setSearchData({
+          entries,
+          engine: searchMod.createSearchEngine(entries),
+          searchWithHighlights: searchMod.searchWithHighlights,
+        });
+      })
+      .catch(error => console.error('Failed to load search index:', error));
+    return () => {
+      cancelled = true;
+    };
+  }, [open, searchData]);
 
   const results = useMemo(() => {
-    if (!engine || !entries.length) {
+    if (!searchData || !searchData.entries.length) {
       return { grouped: {}, isSearching: false };
     }
+    const { engine, entries, searchWithHighlights } = searchData;
 
     if (!search.trim()) {
       const grouped: Partial<Record<SearchEntry['type'], SearchEntry[]>> = {};
@@ -105,7 +130,7 @@ export default function CommandPalette() {
       console.error('Search failed:', error);
       return { grouped: {}, isSearching: false };
     }
-  }, [search, engine, entries]);
+  }, [search, searchData]);
 
   // Cmd+K / Ctrl+K toggle
   useEffect(() => {
@@ -314,7 +339,7 @@ export default function CommandPalette() {
 
           <Command.List className='max-h-96 overflow-y-auto'>
             <Command.Empty className='px-4 py-8 text-center text-sm text-neutral-400'>
-              No results found.
+              {searchData ? 'No results found.' : 'Loading…'}
             </Command.Empty>
 
             {hasGroupedResults && (


### PR DESCRIPTION
## Summary
Phase 3 perf. The production Lighthouse score is **96** — held back only by **TBT (210ms, 88)** and **TTI (5.3s, 73)**, both pure JS-execution. I profiled the bundle to find what's eager and deferrable.

### What I found
- **Sentry** (~507KB chunk): already well-optimized — `integrations: []` with browser-tracing + replay deferred post-load and low sample rates. Left as-is.
- **The command palette** is mounted on every page (for the ⌘K listener) and statically imported **MiniSearch + the ~288KB generated content index** — so that parsed + indexed on every page's post-hydration path, for a feature most visitors never open.

### The fix
Make the heavy search imports **type-only** and **dynamically import** MiniSearch + the index on first open (a separate chunk). The palette shell (⌘K listener, dialog, focus trap) stays light; first open shows a brief "Loading…" then results; later opens are instant.

## Validation (production build, fresh isolated context)
- **283KB search chunk no longer loads on the home page** (`searchChunkLoadedOnHome: false`) — it loads on first ⌘K (`searchChunkLoadedAfterOpen: true`).
- **Search still works**: typing "llm" returns 8 results ("Operating LLM Pipelines…").
- **A11y intact**: the focus trap from #1047 still holds (focus never escapes the palette).
- `pnpm tsc --noEmit` clean · root tests pass (incl. `CommandPalette.spec`) · ESLint clean · prod build succeeds.

## Honest note on the score
I can't measure the prod Lighthouse delta from here (no deploy), so I'm not claiming a specific 96→N. What's **measured** is the deterministic cause: ~283KB of parse+index work removed from every page's post-hydration path, which is exactly what TBT/TTI pay for. The score should improve on the next deploy; worth confirming with a post-deploy audit.

Trade-off: first ⌘K has a ~one-chunk load delay (brief "Loading…"); search isn't a critical-path action, so this is a good trade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Negative / edge cases
- **The deferral assertion is itself the guard**: `searchChunkLoadedOnHome` would be `true` if the lazy split silently broke (e.g. a stray static import pulling the index back into an eager chunk). It's `false` — so the guard would catch a regression.
- **Import-failure path is handled**: the dynamic `import()` has a `.catch()` that logs and leaves the palette in its "Loading…" state rather than crashing — no unhandled rejection, no broken UI.
- **Open/close race is guarded**: a `cancelled` flag prevents `setSearchData` from firing after the palette closes/unmounts mid-load.
- **First-open latency tested**: typed a query immediately after opening (before the chunk settled) and results still appeared once the index resolved.