### PR TITLE
feat(shared-ui): composable Popover/Dropdown triggers + Dropdown controlled mode

### DIFF
--- a/.changeset/composable-triggers.md
+++ b/.changeset/composable-triggers.md
@@ -1,0 +1,7 @@
+---
+'@danieljoffe/shared-ui': minor
+---
+
+Composable triggers for Popover and Dropdown: pass a render function as `trigger` to supply your own trigger element (e.g. the design-system `Button`) — the primitive injects `ref`, `id`, `type`, `aria-*`, and handlers (`PopoverTriggerProps` / `DropdownTriggerProps`), and keeps owning open state, dismiss, keyboard nav, and focus return. The node form of `trigger` is unchanged.
+
+Dropdown parity with Popover: controlled `open`/`onOpenChange` and `panelClassName`; its outside-click listener now attaches only while the menu is open.

--- a/libs/shared/ui/src/lib/Dropdown.mdx
+++ b/libs/shared/ui/src/lib/Dropdown.mdx
@@ -490,6 +490,19 @@ import { Dropdown } from './Dropdown';
   items, reach for <code>Popover</code> instead.
 </p>
 
+<p className='doc-p'>
+  Whole-menu states (initial load, empty, error) are expressed as a single
+  non-actionable item — e.g.{' '}
+  <code>
+    {'{'} label: 'Loading targets…', loading: true, disabled: true {'}'}
+  </code>{' '}
+  — with <code>content</code> for richer status rows. When items arrive after
+  the menu opened in that state, focus deliberately stays where it is (no focus
+  stealing mid-read); <span className='doc-kbd'>↓</span> /{' '}
+  <span className='doc-kbd'>↑</span> on the trigger then moves focus to the
+  first / last item.
+</p>
+
 ```jsx
 <Dropdown
   trigger={<>Add to target ▾</>}
@@ -537,7 +550,11 @@ import { Dropdown } from './Dropdown';
         <span className='doc-kbd'>↓</span>
       </td>
       <td>Trigger focused</td>
-      <td>Opens menu and focuses first item</td>
+      <td>
+        Opens menu and focuses first item; on an already-open menu, moves focus
+        to the first (<span className='doc-kbd'>↓</span>) or last (
+        <span className='doc-kbd'>↑</span>) item
+      </td>
     </tr>
     <tr>
       <td>

--- a/libs/shared/ui/src/lib/Dropdown.mdx
+++ b/libs/shared/ui/src/lib/Dropdown.mdx
@@ -213,10 +213,14 @@ import { Dropdown } from './Dropdown';
         <code>trigger</code>
       </td>
       <td>
-        <code>ReactNode</code>
+        <code>ReactNode | (props: DropdownTriggerProps) =&gt; ReactNode</code>
       </td>
       <td>—</td>
-      <td>Content rendered inside the trigger button.</td>
+      <td>
+        Content rendered inside the built-in trigger button — or a render
+        function that returns your own trigger element with the injected props
+        spread onto it (see Composed Trigger below).
+      </td>
     </tr>
     <tr>
       <td>
@@ -242,6 +246,33 @@ import { Dropdown } from './Dropdown';
     </tr>
     <tr>
       <td>
+        <code>open</code>
+      </td>
+      <td>
+        <code>boolean</code>
+      </td>
+      <td>
+        <code>undefined</code>
+      </td>
+      <td>Controlled open state; omit to let the Dropdown manage its own.</td>
+    </tr>
+    <tr>
+      <td>
+        <code>onOpenChange</code>
+      </td>
+      <td>
+        <code>(open: boolean) =&gt; void</code>
+      </td>
+      <td>
+        <code>undefined</code>
+      </td>
+      <td>
+        Called with the next open state on trigger interaction, item activation,
+        outside click, and Escape.
+      </td>
+    </tr>
+    <tr>
+      <td>
         <code>className</code>
       </td>
       <td>
@@ -251,6 +282,18 @@ import { Dropdown } from './Dropdown';
         <code>undefined</code>
       </td>
       <td>Additional classes on the wrapper div.</td>
+    </tr>
+    <tr>
+      <td>
+        <code>panelClassName</code>
+      </td>
+      <td>
+        <code>string</code>
+      </td>
+      <td>
+        <code>undefined</code>
+      </td>
+      <td>Merged onto the menu — override width, padding, etc.</td>
     </tr>
   </tbody>
 </table>
@@ -411,6 +454,30 @@ import { Dropdown } from './Dropdown';
   edge of the viewport to prevent the menu from overflowing.
 </p>
 
+<h3 className='doc-sub'>Composed Trigger</h3>
+
+<p className='doc-p'>
+  When the trigger must be a specific element — the design-system{' '}
+  <code>Button</code> beside another <code>Button</code>, a styled filter pill —
+  pass a render function as <code>trigger</code>. It receives{' '}
+  <code>DropdownTriggerProps</code> (<code>ref</code>, <code>id</code>,{' '}
+  <code>type</code>, <code>aria-*</code>, <code>onClick</code>,{' '}
+  <code>onKeyDown</code>); spread them all onto the element you return. The
+  Dropdown keeps owning open state, keyboard navigation, dismiss, and focus
+  return — your element only supplies the look.
+</p>
+
+```jsx
+<Dropdown
+  trigger={props => (
+    <Button {...props} variant='secondary'>
+      Add to target ▾
+    </Button>
+  )}
+  items={items}
+/>
+```
+
 <h3 className='doc-sub'>Async Picker</h3>
 
 <p className='doc-p'>
@@ -516,17 +583,19 @@ import { Dropdown } from './Dropdown';
   <div className='doc-do'>
     <div className='doc-do-label'>Do</div>
     <p className='doc-do-body'>
-      Pass descriptive content as the <code>trigger</code>, like a label with an
-      icon. The trigger renders inside a <code>&lt;button&gt;</code>{' '}
-      automatically, so pass inline content, not another button.
+      Pass inline content (label + icon) to render inside the built-in{' '}
+      <code>&lt;button&gt;</code> — or pass a render function and spread the
+      injected props when the trigger must be a <code>&lt;Button&gt;</code> or
+      another styled element.
     </p>
   </div>
   <div className='doc-dont'>
     <div className='doc-dont-label'>Don't</div>
     <p className='doc-dont-body'>
-      Don't pass a <code>&lt;Button&gt;</code> component as the trigger. The
-      Dropdown already wraps the trigger in a native button element. Nesting
-      buttons is invalid HTML and breaks accessibility.
+      Don't pass a <code>&lt;Button&gt;</code> <em>element</em> as the node form
+      of <code>trigger</code> — it nests buttons, which is invalid HTML. Use the
+      render-function form instead, and spread every injected prop, or the aria
+      wiring and focus return break.
     </p>
   </div>
 </div>

--- a/libs/shared/ui/src/lib/Dropdown.spec.tsx
+++ b/libs/shared/ui/src/lib/Dropdown.spec.tsx
@@ -1,6 +1,7 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import { axe, toHaveNoViolations } from 'jest-axe';
-import { Dropdown } from './Dropdown';
+import { Button } from './Button';
+import { Dropdown, type DropdownTriggerProps } from './Dropdown';
 
 expect.extend(toHaveNoViolations);
 
@@ -512,6 +513,171 @@ describe('Dropdown', () => {
       fireEvent.click(screen.getByText('Menu'));
       expect(await axe(container)).toHaveNoViolations();
     });
+  });
+
+  describe('composable trigger', () => {
+    const buttonTrigger = (props: DropdownTriggerProps) => (
+      <Button {...props} variant='secondary'>
+        Menu
+      </Button>
+    );
+
+    it('renders the composed element as the only trigger, with full wiring', () => {
+      const { container } = render(
+        <Dropdown trigger={buttonTrigger} items={items} />
+      );
+      const trigger = screen.getByRole('button', { name: 'Menu' });
+      expect(trigger).toHaveAttribute('aria-haspopup', 'menu');
+      expect(trigger).toHaveAttribute('type', 'button');
+      // No built-in button wraps the composed one — that would nest buttons
+      expect(container.querySelectorAll('button')).toHaveLength(1);
+    });
+
+    it('opens the menu from a click on the composed trigger', () => {
+      render(<Dropdown trigger={buttonTrigger} items={items} />);
+      const trigger = screen.getByRole('button', { name: 'Menu' });
+      fireEvent.click(trigger);
+      expect(screen.getByRole('menu')).toBeInTheDocument();
+      expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    });
+
+    it('opens the menu and focuses the first item from ArrowDown on the composed trigger', () => {
+      render(<Dropdown trigger={buttonTrigger} items={items} />);
+      fireEvent.keyDown(screen.getByRole('button', { name: 'Menu' }), {
+        key: 'ArrowDown',
+      });
+      expect(screen.getByRole('menu')).toBeInTheDocument();
+      expect(screen.getAllByRole('menuitem')[0]).toHaveFocus();
+    });
+
+    it('labels the menu by the composed trigger', () => {
+      render(<Dropdown trigger={buttonTrigger} items={items} />);
+      const trigger = screen.getByRole('button', { name: 'Menu' });
+      fireEvent.click(trigger);
+      expect(screen.getByRole('menu')).toHaveAttribute(
+        'aria-labelledby',
+        trigger.id
+      );
+    });
+
+    it('closes on Escape and returns focus to the composed trigger', () => {
+      render(<Dropdown trigger={buttonTrigger} items={items} />);
+      const trigger = screen.getByRole('button', { name: 'Menu' });
+      fireEvent.click(trigger);
+      fireEvent.keyDown(screen.getByRole('menu'), { key: 'Escape' });
+      expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+      expect(trigger).toHaveFocus();
+    });
+
+    it('open menu with a composed Button trigger has no a11y violations', async () => {
+      const { container } = render(
+        <Dropdown trigger={buttonTrigger} items={items} />
+      );
+      fireEvent.click(screen.getByRole('button', { name: 'Menu' }));
+      expect(await axe(container)).toHaveNoViolations();
+    });
+  });
+
+  describe('controlled mode', () => {
+    it('renders open when open prop is true', () => {
+      render(
+        <Dropdown
+          trigger={<span>Menu</span>}
+          items={items}
+          open
+          onOpenChange={() => {}}
+        />
+      );
+      expect(screen.getByRole('menu')).toBeInTheDocument();
+    });
+
+    it('stays open until the parent flips the prop', () => {
+      const onOpenChange = jest.fn();
+      render(
+        <Dropdown
+          trigger={<span>Menu</span>}
+          items={items}
+          open
+          onOpenChange={onOpenChange}
+        />
+      );
+      fireEvent.keyDown(screen.getByRole('menu'), { key: 'Escape' });
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+      expect(screen.getByRole('menu')).toBeInTheDocument();
+    });
+
+    it('requests opening via onOpenChange on trigger click', () => {
+      const onOpenChange = jest.fn();
+      render(
+        <Dropdown
+          trigger={<span>Menu</span>}
+          items={items}
+          open={false}
+          onOpenChange={onOpenChange}
+        />
+      );
+      fireEvent.click(screen.getByText('Menu'));
+      expect(onOpenChange).toHaveBeenCalledWith(true);
+      expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+    });
+
+    it('notifies onOpenChange on outside click', () => {
+      const onOpenChange = jest.fn();
+      render(
+        <div>
+          <Dropdown
+            trigger={<span>Menu</span>}
+            items={items}
+            open
+            onOpenChange={onOpenChange}
+          />
+          <span>Outside</span>
+        </div>
+      );
+      fireEvent.mouseDown(screen.getByText('Outside'));
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
+
+    it('notifies onOpenChange when an item activation closes the menu', () => {
+      const onOpenChange = jest.fn();
+      render(
+        <Dropdown
+          trigger={<span>Menu</span>}
+          items={[{ label: 'Action', onClick: jest.fn() }]}
+          open
+          onOpenChange={onOpenChange}
+        />
+      );
+      fireEvent.click(screen.getByRole('menuitem', { name: 'Action' }));
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
+  });
+
+  it('fires onOpenChange in uncontrolled mode too', () => {
+    const onOpenChange = jest.fn();
+    render(
+      <Dropdown
+        trigger={<span>Menu</span>}
+        items={items}
+        onOpenChange={onOpenChange}
+      />
+    );
+    fireEvent.click(screen.getByText('Menu'));
+    expect(onOpenChange).toHaveBeenLastCalledWith(true);
+    fireEvent.click(screen.getByText('Menu'));
+    expect(onOpenChange).toHaveBeenLastCalledWith(false);
+  });
+
+  it('merges panelClassName onto the menu', () => {
+    render(
+      <Dropdown
+        trigger={<span>Menu</span>}
+        items={items}
+        panelClassName='w-64'
+      />
+    );
+    fireEvent.click(screen.getByText('Menu'));
+    expect(screen.getByRole('menu')).toHaveClass('w-64');
   });
 
   it('has no accessibility violations', async () => {

--- a/libs/shared/ui/src/lib/Dropdown.spec.tsx
+++ b/libs/shared/ui/src/lib/Dropdown.spec.tsx
@@ -513,6 +513,50 @@ describe('Dropdown', () => {
       fireEvent.click(screen.getByText('Menu'));
       expect(await axe(container)).toHaveNoViolations();
     });
+
+    it('does not steal focus when items become actionable after opening', () => {
+      const { rerender } = render(
+        <Dropdown
+          trigger={<span>Menu</span>}
+          items={[{ label: 'Loading targets…', loading: true, disabled: true }]}
+        />
+      );
+      const trigger = screen.getByRole('button', { name: 'Menu' });
+      trigger.focus();
+      fireEvent.click(trigger);
+      expect(screen.getByRole('menu')).toBeInTheDocument();
+      rerender(<Dropdown trigger={<span>Menu</span>} items={items} />);
+      expect(trigger).toHaveFocus();
+    });
+
+    it('ArrowDown on the open trigger moves focus to the first item once items arrive', () => {
+      const { rerender } = render(
+        <Dropdown
+          trigger={<span>Menu</span>}
+          items={[{ label: 'Loading targets…', loading: true, disabled: true }]}
+        />
+      );
+      const trigger = screen.getByRole('button', { name: 'Menu' });
+      fireEvent.click(trigger);
+      rerender(<Dropdown trigger={<span>Menu</span>} items={items} />);
+      fireEvent.keyDown(trigger, { key: 'ArrowDown' });
+      expect(screen.getAllByRole('menuitem')[0]).toHaveFocus();
+    });
+
+    it('ArrowUp on the open trigger moves focus to the last item once items arrive', () => {
+      const { rerender } = render(
+        <Dropdown
+          trigger={<span>Menu</span>}
+          items={[{ label: 'Loading targets…', loading: true, disabled: true }]}
+        />
+      );
+      const trigger = screen.getByRole('button', { name: 'Menu' });
+      fireEvent.click(trigger);
+      rerender(<Dropdown trigger={<span>Menu</span>} items={items} />);
+      fireEvent.keyDown(trigger, { key: 'ArrowUp' });
+      const menuItems = screen.getAllByRole('menuitem');
+      expect(menuItems[menuItems.length - 1]).toHaveFocus();
+    });
   });
 
   describe('composable trigger', () => {

--- a/libs/shared/ui/src/lib/Dropdown.stories.tsx
+++ b/libs/shared/ui/src/lib/Dropdown.stories.tsx
@@ -1,7 +1,8 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
 import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
-import { Dropdown } from './Dropdown';
+import { Button } from './Button';
+import { Dropdown, type DropdownTriggerProps } from './Dropdown';
 
 const meta = {
   title: 'Overlay/Dropdown',
@@ -12,6 +13,15 @@ const meta = {
       control: 'select',
       options: ['left', 'right'],
       table: { defaultValue: { summary: 'left' } },
+    },
+    open: {
+      description:
+        'Controlled open state — omit to let the Dropdown manage its own',
+      control: 'boolean',
+    },
+    panelClassName: {
+      description: 'Merged onto the menu to override width, padding, etc.',
+      control: 'text',
     },
   },
 } satisfies Meta<typeof Dropdown>;
@@ -30,6 +40,101 @@ export const Default: Story = {
       { label: '', divider: true },
       { label: 'Delete', danger: true },
     ],
+  },
+};
+
+/**
+ * Pass a render function as `trigger` to supply your own trigger element —
+ * here the design-system Button, sitting beside another Button without a
+ * style mismatch. Spread every injected prop onto the element you return;
+ * the Dropdown keeps owning open state, keyboard nav, dismiss, focus
+ * return, and aria wiring.
+ */
+export const ComposedTrigger: Story = {
+  args: {
+    trigger: (props: DropdownTriggerProps) => (
+      <Button {...props} variant='secondary' size='sm'>
+        Add to target
+      </Button>
+    ),
+    items: [
+      { label: 'Design Systems Team' },
+      { label: 'Platform Guild' },
+      { label: 'Frontend Chapter' },
+    ],
+  },
+  render: args => (
+    <div className='flex items-center gap-2'>
+      <Dropdown {...args} />
+      <Button variant='secondary' size='sm'>
+        Create target
+      </Button>
+    </div>
+  ),
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+    const trigger = canvas.getByRole('button', { name: 'Add to target' });
+
+    await step('Open from the composed Button trigger', async () => {
+      await userEvent.click(trigger);
+      await waitFor(() => expect(canvas.getByRole('menu')).toBeInTheDocument());
+      await expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    });
+
+    await step('Escape closes and restores focus to the Button', async () => {
+      await userEvent.keyboard('{Escape}');
+      await waitFor(() =>
+        expect(canvas.queryByRole('menu')).not.toBeInTheDocument()
+      );
+      await expect(trigger).toHaveFocus();
+    });
+  },
+};
+
+/**
+ * Controlled mode: drive `open` yourself and react to `onOpenChange`. The
+ * Dropdown still owns dismissal interactions (outside click, Escape, trigger
+ * toggle, item activation) and reports them through `onOpenChange`.
+ */
+export const Controlled: Story = {
+  args: {
+    trigger: (
+      <span className='px-3 py-1.5 border rounded-md text-sm'>Controlled</span>
+    ),
+    items: [{ label: 'Option A' }, { label: 'Option B' }],
+    open: false,
+    onOpenChange: fn(),
+  },
+  render: function ControlledDropdown(args) {
+    const [isOpen, setIsOpen] = useState(false);
+    return (
+      <Dropdown
+        {...args}
+        open={isOpen}
+        onOpenChange={next => {
+          setIsOpen(next);
+          args.onOpenChange?.(next);
+        }}
+      />
+    );
+  },
+  play: async ({ args, canvasElement, step }) => {
+    const canvas = within(canvasElement);
+    const trigger = canvas.getByRole('button', { name: 'Controlled' });
+
+    await step('Open via trigger', async () => {
+      await userEvent.click(trigger);
+      await waitFor(() => expect(canvas.getByRole('menu')).toBeInTheDocument());
+      await expect(args.onOpenChange).toHaveBeenCalledWith(true);
+    });
+
+    await step('Close via Escape', async () => {
+      await userEvent.keyboard('{Escape}');
+      await waitFor(() =>
+        expect(canvas.queryByRole('menu')).not.toBeInTheDocument()
+      );
+      await expect(args.onOpenChange).toHaveBeenCalledWith(false);
+    });
   },
 };
 

--- a/libs/shared/ui/src/lib/Dropdown.tsx
+++ b/libs/shared/ui/src/lib/Dropdown.tsx
@@ -53,7 +53,10 @@ export interface DropdownTriggerProps {
   'aria-expanded': boolean;
   'aria-controls': string | undefined;
   onClick: () => void;
-  /** Opens the menu from ArrowDown/ArrowUp on the trigger. */
+  /**
+   * Opens the menu from ArrowDown/ArrowUp on the trigger; on an already-open
+   * menu, moves focus to the first (ArrowDown) or last (ArrowUp) item.
+   */
   onKeyDown: (e: React.KeyboardEvent) => void;
 }
 
@@ -115,7 +118,10 @@ export function Dropdown({
     if (!isOpen) setActiveIndex(-1);
   }, [isOpen]);
 
-  // Focus first actionable item when menu opens
+  // Focus first actionable item when menu opens. Deliberately does NOT fire
+  // when items become actionable later (async pickers that open in a loading
+  // state): stealing focus mid-read could preempt a dismissal — the trigger's
+  // ArrowDown/ArrowUp is the explicit way in once items arrive.
   const prevOpenRef = useRef(false);
   useEffect(() => {
     const firstActionable = actionableItems[0];
@@ -132,6 +138,16 @@ export function Dropdown({
       e.preventDefault();
       if (!isOpen) {
         setOpen(true);
+      } else {
+        // Menu already open with focus still on the trigger — happens when it
+        // opened with no actionable items (async loading) and items arrived
+        // later. Arrowing is the deliberate way in; ArrowUp enters from the
+        // end, per the menu-button pattern.
+        const target =
+          e.key === 'ArrowDown'
+            ? actionableItems[0]
+            : actionableItems[actionableItems.length - 1];
+        if (target != null) focusItem(target);
       }
     }
   };

--- a/libs/shared/ui/src/lib/Dropdown.tsx
+++ b/libs/shared/ui/src/lib/Dropdown.tsx
@@ -9,9 +9,11 @@ import {
   useRef,
   useState,
   type ReactNode,
+  type Ref,
 } from 'react';
 import { Spinner } from './Spinner';
 import { cn } from './utils/cn';
+import { useAnchoredPanel } from './utils/useAnchoredPanel';
 
 export interface DropdownItem {
   /** Item text — also the accessible name when `content` is provided. */
@@ -37,23 +39,57 @@ export interface DropdownItem {
   closeOnClick?: boolean;
 }
 
+/**
+ * Wiring the Dropdown injects into a composed trigger. Spread every prop onto
+ * your interactive element — the dropdown keeps owning open state, keyboard
+ * nav, dismiss, focus return, and aria wiring.
+ */
+export interface DropdownTriggerProps {
+  ref: Ref<HTMLButtonElement>;
+  id: string;
+  /** Guards against implicit form submission when the menu sits in a form. */
+  type: 'button';
+  'aria-haspopup': 'menu';
+  'aria-expanded': boolean;
+  'aria-controls': string | undefined;
+  onClick: () => void;
+  /** Opens the menu from ArrowDown/ArrowUp on the trigger. */
+  onKeyDown: (e: React.KeyboardEvent) => void;
+}
+
 export interface DropdownProps {
-  trigger: ReactNode;
+  /**
+   * Content rendered inside the built-in trigger button — or a render
+   * function receiving {@link DropdownTriggerProps} to supply your own
+   * trigger element (a design-system Button, a styled pill…). Spread all
+   * injected props onto the element you return.
+   */
+  trigger: ReactNode | ((props: DropdownTriggerProps) => ReactNode);
   items: DropdownItem[];
   align?: 'left' | 'right';
-  className?: string;
+  /** Controlled open state; omit to let the Dropdown manage its own. */
+  open?: boolean | undefined;
+  /** Called with the next open state on trigger interaction, item activation, outside click, and Escape. */
+  onOpenChange?: ((open: boolean) => void) | undefined;
+  className?: string | undefined;
+  /** Merged onto the menu — override width, padding, etc. */
+  panelClassName?: string | undefined;
 }
 
 export function Dropdown({
   trigger,
   items,
   align = 'left',
+  open,
+  onOpenChange,
   className,
+  panelClassName,
 }: DropdownProps) {
-  const [open, setOpen] = useState(false);
+  const { isOpen, setOpen, close, wrapperRef, triggerRef } = useAnchoredPanel({
+    open,
+    onOpenChange,
+  });
   const [activeIndex, setActiveIndex] = useState(-1);
-  const ref = useRef<HTMLDivElement>(null);
-  const triggerRef = useRef<HTMLButtonElement>(null);
   const itemRefs = useRef<(HTMLButtonElement | HTMLAnchorElement | null)[]>([]);
   const uid = useId();
   const menuId = `dropdown-menu-${uid}`;
@@ -73,48 +109,30 @@ export function Dropdown({
     itemRefs.current[index]?.focus();
   }, []);
 
-  const openMenu = useCallback(() => {
-    setOpen(true);
-  }, []);
-
-  const closeMenu = useCallback(() => {
-    setOpen(false);
-    setActiveIndex(-1);
-    triggerRef.current?.focus();
-  }, []);
+  // Reset roving focus whenever the menu closes, whichever path closed it
+  // (item click, Escape, outside click, controlled flip).
+  useEffect(() => {
+    if (!isOpen) setActiveIndex(-1);
+  }, [isOpen]);
 
   // Focus first actionable item when menu opens
   const prevOpenRef = useRef(false);
   useEffect(() => {
     const firstActionable = actionableItems[0];
-    if (open && !prevOpenRef.current && firstActionable != null) {
+    if (isOpen && !prevOpenRef.current && firstActionable != null) {
       requestAnimationFrame(() => {
         focusItem(firstActionable);
       });
     }
-    prevOpenRef.current = open;
-  }, [open, actionableItems, focusItem]);
-
-  useEffect(() => {
-    const handler = (e: MouseEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node)) {
-        setOpen(false);
-        setActiveIndex(-1);
-      }
-    };
-    document.addEventListener('mousedown', handler);
-    return () => document.removeEventListener('mousedown', handler);
-  }, []);
+    prevOpenRef.current = isOpen;
+  }, [isOpen, actionableItems, focusItem]);
 
   const handleTriggerKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
       e.preventDefault();
-      if (!open) {
-        openMenu();
+      if (!isOpen) {
+        setOpen(true);
       }
-    } else if (e.key === 'Escape' && open) {
-      e.preventDefault();
-      closeMenu();
     }
   };
 
@@ -152,11 +170,6 @@ export function Dropdown({
         if (last != null) focusItem(last);
         break;
       }
-      case 'Escape': {
-        e.preventDefault();
-        closeMenu();
-        break;
-      }
       case 'Enter':
       case ' ': {
         e.preventDefault();
@@ -171,9 +184,7 @@ export function Dropdown({
             } else {
               item.onClick?.();
               if (item.closeOnClick !== false) {
-                setOpen(false);
-                setActiveIndex(-1);
-                triggerRef.current?.focus();
+                close();
               }
             }
           }
@@ -181,28 +192,33 @@ export function Dropdown({
         break;
       }
       case 'Tab': {
-        closeMenu();
+        close();
         break;
       }
     }
   };
 
+  const triggerProps: DropdownTriggerProps = {
+    ref: triggerRef,
+    id: triggerId,
+    type: 'button',
+    'aria-haspopup': 'menu',
+    'aria-expanded': isOpen,
+    'aria-controls': isOpen ? menuId : undefined,
+    onClick: () => (isOpen ? close() : setOpen(true)),
+    onKeyDown: handleTriggerKeyDown,
+  };
+
   return (
-    <div ref={ref} className={cn('relative inline-flex', className)}>
-      <button
-        ref={triggerRef}
-        id={triggerId}
-        type='button'
-        aria-haspopup='menu'
-        aria-expanded={open}
-        aria-controls={open ? menuId : undefined}
-        onClick={() => (open ? closeMenu() : openMenu())}
-        onKeyDown={handleTriggerKeyDown}
-        className='inline-flex items-center'
-      >
-        {trigger}
-      </button>
-      {open && (
+    <div ref={wrapperRef} className={cn('relative inline-flex', className)}>
+      {typeof trigger === 'function' ? (
+        trigger(triggerProps)
+      ) : (
+        <button {...triggerProps} className='inline-flex items-center'>
+          {trigger}
+        </button>
+      )}
+      {isOpen && (
         <div
           id={menuId}
           role='menu'
@@ -213,7 +229,8 @@ export function Dropdown({
             'absolute z-50 mt-1 top-full min-w-[180px]',
             'bg-surface-elevated border border-border rounded-lg shadow-lg',
             'py-1 animate-slide-down motion-reduce:animate-none',
-            align === 'right' ? 'right-0' : 'left-0'
+            align === 'right' ? 'right-0' : 'left-0',
+            panelClassName
           )}
         >
           {items.map((item, i) => {
@@ -278,9 +295,7 @@ export function Dropdown({
                   onClick={() => {
                     item.onClick?.();
                     if (item.closeOnClick !== false) {
-                      setOpen(false);
-                      setActiveIndex(-1);
-                      triggerRef.current?.focus();
+                      close();
                     }
                   }}
                   className={itemClassName}
@@ -305,9 +320,7 @@ export function Dropdown({
                   if (item.disabled || item.loading) return;
                   item.onClick?.();
                   if (item.closeOnClick !== false) {
-                    setOpen(false);
-                    setActiveIndex(-1);
-                    triggerRef.current?.focus();
+                    close();
                   }
                 }}
                 className={itemClassName}

--- a/libs/shared/ui/src/lib/Popover.spec.tsx
+++ b/libs/shared/ui/src/lib/Popover.spec.tsx
@@ -1,6 +1,7 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import { axe, toHaveNoViolations } from 'jest-axe';
-import { Popover } from './Popover';
+import { Button } from './Button';
+import { Popover, type PopoverTriggerProps } from './Popover';
 
 expect.extend(toHaveNoViolations);
 
@@ -266,6 +267,118 @@ describe('Popover', () => {
       );
       fireEvent.mouseDown(screen.getByText('Outside'));
       expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
+  });
+
+  describe('composable trigger', () => {
+    const pillTrigger = (props: PopoverTriggerProps) => (
+      <button {...props} className='pill'>
+        Filters
+      </button>
+    );
+
+    it('renders the composed element as the only trigger, with full wiring', () => {
+      const { container } = render(
+        <Popover trigger={pillTrigger}>
+          <p>Panel content</p>
+        </Popover>
+      );
+      const trigger = screen.getByRole('button', { name: 'Filters' });
+      expect(trigger).toHaveClass('pill');
+      expect(trigger).toHaveAttribute('aria-haspopup', 'dialog');
+      expect(trigger).toHaveAttribute('type', 'button');
+      // No built-in button wraps the composed one — that would nest buttons
+      expect(container.querySelectorAll('button')).toHaveLength(1);
+    });
+
+    it('opens and closes from the composed trigger', () => {
+      render(
+        <Popover trigger={pillTrigger}>
+          <p>Panel content</p>
+        </Popover>
+      );
+      const trigger = screen.getByRole('button', { name: 'Filters' });
+      fireEvent.click(trigger);
+      expect(screen.getByText('Panel content')).toBeInTheDocument();
+      expect(trigger).toHaveAttribute('aria-expanded', 'true');
+      fireEvent.click(trigger);
+      expect(screen.queryByText('Panel content')).not.toBeInTheDocument();
+    });
+
+    it('labels the panel by the composed trigger', () => {
+      render(
+        <Popover trigger={pillTrigger}>
+          <p>Panel content</p>
+        </Popover>
+      );
+      const trigger = screen.getByRole('button', { name: 'Filters' });
+      fireEvent.click(trigger);
+      expect(screen.getByRole('dialog')).toHaveAttribute(
+        'aria-labelledby',
+        trigger.id
+      );
+    });
+
+    it('closes on Escape and returns focus to the composed trigger', () => {
+      render(
+        <Popover trigger={pillTrigger}>
+          <input aria-label='City' />
+        </Popover>
+      );
+      const trigger = screen.getByRole('button', { name: 'Filters' });
+      fireEvent.click(trigger);
+      fireEvent.keyDown(screen.getByRole('dialog'), { key: 'Escape' });
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+      expect(trigger).toHaveFocus();
+    });
+
+    it('closes on outside click with a composed trigger', () => {
+      render(
+        <div>
+          <Popover trigger={pillTrigger}>
+            <p>Panel content</p>
+          </Popover>
+          <span>Outside</span>
+        </div>
+      );
+      fireEvent.click(screen.getByRole('button', { name: 'Filters' }));
+      fireEvent.mouseDown(screen.getByText('Outside'));
+      expect(screen.queryByText('Panel content')).not.toBeInTheDocument();
+    });
+
+    it('composes with the design-system Button as the trigger', () => {
+      const { container } = render(
+        <Popover
+          trigger={props => (
+            <Button {...props} variant='secondary'>
+              Filters
+            </Button>
+          )}
+        >
+          <p>Panel content</p>
+        </Popover>
+      );
+      const trigger = screen.getByRole('button', { name: 'Filters' });
+      expect(container.querySelectorAll('button')).toHaveLength(1);
+      fireEvent.click(trigger);
+      expect(screen.getByText('Panel content')).toBeInTheDocument();
+      expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    });
+
+    it('open popover with a composed Button trigger has no a11y violations', async () => {
+      const { container } = render(
+        <Popover
+          trigger={props => (
+            <Button {...props} variant='secondary'>
+              Filters
+            </Button>
+          )}
+        >
+          <input aria-label='City' />
+        </Popover>
+      );
+      fireEvent.click(screen.getByRole('button', { name: 'Filters' }));
+      expect(await axe(container)).toHaveNoViolations();
     });
   });
 

--- a/libs/shared/ui/src/lib/Popover.stories.tsx
+++ b/libs/shared/ui/src/lib/Popover.stories.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
 import { Button } from './Button';
 import { Input } from './Input';
-import { Popover } from './Popover';
+import { Popover, type PopoverTriggerProps } from './Popover';
 
 const meta = {
   title: 'Overlay/Popover',
@@ -43,6 +43,48 @@ export const Default: Story = {
         <Input label='Radius (km)' size='sm' placeholder='25' />
       </div>
     ),
+  },
+};
+
+/**
+ * Pass a render function as `trigger` to supply your own trigger element —
+ * here the design-system Button. Spread every injected prop onto the element
+ * you return; the Popover keeps owning open state, dismiss, focus return,
+ * and aria wiring.
+ */
+export const ComposedTrigger: Story = {
+  args: {
+    trigger: (props: PopoverTriggerProps) => (
+      <Button {...props} variant='secondary' size='sm'>
+        Location filters
+      </Button>
+    ),
+    children: (
+      <div className='flex flex-col gap-3'>
+        <Input label='City' size='sm' placeholder='e.g. Berlin' />
+        <Input label='Radius (km)' size='sm' placeholder='25' />
+      </div>
+    ),
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+    const trigger = canvas.getByRole('button', { name: 'Location filters' });
+
+    await step('Open from the composed Button trigger', async () => {
+      await userEvent.click(trigger);
+      await waitFor(() =>
+        expect(canvas.getByRole('dialog')).toBeInTheDocument()
+      );
+      await expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    });
+
+    await step('Escape closes and restores focus to the Button', async () => {
+      await userEvent.keyboard('{Escape}');
+      await waitFor(() =>
+        expect(canvas.queryByRole('dialog')).not.toBeInTheDocument()
+      );
+      await expect(trigger).toHaveFocus();
+    });
   },
 };
 

--- a/libs/shared/ui/src/lib/Popover.tsx
+++ b/libs/shared/ui/src/lib/Popover.tsx
@@ -1,18 +1,32 @@
 'use client';
 
-import {
-  useCallback,
-  useEffect,
-  useId,
-  useRef,
-  useState,
-  type ReactNode,
-} from 'react';
-import { cn, FOCUSABLE_SELECTOR } from './utils';
+import { useEffect, useId, useRef, type ReactNode, type Ref } from 'react';
+import { cn, FOCUSABLE_SELECTOR, useAnchoredPanel } from './utils';
+
+/**
+ * Wiring the Popover injects into a composed trigger. Spread every prop onto
+ * your interactive element — the popover keeps owning open state, dismiss,
+ * focus return, and aria wiring.
+ */
+export interface PopoverTriggerProps {
+  ref: Ref<HTMLButtonElement>;
+  id: string;
+  /** Guards against implicit form submission when the popover sits in a form. */
+  type: 'button';
+  'aria-haspopup': 'dialog';
+  'aria-expanded': boolean;
+  'aria-controls': string | undefined;
+  onClick: () => void;
+}
 
 export interface PopoverProps {
-  /** Content rendered inside the trigger button. */
-  trigger: ReactNode;
+  /**
+   * Content rendered inside the built-in trigger button — or a render
+   * function receiving {@link PopoverTriggerProps} to supply your own trigger
+   * element (a design-system Button, a styled pill…). Spread all injected
+   * props onto the element you return.
+   */
+  trigger: ReactNode | ((props: PopoverTriggerProps) => ReactNode);
   /**
    * Panel content. Pass a render function to receive `close` for explicit
    * dismissal (e.g. an "Apply" button or after an async action completes).
@@ -46,28 +60,14 @@ export function Popover({
   panelClassName,
   'aria-label': ariaLabel,
 }: PopoverProps) {
-  const [uncontrolledOpen, setUncontrolledOpen] = useState(false);
-  const isControlled = open !== undefined;
-  const isOpen = isControlled ? open : uncontrolledOpen;
-  const ref = useRef<HTMLDivElement>(null);
-  const triggerRef = useRef<HTMLButtonElement>(null);
+  const { isOpen, setOpen, close, wrapperRef, triggerRef } = useAnchoredPanel({
+    open,
+    onOpenChange,
+  });
   const panelRef = useRef<HTMLDivElement>(null);
   const uid = useId();
   const panelId = `popover-panel-${uid}`;
   const triggerId = `popover-trigger-${uid}`;
-
-  const setOpen = useCallback(
-    (next: boolean) => {
-      if (!isControlled) setUncontrolledOpen(next);
-      onOpenChange?.(next);
-    },
-    [isControlled, onOpenChange]
-  );
-
-  const close = useCallback(() => {
-    setOpen(false);
-    triggerRef.current?.focus();
-  }, [setOpen]);
 
   // Move focus into the panel when it opens: first focusable, else the panel
   const prevOpenRef = useRef(false);
@@ -83,49 +83,25 @@ export function Popover({
     prevOpenRef.current = isOpen;
   }, [isOpen]);
 
-  // Outside click dismisses without moving focus (matches Dropdown)
-  useEffect(() => {
-    if (!isOpen) return;
-    const handler = (e: MouseEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node)) {
-        setOpen(false);
-      }
-    };
-    document.addEventListener('mousedown', handler);
-    return () => document.removeEventListener('mousedown', handler);
-  }, [isOpen, setOpen]);
-
-  // Escape from anywhere inside (trigger or panel fields) dismisses. A native
-  // listener on the wrapper keeps interaction handlers off non-interactive
-  // JSX elements (jsx-a11y) while still scoping Escape to this popover.
-  useEffect(() => {
-    if (!isOpen) return;
-    const node = ref.current;
-    if (!node) return;
-    const handler = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        e.preventDefault();
-        close();
-      }
-    };
-    node.addEventListener('keydown', handler);
-    return () => node.removeEventListener('keydown', handler);
-  }, [isOpen, close]);
+  const triggerProps: PopoverTriggerProps = {
+    ref: triggerRef,
+    id: triggerId,
+    type: 'button',
+    'aria-haspopup': 'dialog',
+    'aria-expanded': isOpen,
+    'aria-controls': isOpen ? panelId : undefined,
+    onClick: () => (isOpen ? close() : setOpen(true)),
+  };
 
   return (
-    <div ref={ref} className={cn('relative inline-flex', className)}>
-      <button
-        ref={triggerRef}
-        id={triggerId}
-        type='button'
-        aria-haspopup='dialog'
-        aria-expanded={isOpen}
-        aria-controls={isOpen ? panelId : undefined}
-        onClick={() => (isOpen ? close() : setOpen(true))}
-        className='inline-flex items-center'
-      >
-        {trigger}
-      </button>
+    <div ref={wrapperRef} className={cn('relative inline-flex', className)}>
+      {typeof trigger === 'function' ? (
+        trigger(triggerProps)
+      ) : (
+        <button {...triggerProps} className='inline-flex items-center'>
+          {trigger}
+        </button>
+      )}
       {isOpen && (
         <div
           ref={panelRef}

--- a/libs/shared/ui/src/lib/index.tsx
+++ b/libs/shared/ui/src/lib/index.tsx
@@ -82,7 +82,11 @@ export type { HeadingProps, HeadingVariant } from './Heading';
 export type { IconTextProps, IconTextPosition } from './IconText';
 export type { TextProps, TextVariant } from './Text';
 export type { FormFieldErrorProps } from './FormFieldError';
-export type { DropdownItem, DropdownProps } from './Dropdown';
+export type {
+  DropdownItem,
+  DropdownProps,
+  DropdownTriggerProps,
+} from './Dropdown';
 export type { PageContainerProps } from './PageContainer';
 export type { PageLayoutProps } from './PageLayout';
 export type { GridProps, GridItemProps } from './Grid';
@@ -92,7 +96,7 @@ export type { KbdProps } from './Kbd';
 export type { LoadingProps } from './Loading';
 export type { ModalPlacement, ModalProps } from './Modal';
 export type { PaginationProps } from './Pagination';
-export type { PopoverProps } from './Popover';
+export type { PopoverProps, PopoverTriggerProps } from './Popover';
 export type { ProgressBarProps } from './ProgressBar';
 export type { SectionProps } from './Section';
 export type { SectionLabelProps } from './SectionLabel';

--- a/libs/shared/ui/src/lib/utils/index.ts
+++ b/libs/shared/ui/src/lib/utils/index.ts
@@ -1,5 +1,6 @@
 export { cn } from './cn';
 export { FOCUSABLE_SELECTOR } from './focusable';
+export { useAnchoredPanel } from './useAnchoredPanel';
 export { validateProps } from './validateProps';
 export { ErrorBoundary } from './ErrorBoundary';
 export { ModalErrorBoundary } from './ModalErrorBoundary';

--- a/libs/shared/ui/src/lib/utils/useAnchoredPanel.ts
+++ b/libs/shared/ui/src/lib/utils/useAnchoredPanel.ts
@@ -1,0 +1,75 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export interface AnchoredPanelOptions {
+  /** Controlled open state; omit for internal state. */
+  open?: boolean | undefined;
+  /** Called with the next open state on every open/close request. */
+  onOpenChange?: ((open: boolean) => void) | undefined;
+}
+
+/**
+ * Open state and dismiss behaviour shared by anchored popups (Popover,
+ * Dropdown): controlled/uncontrolled open, outside-mousedown close (without
+ * moving focus), and Escape close returning focus to the trigger. Both
+ * dismiss listeners attach only while open and are scoped to `wrapperRef`;
+ * `triggerRef` is the focus-return target, wherever the trigger element
+ * comes from (built-in button or a composed one).
+ *
+ * Internal to the library — components remain the public surface.
+ */
+export function useAnchoredPanel({ open, onOpenChange }: AnchoredPanelOptions) {
+  const [uncontrolledOpen, setUncontrolledOpen] = useState(false);
+  const isControlled = open !== undefined;
+  const isOpen = isControlled ? open : uncontrolledOpen;
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+
+  const setOpen = useCallback(
+    (next: boolean) => {
+      if (!isControlled) setUncontrolledOpen(next);
+      onOpenChange?.(next);
+    },
+    [isControlled, onOpenChange]
+  );
+
+  const close = useCallback(() => {
+    setOpen(false);
+    triggerRef.current?.focus();
+  }, [setOpen]);
+
+  // Outside click dismisses without moving focus
+  useEffect(() => {
+    if (!isOpen) return;
+    const handler = (e: MouseEvent) => {
+      if (
+        wrapperRef.current &&
+        !wrapperRef.current.contains(e.target as Node)
+      ) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [isOpen, setOpen]);
+
+  // Escape from anywhere inside (trigger or panel fields) dismisses. A native
+  // listener on the wrapper keeps interaction handlers off non-interactive
+  // JSX elements (jsx-a11y) while still scoping Escape to this popup.
+  useEffect(() => {
+    if (!isOpen) return;
+    const node = wrapperRef.current;
+    if (!node) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        close();
+      }
+    };
+    node.addEventListener('keydown', handler);
+    return () => node.removeEventListener('keydown', handler);
+  }, [isOpen, close]);
+
+  return { isOpen, setOpen, close, wrapperRef, triggerRef };
+}

--- a/libs/shared/ui/src/lib/utils/useAnchoredPanel.ts
+++ b/libs/shared/ui/src/lib/utils/useAnchoredPanel.ts
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 
-export interface AnchoredPanelOptions {
+interface AnchoredPanelOptions {
   /** Controlled open state; omit for internal state. */
   open?: boolean | undefined;
   /** Called with the next open state on every open/close request. */


### PR DESCRIPTION
Closes #1107. Unblocks the two wyrdfold migrations tracked in danieljoffe/wyrdfold#485.

## What

- **Composable trigger on `Popover` and `Dropdown`**: the `trigger` prop now also accepts a render function receiving the full wiring — `ref`, `id`, `type='button'`, `aria-haspopup`, `aria-expanded`, `aria-controls`, `onClick` (+ `onKeyDown` on Dropdown for ArrowDown/ArrowUp open). Spread it onto your own element (design-system `Button`, styled pill) and the primitive keeps owning open state, dismiss, keyboard nav, and focus return. Node-form triggers render exactly as before. New exported types: `PopoverTriggerProps`, `DropdownTriggerProps`.
- **Dropdown parity with Popover**: controlled `open`/`onOpenChange`, `panelClassName`, and its outside-click document listener now attaches only while the menu is open (Popover already did this).
- **Internal `useAnchoredPanel` hook** (`utils/`, deliberately not exported): the shared open-state/outside-click/Escape/focus-return logic both components now sit on. Dropdown's Escape moved from per-handler switch cases to the same native wrapper listener Popover uses — behavior unchanged, verified by the pre-existing Escape specs.
- **Docs**: `Dropdown.mdx` props table + new Composed Trigger pattern; the old "Don't pass a `<Button>` as trigger" guidance is rewritten (that's now the headline use case, via the function form). Composed-trigger stories for both components + a Controlled Dropdown story.
- Changeset: **minor** (→ 0.10.0).

## Why render-prop over asChild

It's the existing house idiom (Popover `children` already accepts `node | fn`), adds zero new prop names, needs no Slot/prop-merging machinery, and TypeScript enforces the spread contract instead of cloning failing silently. Details in #1107 discussion.

## Validated

- shared-ui: lint ✅ (one pre-existing Toast.tsx warning, untouched) · typecheck ✅ · Jest 868/868 ✅ (13 new specs: composed-trigger wiring/no-nested-button/focus-return on both components, controlled Dropdown, `panelClassName`, `onOpenChange` uncontrolled, a11y axe on composed-Button popups)
- Storybook: build ✅ · Vitest interaction tests 338/338 ✅ (new plays: ComposedTrigger ×2, Controlled Dropdown)
- Consumer boundary: `nx build root` ✅ · workspace `tsc --noEmit` ✅ · `nx test root` ✅
- Negative case proven: composed trigger renders exactly one `<button>` in the DOM (guards the double-wrap regression)

## Residual risk

- New stories add visual snapshots → expect the usual shared-ui visual-baseline churn on the develop push; regenerate via `visual-baselines.yml` if the visual job flags them (feature→develop PRs only run `fast`).
- Consumers who pass a component that doesn't forward props/ref to its DOM node would get a dead trigger — documented ("spread every injected prop"); both known consumers' Buttons forward correctly (verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)