### PR TITLE
feat(shared-ui): ref + rest-spread escape hatches (Sidebar/ThemeToggle/Avatar/Breadcrumb)

### DIFF
--- a/.changeset/ref-escape-hatches.md
+++ b/.changeset/ref-escape-hatches.md
@@ -1,0 +1,7 @@
+---
+'@danieljoffe/shared-ui': minor
+---
+
+Add `ref` + rest-prop escape hatches to Sidebar, ThemeToggle, Avatar, and Breadcrumb.
+
+Each now accepts a React 19 `ref` on its root element and spreads unrecognized props (`data-*`, `id`, `style`, event handlers, etc.) onto it — matching the pattern already used by Button/Badge — so consumers can extend them without forking. ThemeToggle additionally gains a `className` prop.

--- a/libs/shared/ui/src/lib/Avatar.spec.tsx
+++ b/libs/shared/ui/src/lib/Avatar.spec.tsx
@@ -1,3 +1,4 @@
+import { createRef } from 'react';
 import { render, screen } from '@testing-library/react';
 import { axe, toHaveNoViolations } from 'jest-axe';
 import { Avatar } from './Avatar';
@@ -5,6 +6,14 @@ import { Avatar } from './Avatar';
 expect.extend(toHaveNoViolations);
 
 describe('Avatar', () => {
+  it('forwards ref and spreads rest props to the root element', () => {
+    const ref = createRef<HTMLDivElement>();
+    render(<Avatar ref={ref} data-testid='avatar-root' title='avatar' />);
+    expect(ref.current).toBeInstanceOf(HTMLDivElement);
+    expect(ref.current).toHaveAttribute('data-testid', 'avatar-root');
+    expect(ref.current).toHaveAttribute('title', 'avatar');
+  });
+
   it('renders initials when no src provided', () => {
     render(<Avatar initials='DJ' />);
     expect(screen.getByText('DJ')).toBeInTheDocument();

--- a/libs/shared/ui/src/lib/Avatar.tsx
+++ b/libs/shared/ui/src/lib/Avatar.tsx
@@ -1,7 +1,12 @@
+import { type HTMLAttributes, type Ref } from 'react';
 import type { ComponentSize } from './types';
 import { cn } from './utils/cn';
 
-export interface AvatarProps {
+export interface AvatarProps extends Omit<
+  HTMLAttributes<HTMLDivElement>,
+  'className'
+> {
+  ref?: Ref<HTMLDivElement> | undefined;
   src?: string;
   alt?: string;
   initials?: string;
@@ -30,9 +35,15 @@ export function Avatar({
   size = 'md',
   status,
   className,
+  ref,
+  ...rest
 }: AvatarProps) {
   return (
-    <div className={cn('relative inline-flex shrink-0', className)}>
+    <div
+      ref={ref}
+      className={cn('relative inline-flex shrink-0', className)}
+      {...rest}
+    >
       <div
         className={cn(
           'rounded-full flex items-center justify-center font-medium overflow-hidden',

--- a/libs/shared/ui/src/lib/Breadcrumb.spec.tsx
+++ b/libs/shared/ui/src/lib/Breadcrumb.spec.tsx
@@ -1,3 +1,4 @@
+import { createRef } from 'react';
 import { render, screen } from '@testing-library/react';
 import { axe, toHaveNoViolations } from 'jest-axe';
 import { Breadcrumb } from './Breadcrumb';
@@ -10,6 +11,13 @@ describe('Breadcrumb', () => {
     { label: 'Projects', href: '/projects' },
     { label: 'Current' },
   ];
+
+  it('forwards ref and spreads rest props to the root element', () => {
+    const ref = createRef<HTMLElement>();
+    render(<Breadcrumb items={items} ref={ref} data-testid='crumb-root' />);
+    expect(ref.current?.tagName).toBe('NAV');
+    expect(ref.current).toHaveAttribute('data-testid', 'crumb-root');
+  });
 
   it('renders all items', () => {
     render(<Breadcrumb items={items} />);

--- a/libs/shared/ui/src/lib/Breadcrumb.tsx
+++ b/libs/shared/ui/src/lib/Breadcrumb.tsx
@@ -1,5 +1,5 @@
 import { ChevronRight } from 'lucide-react';
-import type { ReactNode } from 'react';
+import { type HTMLAttributes, type ReactNode, type Ref } from 'react';
 import { cn } from './utils/cn';
 
 export interface BreadcrumbItem {
@@ -8,16 +8,27 @@ export interface BreadcrumbItem {
   icon?: ReactNode;
 }
 
-export interface BreadcrumbProps {
+export interface BreadcrumbProps extends Omit<
+  HTMLAttributes<HTMLElement>,
+  'className'
+> {
+  ref?: Ref<HTMLElement> | undefined;
   items: BreadcrumbItem[];
   className?: string;
 }
 
-export function Breadcrumb({ items, className }: BreadcrumbProps) {
+export function Breadcrumb({
+  items,
+  className,
+  ref,
+  ...rest
+}: BreadcrumbProps) {
   return (
     <nav
+      ref={ref}
       aria-label='Breadcrumb'
       className={cn('flex items-center gap-1 text-sm', className)}
+      {...rest}
     >
       {items.map((item, i) => {
         const isLast = i === items.length - 1;

--- a/libs/shared/ui/src/lib/Sidebar.spec.tsx
+++ b/libs/shared/ui/src/lib/Sidebar.spec.tsx
@@ -1,3 +1,4 @@
+import { createRef } from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { axe, toHaveNoViolations } from 'jest-axe';
 import { Sidebar } from './Sidebar';
@@ -18,6 +19,13 @@ const items = [
 ];
 
 describe('Sidebar', () => {
+  it('forwards ref and spreads rest props to the root element', () => {
+    const ref = createRef<HTMLElement>();
+    render(<Sidebar items={items} ref={ref} data-testid='sidebar-root' />);
+    expect(ref.current?.tagName).toBe('ASIDE');
+    expect(ref.current).toHaveAttribute('data-testid', 'sidebar-root');
+  });
+
   it('renders all top-level items', () => {
     render(<Sidebar items={items} />);
     expect(screen.getByText('Home')).toBeInTheDocument();

--- a/libs/shared/ui/src/lib/Sidebar.tsx
+++ b/libs/shared/ui/src/lib/Sidebar.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { ChevronDown } from 'lucide-react';
-import { useState, type ReactNode } from 'react';
+import { useState, type HTMLAttributes, type ReactNode, type Ref } from 'react';
 import { Button } from './Button';
 import { cn } from './utils/cn';
 
@@ -14,7 +14,11 @@ export interface SidebarItem {
   children?: SidebarItem[];
 }
 
-export interface SidebarProps {
+export interface SidebarProps extends Omit<
+  HTMLAttributes<HTMLElement>,
+  'className' | 'onSelect'
+> {
+  ref?: Ref<HTMLElement> | undefined;
   items: SidebarItem[];
   activeId?: string;
   onSelect?: (id: string) => void;
@@ -112,15 +116,19 @@ export function Sidebar({
   footer,
   collapsed = false,
   className,
+  ref,
+  ...rest
 }: SidebarProps) {
   return (
     <aside
+      ref={ref}
       className={cn(
         'flex flex-col h-full bg-surface border-r border-border',
         'transition-all duration-200 motion-reduce:transition-none',
         collapsed ? 'w-16' : 'w-48 md:w-60',
         className
       )}
+      {...rest}
     >
       {header && (
         <div className='p-4 border-b border-border shrink-0'>{header}</div>

--- a/libs/shared/ui/src/lib/ThemeToggle.spec.tsx
+++ b/libs/shared/ui/src/lib/ThemeToggle.spec.tsx
@@ -1,3 +1,4 @@
+import { createRef } from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { axe, toHaveNoViolations } from 'jest-axe';
 import { ThemeProvider } from './ThemeProvider';
@@ -23,6 +24,17 @@ describe('ThemeToggle', () => {
         removeEventListener: jest.fn(),
       }),
     });
+  });
+
+  it('forwards ref and spreads rest props to the root element', () => {
+    const ref = createRef<HTMLDivElement>();
+    render(
+      <ThemeProvider>
+        <ThemeToggle ref={ref} data-testid='theme-toggle' />
+      </ThemeProvider>
+    );
+    expect(ref.current).toBeInstanceOf(HTMLDivElement);
+    expect(ref.current).toHaveAttribute('data-testid', 'theme-toggle');
   });
 
   it('renders three theme buttons', () => {

--- a/libs/shared/ui/src/lib/ThemeToggle.tsx
+++ b/libs/shared/ui/src/lib/ThemeToggle.tsx
@@ -1,10 +1,19 @@
 'use client';
 
 import { Sun, Moon, Monitor } from 'lucide-react';
+import { type HTMLAttributes, type Ref } from 'react';
 import { useTheme } from './ThemeProvider';
 import { cn } from './utils/cn';
 
-export function ThemeToggle() {
+export interface ThemeToggleProps extends Omit<
+  HTMLAttributes<HTMLDivElement>,
+  'className'
+> {
+  ref?: Ref<HTMLDivElement> | undefined;
+  className?: string;
+}
+
+export function ThemeToggle({ className, ref, ...rest }: ThemeToggleProps) {
   const { theme, setTheme } = useTheme();
 
   const options = [
@@ -14,7 +23,14 @@ export function ThemeToggle() {
   ];
 
   return (
-    <div className='inline-flex items-center gap-0.5 p-0.5 bg-surface-tertiary rounded-lg'>
+    <div
+      ref={ref}
+      className={cn(
+        'inline-flex items-center gap-0.5 p-0.5 bg-surface-tertiary rounded-lg',
+        className
+      )}
+      {...rest}
+    >
       {options.map(({ value, icon: Icon, label }) => (
         <button
           key={value}


### PR DESCRIPTION
Adds `ref` + rest-prop escape hatches to four components that lacked them, so consumers can extend without forking (the shared-ui adoption theme).

- **Sidebar, ThemeToggle, Avatar, Breadcrumb** — each root element now accepts a React 19 `ref` and spreads unrecognized props (`data-*`, `id`, `style`, event handlers, `aria-*`) onto it, via `HTMLAttributes`, matching the Button/Badge pattern. **ThemeToggle** additionally gains a `className` prop (it previously accepted none).
- Sidebar omits the DOM `onSelect` from its inherited attributes so it doesn't collide with its own `onSelect(id)` callback.

Each component gets a ref + rest-spread unit test.

**Verified:** `typecheck` · **782 unit tests** · `lint` (0 errors).

Changeset: `@danieljoffe/shared-ui: minor`.

Note: Pagination + Skeleton also want this, but they're already touched by #1082 (a11y fixes); their `ref`/rest-spread will follow once #1082 lands, to avoid a merge conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
