### PR TITLE
fix(e2e): sync project slugs and scope projects tag-filter aria-live

### DIFF
--- a/apps/root-e2e/src/fixtures/test-data.ts
+++ b/apps/root-e2e/src/fixtures/test-data.ts
@@ -5,7 +5,8 @@ export const PRIMARY_NAV_LINKS = [
   { href: '/about', label: 'About' },
 ];
 
-// Project slugs for parametrized tests (from apps/root/src/data/project.ts)
+// Project slugs for parametrized tests (mirrors projectPageSlugs in
+// apps/root/src/data/project.ts — keep in sync when projects are added/removed)
 export const PROJECT_SLUGS = [
   'ui-components-v1',
   'ui-components-v2',
@@ -13,8 +14,14 @@ export const PROJECT_SLUGS = [
   'component-library-case-study',
   'cms-tooling-case-study',
   'accessibility-serials-study-case',
-  'portfolio-modern-practice-study-case',
   'logistics-dashboard-study-case',
+  'contact-form-case-study',
+  'appcontext-simplification-case-study',
+  'job-pipeline-case-study',
+  'api-performance-case-study',
+  'audit-tool-case-study',
+  'shared-ui-case-study',
+  'wyrdfold-case-study',
 ];
 
 // Experience slugs for parametrized tests (from apps/root/src/data/experience.ts)

--- a/apps/root-e2e/src/project-tags.spec.ts
+++ b/apps/root-e2e/src/project-tags.spec.ts
@@ -32,9 +32,14 @@ test.describe('project listing and tag filtering', () => {
     // Click the tag to filter
     await firstTagButton.click();
 
-    // A filter summary should appear
-    const filterSummary = page.locator('[aria-live="polite"]');
-    await expect(filterSummary).toBeVisible();
+    // A filter summary should appear. Scope to the polite region that carries
+    // the tag-count text — the page has several aria-live="polite" regions
+    // (the site-wide RouteAnnouncer being the other), so an unscoped locator
+    // is a strict-mode violation.
+    const filterSummary = page
+      .locator('[aria-live="polite"]')
+      .filter({ hasText: /\d+ case stud(y|ies) tagged/ });
+    await expect(filterSummary).toBeVisible({ timeout: 15000 });
     await expect(filterSummary).toContainText(/\d+ case stud(y|ies) tagged/);
 
     // The number of visible projects should change (could be same if all match,
@@ -73,9 +78,13 @@ test.describe('project listing and tag filtering', () => {
     await firstTagButton.click();
     await expect(firstTagButton).toHaveAttribute('aria-pressed', 'true');
 
-    // Filter summary should be visible
-    const filterSummary = page.locator('[aria-live="polite"]');
-    await expect(filterSummary).toBeVisible();
+    // Filter summary should be visible. Scope to the tag-count polite region —
+    // the site-wide RouteAnnouncer is another aria-live="polite" element, so an
+    // unscoped locator is a strict-mode violation.
+    const filterSummary = page
+      .locator('[aria-live="polite"]')
+      .filter({ hasText: /\d+ case stud(y|ies) tagged/ });
+    await expect(filterSummary).toBeVisible({ timeout: 15000 });
 
     // Deactivate the tag by clicking again
     await firstTagButton.click();


### PR DESCRIPTION
## What

After the contact-form locator fix (#1066) let the `full / full` e2e job progress past `maxFailures`, two further failures surfaced and are blocking the `develop → main` release PR **#1063**:

1. **`dynamic-routes.spec.ts`** parametrizes over `PROJECT_SLUGS`, which still included `portfolio-modern-practice-study-case` — a study that was pruned. That page no longer renders a project detail (no breadcrumb), so the test failed. The fixture had also drifted: it was missing 7 real studies.
2. **`project-tags.spec.ts`** located the filter summary with an unscoped `page.locator('[aria-live="polite"]')`, which also matches the site-wide `RouteAnnouncer` → **strict-mode violation** (2 elements). Same class of bug as #1064 (blog-search), now on the projects page — in **two** tests.

## Fix

- **`fixtures/test-data.ts`** — re-sync `PROJECT_SLUGS` to `projectPageSlugs` in `data/project.ts`: drop the dead slug, add the 7 that had drifted out (`contact-form`, `appcontext`, `job-pipeline`, `api-performance`, `audit-tool`, `shared-ui`, `wyrdfold`). Restores detail-page coverage for every current study.
- **`project-tags.spec.ts`** — scope both `[aria-live="polite"]` locators with `.filter({ hasText: /\d+ case stud(y|ies) tagged/ })`, matching the #1064 pattern.

## Verification (local, chromium)

- Ran `dynamic-routes.spec.ts` + `project-tags.spec.ts` in isolation — **all pass** (every one of the 14 project detail pages loads with a breadcrumb; both tag-filter tests pass).
- Full chromium suite: 124 passed. The only failures are the home-page axe scans in `accessibility.spec.ts`, which **flake locally** (the `ScrollReveal` "Currently building" spotlight gets revealed during the local run, so axe scans its sub-4.5:1 colors). Those tests **pass deterministically in CI** (verified: all 12 a11y tests green in the actual `full / full` job) and are unrelated to this change.

> Note: there is a genuine, pre-existing color-contrast issue in that home-page spotlight section when it's visible. Tracking that separately — it is not part of this CI fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)