### PR TITLE
ci: drive all Vercel deploys from CI; disable native auto-deploy

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -3,10 +3,12 @@ name: Deploy Preview
 # Auto-deploys a Vercel preview for the root app on every PR to develop and
 # posts the URL as a PR comment. PRs to main are handled by ci-preview.yml.
 #
-# The root project's Vercel Git-integration build is disabled (dashboard
-# "Ignored Build Step"), so feature-branch previews would otherwise never
-# build. This workflow drives the preview from CI using the same vercel-deploy
-# action production uses, so previews are generated automatically.
+# Vercel's native Git auto-deploy is disabled for both projects via
+# `git.deploymentEnabled: false` (apps/root/vercel.json,
+# libs/shared/ui/vercel.json) to stay under the free-tier daily deploy cap, so
+# all deploys are CI-driven: previews here + in ci-preview.yml, production in
+# deploy-production.yml. This workflow drives the develop-PR preview using the
+# same vercel-deploy action production uses.
 
 on:
   pull_request:

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -2,6 +2,11 @@
 name: Deploy Production
 
 on:
+  # Auto-deploy production when the release lands on main (develop -> main).
+  # Vercel's native Git auto-deploy is disabled (see apps/root/vercel.json and
+  # libs/shared/ui/vercel.json), so this workflow is the sole production path.
+  push:
+    branches: [main]
   workflow_dispatch:
     inputs:
       confirm:
@@ -20,7 +25,10 @@ concurrency:
 jobs:
   preflight:
     name: Preflight
-    if: github.ref == 'refs/heads/main' && github.event.inputs.confirm == 'deploy'
+    # Auto-run on push to main; manual dispatch still requires the typed confirm.
+    if: >-
+      github.ref == 'refs/heads/main' &&
+      (github.event_name == 'push' || github.event.inputs.confirm == 'deploy')
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:

--- a/apps/root/vercel.json
+++ b/apps/root/vercel.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": "nextjs",
+  "git": {
+    "deploymentEnabled": false
+  },
   "headers": [
     {
       "source": "/_next/static/css/(.*)",

--- a/libs/shared/ui/vercel.json
+++ b/libs/shared/ui/vercel.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "git": {
+    "deploymentEnabled": false
+  }
+}


### PR DESCRIPTION
> ⚠️ **Do not merge until cutover** — see runbook below. This changes how the **live site** deploys to production. Hold until you're ready to watch the first CI production deploy.

## Why

We hit Vercel's **free-tier 100-deploys/day, team-wide** cap (verified: `api-deployments-free-per-day`, ~88 deploys in 24h). The bulk comes from **Vercel's native Git integration auto-deploying every push to every branch** for **both** projects — the live site *and* the Storybook showcase (Storybook even rebuilds on pushes that never touch `shared-ui`).

The repo already *intended* CI-driven previews (`deploy-preview.yml`), but native auto-deploy was **never actually disabled** — `commandForIgnoringBuildStep` is empty and `createDeployments` is `enabled`. So both paths fire.

## What this does — one CI-driven deploy model

| Surface | Before | After |
|---|---|---|
| Production (app + Storybook) | Vercel native push-to-`main` | **`deploy-production.yml`** gains a `push: [main]` trigger (manual dispatch still needs the typed confirm). Already builds + deploys both behind full CI (ci-fast + ci-full). |
| Preview — PRs to `develop` | native **+** `deploy-preview.yml` (dup) | `deploy-preview.yml` only |
| Preview — PRs to `main` | native **+** `ci-preview.yml` (dup) | `ci-preview.yml` only |
| Native Git auto-deploy | on (every branch, both projects) | **off** via `git.deploymentEnabled: false` |

Files: `apps/root/vercel.json` + new `libs/shared/ui/vercel.json` (disable native), `deploy-production.yml` (push trigger), `deploy-preview.yml` (corrected stale comment).

Expected effect: removes the ~44 redundant native deploys/day; deploys happen only on PRs (preview) and main merges (production).

## ⚠️ Cutover runbook (do this, in order)

1. **Merge this PR** into `develop`, then let it reach `main` (or cherry-pick if you want it live sooner).
2. **Confirm the CI production path works**: on the next push to `main`, watch `Deploy Production` run green and the live site update.
3. **Verify native is actually off.** Both projects have **Root Directory = null**, so they resolve `vercel.json` from the repo root — `git.deploymentEnabled` here may not be honored. If you still see `source: git` deploys after merge, also turn off automatic deployments in each project's **Vercel dashboard → Settings → Git** (or I can set `createDeployments: disabled` via the API). Until then, a `main` push may deploy twice (native + CI) — wasteful but not broken.

## Known trade-offs
- Branch pushes **without** an open PR no longer get a preview (previews are now PR-scoped). 
- Storybook previews come only from `ci-preview.yml` (PRs to `main`); a `develop` PR touching `shared-ui` won't get a Storybook preview unless we add one (easy follow-up if wanted).

## Not included
- `wyrdfold-com` (you're keeping it in this team for now — it shares the same daily cap, ~28/day).

🤖 Generated with [Claude Code](https://claude.com/claude-code)