### PR TITLE
fix(e2e): match contact-form submit button by accessible name

### DIFF
--- a/apps/root-e2e/src/contact-form.spec.ts
+++ b/apps/root-e2e/src/contact-form.spec.ts
@@ -18,7 +18,9 @@ test.describe('contact form validation', () => {
     // instead of React's handleSubmit (no validation errors appear).
     await waitForHydration(page);
     await page.locator('form').waitFor({ state: 'visible' });
-    await expect(page.getByRole('button', { name: /submit/i })).toBeEnabled();
+    await expect(
+      page.getByRole('button', { name: /send message/i })
+    ).toBeEnabled();
   });
 
   test('form is visible on about page', async ({ page }) => {
@@ -27,7 +29,7 @@ test.describe('contact form validation', () => {
   });
 
   test('shows validation error for empty name field', async ({ page }) => {
-    const submitButton = page.getByRole('button', { name: /submit/i });
+    const submitButton = page.getByRole('button', { name: /send message/i });
     await submitButton.click();
 
     // Wait for validation to trigger and re-render
@@ -52,7 +54,7 @@ test.describe('contact form validation', () => {
     );
 
     // Submit form to trigger validation
-    const submitButton = page.getByRole('button', { name: /submit/i });
+    const submitButton = page.getByRole('button', { name: /send message/i });
     await submitButton.click();
 
     // Wait for validation error to appear
@@ -78,7 +80,7 @@ test.describe('contact form validation', () => {
     await fillInput(emailInput, INVALID_FORM_DATA.invalidEmail);
 
     // Submit form to trigger validation
-    const submitButton = page.getByRole('button', { name: /submit/i });
+    const submitButton = page.getByRole('button', { name: /send message/i });
     await submitButton.click();
 
     // Wait for validation error to appear
@@ -104,7 +106,7 @@ test.describe('contact form validation', () => {
     await fillInput(messageInput, INVALID_FORM_DATA.shortMessage);
 
     // Submit form to trigger validation
-    const submitButton = page.getByRole('button', { name: /submit/i });
+    const submitButton = page.getByRole('button', { name: /send message/i });
     await submitButton.click();
 
     // Wait for validation error to appear
@@ -129,7 +131,7 @@ test.describe('contact form validation', () => {
     await fillInput(messageInput, INVALID_FORM_DATA.messageWithUrl);
 
     // Submit form to trigger validation
-    const submitButton = page.getByRole('button', { name: /submit/i });
+    const submitButton = page.getByRole('button', { name: /send message/i });
     await submitButton.click();
 
     // Wait for validation error to appear
@@ -170,7 +172,9 @@ test.describe('contact form submission', () => {
     await page.goto('/about', { waitUntil: 'domcontentloaded' });
     await waitForHydration(page);
     await page.locator('form').waitFor({ state: 'visible' });
-    await expect(page.getByRole('button', { name: /submit/i })).toBeEnabled();
+    await expect(
+      page.getByRole('button', { name: /send message/i })
+    ).toBeEnabled();
 
     // Fill form with valid data
     await fillInput(
@@ -190,7 +194,7 @@ test.describe('contact form submission', () => {
     await completeHCaptcha(page);
 
     // Submit form
-    const submitButton = page.getByRole('button', { name: /submit/i });
+    const submitButton = page.getByRole('button', { name: /send message/i });
     await submitButton.click();
 
     // Wait for navigation to thank-you page
@@ -205,7 +209,9 @@ test.describe('contact form submission', () => {
     await page.goto('/about', { waitUntil: 'domcontentloaded' });
     await waitForHydration(page);
     await page.locator('form').waitFor({ state: 'visible' });
-    await expect(page.getByRole('button', { name: /submit/i })).toBeEnabled();
+    await expect(
+      page.getByRole('button', { name: /send message/i })
+    ).toBeEnabled();
 
     // Fill form with valid data
     await fillInput(
@@ -225,7 +231,7 @@ test.describe('contact form submission', () => {
     await completeHCaptcha(page);
 
     // Submit form
-    const submitButton = page.getByRole('button', { name: /submit/i });
+    const submitButton = page.getByRole('button', { name: /send message/i });
     await submitButton.click();
 
     // Wait for error alert
@@ -245,7 +251,9 @@ test.describe('contact form submission', () => {
     await page.goto('/about', { waitUntil: 'domcontentloaded' });
     await waitForHydration(page);
     await page.locator('form').waitFor({ state: 'visible' });
-    await expect(page.getByRole('button', { name: /submit/i })).toBeEnabled();
+    await expect(
+      page.getByRole('button', { name: /send message/i })
+    ).toBeEnabled();
 
     // Fill form with valid data
     await fillInput(
@@ -266,10 +274,12 @@ test.describe('contact form submission', () => {
     await form.scrollIntoViewIfNeeded();
 
     // Wait for the submit button to be ready
-    await expect(page.getByRole('button', { name: /submit/i })).toBeEnabled();
+    await expect(
+      page.getByRole('button', { name: /send message/i })
+    ).toBeEnabled();
 
     // Submit form without completing captcha
-    const submitButton = page.getByRole('button', { name: /submit/i });
+    const submitButton = page.getByRole('button', { name: /send message/i });
     await submitButton.click();
 
     // Should show captcha error - wait for it to appear using auto-waiting
@@ -281,7 +291,7 @@ test.describe('contact form submission', () => {
     await page.goto('/about', { waitUntil: 'domcontentloaded' });
     await page.locator('form').waitFor({ state: 'visible' });
 
-    const submitButton = page.getByRole('button', { name: /submit/i });
+    const submitButton = page.getByRole('button', { name: /send message/i });
     await expect(submitButton).toBeEnabled();
   });
 });

--- a/apps/root-e2e/src/error-handling.spec.ts
+++ b/apps/root-e2e/src/error-handling.spec.ts
@@ -96,7 +96,9 @@ test.describe('thank-you page protection', () => {
     await page.goto('/about', { waitUntil: 'domcontentloaded' });
     await waitForHydration(page);
     await page.locator('form').waitFor({ state: 'visible' });
-    await expect(page.getByRole('button', { name: /submit/i })).toBeEnabled();
+    await expect(
+      page.getByRole('button', { name: /send message/i })
+    ).toBeEnabled();
 
     // Fill and submit form — scope to form to avoid matching nav "Send Email" links
     const form = page.locator('form');
@@ -107,7 +109,7 @@ test.describe('thank-you page protection', () => {
     // Complete hCaptcha verification
     await completeHCaptcha(page);
 
-    const submitButton = page.getByRole('button', { name: /submit/i });
+    const submitButton = page.getByRole('button', { name: /send message/i });
     await submitButton.click();
 
     // Wait for navigation to thank-you page
@@ -127,7 +129,9 @@ test.describe('thank-you page protection', () => {
     await page.goto('/about', { waitUntil: 'domcontentloaded' });
     await waitForHydration(page);
     await page.locator('form').waitFor({ state: 'visible' });
-    await expect(page.getByRole('button', { name: /submit/i })).toBeEnabled();
+    await expect(
+      page.getByRole('button', { name: /send message/i })
+    ).toBeEnabled();
 
     const form1 = page.locator('form');
     await fillInput(form1.getByLabel(/name/i), VALID_FORM_DATA.name);
@@ -136,7 +140,7 @@ test.describe('thank-you page protection', () => {
 
     await completeHCaptcha(page);
 
-    await page.getByRole('button', { name: /submit/i }).click();
+    await page.getByRole('button', { name: /send message/i }).click();
     await expect(page).toHaveURL(/.*thank-you.*email/, { timeout: 15000 });
 
     // Check for noindex
@@ -155,7 +159,9 @@ test.describe('thank-you page protection', () => {
     await page.goto('/about', { waitUntil: 'domcontentloaded' });
     await waitForHydration(page);
     await page.locator('form').waitFor({ state: 'visible' });
-    await expect(page.getByRole('button', { name: /submit/i })).toBeEnabled();
+    await expect(
+      page.getByRole('button', { name: /send message/i })
+    ).toBeEnabled();
 
     const form2 = page.locator('form');
     await fillInput(form2.getByLabel(/name/i), VALID_FORM_DATA.name);
@@ -164,7 +170,7 @@ test.describe('thank-you page protection', () => {
 
     await completeHCaptcha(page);
 
-    await page.getByRole('button', { name: /submit/i }).click();
+    await page.getByRole('button', { name: /send message/i }).click();
     await expect(page).toHaveURL(/.*thank-you.*email/, { timeout: 15000 });
 
     // Check for the "Back to home" button (not the nav link, which is hidden on mobile)


### PR DESCRIPTION
## What

The contact-form E2E specs located the submit button with `getByRole('button', { name: /submit/i })`, but the button renders the label **"Send message"**. Its `name='submit'` attribute (required by the `require-button-name` lint rule) is the HTML `name`, which does **not** contribute to the accessible name Playwright matches on — so the locator found nothing and timed out.

This made the `full / full` CI job fail on `/about` across the **contact-form** and **error-handling** suites, which is what's blocking the `develop → main` release PR **#1063**.

## Fix

- Replace `/submit/i` → `/send message/i` in `contact-form.spec.ts` (14 sites) and `error-handling.spec.ts` (6 sites).
- Regex kept precise so it matches the submit button's resting label and won't collide with the nav **"Send Email"** link.

This aligns the E2E specs with the existing `Form.spec.tsx` unit test, which already queries `/send message/i`.

## Verification

- Pre-commit hooks (lint-staged + full typecheck) passed.
- Unit test (`Form.spec.tsx`) confirms the button's accessible name is "Send message".
- E2E will run on this PR; merging into `develop` unblocks #1063.

🤖 Generated with [Claude Code](https://claude.com/claude-code)