### PR TITLE
content(case-studies): restructure the 2 non-featured legacy studies + fix banned phrases

### DIFF
--- a/apps/root/src/data/content/projects/accessibility-serials-study-case.mdx
+++ b/apps/root/src/data/content/projects/accessibility-serials-study-case.mdx
@@ -18,91 +18,16 @@ export const metadata = {
   },
 };
 
-## Case Study 4: The Library Corporation — Accessibility & Serials Cataloging
+I fixed 200+ WCAG violations across The Library Corporation's cataloging apps in about a month, which was the work that got the company's government contracts renewed; accessibility compliance was a hard requirement to keep selling to public institutions. It mattered because those apps reach 5,500+ school and public libraries nationwide, so every unlabeled input and broken focus state was a real barrier for real users. Three months in, the lead developer moved off the project and I became the sole frontend developer for the next 23 months, on my first Java codebase and in a domain I'd never touched.
 
-## Overview
+## The remediation
 
-**Company:** The Library Corporation
+The cataloging apps were legacy Java Spring and Thymeleaf templates that had accumulated accessibility debt for years: missing alt text, missing input labels and ARIA roles, broken links and empty buttons, low contrast, out-of-order headings, and no visible focus states. I audited 15+ views with WebAIM and browser tools, categorized and prioritized the 200+ violations, then worked through them systematically over roughly a month, fixing the markup and pulling it back toward semantic HTML as I went.
 
-**Role:** Software Engineer
+## The serials cataloging system
 
-**Duration:** September 2019 - November 2021
+With the apps compliant, I took on the feature that had been requested for years and never delivered. I worked closely with a retiring senior cataloger to learn library science well enough to translate cataloging workflows into UI, then architected and built the serials cataloging system alone: pagination, advanced search filtering, and an algorithm-driven serial generator that handled limited and indefinite schedules, multiple formats from periodicals to academic journals, create/clone/duplicate/generate operations, cadences from daily through biannual, and Volume/Part/Issue/Index/Section types. To keep it from sprawling, I built polymorphic AngularJS components where a single component class handled books, magazines, encyclopedias, and serials, which killed the need for asset-specific forms and kept the design language consistent. Across 30+ delivered features I roughly doubled the application's capabilities, and accessibility testing patterns I established along the way kept new work from regressing.
 
-**Industry:** Library Software / B2B SaaS
+## What I took from it
 
-## Business Impact
-
-- Achieved WCAG compliance, reducing legal exposure for accessibility-related claims
-- Improved usability for users with disabilities, expanding the accessible user base
-- Established accessibility testing patterns that prevented future regressions
-
-## The Challenge
-
-The Library Corporation serves 5,500+ school and public libraries across the United States, and their cataloging applications were overdue for modernization: accessibility compliance was mandatory for government contracts, and a major serials cataloging feature had been requested for years but never delivered. Three months in, the lead developer moved to another project, and I was suddenly the sole frontend developer for the next 23 months.
-
-### Key Problems:
-
-- Legacy Java Spring/Thymeleaf templates with accessibility violations
-- WCAG compliance required for government contract renewals
-- Serials cataloging feature postponed for years
-- Sole frontend developer for 23 months
-- Unfamiliar domain (library science) and tech stack (first Java project)
-- Waterfall methodology with long feedback cycles
-
-## My Approach
-
-### First: Accessibility Remediation
-
-- Audited 15+ views using WebAIM and browser tools
-- Categorized and prioritized 200+ WCAG violations
-- Systematically fixed issues over 1 month:
-  - Missing alt text on images
-  - Missing input labels and ARIA roles
-  - Broken links and empty buttons
-  - Low contrast and incorrect heading order
-  - Missing focus states and semantic HTML
-
-### Second: Domain Immersion
-
-- Collaborated closely with retiring senior cataloger (SME)
-- Learned library science fundamentals and cataloging workflows
-- Translated complex requirements into intuitive UI patterns
-
-### Third: Serials Cataloging System
-
-- Architected year-long initiative as sole frontend developer
-- Built pagination, advanced search filtering, and navigation patterns
-- Developed algorithm-driven serial generation handling:
-  - Limited and indefinite schedules
-  - Multiple formats (periodicals, magazines, academic journals)
-  - Create/clone/duplicate/generate operations
-  - Cadence options (daily through biannual)
-  - Volume, Part, Issue, Index, Section types
-
-### Fifth: Polymorphic Component Architecture
-
-- Engineered scalable cataloging components using AngularJS directives
-- Single component class handling multiple asset types (books, magazines, encyclopedias, serials)
-- Reduced code duplication while maintaining consistent design language
-- Eliminated need for asset-specific forms
-
-## The Results
-
-| Metric                    | Value     | Impact                      |
-| ------------------------- | --------- | --------------------------- |
-| WCAG Violations Fixed     | 200+      | Full compliance achieved    |
-| Libraries Served          | 5,500+    | Nationwide impact           |
-| Solo Developer Duration   | 23 months | Resilience demonstrated     |
-| Features Delivered        | 30+       | Serials cataloging complete |
-| Application Feature Count | 2x        | Doubled capabilities        |
-| Government Contracts      | Renewed   | Compliance unlocked revenue |
-
-## Key Takeaways
-
-- **Domain expertise matters.** Technical skills don't get you far without understanding user needs, and librarians have complex, specialized workflows.
-- **Accessibility isn't optional.** It's not just about compliance; fixing these issues made the apps easier to use for everyone.
-- **Running solo builds confidence.** Holding the frontend alone for 23 months in a domain I'd never touched proved to me I could adapt to just about anything.
-
-## Technologies Used
-
-AngularJS, JavaScript ES6+, Java, Spring, Thymeleaf, HTML5, CSS3, WebAIM, WCAG 2.0 AA, Git, Browser Accessibility Tools
+Holding the frontend alone for 23 months in an unfamiliar domain and stack taught me that the accessibility fixes weren't a compliance chore bolted on at the end; building semantic, labeled, keyboard-navigable markup from the start made the apps easier to use for everyone, sighted users included.

