### PR TITLE
feat(home): conversion fixes — availability signal, visible email, full-stack-first grid

### DIFF
--- a/apps/root/src/app/(public)/page.tsx
+++ b/apps/root/src/app/(public)/page.tsx
@@ -42,8 +42,12 @@ const companies = getContentByType('experience').map(e => ({
   company: e.metadata.company ?? e.metadata.title,
   logo: e.metadata.logo,
 }));
+// Reversed so the grid leads with the newest, full-stack flagship work
+// (WyrdFold, api-performance, job-pipeline) rather than the oldest frontend
+// studies — matches the descending order on /projects.
 const featuredProjects = getContentByType('project')
   .filter(e => e.thumbnail.featured)
+  .reverse()
   .map(e => e.thumbnail);
 
 export default function Index() {
@@ -63,6 +67,13 @@ export default function Index() {
         <Container size='sm'>
           <div className='relative space-y-6'>
             <div className='flex flex-wrap items-center gap-x-5 gap-y-2 text-sm text-text-tertiary'>
+              <span className='inline-flex items-center gap-1.5 rounded-full bg-emerald-500/15 px-2.5 py-0.5 text-xs font-medium text-emerald-800 dark:text-emerald-300'>
+                <span
+                  className='h-1.5 w-1.5 rounded-full bg-emerald-600'
+                  aria-hidden='true'
+                />
+                Open to full-time roles
+              </span>
               <IconText icon={<MapPin className='h-3.5 w-3.5' />}>
                 Los Angeles, CA
               </IconText>

--- a/apps/root/src/app/(public)/page.tsx
+++ b/apps/root/src/app/(public)/page.tsx
@@ -67,7 +67,7 @@ export default function Index() {
         <Container size='sm'>
           <div className='relative space-y-6'>
             <div className='flex flex-wrap items-center gap-x-5 gap-y-2 text-sm text-text-tertiary'>
-              <span className='inline-flex items-center gap-1.5 rounded-full bg-emerald-500/15 px-2.5 py-0.5 text-xs font-medium text-emerald-800 dark:text-emerald-300'>
+              <span className='inline-flex items-center gap-1.5 rounded-full bg-emerald-100 px-2.5 py-0.5 text-xs font-medium text-emerald-800 dark:bg-emerald-950 dark:text-emerald-300'>
                 <span
                   className='h-1.5 w-1.5 rounded-full bg-emerald-600'
                   aria-hidden='true'

--- a/apps/root/src/app/home/HeroActions.tsx
+++ b/apps/root/src/app/home/HeroActions.tsx
@@ -34,17 +34,19 @@ export default function HeroActions() {
         <Download className='h-4 w-4' />
         Download resume
       </Button>
-      <a
+      <Button
+        as='link'
         href={`mailto:${EMAIL_ADDRESS}`}
+        variant='secondary'
+        size='sm'
         aria-label={`Email ${EMAIL_ADDRESS}`}
-        className='inline-flex items-center gap-1.5 text-sm text-text-tertiary hover:text-text-primary transition-colors'
         onClick={() =>
           analytics.ctaClick('email_hero', `mailto:${EMAIL_ADDRESS}`)
         }
       >
         <Mail className='h-4 w-4' />
         {EMAIL_ADDRESS}
-      </a>
+      </Button>
     </div>
   );
 }

--- a/apps/root/src/app/home/HeroActions.tsx
+++ b/apps/root/src/app/home/HeroActions.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { ArrowUpRight, Download } from 'lucide-react';
-import { PROJECTS_LINK, HOME_LINK } from '@/utils/constants';
+import { ArrowUpRight, Download, Mail } from 'lucide-react';
+import { PROJECTS_LINK, HOME_LINK, EMAIL_ADDRESS } from '@/utils/constants';
 import { downloadResume } from '@/utils/helpers';
 import { analytics } from '@/lib/analytics';
 import Button from '@/components/Button';
@@ -34,6 +34,17 @@ export default function HeroActions() {
         <Download className='h-4 w-4' />
         Download resume
       </Button>
+      <a
+        href={`mailto:${EMAIL_ADDRESS}`}
+        aria-label={`Email ${EMAIL_ADDRESS}`}
+        className='inline-flex items-center gap-1.5 text-sm text-text-tertiary hover:text-text-primary transition-colors'
+        onClick={() =>
+          analytics.ctaClick('email_hero', `mailto:${EMAIL_ADDRESS}`)
+        }
+      >
+        <Mail className='h-4 w-4' />
+        {EMAIL_ADDRESS}
+      </a>
     </div>
   );
 }

--- a/apps/root/src/components/Footer/index.tsx
+++ b/apps/root/src/components/Footer/index.tsx
@@ -55,6 +55,12 @@ export default function Footer() {
             <Text variant='detail' className='mt-0.5'>
               {profileData.title}
             </Text>
+            <a
+              href={`mailto:${profileData.social.email}`}
+              className={`mt-1 inline-block text-sm text-text-secondary hover:text-text-primary hover:underline transition-colors ${FOCUS_RING} ${FOCUS_RING_OFFSET} rounded-sm`}
+            >
+              {profileData.social.email}
+            </a>
           </div>
           <div className='flex items-center gap-1'>
             {socialLinks.map(({ href, label, icon: Icon }) => (

--- a/apps/root/src/data/content/projects/api-performance-case-study.mdx
+++ b/apps/root/src/data/content/projects/api-performance-case-study.mdx
@@ -19,6 +19,7 @@ export const metadata = {
   type: 'project',
   role: 'Solo Developer',
   duration: 'April 2026',
+  featured: true,
   cover: {
     alt: 'Industrial gauges and pressure meters on metal pipes',
     src: '/images/covers/api-performance-case-study.webp',

--- a/apps/root/src/data/content/projects/job-pipeline-case-study.mdx
+++ b/apps/root/src/data/content/projects/job-pipeline-case-study.mdx
@@ -19,6 +19,7 @@ export const metadata = {
   type: 'project',
   role: 'Solo Developer',
   duration: 'April 2026',
+  featured: true,
   cover: {
     alt: 'Organized filing cards in a wooden tray',
     src: '/images/covers/job-pipeline-case-study.webp',


### PR DESCRIPTION
## Summary
**Phase 5 (conversion & funnel), first batch.** From a hiring-manager first-impression audit of the live site, three gaps were costing reach-outs. All three were your calls (availability wording, email visibility, ordering).

| Gap | Fix |
|---|---|
| **No availability signal above the fold** — the "open to roles" copy sat ~3.5 screens down | Added an **"Open to full-time roles"** badge to the hero meta row (location/tenure). A 30-second skim sees it in the first 5 seconds. |
| **Contact was form-only**, email buried as one footer icon | Surfaced **hello@danieljoffe.com** as a visible `mailto:` in the hero CTA row **and** the footer — low-friction, and a fallback if the captcha ever fails. |
| **Featured grid led with the oldest *frontend* studies**, WyrdFold buried last | Reversed the home grid (descending, matching `/projects`) and featured `job-pipeline` + `api-performance`, so the **lead row is all full-stack** (WyrdFold → API Performance → Job Pipeline). |

### Note on the "broken contact form" finding
The audit flagged the contact form as a dead end (captcha never loads, submit blocked). **Re-grounded: not a real bug** — the CSP explicitly allows hCaptcha (`frame-src`/`connect-src` list it; `strict-dynamic` lets the widget's script inject), and the failure is hCaptcha refusing the *automation* browser. Worth a 10-second check in your own incognito window, but I didn't treat it as urgent. The visible-email change gives a fallback regardless.

## Validation
- In a **production build** (fresh context): badge renders; both `mailto:hello@danieljoffe.com` links present (hero + footer); featured grid leads WyrdFold → API Performance → Job Pipeline (all full-stack), then FightCamp (Full-Stack Engineer), then the two Frontend cards.
- `pnpm tsc --noEmit` clean · ESLint clean · **66 suites / 589 tests** pass · build validates 68 content files.

## Still open in Phase 5 (your call, later)
The persona also noted the contact form asks the right (minimal) fields; a "what GA already shows" review; and whether to add a one-pager beyond the resume. Happy to take any of those next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Negative / guard checks
- **Full suite (589 tests) is the regression guard**: featuring two more projects changes the featured set; the whole root suite still passes, so no count/render/order test broke — and the count assertions would have failed if the set changed unexpectedly (they did exactly that on the prune PR #1052).
- **The grid-order assertion is the proof the reverse worked**: the in-browser check reads the actual rendered card order (WyrdFold → API Performance → Job Pipeline → FightCamp → 2 frontend). If the `.reverse()` or the `featured` flags were wrong, it would read frontend-first — it doesn't.
- **The persona's 'broken form' finding was re-grounded, not trusted**: I checked the CSP source (it allows hCaptcha) and concluded it's an automation artifact, avoiding a fix for a non-bug.
- Both `mailto` links and the badge confirmed present in the rendered DOM, not just the source.