### PR TITLE
chore(ci): prune redundant prod CI gate + workflow cleanup

### DIFF
--- a/.github/workflows/ci-fast.yml
+++ b/.github/workflows/ci-fast.yml
@@ -48,7 +48,7 @@ jobs:
         run: echo "version=$(node -e "console.log(require('@playwright/test/package.json').version)")" >> "$GITHUB_OUTPUT"
 
       - name: Cache Playwright browsers
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ steps.pw-version.outputs.version }}

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -25,7 +25,7 @@ concurrency:
 
 jobs:
   preview:
-    name: Vercel Preview
+    name: Vercel Preview (develop)
     # Skip drafts; the ready_for_review trigger runs it once the PR is opened.
     if: ${{ github.event.pull_request.draft != true }}
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -55,18 +55,9 @@ jobs:
       nx-head: ${{ needs.preflight.outputs.nx-head }}
     secrets: inherit
 
-  full:
-    name: CI Full
-    needs: [preflight, fast]
-    uses: ./.github/workflows/ci-full.yml
-    with:
-      nx-base: ${{ needs.preflight.outputs.nx-base }}
-      nx-head: ${{ needs.preflight.outputs.nx-head }}
-    secrets: inherit
-
   deploy:
     name: Production Deploy
-    needs: [fast, full]
+    needs: [fast]
     runs-on: ubuntu-latest
     timeout-minutes: 20
     environment:
@@ -94,7 +85,7 @@ jobs:
 
   deploy-storybook:
     name: Storybook Production Deploy
-    needs: [fast, full]
+    needs: [fast]
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:

--- a/.github/workflows/size-limit.yml
+++ b/.github/workflows/size-limit.yml
@@ -22,14 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: pnpm/action-setup@v5
-
-      - uses: actions/setup-node@v5
-        with:
-          node-version-file: '.nvmrc'
-          cache: pnpm
-
-      - run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/setup-workspace
 
       - uses: andresz1/size-limit-action@v1
         with:


### PR DESCRIPTION
Review + cleanup of the GitHub Actions workflows. **No workflow was obsolete enough to delete** — the CI-driven-deploy migration is clean (no dead native-Vercel assumptions, no broken `uses:`, comments match the real `vercel.json` state). This is dedup + trimming redundancy.

## Changes

- **`deploy-production.yml` — drop the redundant CI Full gate** (the meaningful prune). It re-ran the entire suite (lint/test/build **+ e2e + Lighthouse + Chromatic**) on every push to `main`, even though that exact commit already passed `ci.yml` on `develop` and was gated by the release PR. Now: `preflight → CI Fast → deploy + deploy-storybook`. Keeps a quick lint/typecheck/test/build sanity gate before deploying; drops the slow/expensive re-run. (`ci-full.yml` still runs on develop pushes via `ci.yml`.)
- **`deploy-preview.yml` — rename** the develop-PR job to `Vercel Preview (develop)` so it can't be confused with the `main`-ruleset-required `Vercel Preview` check. `develop` requires no status checks, so this is safe.
- **`ci-fast.yml` — `actions/cache@v4 → @v5`** (every other usage was already `@v5`).
- **`size-limit.yml` — use `./.github/actions/setup-workspace`** instead of a hand-rolled pnpm+node+install block.

## Validated
- `actionlint` clean on all four; YAML parses.
- `deploy-production.yml` structure verified (no dangling `full`/`ci-full` references).
- The develop-PR CI on this PR exercises the `ci-fast` cache change, the `size-limit` setup swap, and the preview rename. (The `deploy-production` change only runs on push to `main`, so it's validated by actionlint + structure here and will be exercised on the next release.)

## Deferred (flagged, not done here)
- **Extract a `setup-playwright` composite** — Playwright setup is duplicated across `ci.yml`/`ci-fast.yml`/`ci-full.yml` (with `--with-deps` differences). Higher-risk refactor that can't be validated on a develop PR (full e2e only runs on push), so left for a focused follow-up.
- **Verify `CHROMATIC_PROJECT_TOKEN` and `RELEASE_TOKEN` are set** — both silently degrade if missing (no visual tests / stuck Version-Packages PR). Repo-settings check on your side.
- **`ci-status` coupling:** the required `ci-status` check on a `main` PR is satisfied by the commit's `develop`-branch run (since `ci.yml` ignores main PRs). Works, but it's load-bearing — noting it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)