### PR TITLE
feat(shared-ui): Table sortable columns + aria-sort (+ outline-accent fix)

### DIFF
--- a/.changeset/table-sortable-columns.md
+++ b/.changeset/table-sortable-columns.md
@@ -1,0 +1,9 @@
+---
+'@danieljoffe/shared-ui': minor
+---
+
+Table: controlled sortable columns + `ref`/rest-spread, and a focus-ring bug fix.
+
+- **Sortable columns** — mark a `Column` as `sortable` and pass `sortKey` / `sortDirection` / `onSort`. Sortable headers become keyboard-operable buttons with a direction indicator, and each `<th>` exposes the correct `aria-sort` (`ascending` / `descending` / `none`). Sorting is **controlled**: the Table renders the state and header control, while the consumer owns the order and re-sorts `data` in response to `onSort`.
+- **Escape hatch** — Table now accepts a `ref` on its wrapper element and spreads rest props onto it.
+- **Fix** — the clickable-row focus outline used `outline-accent`, but `--color-accent` is not defined in any theme (so the outline rendered with no color); switched to the defined `outline-brand-500`.

--- a/libs/shared/ui/src/lib/Table.spec.tsx
+++ b/libs/shared/ui/src/lib/Table.spec.tsx
@@ -1,3 +1,4 @@
+import { createRef } from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { Table } from './Table';
 
@@ -242,6 +243,81 @@ describe('Table', () => {
     const bodyRows = rows.slice(1);
     bodyRows.forEach(row => {
       expect(row.className).not.toContain('focus-visible:outline-2');
+    });
+  });
+
+  it('forwards ref and spreads rest props to the wrapper element', () => {
+    const ref = createRef<HTMLDivElement>();
+    render(
+      <Table columns={columns} data={data} ref={ref} data-testid='table-root' />
+    );
+    expect(ref.current).toBeInstanceOf(HTMLDivElement);
+    expect(ref.current).toHaveAttribute('data-testid', 'table-root');
+  });
+
+  it('uses a defined focus-ring token on clickable rows (not the phantom accent)', () => {
+    render(<Table columns={columns} data={data} onRowClick={jest.fn()} />);
+    const row = screen.getAllByRole('button')[0];
+    expect(row.className).toContain('focus-visible:outline-brand-500');
+    expect(row.className).not.toContain('outline-accent');
+  });
+
+  describe('sortable columns', () => {
+    const sortableColumns = [
+      { key: 'name', header: 'Name', sortable: true },
+      { key: 'age', header: 'Age', sortable: true },
+      { key: 'role', header: 'Role' },
+    ];
+
+    it('renders a header button only for sortable columns', () => {
+      render(<Table columns={sortableColumns} data={data} />);
+      expect(screen.getByRole('button', { name: 'Name' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Age' })).toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: 'Role' })
+      ).not.toBeInTheDocument();
+    });
+
+    it('defaults aria-sort to "none" on unsorted sortable columns and omits it on non-sortable', () => {
+      render(<Table columns={sortableColumns} data={data} />);
+      expect(
+        screen.getByRole('columnheader', { name: /Name/ })
+      ).toHaveAttribute('aria-sort', 'none');
+      expect(
+        screen.getByRole('columnheader', { name: 'Role' })
+      ).not.toHaveAttribute('aria-sort');
+    });
+
+    it('reflects sortKey + sortDirection as aria-sort ascending/descending', () => {
+      const { rerender } = render(
+        <Table
+          columns={sortableColumns}
+          data={data}
+          sortKey='name'
+          sortDirection='asc'
+        />
+      );
+      expect(
+        screen.getByRole('columnheader', { name: /Name/ })
+      ).toHaveAttribute('aria-sort', 'ascending');
+      rerender(
+        <Table
+          columns={sortableColumns}
+          data={data}
+          sortKey='name'
+          sortDirection='desc'
+        />
+      );
+      expect(
+        screen.getByRole('columnheader', { name: /Name/ })
+      ).toHaveAttribute('aria-sort', 'descending');
+    });
+
+    it('calls onSort with the column key when a sortable header is activated', () => {
+      const onSort = jest.fn();
+      render(<Table columns={sortableColumns} data={data} onSort={onSort} />);
+      fireEvent.click(screen.getByRole('button', { name: 'Age' }));
+      expect(onSort).toHaveBeenCalledWith('age');
     });
   });
 });

