### PR TITLE
Release: CI-driven Vercel deploys — disable native auto-deploy (#1070)

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -3,10 +3,12 @@ name: Deploy Preview
 # Auto-deploys a Vercel preview for the root app on every PR to develop and
 # posts the URL as a PR comment. PRs to main are handled by ci-preview.yml.
 #
-# The root project's Vercel Git-integration build is disabled (dashboard
-# "Ignored Build Step"), so feature-branch previews would otherwise never
-# build. This workflow drives the preview from CI using the same vercel-deploy
-# action production uses, so previews are generated automatically.
+# Vercel's native Git auto-deploy is disabled for both projects via
+# `git.deploymentEnabled: false` (apps/root/vercel.json,
+# libs/shared/ui/vercel.json) to stay under the free-tier daily deploy cap, so
+# all deploys are CI-driven: previews here + in ci-preview.yml, production in
+# deploy-production.yml. This workflow drives the develop-PR preview using the
+# same vercel-deploy action production uses.
 
 on:
   pull_request:

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -2,6 +2,11 @@
 name: Deploy Production
 
 on:
+  # Auto-deploy production when the release lands on main (develop -> main).
+  # Vercel's native Git auto-deploy is disabled (see apps/root/vercel.json and
+  # libs/shared/ui/vercel.json), so this workflow is the sole production path.
+  push:
+    branches: [main]
   workflow_dispatch:
     inputs:
       confirm:
@@ -20,7 +25,10 @@ concurrency:
 jobs:
   preflight:
     name: Preflight
-    if: github.ref == 'refs/heads/main' && github.event.inputs.confirm == 'deploy'
+    # Auto-run on push to main; manual dispatch still requires the typed confirm.
+    if: >-
+      github.ref == 'refs/heads/main' &&
+      (github.event_name == 'push' || github.event.inputs.confirm == 'deploy')
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:

--- a/apps/root/vercel.json
+++ b/apps/root/vercel.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": "nextjs",
+  "git": {
+    "deploymentEnabled": false
+  },
   "headers": [
     {
       "source": "/_next/static/css/(.*)",

--- a/libs/shared/ui/vercel.json
+++ b/libs/shared/ui/vercel.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "git": {
+    "deploymentEnabled": false
+  }
+}


### PR DESCRIPTION
Release of **develop → main**. Contains **#1070** — the deploy-volume cutover.

## What ships
Switches all Vercel deploys to a single CI-driven model and disables Vercel's native Git auto-deploy (which was auto-deploying every push to every branch for both the live site and the Storybook showcase, blowing through the free-tier 100/day team-wide cap).

- Native Git auto-deploy **off** via `git.deploymentEnabled: false` (`apps/root/vercel.json` + new `libs/shared/ui/vercel.json`).
- Production now deploys via **`deploy-production.yml`** (gains a `push: [main]` trigger; manual dispatch still needs the typed confirm) — it builds + deploys both the app and Storybook behind the full CI gate.
- Previews unchanged: `deploy-preview.yml` (develop PRs) + `ci-preview.yml` (main PRs).

## ⚠️ This merge IS the cutover — watch it

Merging this PR pushes to `main`, which:
1. **Triggers `Deploy Production`** (the new CI path) — watch it run green and confirm the live site + Storybook update.
2. Attempts to disable native auto-deploy. **Caveat:** both Vercel projects have **Root Directory = null** (they read `vercel.json` from the repo root), so `git.deploymentEnabled` may not be honored. If you still see `source: git` production deploys, turn off automatic deployments in each project's **Vercel dashboard → Settings → Git** (or have me set `createDeployments: disabled` via the API). Until then a `main` push may deploy twice (native + CI) — wasteful, not broken.

> Recommend watching the first `Deploy Production` run before considering the cutover complete.

## Notes
- Code/test gates already passed on `develop` (this is config-only; no app/test changes).
- `wyrdfold-com` intentionally left in this team for now (shares the same daily cap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)