### PR TITLE
feat(analytics): coverage v2 — form-engage, footer, 404, search

### DIFF
--- a/apps/root/src/app/(public)/about/Contact/Form.spec.tsx
+++ b/apps/root/src/app/(public)/about/Contact/Form.spec.tsx
@@ -18,6 +18,7 @@ jest.mock('next/navigation', () => ({
 jest.mock('@/lib/analytics', () => ({
   analytics: {
     formStart: jest.fn(),
+    formEngage: jest.fn(),
     formSubmit: jest.fn(),
     formError: jest.fn(),
   },

--- a/apps/root/src/app/(public)/about/Contact/Form.tsx
+++ b/apps/root/src/app/(public)/about/Contact/Form.tsx
@@ -61,6 +61,14 @@ export default function Form() {
   const { toast } = useToast();
   const [shouldLoadCaptcha, setShouldLoadCaptcha] = useState(false);
   const captchaContainerRef = useRef<HTMLDivElement>(null);
+  // Fire form_engage once, on the first real field focus (form_start only means
+  // the form scrolled into view). focus bubbles via React's onFocus → focusin.
+  const engagedRef = useRef(false);
+  const handleFirstEngage = () => {
+    if (engagedRef.current) return;
+    engagedRef.current = true;
+    analytics.formEngage('contact');
+  };
 
   const {
     register,
@@ -169,6 +177,7 @@ export default function Form() {
       id={CONTACT_FORM_ID}
       className='flex flex-col gap-4 relative'
       onSubmit={handleSubmit(onSubmit)}
+      onFocus={handleFirstEngage}
       action=''
       aria-labelledby='contact-form-heading'
       noValidate

--- a/apps/root/src/app/(public)/about/SocialLinks.tsx
+++ b/apps/root/src/app/(public)/about/SocialLinks.tsx
@@ -53,7 +53,7 @@ export default function SocialLinks() {
       <button
         aria-label='Download Resume (PDF)'
         onClick={() => {
-          analytics.ctaClick('download_resume', PROJECTS_LINK.href);
+          analytics.ctaClick('resume_download', PROJECTS_LINK.href);
           downloadResume();
         }}
         className={`p-2 rounded-lg text-text-tertiary hover:text-text-primary hover:bg-surface-tertiary transition-colors cursor-pointer ${FOCUS_RING} ${FOCUS_RING_OFFSET}`}

--- a/apps/root/src/app/__tests__/not-found.spec.tsx
+++ b/apps/root/src/app/__tests__/not-found.spec.tsx
@@ -19,6 +19,11 @@ jest.mock('@/components/Footer', () => ({
   default: () => null,
 }));
 
+jest.mock('@/components/NotFoundTracker', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
 describe('NotFound', () => {
   it('renders the 404 heading', () => {
     render(<NotFound />);

--- a/apps/root/src/app/home/HeroActions.tsx
+++ b/apps/root/src/app/home/HeroActions.tsx
@@ -27,7 +27,7 @@ export default function HeroActions() {
         aria-label='Download resume'
         name='download-resume'
         onClick={() => {
-          analytics.ctaClick('download_resume', HOME_LINK.href);
+          analytics.ctaClick('resume_download', HOME_LINK.href);
           downloadResume();
         }}
       >

--- a/apps/root/src/app/not-found.tsx
+++ b/apps/root/src/app/not-found.tsx
@@ -6,12 +6,14 @@ import { notFoundMetadata } from '@/data/metadata/notFound';
 import Button from '@/components/Button';
 import Footer from '@/components/Footer';
 import Nav from '@/components/Nav';
+import NotFoundTracker from '@/components/NotFoundTracker';
 
 export const metadata: Metadata = notFoundMetadata;
 
 export default function NotFound() {
   return (
     <>
+      <NotFoundTracker />
       <Nav />
       <main>
         <div className='max-w-3xl mx-auto w-full px-4 sm:px-6 py-8 md:py-14'>

--- a/apps/root/src/components/CommandPalette.tsx
+++ b/apps/root/src/components/CommandPalette.tsx
@@ -12,6 +12,7 @@ import { useRouter } from 'next/navigation';
 import { Command } from 'cmdk';
 import { Search, FileText, Briefcase, BookOpen, Globe } from 'lucide-react';
 import { Text } from '@danieljoffe/shared-ui/Text';
+import { analytics } from '@/lib/analytics';
 import { cn } from '@/lib/cn';
 import { type SearchEntry } from '@/lib/searchIndex';
 import { Z_INDEX } from '@/utils/constants';
@@ -68,6 +69,7 @@ export default function CommandPalette() {
     triggerRef.current = document.activeElement as HTMLElement | null;
     selectedRef.current = false;
     setOpen(true);
+    analytics.searchOpen();
   }, []);
 
   // Restore focus to whatever opened the palette once it closes. Deferred to
@@ -169,9 +171,12 @@ export default function CommandPalette() {
     (url: string) => {
       selectedRef.current = true;
       setOpen(false);
+      // Only log when there was an actual query — an empty query means the
+      // palette was used as a launcher, not a search.
+      if (search.trim()) analytics.search(search, url);
       router.push(url);
     },
-    [router]
+    [router, search]
   );
 
   // Trap Tab within the dialog so focus can't reach the page behind the modal.

--- a/apps/root/src/components/Footer/index.tsx
+++ b/apps/root/src/components/Footer/index.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import Link from 'next/link';
 import { AtSign, Download, Github, Linkedin, ChevronRight } from 'lucide-react';
 import { Text } from '@danieljoffe/shared-ui/Text';
@@ -6,6 +8,7 @@ import {
   FOCUS_RING_OFFSET,
 } from '@danieljoffe/shared-ui/styles/formStyles';
 import { profileData } from '@/data/profileData';
+import { analytics } from '@/lib/analytics';
 import {
   FULL_NAME,
   NAV_LINKS,
@@ -20,21 +23,25 @@ const socialLinks = [
     href: `mailto:${profileData.social.email}`,
     label: 'Send Email',
     icon: AtSign,
+    cta: 'footer_email_icon',
   },
   {
     href: profileData.social.linkedin,
     label: 'Visit LinkedIn Profile',
     icon: Linkedin,
+    cta: 'footer_linkedin',
   },
   {
     href: profileData.social.github,
     label: 'Visit GitHub Profile',
     icon: Github,
+    cta: 'footer_github',
   },
   {
     href: RESUME_URL,
     label: 'Download Resume (PDF)',
     icon: Download,
+    cta: 'footer_resume',
   },
 ];
 
@@ -57,13 +64,19 @@ export default function Footer() {
             </Text>
             <a
               href={`mailto:${profileData.social.email}`}
+              onClick={() =>
+                analytics.ctaClick(
+                  'footer_email',
+                  `mailto:${profileData.social.email}`
+                )
+              }
               className={`mt-1 inline-block text-sm text-text-secondary hover:text-text-primary hover:underline transition-colors ${FOCUS_RING} ${FOCUS_RING_OFFSET} rounded-sm`}
             >
               {profileData.social.email}
             </a>
           </div>
           <div className='flex items-center gap-1'>
-            {socialLinks.map(({ href, label, icon: Icon }) => (
+            {socialLinks.map(({ href, label, icon: Icon, cta }) => (
               <a
                 key={label}
                 href={href}
@@ -71,6 +84,7 @@ export default function Footer() {
                 rel='noopener noreferrer'
                 aria-label={label}
                 title={label.replace(/^(Send |Visit |Download )/, '')}
+                onClick={() => analytics.ctaClick(cta, href)}
                 className={`inline-flex min-h-[40px] min-w-[40px] items-center justify-center rounded-lg text-text-tertiary hover:text-text-primary hover:bg-surface-tertiary transition-colors ${FOCUS_RING} ${FOCUS_RING_OFFSET}`}
               >
                 <Icon className='h-4 w-4' />
@@ -104,6 +118,9 @@ export default function Footer() {
             href={STORYBOOK_URL}
             target='_blank'
             rel='noopener noreferrer'
+            onClick={() =>
+              analytics.ctaClick('footer_storybook', STORYBOOK_URL)
+            }
             className={`flex items-center gap-1 rounded-sm ${FOCUS_RING} ${FOCUS_RING_OFFSET}`}
           >
             <Text variant='meta' as='span'>

--- a/apps/root/src/components/Footer/index.tsx
+++ b/apps/root/src/components/Footer/index.tsx
@@ -41,7 +41,8 @@ const socialLinks = [
     href: RESUME_URL,
     label: 'Download Resume (PDF)',
     icon: Download,
-    cta: 'footer_resume',
+    // All résumé-download triggers share one cta_name so it's a clean GA Key Event
+    cta: 'resume_download',
   },
 ];
 

--- a/apps/root/src/components/NotFoundTracker.tsx
+++ b/apps/root/src/components/NotFoundTracker.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import { useEffect } from 'react';
+import { usePathname } from 'next/navigation';
+import { analytics } from '@/lib/analytics';
+
+/**
+ * Fires a GA `not_found` event with the requested path when the 404 page mounts,
+ * so broken inbound links (stale URLs, mistyped paths) surface in analytics.
+ * Renders nothing.
+ */
+export default function NotFoundTracker() {
+  const pathname = usePathname();
+
+  useEffect(() => {
+    analytics.notFound(pathname);
+  }, [pathname]);
+
+  return null;
+}

--- a/apps/root/src/lib/analytics.spec.ts
+++ b/apps/root/src/lib/analytics.spec.ts
@@ -84,4 +84,31 @@ describe('analytics', () => {
       theme: 'dark',
     });
   });
+
+  it('tracks form engage events', () => {
+    analytics.formEngage('contact');
+    expect(mockGtag).toHaveBeenCalledWith('event', 'form_engage', {
+      form_name: 'contact',
+    });
+  });
+
+  it('tracks search open events', () => {
+    analytics.searchOpen();
+    expect(mockGtag).toHaveBeenCalledWith('event', 'search_open', {});
+  });
+
+  it('tracks search events with the query and destination', () => {
+    analytics.search('react', '/projects/component-library-case-study');
+    expect(mockGtag).toHaveBeenCalledWith('event', 'search', {
+      search_term: 'react',
+      destination: '/projects/component-library-case-study',
+    });
+  });
+
+  it('tracks not found events with the path', () => {
+    analytics.notFound('/old/dead/link');
+    expect(mockGtag).toHaveBeenCalledWith('event', 'not_found', {
+      page_path: '/old/dead/link',
+    });
+  });
 });

--- a/apps/root/src/lib/analytics.ts
+++ b/apps/root/src/lib/analytics.ts
@@ -15,9 +15,12 @@ export const analytics = {
   ctaClick: (ctaName: string, destination: string) =>
     trackEvent('cta_click', { cta_name: ctaName, destination }),
 
-  // Form events
+  // Form events. form_start fires when the form scrolls into view (impression);
+  // form_engage fires on first field focus (the real "started filling it in").
   formStart: (formName: string) =>
     trackEvent('form_start', { form_name: formName }),
+  formEngage: (formName: string) =>
+    trackEvent('form_engage', { form_name: formName }),
   formSubmit: (formName: string) =>
     trackEvent('form_submit', { form_name: formName }),
   formError: (formName: string, error: string) =>
@@ -35,4 +38,12 @@ export const analytics = {
   // Theme events
   themeToggle: (theme: 'light' | 'dark' | 'system') =>
     trackEvent('theme_toggle', { theme }),
+
+  // Site search (⌘K command palette)
+  searchOpen: () => trackEvent('search_open'),
+  search: (query: string, destination: string) =>
+    trackEvent('search', { search_term: query, destination }),
+
+  // 404s — surfaces broken inbound links by path
+  notFound: (path: string) => trackEvent('not_found', { page_path: path }),
 };


### PR DESCRIPTION
Surfaced by the GA funnel read. Closes the tracking gaps; the remaining (non-code) improvements are documented below for you to action in GA + your other sources.

## What ships (code)

| New event | Fires when | Params |
| --- | --- | --- |
| `form_engage` | first **field focus** on the contact form (vs `form_start` = scrolled into view) | `form_name` |
| `cta_click` (footer) | footer email / LinkedIn / GitHub / résumé / storybook click | `cta_name` (`footer_*`), `destination` |
| `not_found` | the 404 page mounts | `page_path` |
| `search_open` | ⌘K palette opens | — |
| `search` | a search result is selected | `search_term`, `destination` |

Plus a small cleanup: **all four résumé-download triggers** (hero, about, footer, /resume) now fire one `cta_name='resume_download'` (was three different names), so it's a clean GA Key Event.

This gives a real **viewed → engaged → submitted** contact funnel, footer contact-path tracking, broken-inbound-link visibility, and "what people search for."

## Validation
- Full suite green: **67 suites / 595 tests** (+4 new analytics tests); build compiles; lint clean.
- In-browser (prod build): all five events verified firing with correct params — incl. `form_engage` firing **once** (not on refocus), and `search` carrying `{search_term, destination}`.

---

## 📋 Non-code improvements — your checklist (GA + other sources)

### In GA4 (Admin)
- [ ] **Register custom dimensions** (Data display → Custom definitions, scope Event): **`search_term`**, **`page_path`**, `destination`. Forward-only, ~24–48h to populate.
- [ ] **Mark a `resume_download` Key Event** — now trivial since all downloads share one name: Events → Create event → Create without code → name `resume_download`, condition `event_name` equals `cta_click` AND `cta_name` equals `resume_download` → then Key events → New key event → `resume_download`. (Optionally do the same for email clicks, and mark `form_engage` mid-funnel.)
- [ ] **Data retention → 14 months** (Admin → Data settings). Default 2 months loses history.
- [ ] **Build a Funnel exploration**: `page_view` → `cta_click` → `form_engage` → `form_submit`.

### Source attribution (highest leverage — fixes the 75% "Direct")
- [ ] **UTM-tag every link you publish** (LinkedIn, résumé link, email signature, applications), e.g. `?utm_source=linkedin&utm_medium=profile&utm_campaign=job_search`.

### Other sources
- [ ] **Link Google Search Console to GA4** (Admin → Product links).
- [ ] **Add Vercel Web Analytics + Speed Insights** (privacy-first, real-user Core Web Vitals) — toggle in Vercel + I wire the code.
- [ ] **Cross-check the 1 GA `exception`** against Sentry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)