--- a/libs/shared/ui/src/lib/Table.stories.tsx
+++ b/libs/shared/ui/src/lib/Table.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
 import { expect, fn, userEvent, within } from 'storybook/test';
 import { Badge } from './Badge';
 import { Table } from './Table';
@@ -43,6 +44,44 @@ export const Default: Story = {
 
 export const Striped: Story = {
   args: { columns, data: sampleData, striped: true },
+};
+
+// Controlled sorting: the Table renders aria-sort + the header controls; the
+// consumer owns the sort order and re-sorts `data` in response to `onSort`.
+export const Sortable: Story = {
+  render: function SortableStory() {
+    const [sortKey, setSortKey] = useState('name');
+    const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('asc');
+    const sortableColumns = [
+      { key: 'name', header: 'Name', sortable: true },
+      { key: 'email', header: 'Email' },
+      { key: 'role', header: 'Role', sortable: true },
+      { key: 'status', header: 'Status', sortable: true },
+    ];
+    const sorted = [...sampleData].sort((a, b) => {
+      const cmp = String(a[sortKey as keyof User]).localeCompare(
+        String(b[sortKey as keyof User])
+      );
+      return sortDirection === 'asc' ? cmp : -cmp;
+    });
+    return (
+      <Table
+        columns={sortableColumns}
+        data={sorted}
+        sortKey={sortKey}
+        sortDirection={sortDirection}
+        onSort={key => {
+          if (key === sortKey) {
+            setSortDirection(d => (d === 'asc' ? 'desc' : 'asc'));
+          } else {
+            setSortKey(key);
+            setSortDirection('asc');
+          }
+        }}
+        ariaLabel='Sortable users'
+      />
+    );
+  },
 };
 
 export const Empty: Story = {

--- a/libs/shared/ui/src/lib/Table.tsx
+++ b/libs/shared/ui/src/lib/Table.tsx
@@ -1,6 +1,8 @@
 'use client';
 
-import type { KeyboardEvent, ReactNode } from 'react';
+import { ChevronDown, ChevronUp, ChevronsUpDown } from 'lucide-react';
+import type { HTMLAttributes, KeyboardEvent, ReactNode, Ref } from 'react';
+import { FOCUS_RING, FOCUS_RING_OFFSET } from './styles/formStyles';
 import { Text } from './Text';
 import { cn } from './utils/cn';
 
@@ -10,9 +12,15 @@ export interface Column<T> {
   render?: (row: T) => ReactNode;
   align?: 'left' | 'center' | 'right';
   width?: string;
+  /** When true, the header becomes a sort control (aria-sort + click/keyboard). */
+  sortable?: boolean;
 }
 
-export interface TableProps<T> {
+export interface TableProps<T> extends Omit<
+  HTMLAttributes<HTMLDivElement>,
+  'className'
+> {
+  ref?: Ref<HTMLDivElement> | undefined;
   columns: Column<T>[];
   data: T[];
   onRowClick?: (row: T) => void;
@@ -26,6 +34,17 @@ export interface TableProps<T> {
   rowKey?: (row: T) => string | number;
   /** Function to derive an accessible label for clickable rows */
   getRowAriaLabel?: (row: T) => string;
+  /**
+   * Controlled sort — the key of the currently-sorted column. Sorting is
+   * controlled: the Table renders the aria-sort state and the header control,
+   * but the consumer owns the sort order and re-sorts `data` in response to
+   * `onSort`.
+   */
+  sortKey?: string;
+  /** Controlled sort — direction of the current sort. */
+  sortDirection?: 'asc' | 'desc';
+  /** Called with a column's `key` when its sortable header is activated. */
+  onSort?: (key: string) => void;
 }
 
 export function Table<T extends Record<string, unknown>>({
@@ -38,6 +57,11 @@ export function Table<T extends Record<string, unknown>>({
   ariaLabel,
   rowKey,
   getRowAriaLabel,
+  sortKey,
+  sortDirection,
+  onSort,
+  ref,
+  ...rest
 }: TableProps<T>) {
   const alignClass = {
     left: 'text-left',
@@ -54,10 +78,12 @@ export function Table<T extends Record<string, unknown>>({
 
   return (
     <div
+      ref={ref}
       className={cn(
         'w-full overflow-x-auto border border-border rounded-xl',
         className
       )}
+      {...rest}
     >
       <table
         className='w-full text-sm'
@@ -70,19 +96,64 @@ export function Table<T extends Record<string, unknown>>({
         )}
         <thead>
           <tr className='border-b border-border bg-surface-secondary'>
-            {columns.map(col => (
-              <th
-                key={col.key}
-                scope='col'
-                className={cn(
-                  'px-4 py-3 font-medium text-text-secondary',
-                  alignClass[col.align || 'left']
-                )}
-                style={col.width ? { width: col.width } : undefined}
-              >
-                {col.header}
-              </th>
-            ))}
+            {columns.map(col => {
+              const isSorted = Boolean(col.sortable) && sortKey === col.key;
+              return (
+                <th
+                  key={col.key}
+                  scope='col'
+                  aria-sort={
+                    col.sortable
+                      ? isSorted
+                        ? sortDirection === 'asc'
+                          ? 'ascending'
+                          : 'descending'
+                        : 'none'
+                      : undefined
+                  }
+                  className={cn(
+                    'px-4 py-3 font-medium text-text-secondary',
+                    alignClass[col.align || 'left']
+                  )}
+                  style={col.width ? { width: col.width } : undefined}
+                >
+                  {col.sortable ? (
+                    <button
+                      type='button'
+                      onClick={() => onSort?.(col.key)}
+                      className={cn(
+                        'inline-flex items-center gap-1 rounded-sm font-medium cursor-pointer transition-colors hover:text-text-primary',
+                        FOCUS_RING,
+                        FOCUS_RING_OFFSET,
+                        isSorted && 'text-text-primary'
+                      )}
+                    >
+                      {col.header}
+                      {isSorted ? (
+                        sortDirection === 'asc' ? (
+                          <ChevronUp
+                            aria-hidden='true'
+                            className='h-3.5 w-3.5'
+                          />
+                        ) : (
+                          <ChevronDown
+                            aria-hidden='true'
+                            className='h-3.5 w-3.5'
+                          />
+                        )
+                      ) : (
+                        <ChevronsUpDown
+                          aria-hidden='true'
+                          className='h-3.5 w-3.5 text-text-tertiary'
+                        />
+                      )}
+                    </button>
+                  ) : (
+                    col.header
+                  )}
+                </th>
+              );
+            })}
           </tr>
         </thead>
         <tbody>
@@ -105,7 +176,7 @@ export function Table<T extends Record<string, unknown>>({
                 className={cn(
                   'border-b border-border last:border-b-0 transition-colors',
                   onRowClick &&
-                    'cursor-pointer hover:bg-surface-secondary focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-accent',
+                    'cursor-pointer hover:bg-surface-secondary focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-brand-500',
                   striped && i % 2 === 1 && 'bg-surface-secondary'
                 )}
               >


### PR DESCRIPTION
Adds controlled **sortable columns** to Table (the one real feature gap from the a11y audit), a `ref` escape hatch, and a focus-ring bug fix.

## Sortable columns (controlled)
- Mark a `Column` as `sortable`; pass `sortKey` / `sortDirection` / `onSort`.
- Sortable headers render a keyboard-operable `<button>` with a direction indicator, and each `<th>` exposes the correct `aria-sort` (`ascending` / `descending` / `none`).
- **Controlled**: the Table renders the sort state + header control; the consumer owns the order and re-sorts `data` in response to `onSort`. See the new **Sortable** story.

## Escape hatch
- Table now accepts a `ref` on its wrapper element and spreads rest props onto it (matching Button/Badge/etc.).

## Bug fix
- The clickable-row focus outline used `outline-accent`, but `--color-accent` is not defined in any theme — the outline rendered with no color. Switched to the defined `outline-brand-500`.

**Verified:** `typecheck` · **784 unit tests** · `lint` · Storybook build.

Changeset: `@danieljoffe/shared-ui: minor`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
