### PR TITLE
fix(shared-ui): repair Table Sortable story typecheck (unblock develop)

### DIFF
--- a/libs/shared/ui/src/lib/Table.stories.tsx
+++ b/libs/shared/ui/src/lib/Table.stories.tsx
@@ -38,6 +38,13 @@ const columns = [
   { key: 'status', header: 'Status' },
 ];
 
+const sortableColumns = [
+  { key: 'name', header: 'Name', sortable: true },
+  { key: 'email', header: 'Email' },
+  { key: 'role', header: 'Role', sortable: true },
+  { key: 'status', header: 'Status', sortable: true },
+];
+
 export const Default: Story = {
   args: { columns, data: sampleData },
 };
@@ -49,15 +56,12 @@ export const Striped: Story = {
 // Controlled sorting: the Table renders aria-sort + the header controls; the
 // consumer owns the sort order and re-sorts `data` in response to `onSort`.
 export const Sortable: Story = {
+  // Required args satisfy the generic component's type; the custom render owns
+  // the controlled sort state and re-sorts the data itself.
+  args: { columns: sortableColumns, data: sampleData },
   render: function SortableStory() {
     const [sortKey, setSortKey] = useState('name');
     const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('asc');
-    const sortableColumns = [
-      { key: 'name', header: 'Name', sortable: true },
-      { key: 'email', header: 'Email' },
-      { key: 'role', header: 'Role', sortable: true },
-      { key: 'status', header: 'Status', sortable: true },
-    ];
     const sorted = [...sampleData].sort((a, b) => {
       const cmp = String(a[sortKey as keyof User]).localeCompare(
         String(b[sortKey as keyof User])


### PR DESCRIPTION
## What

Fixes a `tsc --build` failure (`TS2322`) in `Table.stories.tsx` that turned **develop red** after the four shared-ui PRs (#1082–#1085) were merged.

## Why it surfaced only after merge

`@danieljoffe/shared-ui:typecheck` got a **remote-cache hit** on #1084's own PR run, so the error was masked there. The fresh, post-merge run on `develop` recomputed it cache-cold and caught it.

## Root cause

`Table<User>` is generic and `TableProps` extends `HTMLAttributes<HTMLDivElement>`, so its args type has required `columns`/`data` plus ~285 optional DOM props. The `Sortable` story is the only one using `render:` instead of `args:` — and Storybook's CSF3 types do **not** relax the required-args check for a render-only story. So `{ render }` wasn't assignable to `StoryObj<typeof meta>`.

## Fix

Hoist `sortableColumns` to module scope and give the `Sortable` story `args: { columns, data }` to satisfy the type. The custom `render` is unchanged — it still owns the controlled sort state and re-sorts the data itself, so the demo behaves exactly as before. Story-only change; `Table.tsx` is untouched, so no changeset / version bump.

## Testing

`nx run-many -t lint typecheck test build -p @danieljoffe/shared-ui` — all green locally (typecheck was the failing target; now passes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
