### PR TITLE
refactor(nav): composed More trigger + fix Jest shared-ui source resolution

### DIFF
--- a/apps/root/jest.config.ts
+++ b/apps/root/jest.config.ts
@@ -43,11 +43,13 @@ const config = {
   forceExit: true,
   setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
   moduleNameMapper: {
-    '^@danieljoffe\\.com/shared-ui$':
-      '<rootDir>/../../libs/shared/ui/src/index.ts',
-    '^@danieljoffe\\.com/shared-ui/styles/(.*)$':
+    // Map the published scope to library SOURCE, not the built dist a stale
+    // node_modules symlink would serve — app tests must exercise the same
+    // shared-ui code the repo ships from.
+    '^@danieljoffe/shared-ui$': '<rootDir>/../../libs/shared/ui/src/index.ts',
+    '^@danieljoffe/shared-ui/styles/(.*)$':
       '<rootDir>/../../libs/shared/ui/src/lib/styles/$1.ts',
-    '^@danieljoffe\\.com/shared-ui/(.*)$':
+    '^@danieljoffe/shared-ui/(.*)$':
       '<rootDir>/../../libs/shared/ui/src/lib/$1.tsx',
     '^@/(.*)$': '<rootDir>/src/$1',
   },

--- a/apps/root/src/components/Nav/TabletUpNav.spec.tsx
+++ b/apps/root/src/components/Nav/TabletUpNav.spec.tsx
@@ -100,6 +100,42 @@ describe('TabletUpNav', () => {
     ).toBeInTheDocument();
   });
 
+  describe('composed More trigger (shared-ui 0.10 render-prop)', () => {
+    test('renders as a single styled button with menu wiring', () => {
+      const { container } = render(<TabletUpNav pathname='/' />);
+      const trigger = screen.getByRole('button', { name: 'More' });
+      expect(trigger).toHaveAttribute('aria-haspopup', 'menu');
+      expect(trigger).toHaveAttribute('type', 'button');
+      // The interactive element itself carries the nav-item styling — no
+      // unstyled wrapper button around a styled span, and no nested buttons.
+      expect(trigger).toHaveClass('rounded-lg');
+      expect(trigger.querySelector('button')).toBeNull();
+      expect(
+        container.querySelectorAll("button[aria-haspopup='menu']")
+      ).toHaveLength(1);
+    });
+
+    test('marks the trigger active when the current page is a More link', () => {
+      render(<TabletUpNav pathname='/blog' />);
+      expect(screen.getByRole('button', { name: 'More' })).toHaveClass(
+        'bg-surface-tertiary'
+      );
+    });
+
+    test('navigates via router when an internal More item is clicked', () => {
+      render(<TabletUpNav pathname='/' />);
+      fireEvent.click(screen.getByRole('button', { name: 'More' }));
+      fireEvent.click(screen.getByRole('menuitem', { name: /Blog/i }));
+      expect(mockPush).toHaveBeenCalledWith('/blog');
+    });
+
+    it('has no accessibility violations with the menu open', async () => {
+      const { container } = render(<TabletUpNav pathname='/' />);
+      fireEvent.click(screen.getByRole('button', { name: 'More' }));
+      expect(await axe(container)).toHaveNoViolations();
+    });
+  });
+
   it('has no accessibility violations', async () => {
     const { container } = render(<TabletUpNav pathname='/' />);
     expect(await axe(container)).toHaveNoViolations();

--- a/apps/root/src/components/Nav/TabletUpNav.tsx
+++ b/apps/root/src/components/Nav/TabletUpNav.tsx
@@ -11,7 +11,11 @@ import {
   FileText,
 } from 'lucide-react';
 import Image from 'next/image';
-import { Dropdown, type DropdownItem } from '@danieljoffe/shared-ui/Dropdown';
+import {
+  Dropdown,
+  type DropdownItem,
+  type DropdownTriggerProps,
+} from '@danieljoffe/shared-ui/Dropdown';
 import { cn } from '@/lib/cn';
 import { analytics } from '@/lib/analytics';
 import {
@@ -87,10 +91,11 @@ export default function TabletUpNav({ pathname }: { pathname: string }) {
         ))}
 
         <Dropdown
-          trigger={
-            <span
+          trigger={(props: DropdownTriggerProps) => (
+            <button
+              {...props}
               className={cn(
-                'flex items-center gap-0.5 px-3 py-1.5 rounded-lg text-sm font-medium transition-colors',
+                'flex items-center gap-0.5 px-3 py-1.5 rounded-lg text-sm font-medium transition-colors cursor-pointer',
                 isMoreActive
                   ? 'text-text-primary bg-surface-tertiary'
                   : 'text-text-secondary hover:text-text-primary hover:bg-surface-tertiary'
@@ -98,8 +103,8 @@ export default function TabletUpNav({ pathname }: { pathname: string }) {
             >
               More
               <ChevronDown className='h-3.5 w-3.5' aria-hidden='true' />
-            </span>
-          }
+            </button>
+          )}
           items={moreItems}
           align='left'
         />


### PR DESCRIPTION
First in-repo consumer of shared-ui 0.10.0's composed triggers (#1107), from the post-release skim pass.

## What

- **`TabletUpNav` "More" menu** now uses the render-prop `trigger`: the interactive `<button>` itself carries the exact nav-item classes of its sibling `Link`s (active state included, plus `cursor-pointer` the old wrapper lacked), replacing the styled-span-inside-unstyled-button indirection.
- **Jest resolution fix (repo-wide for app tests)**: `apps/root/jest.config.ts` mapped only the retired `@danieljoffe.com/*` scope to library source — the live `@danieljoffe/shared-ui` scope (34 importing files, 0 on the old scope) fell through to the node_modules symlink and a **stale July-10 dist**. App tests were silently exercising two-week-old shared-ui; the new API failing in spec is what exposed it. Mapper now targets source; dead `.com` entries removed.
- Consolidated `TabletUpNav` specs into the existing co-located file (removed an accidental duplicate location) with 4 new tests: single-button trigger wiring (guards the double-wrap/nested-button regression), active-state class, router navigation on internal item click (`mockPush` existed but was never asserted), axe on the open menu.

## Validated

- `nx test root --skip-nx-cache`: **602/602** (68 suites) — cache-cold against source-mapped shared-ui, so the resolution change is proven across all 34 importing files, not just Nav
- Workspace `tsc --noEmit` clean · `nx lint root` no errors (pre-existing warnings only) · knip clean
- Negative case: composed trigger renders exactly one `aria-haspopup` button, no nested buttons

## Residual risk

- Visual: the More trigger's rendered look is unchanged by inspection of classes (same recipe as before, one added `cursor-pointer`); no shared-ui stories touched, so no baseline churn expected.
- The mapper change means future app tests fail fast on real shared-ui source breaks instead of passing against stale dist — intended, but it shifts when breaks surface.

Follow-up from the same skim (filed separately): adopt `Modal placement='sheet'` in `TableOfContents` + `MobileNav`, which hand-roll backdrop/scroll-lock/focus-trap/Escape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)