--- a/apps/root/src/data/content/projects/logistics-dashboard-study-case.mdx
+++ b/apps/root/src/data/content/projects/logistics-dashboard-study-case.mdx
@@ -18,78 +18,16 @@ export const metadata = {
   },
 };
 
-## Case Study 5: Contract Work — Logistics Dashboard MVP
+I shipped a working logistics dashboard MVP in three months, on the deadline pinned to the founder's investor presentations, so the startup could start user testing on schedule. The catch was that the backend didn't exist yet: the frontend had to be ready to wire up to an API that hadn't been built. The work came from a former CEO I'd worked with at Winc, who was launching a logistics and operations venture and needed something concrete to put in front of investors and validate the concept.
 
-## Overview
+## Building API-ready against a backend that didn't exist
 
-**Company:** Seed-Stage Logistics Venture
+With no backend to integrate against, I designed the component structure to scale later and planned explicit integration points where the API would eventually plug in, on TypeScript patterns that kept everything type-safe. For login I wired up AWS Cognito and built role-based access control on top of it, carving out distinct permission levels for the three user types: shippers got a dashboard for outbound logistics metrics, receivers got inbound tracking and delivery management, and sales teams got pipeline and customer views. The data visualization layer was chart-ready components built to take real-time updates once the API was live, with layouts responsive across desktop and tablet.
 
-**Role:** Contracted Engineer
+## What I shipped
 
-**Duration:** May 2023 - August 2023
+I delivered the MVP inside the three-month window and handed over complete documentation so the client's team could maintain and extend it without me. The whole engagement came from a relationship rather than a job board, which is its own reminder that earlier work pays off later; the discipline that made it work was scoping hard to the deadline while still building for the scale that would come.
 
-**Industry:** Logistics / Operations
+## What I took from it
 
