### PR TITLE
fix(csp): allow hCaptcha worker subdomains (contact form was broken)

### DIFF
--- a/apps/root/src/proxy.ts
+++ b/apps/root/src/proxy.ts
@@ -4,6 +4,7 @@ import {
   allowedImageOrigins,
   HCAPTCHA_URL,
   HCAPTCHA_ASSETS_URL,
+  HCAPTCHA_WILDCARD_URL,
   STORYBOOK_URL,
   CALENDLY_EMBED_URL,
 } from '@/utils/constants';
@@ -20,7 +21,7 @@ function buildCspValue(request: NextRequest, nonce: string): string {
     object-src 'none';
     base-uri 'self';
     form-action 'self';
-    frame-src ${HCAPTCHA_URL} ${HCAPTCHA_ASSETS_URL} ${STORYBOOK_URL} ${CALENDLY_EMBED_URL};
+    frame-src ${HCAPTCHA_URL} ${HCAPTCHA_ASSETS_URL} ${HCAPTCHA_WILDCARD_URL} ${STORYBOOK_URL} ${CALENDLY_EMBED_URL};
     frame-ancestors 'none';${
       request.nextUrl.protocol === 'https:'
         ? `\n    upgrade-insecure-requests;`

--- a/apps/root/src/utils/constants.ts
+++ b/apps/root/src/utils/constants.ts
@@ -15,6 +15,10 @@ const SENTRY_INGEST_URL = 'https://*.ingest.us.sentry.io';
 const SCHEMA_ORG_URL = 'https://schema.org';
 export const HCAPTCHA_URL = 'https://www.hcaptcha.com';
 export const HCAPTCHA_ASSETS_URL = 'https://newassets.hcaptcha.com';
+// hCaptcha serves challenge/telemetry from dynamic worker subdomains
+// (e.g. *.w.hcaptcha.com) at runtime, so the widget needs the wildcard on
+// connect-src + frame-src — www/newassets alone leave it CSP-blocked and blank.
+export const HCAPTCHA_WILDCARD_URL = 'https://*.hcaptcha.com';
 export const CALENDLY_EMBED_URL = 'https://calendly.com';
 
 // ============================================================================
@@ -49,6 +53,7 @@ export const allowedOrigins = [
   SENTRY_INGEST_URL,
   SCHEMA_ORG_URL,
   HCAPTCHA_URL,
+  HCAPTCHA_WILDCARD_URL,
 ];
 
 // ============================================================================


### PR DESCRIPTION
## 🔴 Real production bug — the contact form has been a dead end for everyone

Daniel checked the form in **incognito** and the hCaptcha widget didn't render. Live-site inspection showed the cause:

```
Refused to connect to https://<id>.w.hcaptcha.com/logo.png — violates connect-src
```

hCaptcha loads its challenge/telemetry from **dynamic worker subdomains** (`*.w.hcaptcha.com`) at runtime, but the CSP only allowlisted `www.hcaptcha.com` + `newassets.hcaptcha.com`. So `connect-src` blocked those requests and the widget rendered **blank** → no captcha token → no submit. **This is why GA showed contact-form views but zero submissions.**

(I'd earlier mis-diagnosed this as an automation-only artifact — Daniel's incognito test proved it's real.)

## Fix

Added `https://*.hcaptcha.com` to:
- **`connect-src`** (via `allowedOrigins`) — the blocked directive
- **`frame-src`** (in `proxy.ts`) — so the challenge iframe is covered too

New `HCAPTCHA_WILDCARD_URL` constant. `www`/`newassets` kept (harmless, subsumed by the wildcard).

## Validation
- Full suite green: **68 suites / 598 tests**; prod build compiles; typecheck clean.
- **In-browser (prod build)**: confirmed the served CSP now includes `*.hcaptcha.com` on both `connect-src` and `frame-src`, the hCaptcha iframe renders, and there are **zero hCaptcha CSP violations** (vs. the live site which had them).

## After merge
Deploy, then re-check the form in **incognito** — the widget should now render and submit. (The earlier "automation refused" behavior was a separate red herring; the CSP block was the real issue.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)