### PR TITLE
chore(eslint-config): make @danieljoffe/eslint-config publishable to npm

### DIFF
--- a/libs/shared/eslint-config/LICENSE.md
+++ b/libs/shared/eslint-config/LICENSE.md
@@ -1,0 +1,117 @@
+# Functional Source License, Version 1.1, MIT Future License
+
+## Abbreviation
+
+FSL-1.1-MIT
+
+## Notice
+
+Copyright 2026 Daniel Joffe
+
+## Terms and Conditions
+
+### Licensor ("We")
+
+The party offering the Software under these Terms and Conditions.
+
+### The Software
+
+The "Software" is each version of the software that we make available
+under these Terms and Conditions, as indicated by our inclusion of these
+Terms and Conditions with the Software.
+
+### License Grant
+
+Subject to your compliance with this License Grant and the Patents,
+Redistribution and Trademark clauses below, we hereby grant you the right
+to use, copy, modify, create derivative works, publish, and redistribute
+the Software, in whole or in part, solely for any Permitted Purpose.
+
+### Permitted Purpose
+
+A Permitted Purpose is any purpose other than a Competing Use. A
+Competing Use means making the Software available to others in a
+commercial product or service that:
+
+1. substitutes for the Software;
+
+2. substitutes for any other product or service we offer using the
+   Software that exists as of the date we make the Software available; or
+
+3. offers the same or substantially similar functionality as the Software.
+
+Permitted Purposes specifically include using the Software:
+
+1. for your internal use and access;
+
+2. for non-commercial education;
+
+3. for non-commercial research; and
+
+4. in connection with professional services that you provide to a
+   licensee using the Software in accordance with these Terms and
+   Conditions.
+
+### Patents
+
+To the extent your use for a Permitted Purpose would necessarily infringe
+our patents, the license grant above includes a license under our patents.
+If you make a claim against any party that the Software infringes or
+contributes to the infringement of any patent, then your patent license
+to the Software ends immediately.
+
+### Redistribution
+
+The Terms and Conditions apply to all copies, modifications and
+derivatives of the Software.
+
+If you redistribute any copies, modifications or derivatives of the
+Software, you must include a copy of or a link to these Terms and
+Conditions and not remove any copyright notices provided in or with the
+Software.
+
+### Disclaimer
+
+THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND,
+INCLUDING WITHOUT LIMITATION WARRANTIES OF MERCHANTABILITY, FITNESS FOR
+A PARTICULAR PURPOSE, NON-INFRINGEMENT AND TITLE.
+
+OUR TOTAL LIABILITY TO YOU FOR ANY DAMAGES ARISING OUT OF OR RELATED TO
+THIS AGREEMENT IS LIMITED TO US$500.
+
+WE WILL NOT BE LIABLE TO YOU FOR ANY LOST PROFITS, REVENUES, OR DATA, OR
+FOR CONSEQUENTIAL, INDIRECT, SPECIAL, INCIDENTAL, OR PUNITIVE DAMAGES.
+
+### Trademarks
+
+Except for displaying the License Details and identifying us as the
+origin of the Software, you have no right under these Terms and
+Conditions to use our trademarks, trade names, service marks or product
+names.
+
+## Grant of Future License
+
+We hereby irrevocably grant you an additional license to use the Software
+under the MIT license that is effective on the second anniversary of the
+date we make the Software available. On or after that date, you may use
+the Software under the MIT license, in which case the following will
+apply:
+
+> Permission is hereby granted, free of charge, to any person obtaining a
+> copy of this software and associated documentation files (the
+> "Software"), to deal in the Software without restriction, including
+> without limitation the rights to use, copy, modify, merge, publish,
+> distribute, sublicense, and/or sell copies of the Software, and to
+> permit persons to whom the Software is furnished to do so, subject to
+> the following conditions:
+>
+> The above copyright notice and this permission notice shall be included
+> in all copies or substantial portions of the Software.
+>
+> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+> OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+> MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+> IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+> CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+> TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+> SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/libs/shared/eslint-config/README.md
+++ b/libs/shared/eslint-config/README.md
@@ -4,20 +4,13 @@ Shareable ESLint rules for the [danieljoffe.com](https://danieljoffe.com) design
 
 ## Install
 
-This package currently ships inside the danieljoffe.com monorepo and is consumed as a workspace dependency:
-
-```jsonc
-// package.json
-{
-  "devDependencies": {
-    "@danieljoffe/eslint-config": "workspace:*",
-  },
-}
+```bash
+npm install -D @danieljoffe/eslint-config
 ```
 
-Publishing to npm (`npm install -D @danieljoffe/eslint-config`) is planned — it needs a one-time npm trusted-publisher bootstrap for the new package name.
-
 Requires ESLint 9+ (flat config).
+
+> Inside the danieljoffe.com monorepo this package is consumed as a workspace dependency (`"@danieljoffe/eslint-config": "workspace:*"`).
 
 ## Usage
 

--- a/libs/shared/eslint-config/package.json
+++ b/libs/shared/eslint-config/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@danieljoffe/eslint-config",
   "version": "0.1.0",
-  "private": true,
   "description": "Shareable ESLint rules for the danieljoffe.com design system — steer consumers toward @danieljoffe/shared-ui primitives instead of raw HTML.",
   "type": "commonjs",
   "main": "./index.js",
@@ -11,10 +10,33 @@
   "files": [
     "index.js",
     "rules",
-    "README.md"
+    "README.md",
+    "LICENSE.md"
   ],
+  "keywords": [
+    "eslint",
+    "eslint-config",
+    "eslint-plugin",
+    "eslint-flat-config",
+    "design-system",
+    "shared-ui"
+  ],
+  "author": "Daniel Joffe",
+  "license": "FSL-1.1-MIT",
+  "homepage": "https://github.com/danieljoffe/danieljoffe.com/tree/main/libs/shared/eslint-config",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/danieljoffe/danieljoffe.com.git",
+    "directory": "libs/shared/eslint-config"
+  },
+  "bugs": {
+    "url": "https://github.com/danieljoffe/danieljoffe.com/issues"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
   "peerDependencies": {
     "eslint": ">=9"
-  },
-  "license": "FSL-1.1-MIT"
+  }
 }


### PR DESCRIPTION
## What

Sets `@danieljoffe/eslint-config` up for npm publishing — reverses the temporary `private: true` from #1085 and mirrors shared-ui's publish setup.

- `package.json`: drop `private`, add `publishConfig` (public), `repository`/`homepage`/`bugs`, `author`, `keywords`
- add `LICENSE.md` (FSL-1.1-MIT) + include in `files`
- README: `npm install` instructions
- `npm pack --dry-run` → 7 files, 4.6 kB (`index.js`, the 3 rules, `README.md`, `LICENSE.md`, `package.json`); rule tests 9/9

**No changeset** — the first publish is a manual bootstrap (see below); `changeset publish` then skips `0.1.0` as already-published, and future *changes* get their own changesets.

## ⚠️ One-time npm bootstrap required before this reaches a `main` release

npm OIDC trusted publishing **cannot create a brand-new package** — the package must already exist on npm before a trusted publisher can be configured ([npm docs](https://docs.npmjs.com/trusted-publishers/)). So the first publish is manual; the automated OIDC flow takes over afterward.

**1. First publish (manual, from this branch):**
```bash
npm login                       # or configure an automation token in ~/.npmrc
cd libs/shared/eslint-config
npm publish --access public     # publishConfig also sets access=public
```
→ creates `@danieljoffe/eslint-config@0.1.0` on npm. (No provenance on this one — that's fine; OIDC publishes get it automatically.)

**2. Configure trusted publishing** — npmjs.com → the package → **Settings → Trusted Publisher → GitHub Actions**:
- Repository: `danieljoffe/danieljoffe.com`
- Workflow filename: `release.yml`
- Environment: `npm-publish`

(Identical to shared-ui's existing config.)

**3. Merge this PR.** From then on, any change to the package + a changeset → the release flow publishes new versions via OIDC (no token, automatic provenance).

> **Do not promote `develop → main` before steps 1–2.** Otherwise `changeset publish` will try to OIDC-publish a package npm doesn't trust yet, failing the release job (and blocking shared-ui's publish in the same job).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
