### PR TITLE
fix(sentry): production-only reporting + correct source-map project

### DIFF
--- a/apps/root/next.config.mjs
+++ b/apps/root/next.config.mjs
@@ -330,7 +330,7 @@ const finalConfig =
         // https://www.npmjs.com/package/@sentry/webpack-plugin#options
 
         org: 'testing-b1',
-        project: 'javascript-nextjs',
+        project: 'danieljoffe-portfolio',
 
         // Only print logs for uploading source maps in CI
         silent: !isCI,

--- a/apps/root/src/lib/sentry.config.ts
+++ b/apps/root/src/lib/sentry.config.ts
@@ -6,7 +6,11 @@ import type * as Sentry from '@sentry/nextjs';
 import { publicEnv } from '@/lib/public.env';
 import { isProduction } from '@/utils/helpers';
 
-export const sentryEnabled = !!publicEnv.NEXT_PUBLIC_SENTRY_CONFIG_ID;
+// Production-only: a DSN is present AND we're in production. This keeps local
+// dev / turbopack errors (e.g. transient RSC-bundler hiccups on localhost) out
+// of the Sentry project, instead of just tagging them environment=development.
+export const sentryEnabled =
+  !!publicEnv.NEXT_PUBLIC_SENTRY_CONFIG_ID && isProduction();
 
 export const sharedSentryConfig: Parameters<typeof Sentry.init>[0] = {
   dsn: publicEnv.NEXT_PUBLIC_SENTRY_CONFIG_ID as string,


### PR DESCRIPTION
## Why

Investigating a GA-reported `exception` (Option-A Sentry lookup) found it was a **dev-only turbopack RSC-bundler hiccup from localhost** (`environment: development`, 0 users) — not a real bug. But it exposed two real config problems.

## What

1. **Production-only Sentry** — `sentryEnabled` previously just checked "is a DSN set?", so local dev sent errors to the project. Now gated with `&& isProduction()`. One change in `lib/sentry.config.ts` covers server, edge, and client (all import the shared flag).
2. **Correct source-map project** — `next.config.mjs` had `project: 'javascript-nextjs'` (setup-wizard default). Pointed it at the real **`danieljoffe-portfolio`** project so production stack traces de-minify. (`org: 'testing-b1'` was already correct.)

## Validation
- Full suite green: **67 suites / 595 tests**; production build compiles.
- No Sentry-config specs to update; `withSentryConfig` is skipped in CI/test (only runs on the Vercel prod build), so tests are unaffected.

## Still needed (outside this PR — your side)
- **`SENTRY_AUTH_TOKEN`** in Vercel env (Production) so the prod build actually uploads source maps to `danieljoffe-portfolio`.
- Confirm `NEXT_PUBLIC_SENTRY_CONFIG_ID` (DSN) points at the `danieljoffe-portfolio` project.
- Bulk-resolve/mute the ~2,729 dead audit-api "fetch failed" issues so they stop burying real errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)