### PR TITLE
fix(shared-ui): fix Storybook dev $RefreshReg$ crash

### DIFF
--- a/libs/shared/ui/.storybook/preview-head.html
+++ b/libs/shared/ui/.storybook/preview-head.html
@@ -1,4 +1,24 @@
 <!doctype html>
+<script>
+  // No-op React Fast Refresh globals. @vitejs/plugin-react (pulled in via the
+  // library vite.config.ts that .storybook/main.ts references through
+  // viteConfigPath) instruments every module with $RefreshReg$/$RefreshSig$, but
+  // the runtime preamble that defines them isn't injected into Storybook's
+  // iframe — so the dev preview crashed with "$RefreshReg$ is not defined". These
+  // no-ops (plus the installed flag) let modules load; Fast Refresh degrades to a
+  // full reload on edit. Plain script, no dev-server import, harmless in the
+  // static build too.
+  window.$RefreshReg$ = window.$RefreshReg$ || function () {};
+  window.$RefreshSig$ =
+    window.$RefreshSig$ ||
+    function () {
+      return function (type) {
+        return type;
+      };
+    };
+  window.__vite_plugin_react_preamble_installed__ = true;
+</script>
+
 <link rel="preconnect" href="https://fonts.googleapis.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 <link


### PR DESCRIPTION
The Storybook **dev** server crashed with `$RefreshReg$ is not defined`.

**Cause:** `.storybook/main.ts` feeds the builder the library `vite.config.ts` (via `viteConfigPath`), which adds `@vitejs/plugin-react`. That plugin instruments every module with `$RefreshReg$`/`$RefreshSig$`, but Storybook's iframe never received the React-Refresh runtime **preamble** that defines them. (Dev-only — the static build has Fast Refresh off, so the built Storybook always rendered.)

**Fix:** a no-op preamble in `.storybook/preview-head.html` that defines those globals + the installed flag. Modules load; Fast Refresh degrades to a full reload on edit. Plain script, no dev-server import → harmless in the static build too.

Dev-only Storybook config — **no change to the published package** (no changeset). Verified locally: dev Storybook renders (Pyre + Indigo), no `$RefreshReg$`, no leaked markup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)