### PR TITLE
feat(contact): conversion fixes to the contact form

### DIFF
--- a/apps/root/src/app/(public)/about/Contact/Form.spec.tsx
+++ b/apps/root/src/app/(public)/about/Contact/Form.spec.tsx
@@ -88,14 +88,14 @@ describe('Contact Form', () => {
     expect(screen.getByLabelText(/name/i)).toBeRequired();
     expect(screen.getByLabelText(/email/i)).toBeRequired();
     expect(screen.getByLabelText(/message/i)).toBeRequired();
-    expect(screen.getByRole('button', { name: /submit/i })).toBeEnabled();
+    expect(screen.getByRole('button', { name: /send message/i })).toBeEnabled();
   });
 
   it('shows validation errors when submitting empty fields', async () => {
     const user = userEvent.setup();
     render(<Form />);
 
-    await user.click(screen.getByRole('button', { name: /submit/i }));
+    await user.click(screen.getByRole('button', { name: /send message/i }));
 
     await waitFor(() => {
       expect(screen.getByLabelText(/name/i)).toHaveAttribute(
@@ -111,7 +111,7 @@ describe('Contact Form', () => {
     render(<Form />);
 
     await fillValidFields(user);
-    await user.click(screen.getByRole('button', { name: /submit/i }));
+    await user.click(screen.getByRole('button', { name: /send message/i }));
 
     await waitFor(() => {
       expect(screen.getByRole('alert')).toHaveTextContent(/captcha/i);
@@ -131,7 +131,7 @@ describe('Contact Form', () => {
     await user.click(
       await screen.findByRole('button', { name: /solve captcha/i })
     );
-    await user.click(screen.getByRole('button', { name: /submit/i }));
+    await user.click(screen.getByRole('button', { name: /send message/i }));
 
     await waitFor(() => {
       expect(fetchMock).toHaveBeenCalledWith(
@@ -157,7 +157,7 @@ describe('Contact Form', () => {
     await user.click(
       await screen.findByRole('button', { name: /solve captcha/i })
     );
-    await user.click(screen.getByRole('button', { name: /submit/i }));
+    await user.click(screen.getByRole('button', { name: /send message/i }));
 
     await waitFor(() => {
       expect(mockToast).toHaveBeenCalledWith(

--- a/apps/root/src/app/(public)/about/Contact/Form.tsx
+++ b/apps/root/src/app/(public)/about/Contact/Form.tsx
@@ -257,7 +257,7 @@ export default function Form() {
                 DISABLED,
                 errors?.message && FIELD_ERROR
               )}
-              placeholder={`Hello, I'm interested in your services.\n\nBest regards,\nJohn Doe`}
+              placeholder="Hi Daniel — we're hiring a full-stack engineer and your work caught my eye. Are you open to a conversation?"
               autoComplete='off'
               rows={5}
               required
@@ -315,7 +315,7 @@ export default function Form() {
           }
           name='submit'
         >
-          {isSubmitting ? 'Submitting...' : 'Submit'}
+          {isSubmitting ? 'Sending…' : 'Send message'}
         </Button>
       </div>
 

--- a/apps/root/src/app/(public)/about/page.tsx
+++ b/apps/root/src/app/(public)/about/page.tsx
@@ -24,7 +24,12 @@ import { experiencePageSlugs } from '@/data/experience';
 import { getContentBySlug } from '@/data/contentRegistry';
 import { getContentByTag, tagToSlug } from '@/lib/tags';
 import { AllowedExperienceSlugs } from '@/types/base';
-import { FULL_NAME, JOB_TITLE, EXPERIENCE_LINK } from '@/utils/constants';
+import {
+  FULL_NAME,
+  JOB_TITLE,
+  EXPERIENCE_LINK,
+  EMAIL_ADDRESS,
+} from '@/utils/constants';
 import { CompanyLogo } from '@/components/kit';
 import Button from '@/components/Button';
 import SocialLinks from './SocialLinks';
@@ -300,6 +305,16 @@ export default function About() {
           <Text variant='meta' as='p'>
             <span className='font-semibold'>Response time:</span> Usually within
             24 hours
+          </Text>
+          <Text variant='meta' as='p'>
+            Prefer email? Reach me directly at{' '}
+            <a
+              href={`mailto:${EMAIL_ADDRESS}`}
+              className='font-medium text-brand-500 hover:underline'
+            >
+              {EMAIL_ADDRESS}
+            </a>
+            .
           </Text>
           <ContactForm />
         </CTACard>


### PR DESCRIPTION
## What

Three low-risk improvements to the about-page contact funnel:

1. **Submit button** "Submit" → **"Send message"** (clearer, warmer CTA; "Submitting…" → "Sending…").
2. **Message placeholder** reframed from the old sales pitch ("interested in your services") to a **hiring context** that fits the job search.
3. **Visible email alternative** — a "Prefer email? hello@danieljoffe.com" line above the form, so the section isn't form-only and anyone who bounces off the captcha still has a path.

## Why

Phase 5 / conversion follow-up. The form was the only contact path on `/about` and its copy read like a freelance sales funnel, not a hiring one.

## Safety

Validation, hCaptcha, honeypot, and `data-sentry-mask` PII masking are **unchanged**.

> Reminder: please confirm hCaptcha renders/submits in your own incognito browser — the earlier "dead end" was the automation browser being refused, not a real bug.

## Validation

- **Full unit suite green**: 66 suites / 589 tests (`pnpm nx test root`). `Form.spec.tsx` button queries updated to `/send message/i` (all 5 captcha/validation/success/error branches still pass).
- **Typecheck** clean · **lint** clean.
- **In-browser** (production build): `/about` 200; submit button reads "Send message"; the new placeholder and the "Prefer email" mailto line render and resolve to `mailto:hello@danieljoffe.com`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)