-## Business Impact
-
-- Delivered working MVP within 3-month deadline, enabling the startup to begin user testing on schedule
-- Implemented enterprise-grade authentication (AWS Cognito) with 3 distinct user roles
-- Provided complete handoff documentation, allowing the client's team to maintain and extend independently
-
-## The Challenge
-
-A former CEO I'd worked with at Winc was launching a new logistics and operations venture, and he needed a frontend MVP to show the platform to investors and validate the concept. The backend wasn't built yet, so the frontend had to be ready to wire up to an API that didn't exist yet.
-
-### Key Problems:
-
-- A 3-month timeline pinned to investor presentations
-- Multiple user roles, each with different access needs
-- No backend yet, so the frontend had to be API-ready
-- Real-time data visualization to build for
-- Authentication and security that couldn't be hand-waved
-
-## My Approach
-
-### First: Architecture Planning
-
-- Designed the component structure so it could scale later
-- Planned the API integration points where the backend would eventually plug in
-- Established TypeScript patterns to keep things type-safe
-
-### Second: Authentication System
-
-- Wired up AWS Cognito for the authentication
-- Built a role-based access control system on top of it
-- Carved out distinct permission levels for the different user types
-
-### Third: Role-Based Interfaces
-
-- **Shippers:** a dashboard for outbound logistics metrics
-- **Receivers:** inbound tracking and delivery management
-- **Sales Teams:** pipeline and customer metrics views
-
-### Fourth: Visualization Components
-
-- Built chart-ready components using modern patterns
-- Designed them to take real-time data updates
-- Made the layouts responsive for desktop and tablet
-
-## The Results
-
-| Deliverable            | Status       | Impact                           |
-| ---------------------- | ------------ | -------------------------------- |
-| Production-Ready MVP   | Delivered    | Supported investor presentations |
-| Timeline               | 3 months     | Met deadline                     |
-| Authentication         | AWS Cognito  | Secure, scalable                 |
-| Role-Based Access      | 3 user types | Distinct experiences             |
-| API-Ready Architecture | Complete     | Backend integration ready        |
-
-## Key Takeaways
-
-- **Professional relationships matter.** This whole thing came from a former CEO who'd valued my earlier work, not from a job board.
-- **MVP discipline is crucial.** I scoped it to fit the timeline while still building for the scale that would come later.
-- **Frontend-first can work.** Building API-ready components before the backend existed let both sides move in parallel.
-
-## Technologies Used
-
-Next.js, React, TypeScript, AWS Cognito, Role-Based Access Control, Chart.js, Tailwind CSS, Vercel
+Building API-ready components before the backend existed let both sides move in parallel instead of one waiting on the other, and that frontend-first sequencing is what kept a three-month MVP on schedule.


### PR DESCRIPTION
## Summary
Finishes the case-study cleanup started in #1049. The two remaining legacy studies — **The Library Corporation** (accessibility-serials) and the **logistics dashboard MVP** — used the same old `## Business Impact` bullet opening + numbered scaffold. Restructured both to the prose-hook shape the rest of the portfolio now uses.

| Study | New opening hook |
|---|---|
| **The Library Corporation** | "I fixed 200+ WCAG violations across … cataloging apps in about a month, which was the work that got the company's government contracts renewed…" |
| **Logistics MVP** | "I shipped a working logistics dashboard MVP in three months, on the deadline pinned to the founder's investor presentations…" |

**Banned phrases fixed** (the audit's vague-authority flags):
- "reducing legal exposure" → the concrete outcome that was already in the file (compliance is what got the government contracts renewed).
- "enterprise-grade authentication" → **AWS Cognito** named plainly ("I wired up AWS Cognito and built role-based access control on top of it").

Structural only — every number preserved, nothing invented. Net **−151 / +14 lines**.

## Validation
- Anti-pattern + banned-phrase grep: clean (zero). Headings h1→h2, no skips.
- Build: all 69 content files validate, MDX compiles.

## Note on the rest of the "prune" task
The audit also flagged `ui-components-v1` and `portfolio-modern-practice` as thin/redundant. **I did not delete them** — `ui-components-v1` turns out to be woven into the content graph (`ui-components-v2` and `shared-ui` both link to it, a blog post tells a story about its cover image, and a test asserts it's `projects[0]`), so deleting it breaks links + a test. Recommendation in the PR thread / chat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Validation completeness (content-only)
2 MDX files, no code — so the guards are content-validation + voice, both exercised:
- **Anti-pattern/banned-phrase grep is the negative check**: it greps for `enterprise-grade`, `reducing legal exposure`, em-dashes, rhetorical questions, etc. — all zero. It *would* fail if a banned phrase survived (it's the same gate that caught "unlocked" on #1049).
- **Content-validation guard**: prod build validates all 69 files (frontmatter, tags, MDX compile) — green.
- **Content unit tests**: `contentRegistry` + content specs (3 suites / 34 tests) pass — ordering/slugs unaffected (these edits change prose + heading levels only, not `order`/`slug`/`featured`).