### PR TITLE
test(sentry): cover sentryEnabled production gating

### DIFF
--- a/apps/root/src/lib/sentry.config.spec.ts
+++ b/apps/root/src/lib/sentry.config.spec.ts
@@ -1,0 +1,41 @@
+/**
+ * `sentryEnabled` is evaluated at module load, so each case mocks its deps then
+ * re-requires the module in isolation.
+ */
+describe('sentryEnabled gating', () => {
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  const loadWith = (dsn: string, production: boolean): boolean => {
+    let enabled = false;
+    jest.isolateModules(() => {
+      jest.doMock('@/lib/public.env', () => ({
+        publicEnv: {
+          NEXT_PUBLIC_SENTRY_CONFIG_ID: dsn,
+          NEXT_PUBLIC_NODE_ENV: production ? 'production' : 'development',
+        },
+      }));
+      jest.doMock('@/utils/helpers', () => ({
+        isProduction: () => production,
+      }));
+      enabled = (require('./sentry.config') as { sentryEnabled: boolean })
+        .sentryEnabled;
+    });
+    return enabled;
+  };
+
+  const DSN = 'https://abc@o1.ingest.us.sentry.io/123';
+
+  it('is false when no DSN is set, even in production', () => {
+    expect(loadWith('', true)).toBe(false);
+  });
+
+  it('is false in development even with a DSN (no local/dev reporting)', () => {
+    expect(loadWith(DSN, false)).toBe(false);
+  });
+
+  it('is true only in production with a DSN', () => {
+    expect(loadWith(DSN, true)).toBe(true);
+  });
+});


### PR DESCRIPTION
Follow-up regression test for #1060 (which merged before this landed).

Proves the `sentryEnabled` guard:
- `false` without a DSN (even in production)
- `false` in development even with a DSN — **no local/dev reporting** (the behavior #1060 introduced)
- `true` only in production with a DSN

Module-load-time constant, so each case mocks deps + re-requires in isolation. 3 tests, passing; full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)