### PR TITLE
fix(shared-ui): Pagination + Skeleton a11y fixes

### DIFF
--- a/.changeset/pagination-skeleton-a11y.md
+++ b/.changeset/pagination-skeleton-a11y.md
@@ -1,0 +1,8 @@
+---
+'@danieljoffe/shared-ui': patch
+---
+
+Accessibility fixes for Pagination and Skeleton.
+
+- **Pagination** — remove the redundant `aria-disabled` on the prev/next buttons. They already use native `disabled`, and per ARIA `aria-disabled` is only for elements that lack a native disabled state.
+- **Skeleton** — mark the decorative loading placeholder `aria-hidden="true"` so screen readers skip it (the loading state should be conveyed by an `aria-busy` container instead).

--- a/libs/shared/ui/src/lib/Pagination.spec.tsx
+++ b/libs/shared/ui/src/lib/Pagination.spec.tsx
@@ -205,20 +205,22 @@ describe('Pagination', () => {
       expect(screen.getByLabelText('Next page')).toBeInTheDocument();
     });
 
-    it('adds aria-disabled to prev button on first page', () => {
+    it('uses native disabled (no redundant aria-disabled) on the prev button on first page', () => {
       render(
         <Pagination currentPage={1} totalPages={5} onPageChange={jest.fn()} />
       );
       const prevButton = screen.getByLabelText('Previous page');
-      expect(prevButton).toHaveAttribute('aria-disabled', 'true');
+      expect(prevButton).toBeDisabled();
+      expect(prevButton).not.toHaveAttribute('aria-disabled');
     });
 
-    it('adds aria-disabled to next button on last page', () => {
+    it('uses native disabled (no redundant aria-disabled) on the next button on last page', () => {
       render(
         <Pagination currentPage={5} totalPages={5} onPageChange={jest.fn()} />
       );
       const nextButton = screen.getByLabelText('Next page');
-      expect(nextButton).toHaveAttribute('aria-disabled', 'true');
+      expect(nextButton).toBeDisabled();
+      expect(nextButton).not.toHaveAttribute('aria-disabled');
     });
 
     it('does not add aria-disabled when buttons are enabled', () => {

--- a/libs/shared/ui/src/lib/Pagination.tsx
+++ b/libs/shared/ui/src/lib/Pagination.tsx
@@ -69,7 +69,6 @@ export function Pagination({
         onClick={() => onPageChange(currentPage - 1)}
         disabled={isPrevDisabled}
         aria-label='Previous page'
-        aria-disabled={isPrevDisabled ? 'true' : undefined}
         className={cn(
           'rounded-md text-text-secondary hover:bg-surface-tertiary transition-colors cursor-pointer',
           DISABLED,
@@ -121,7 +120,6 @@ export function Pagination({
         onClick={() => onPageChange(currentPage + 1)}
         disabled={isNextDisabled}
         aria-label='Next page'
-        aria-disabled={isNextDisabled ? 'true' : undefined}
         className={cn(
           'rounded-md text-text-secondary hover:bg-surface-tertiary transition-colors cursor-pointer',
           DISABLED,

--- a/libs/shared/ui/src/lib/Skeleton.spec.tsx
+++ b/libs/shared/ui/src/lib/Skeleton.spec.tsx
@@ -39,6 +39,15 @@ describe('Skeleton', () => {
     expect(container.firstChild).toHaveClass('rounded-lg');
   });
 
+  it('marks the placeholder aria-hidden (decorative) across variants', () => {
+    const { container: text } = render(<Skeleton />);
+    expect(text.firstChild).toHaveAttribute('aria-hidden', 'true');
+    const { container: circ } = render(<Skeleton variant='circular' />);
+    expect(circ.firstChild).toHaveAttribute('aria-hidden', 'true');
+    const { container: rect } = render(<Skeleton variant='rectangular' />);
+    expect(rect.firstChild).toHaveAttribute('aria-hidden', 'true');
+  });
+
   it('applies custom width and height to circular variant', () => {
     const { container } = render(
       <Skeleton variant='circular' width={60} height={60} />

--- a/libs/shared/ui/src/lib/Skeleton.tsx
+++ b/libs/shared/ui/src/lib/Skeleton.tsx
@@ -42,6 +42,7 @@ export function Skeleton({
     const defaultSize = circularSizeDefaults[size];
     return (
       <div
+        aria-hidden='true'
         className={cn(base, 'rounded-full', className)}
         style={{
           width: width || defaultSize,
@@ -54,6 +55,7 @@ export function Skeleton({
   if (variant === 'rectangular') {
     return (
       <div
+        aria-hidden='true'
         className={cn(base, 'rounded-lg', className)}
         style={{
           width: width || '100%',
@@ -64,7 +66,11 @@ export function Skeleton({
   }
 
   return (
-    <div className={cn('space-y-2', className)} style={{ width }}>
+    <div
+      aria-hidden='true'
+      className={cn('space-y-2', className)}
+      style={{ width }}
+    >
       {Array.from({ length: lines }).map((_, i) => (
         <div
           key={i}


### PR DESCRIPTION
Small accessibility fixes for two components (first of the shared-ui hardening follow-ups; kept intentionally tight).

- **Pagination** — remove the redundant `aria-disabled` on the prev/next buttons. They already use native `disabled`; per ARIA, `aria-disabled` is only for elements that lack a native disabled state.
- **Skeleton** — mark the decorative loading placeholder `aria-hidden="true"` (all three variants) so screen readers skip it (the loading state should be conveyed by an `aria-busy` container instead).

Tests updated: the two Pagination tests that encoded the old anti-pattern now assert `disabled` + no `aria-disabled`; added a Skeleton `aria-hidden` test across variants.

**Verified:** `typecheck` · `lint` (0 errors) · **779 shared-ui unit tests** — all green.

Changeset: `@danieljoffe/shared-ui: patch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
