### PR TITLE
feat(shared-ui,root): Modal sheet exit animation + adopt Modal sheet in TOC/MobileNav

### DIFF
--- a/.changeset/modal-sheet-exit.md
+++ b/.changeset/modal-sheet-exit.md
@@ -1,0 +1,8 @@
+---
+'@danieljoffe/shared-ui': minor
+---
+
+Modal sheet polish + escape hatches for adopting hand-rolled sheets:
+
+- `placement='sheet'` now travels the full height: a true slide-up entrance (`sheet-in`, replacing the subtle 8px `slide-up` pop) and a slide-out exit before unmounting (`sheet-out`, Toast's dismissing pattern — the sheet is inert and the backdrop is gone during the exit; centered dialogs still close instantly). Consuming themes need the new `--animate-sheet-in` / `--animate-sheet-out` tokens + keyframes (in `indigo-theme.css`).
+- New props: `aria-label` (dialog name when there is no `title`), `showCloseButton` (default `true` — hide the built-in X when content supplies its own), `bodyClassName` (override body padding / add safe-area insets).

--- a/apps/root-e2e/src/navigation.spec.ts
+++ b/apps/root-e2e/src/navigation.spec.ts
@@ -137,15 +137,13 @@ test.describe('mobile navigation', () => {
     const sheet = page.locator('[role="dialog"][aria-label="More navigation"]');
     await expect(sheet).toBeVisible();
 
-    // Close via the backdrop overlay — use dispatchEvent because the fixed
-    // bottom nav bar (z-50) sits above the overlay (z-40) and intercepts
-    // normal Playwright clicks.
-    const overlay = page.getByTestId('sheet-overlay');
-    await overlay.dispatchEvent('click');
-    // The sheet slides off-screen via translate-y-full and sets aria-hidden.
-    // Playwright's toBeHidden() requires display:none or visibility:hidden,
-    // so assert the semantic close state instead.
-    await expect(sheet).toHaveAttribute('aria-hidden', 'true');
+    // Close via the Modal backdrop — it covers the whole viewport (bottom
+    // bar included), so a real click lands on it.
+    const backdrop = page.locator('div[aria-hidden="true"].backdrop-blur-sm');
+    await backdrop.click();
+    // The sheet slides out and unmounts; toHaveCount(0) auto-waits through
+    // the exit animation.
+    await expect(sheet).toHaveCount(0);
   });
 
   test('navigates from More sheet', async ({ page }) => {

--- a/apps/root/jest.config.ts
+++ b/apps/root/jest.config.ts
@@ -43,11 +43,13 @@ const config = {
   forceExit: true,
   setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
   moduleNameMapper: {
-    '^@danieljoffe\\.com/shared-ui$':
-      '<rootDir>/../../libs/shared/ui/src/index.ts',
-    '^@danieljoffe\\.com/shared-ui/styles/(.*)$':
+    // Map the published scope to library SOURCE, not the built dist a stale
+    // node_modules symlink would serve — app tests must exercise the same
+    // shared-ui code the repo ships from.
+    '^@danieljoffe/shared-ui$': '<rootDir>/../../libs/shared/ui/src/index.ts',
+    '^@danieljoffe/shared-ui/styles/(.*)$':
       '<rootDir>/../../libs/shared/ui/src/lib/styles/$1.ts',
-    '^@danieljoffe\\.com/shared-ui/(.*)$':
+    '^@danieljoffe/shared-ui/(.*)$':
       '<rootDir>/../../libs/shared/ui/src/lib/$1.tsx',
     '^@/(.*)$': '<rootDir>/src/$1',
   },

--- a/apps/root/src/components/Nav/MobileNav.tsx
+++ b/apps/root/src/components/Nav/MobileNav.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useCallback, useEffect, useRef } from 'react';
+import { useState, useCallback, useRef } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import {
@@ -18,6 +18,7 @@ import {
   ExternalLink,
   X,
 } from 'lucide-react';
+import { Modal } from '@danieljoffe/shared-ui/Modal';
 import Button from '@/components/Button';
 import { cn } from '@/lib/cn';
 import { analytics } from '@/lib/analytics';
@@ -27,7 +28,6 @@ import {
   MORE_NAV_LINKS,
   EXTERNAL_NAV_LINKS,
 } from '@/utils/constants';
-import { useFocusTrap } from '@/hooks/useFocusTrap';
 import DarkModeToggle from './DarkModeToggle';
 
 const primaryIcons: Record<string, typeof Briefcase> = {
@@ -56,7 +56,6 @@ export default function MobileNav({ pathname }: { pathname: string }) {
   const [sheetOpen, setSheetOpen] = useState(false);
   const router = useRouter();
   const moreButtonRef = useRef<HTMLButtonElement>(null);
-  const sheetRef = useFocusTrap(sheetOpen) as React.RefObject<HTMLDivElement>;
 
   const openSheet = useCallback(() => {
     analytics.mobileMenuToggle('open');
@@ -68,28 +67,6 @@ export default function MobileNav({ pathname }: { pathname: string }) {
     setSheetOpen(false);
     moreButtonRef.current?.focus();
   }, []);
-
-  // Close on Escape
-  useEffect(() => {
-    if (!sheetOpen) return;
-    const handleKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') closeSheet();
-    };
-    document.addEventListener('keydown', handleKey);
-    return () => document.removeEventListener('keydown', handleKey);
-  }, [sheetOpen, closeSheet]);
-
-  // Lock body scroll when sheet is open
-  useEffect(() => {
-    if (sheetOpen) {
-      document.body.style.overflow = 'hidden';
-    } else {
-      document.body.style.overflow = '';
-    }
-    return () => {
-      document.body.style.overflow = '';
-    };
-  }, [sheetOpen]);
 
   const handleSheetLink = useCallback(
     (label: string, href: string) => {
@@ -189,103 +166,89 @@ export default function MobileNav({ pathname }: { pathname: string }) {
         </nav>
       </div>
 
-      {/* Backdrop */}
-      {sheetOpen && (
-        <div
-          data-testid='sheet-overlay'
-          className='md:hidden fixed inset-0 z-40 bg-black/40 backdrop-blur-[2px] transition-opacity'
-          onClick={closeSheet}
-          aria-hidden='true'
-        />
-      )}
-
-      {/* Bottom sheet — slides up like TableOfContents */}
-      <div
-        ref={sheetRef}
-        role='dialog'
-        aria-label='More navigation'
-        aria-modal='true'
-        aria-hidden={!sheetOpen}
-        inert={!sheetOpen ? true : undefined}
-        className={cn(
-          'md:hidden fixed bottom-0 left-0 right-0 z-50 bg-surface border-t border-border rounded-t-2xl shadow-2xl transition-transform duration-300 ease-out max-h-[60vh] overflow-y-auto px-6 py-5',
-          sheetOpen ? 'translate-y-0' : 'translate-y-full pointer-events-none'
-        )}
-        style={{
-          paddingBottom: sheetOpen
-            ? 'calc(3.5rem + env(safe-area-inset-bottom, 0px) + 1.25rem)'
-            : undefined,
-        }}
-      >
-        <div className='flex items-center justify-between mb-3'>
-          <span className='text-xs font-semibold text-text-tertiary uppercase tracking-wider'>
-            More
-          </span>
-          <div className='flex items-center gap-1'>
-            <DarkModeToggle />
-            <Button
-              name='close-more-menu'
-              variant='bare'
-              size='sm'
-              iconOnly
-              onClick={closeSheet}
-              aria-label='Close more menu'
-              className='rounded-lg text-text-tertiary hover:text-text-primary'
-            >
-              <X className='h-4 w-4' />
-            </Button>
+      {/* Bottom sheet — the md:hidden wrapper scopes the (non-portaled)
+          Modal to mobile, backdrop included, even if the viewport grows
+          while it is open. */}
+      <div className='md:hidden'>
+        <Modal
+          isOpen={sheetOpen}
+          onClose={closeSheet}
+          placement='sheet'
+          aria-label='More navigation'
+          showCloseButton={false}
+          className='max-w-none rounded-t-2xl border-t border-border max-h-[60vh]'
+          bodyClassName='px-6 py-5 pb-[calc(3.5rem+env(safe-area-inset-bottom,0px)+1.25rem)]'
+        >
+          <div className='flex items-center justify-between mb-3'>
+            <span className='text-xs font-semibold text-text-tertiary uppercase tracking-wider'>
+              More
+            </span>
+            <div className='flex items-center gap-1'>
+              <DarkModeToggle />
+              <Button
+                name='close-more-menu'
+                variant='bare'
+                size='sm'
+                iconOnly
+                onClick={closeSheet}
+                aria-label='Close more menu'
+                className='rounded-lg text-text-tertiary hover:text-text-primary'
+              >
+                <X className='h-4 w-4' />
+              </Button>
+            </div>
           </div>
-        </div>
-        <nav aria-label='More links'>
-          <ul className='space-y-1'>
-            {moreSheetLinks.map(link => {
-              const Icon = link.icon;
-              const active = pathname === link.href;
-              return (
-                <li key={link.href}>
-                  <Button
-                    name={`more-${link.label.toLowerCase().replace(/\s+/g, '-')}`}
-                    variant='bare'
-                    onClick={() => handleSheetLink(link.label, link.href)}
-                    className={cn(
-                      'w-full flex items-center justify-start gap-3 px-3 py-2.5 rounded-lg hover:scale-100 text-sm font-medium transition-colors cursor-pointer',
-                      active
-                        ? 'text-brand-500 bg-surface-tertiary'
-                        : 'text-text-secondary hover:text-text-primary hover:bg-surface-tertiary'
-                    )}
-                  >
-                    <Icon className='h-4 w-4' aria-hidden='true' />
-                    {link.label}
-                  </Button>
-                </li>
-              );
-            })}
-            {EXTERNAL_NAV_LINKS.map(link => {
-              const Icon = externalIcons[link.label] ?? Blocks;
-              return (
-                <li key={link.href}>
-                  <a
-                    href={link.href}
-                    target='_blank'
-                    rel='noopener noreferrer'
-                    onClick={() => {
-                      analytics.navClick(link.label);
-                      setSheetOpen(false);
-                    }}
-                    className='w-full flex items-center justify-start gap-3 px-3 py-2.5 rounded-lg text-sm font-medium transition-colors cursor-pointer text-text-secondary hover:text-text-primary hover:bg-surface-tertiary'
-                  >
-                    <Icon className='h-4 w-4' aria-hidden='true' />
-                    <span className='flex-1'>{link.label}</span>
-                    <ExternalLink
-                      className='h-3.5 w-3.5 shrink-0 opacity-60'
-                      aria-hidden='true'
-                    />
-                  </a>
-                </li>
-              );
-            })}
-          </ul>
-        </nav>
+          <nav aria-label='More links'>
+            <ul className='space-y-1'>
+              {moreSheetLinks.map(link => {
+                const Icon = link.icon;
+                const active = pathname === link.href;
+                return (
+                  <li key={link.href}>
+                    <Button
+                      name={`more-${link.label.toLowerCase().replace(/\s+/g, '-')}`}
+                      variant='bare'
+                      onClick={() => handleSheetLink(link.label, link.href)}
+                      className={cn(
+                        'w-full flex items-center justify-start gap-3 px-3 py-2.5 rounded-lg hover:scale-100 text-sm font-medium transition-colors cursor-pointer',
+                        active
+                          ? 'text-brand-500 bg-surface-tertiary'
+                          : 'text-text-secondary hover:text-text-primary hover:bg-surface-tertiary'
+                      )}
+                    >
+                      <Icon className='h-4 w-4' aria-hidden='true' />
+                      {link.label}
+                    </Button>
+                  </li>
+                );
+              })}
+              {EXTERNAL_NAV_LINKS.map(link => {
+                const Icon = externalIcons[link.label] ?? Blocks;
+                return (
+                  <li key={link.href}>
+                    <a
+                      href={link.href}
+                      target='_blank'
+                      rel='noopener noreferrer'
+                      onClick={() => {
+                        analytics.navClick(link.label);
+                        setSheetOpen(false);
+                      }}
+                      className='w-full flex items-center justify-start gap-3 px-3 py-2.5 rounded-lg text-sm font-medium transition-colors cursor-pointer text-text-secondary hover:text-text-primary hover:bg-surface-tertiary'
+                    >
+                      <Icon className='h-4 w-4' aria-hidden='true' />
+                      <span className='flex-1'>{link.label}</span>
+                      <ExternalLink
+                        className='h-3.5 w-3.5 shrink-0 opacity-60'
+                        aria-hidden='true'
+                      />
+                    </a>
+                  </li>
+                );
+              })}
+            </ul>
+          </nav>
+        </Modal>
       </div>
     </>
   );

--- a/apps/root/src/components/Nav/TabletUpNav.spec.tsx
+++ b/apps/root/src/components/Nav/TabletUpNav.spec.tsx
@@ -100,6 +100,42 @@ describe('TabletUpNav', () => {
     ).toBeInTheDocument();
   });
 
+  describe('composed More trigger (shared-ui 0.10 render-prop)', () => {
+    test('renders as a single styled button with menu wiring', () => {
+      const { container } = render(<TabletUpNav pathname='/' />);
+      const trigger = screen.getByRole('button', { name: 'More' });
+      expect(trigger).toHaveAttribute('aria-haspopup', 'menu');
+      expect(trigger).toHaveAttribute('type', 'button');
+      // The interactive element itself carries the nav-item styling — no
+      // unstyled wrapper button around a styled span, and no nested buttons.
+      expect(trigger).toHaveClass('rounded-lg');
+      expect(trigger.querySelector('button')).toBeNull();
+      expect(
+        container.querySelectorAll("button[aria-haspopup='menu']")
+      ).toHaveLength(1);
+    });
+
+    test('marks the trigger active when the current page is a More link', () => {
+      render(<TabletUpNav pathname='/blog' />);
+      expect(screen.getByRole('button', { name: 'More' })).toHaveClass(
+        'bg-surface-tertiary'
+      );
+    });
+
+    test('navigates via router when an internal More item is clicked', () => {
+      render(<TabletUpNav pathname='/' />);
+      fireEvent.click(screen.getByRole('button', { name: 'More' }));
+      fireEvent.click(screen.getByRole('menuitem', { name: /Blog/i }));
+      expect(mockPush).toHaveBeenCalledWith('/blog');
+    });
+
+    it('has no accessibility violations with the menu open', async () => {
+      const { container } = render(<TabletUpNav pathname='/' />);
+      fireEvent.click(screen.getByRole('button', { name: 'More' }));
+      expect(await axe(container)).toHaveNoViolations();
+    });
+  });
+
   it('has no accessibility violations', async () => {
     const { container } = render(<TabletUpNav pathname='/' />);
     expect(await axe(container)).toHaveNoViolations();

--- a/apps/root/src/components/Nav/TabletUpNav.tsx
+++ b/apps/root/src/components/Nav/TabletUpNav.tsx
@@ -11,7 +11,11 @@ import {
   FileText,
 } from 'lucide-react';
 import Image from 'next/image';
-import { Dropdown, type DropdownItem } from '@danieljoffe/shared-ui/Dropdown';
+import {
+  Dropdown,
+  type DropdownItem,
+  type DropdownTriggerProps,
+} from '@danieljoffe/shared-ui/Dropdown';
 import { cn } from '@/lib/cn';
 import { analytics } from '@/lib/analytics';
 import {
@@ -87,10 +91,11 @@ export default function TabletUpNav({ pathname }: { pathname: string }) {
         ))}
 
         <Dropdown
-          trigger={
-            <span
+          trigger={(props: DropdownTriggerProps) => (
+            <button
+              {...props}
               className={cn(
-                'flex items-center gap-0.5 px-3 py-1.5 rounded-lg text-sm font-medium transition-colors',
+                'flex items-center gap-0.5 px-3 py-1.5 rounded-lg text-sm font-medium transition-colors cursor-pointer',
                 isMoreActive
                   ? 'text-text-primary bg-surface-tertiary'
                   : 'text-text-secondary hover:text-text-primary hover:bg-surface-tertiary'
@@ -98,8 +103,8 @@ export default function TabletUpNav({ pathname }: { pathname: string }) {
             >
               More
               <ChevronDown className='h-3.5 w-3.5' aria-hidden='true' />
-            </span>
-          }
+            </button>
+          )}
           items={moreItems}
           align='left'
         />

--- a/apps/root/src/components/Nav/__tests__/MobileNav.spec.tsx
+++ b/apps/root/src/components/Nav/__tests__/MobileNav.spec.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { axe, toHaveNoViolations } from 'jest-axe';
 import MobileNav from '../MobileNav';
 
@@ -7,10 +7,6 @@ expect.extend(toHaveNoViolations);
 const mockPush = jest.fn();
 jest.mock('next/navigation', () => ({
   useRouter: () => ({ push: mockPush }),
-}));
-
-jest.mock('@/hooks/useFocusTrap', () => ({
-  useFocusTrap: () => ({ current: null }),
 }));
 
 // analytics is imported by MobileNav; mocks prevent the real module from loading.
@@ -106,16 +102,45 @@ describe('MobileNav', () => {
     expect(sharedUi).toHaveAttribute('href', 'https://ui.danieljoffe.com');
   });
 
-  it('closes sheet on Escape key', () => {
+  it('closes sheet on Escape key', async () => {
+    const { analytics } = jest.requireMock('@/lib/analytics');
     render(<MobileNav pathname='/' />);
 
     fireEvent.click(screen.getByRole('button', { name: /open more menu/i }));
+    expect(analytics.mobileMenuToggle).toHaveBeenCalledWith('open');
 
     fireEvent.keyDown(document, { key: 'Escape' });
 
     expect(
       screen.getByRole('button', { name: /open more menu/i })
     ).toBeInTheDocument();
+    expect(analytics.mobileMenuToggle).toHaveBeenCalledWith('close');
+    // The sheet slides out, then unmounts
+    await waitFor(() =>
+      expect(screen.queryByRole('dialog', { hidden: true })).toBeNull()
+    );
+  });
+
+  it('closes sheet on backdrop click', async () => {
+    const { container } = render(<MobileNav pathname='/' />);
+
+    fireEvent.click(screen.getByRole('button', { name: /open more menu/i }));
+    const backdrop = container.querySelector('.backdrop-blur-sm');
+    expect(backdrop).not.toBeNull();
+    fireEvent.click(backdrop!);
+
+    await waitFor(() =>
+      expect(screen.queryByRole('dialog', { hidden: true })).toBeNull()
+    );
+  });
+
+  it('open sheet has no accessibility violations', async () => {
+    const { container } = render(<MobileNav pathname='/' />);
+    fireEvent.click(screen.getByRole('button', { name: /open more menu/i }));
+    expect(
+      screen.getByRole('dialog', { name: /more navigation/i })
+    ).toBeInTheDocument();
+    expect(await axe(container)).toHaveNoViolations();
   });
 
   it('has no accessibility violations', async () => {

--- a/apps/root/src/components/kit/TableOfContents.tsx
+++ b/apps/root/src/components/kit/TableOfContents.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { List } from 'lucide-react';
+import { Modal } from '@danieljoffe/shared-ui/Modal';
 import { cn } from '@/lib/cn';
-import { useFocusTrap } from '@/hooks/useFocusTrap';
 
 interface TocItem {
   id: string;
@@ -164,47 +164,21 @@ function MobileToc({
   activeId: string;
 }) {
   const [isOpen, setIsOpen] = useState(false);
-  const sheetRef = useFocusTrap(isOpen) as React.RefObject<HTMLDivElement>;
-  const fabRef = useRef<HTMLButtonElement>(null);
-
-  // Close on Escape
-  useEffect(() => {
-    if (!isOpen) return;
-    const handleKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        setIsOpen(false);
-        fabRef.current?.focus();
-      }
-    };
-    document.addEventListener('keydown', handleKey);
-    return () => document.removeEventListener('keydown', handleKey);
-  }, [isOpen]);
-
-  // Lock body scroll when open
-  useEffect(() => {
-    if (isOpen) {
-      document.body.style.overflow = 'hidden';
-    } else {
-      document.body.style.overflow = '';
-    }
-    return () => {
-      document.body.style.overflow = '';
-    };
-  }, [isOpen]);
 
   const handleSelect = useCallback((id: string) => {
     setIsOpen(false);
-    // Small delay so the sheet closes before scrolling
+    // Small delay so the sheet starts closing before scrolling
     requestAnimationFrame(() => scrollToHeading(id));
   }, []);
 
   return (
     <div className='lg:hidden'>
-      {/* FAB */}
+      {/* FAB — while the sheet is open it sits under the Modal backdrop, so
+          clicking its spot dismisses via the backdrop; Modal returns focus
+          here on close. */}
       <button
-        ref={fabRef}
         type='button'
-        onClick={() => setIsOpen(prev => !prev)}
+        onClick={() => setIsOpen(true)}
         aria-label={
           isOpen ? 'Close table of contents' : 'Open table of contents'
         }
@@ -214,25 +188,13 @@ function MobileToc({
         <List className='size-4' aria-hidden='true' />
       </button>
 
-      {/* Backdrop */}
-      {isOpen && (
-        <div
-          className='fixed inset-0 z-30 bg-black/40 backdrop-blur-[2px] transition-opacity'
-          onClick={() => setIsOpen(false)}
-          aria-hidden='true'
-        />
-      )}
-
-      {/* Bottom sheet */}
-      <div
-        ref={sheetRef}
-        role='dialog'
+      <Modal
+        isOpen={isOpen}
+        onClose={() => setIsOpen(false)}
+        placement='sheet'
         aria-label='Table of contents'
-        aria-modal={isOpen}
-        className={cn(
-          'fixed bottom-0 left-0 right-0 z-51 bg-surface border-t border-border rounded-t-2xl shadow-2xl transition-transform duration-300 ease-out max-h-[60vh] overflow-y-auto px-6 py-5',
-          isOpen ? 'translate-y-0' : 'translate-y-full pointer-events-none'
-        )}
+        className='max-w-none rounded-t-2xl border-t border-border max-h-[60vh]'
+        bodyClassName='px-6 py-5'
       >
         <span className='text-xs font-semibold text-text-tertiary uppercase tracking-wider mb-3 block'>
           On this page
@@ -242,7 +204,7 @@ function MobileToc({
           activeId={activeId}
           onSelect={handleSelect}
         />
-      </div>
+      </Modal>
     </div>
   );
 }

--- a/apps/root/src/components/kit/__tests__/TableOfContents.spec.tsx
+++ b/apps/root/src/components/kit/__tests__/TableOfContents.spec.tsx
@@ -1,13 +1,14 @@
-import { render, screen, fireEvent, act } from '@testing-library/react';
+import {
+  render,
+  screen,
+  fireEvent,
+  act,
+  waitFor,
+} from '@testing-library/react';
 import { axe, toHaveNoViolations } from 'jest-axe';
 import { TableOfContents } from '../TableOfContents';
 
 expect.extend(toHaveNoViolations);
-
-// Mock useFocusTrap
-jest.mock('@/hooks/useFocusTrap', () => ({
-  useFocusTrap: () => ({ current: null }),
-}));
 
 // Mock IntersectionObserver
 const mockObserve = jest.fn();
@@ -153,6 +154,39 @@ describe('TableOfContents', () => {
     expect(
       screen.getByRole('button', { name: /open table of contents/i })
     ).toBeInTheDocument();
+    // The sheet slides out, then unmounts
+    await waitFor(() =>
+      expect(screen.queryByRole('dialog', { hidden: true })).toBeNull()
+    );
+  });
+
+  it('closes mobile sheet on backdrop click', async () => {
+    const { container: wrapper } = render(<TableOfContents mobile />);
+    await act(() => Promise.resolve());
+
+    fireEvent.click(
+      screen.getByRole('button', { name: /open table of contents/i })
+    );
+    const backdrop = wrapper.querySelector('.backdrop-blur-sm');
+    expect(backdrop).not.toBeNull();
+    fireEvent.click(backdrop!);
+
+    await waitFor(() =>
+      expect(screen.queryByRole('dialog', { hidden: true })).toBeNull()
+    );
+  });
+
+  it('open mobile sheet has no accessibility violations', async () => {
+    const { container: wrapper } = render(<TableOfContents mobile />);
+    await act(() => Promise.resolve());
+
+    fireEvent.click(
+      screen.getByRole('button', { name: /open table of contents/i })
+    );
+    expect(
+      screen.getByRole('dialog', { name: /table of contents/i })
+    ).toBeInTheDocument();
+    expect(await axe(wrapper)).toHaveNoViolations();
   });
 
   it('renders both desktop and mobile when no prop specified', async () => {

--- a/apps/root/src/styles/theme.css
+++ b/apps/root/src/styles/theme.css
@@ -26,6 +26,8 @@
   --animate-slide-up: slide-up 0.2s ease-out;
   --animate-slide-down: slide-down 0.15s ease-out;
   --animate-slide-out-down: slide-out-down 0.15s ease-in forwards;
+  --animate-sheet-in: sheet-in 0.3s ease-out;
+  --animate-sheet-out: sheet-out 0.25s ease-in forwards;
   --animate-scale-in: scale-in 0.15s ease-out;
 
   /* Colors - Brand (blue-indigo, oklch hue 250) */
@@ -521,5 +523,25 @@ code[data-line-numbers-max-digits='3'] > [data-line]::before {
   to {
     opacity: 1;
     transform: rotate(0) scale(1);
+  }
+}
+
+/* Full-height bottom-sheet travel (Modal placement='sheet') — unlike the
+   subtle 8px slide-up/down pop used by anchored popups. */
+@keyframes sheet-in {
+  from {
+    transform: translateY(100%);
+  }
+  to {
+    transform: translateY(0);
+  }
+}
+
+@keyframes sheet-out {
+  from {
+    transform: translateY(0);
+  }
+  to {
+    transform: translateY(100%);
   }
 }

--- a/libs/shared/ui/src/lib/Modal.mdx
+++ b/libs/shared/ui/src/lib/Modal.mdx
@@ -336,7 +336,38 @@ import { Button } from './Button';
       </td>
       <td>
         <code>'sheet'</code> anchors the dialog to the bottom edge as a mobile
-        bottom sheet (rounded top, slide-up entrance).
+        bottom sheet: it slides up from the bottom on open and slides back out
+        on close (centered dialogs close instantly).
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <code>showCloseButton</code>
+      </td>
+      <td>
+        <code>boolean</code>
+      </td>
+      <td>
+        <code>true</code>
+      </td>
+      <td>
+        Set to <code>false</code> when the content supplies its own close
+        affordance — always keep <em>some</em> visible way out besides Escape.
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <code>aria-label</code>
+      </td>
+      <td>
+        <code>string</code>
+      </td>
+      <td>
+        <code>undefined</code>
+      </td>
+      <td>
+        Accessible name when there is no <code>title</code> (falls back to
+        "Dialog").
       </td>
     </tr>
     <tr>
@@ -364,6 +395,22 @@ import { Button } from './Button';
         <code>undefined</code>
       </td>
       <td>Additional classes on the dialog container.</td>
+    </tr>
+    <tr>
+      <td>
+        <code>bodyClassName</code>
+      </td>
+      <td>
+        <code>string</code>
+      </td>
+      <td>
+        <code>undefined</code>
+      </td>
+      <td>
+        Merged onto the scrollable body — override padding or add safe-area
+        insets (e.g.{' '}
+        <code>pb-[calc(env(safe-area-inset-bottom,0px)+1.25rem)]</code>).
+      </td>
     </tr>
   </tbody>
 </table>
@@ -411,8 +458,10 @@ import { Button } from './Button';
 <p className='doc-p'>
   Use <code>placement="sheet"</code> for mobile-first flows (filters, quick
   pickers) where actions should sit within thumb reach. The sheet keeps Modal's
-  focus trap, scroll lock, Escape handling, and backdrop; only the positioning
-  and entrance change.
+  focus trap, scroll lock, Escape handling, and backdrop; it slides up on open
+  and slides back out on close. For a full-bleed sheet, override the width cap
+  with <code>className="max-w-none"</code>; use <code>bodyClassName</code> for
+  safe-area padding on devices with a home indicator.
 </p>
 
 ```jsx

--- a/libs/shared/ui/src/lib/Modal.spec.tsx
+++ b/libs/shared/ui/src/lib/Modal.spec.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
 import { axe, toHaveNoViolations } from 'jest-axe';
 import { Modal } from './Modal';
 
@@ -93,10 +93,10 @@ describe('Modal', () => {
       expect(dialog).not.toHaveClass('rounded-lg');
     });
 
-    it('animates the sheet with slide-up, disabled under reduced motion', () => {
+    it('animates the sheet in with sheet-in, disabled under reduced motion', () => {
       renderModal({ placement: 'sheet' });
       const dialog = screen.getByRole('dialog');
-      expect(dialog).toHaveClass('animate-slide-up');
+      expect(dialog).toHaveClass('animate-sheet-in');
       expect(dialog).toHaveClass('motion-reduce:animate-none');
     });
 
@@ -106,6 +106,75 @@ describe('Modal', () => {
         title: 'Sheet',
       });
       expect(await axe(container)).toHaveNoViolations();
+    });
+  });
+
+  describe('sheet exit animation', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    const sheet = (isOpen: boolean) => (
+      <Modal isOpen={isOpen} onClose={() => {}} placement='sheet'>
+        <button>OK</button>
+      </Modal>
+    );
+
+    it('keeps the sheet mounted and inert while it slides out, then unmounts', () => {
+      const { rerender } = render(sheet(true));
+      rerender(sheet(false));
+
+      const dialog = screen.getByRole('dialog', { hidden: true });
+      expect(dialog).toHaveClass('animate-sheet-out');
+      expect(dialog).toHaveAttribute('inert');
+      // Dismissal is not interactive during the exit
+      expect(dialog.parentElement).toHaveClass('pointer-events-none');
+
+      act(() => {
+        jest.advanceTimersByTime(250);
+      });
+      expect(screen.queryByRole('dialog', { hidden: true })).toBeNull();
+    });
+
+    it('removes the backdrop at close-start, before the sheet finishes exiting', () => {
+      const { rerender, container } = render(sheet(true));
+      expect(container.querySelector('.backdrop-blur-sm')).toBeInTheDocument();
+      rerender(sheet(false));
+      expect(container.querySelector('.backdrop-blur-sm')).toBeNull();
+      expect(screen.getByRole('dialog', { hidden: true })).toBeInTheDocument();
+    });
+
+    it('reopening during the exit renders the sheet as open again', () => {
+      const { rerender } = render(sheet(true));
+      rerender(sheet(false));
+      rerender(sheet(true));
+
+      const dialog = screen.getByRole('dialog');
+      expect(dialog).toHaveClass('animate-sheet-in');
+      expect(dialog).not.toHaveAttribute('inert');
+      // Outlive the (cleared) exit timer: the sheet must remain open
+      act(() => {
+        jest.advanceTimersByTime(1000);
+      });
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+
+    it('closes centered dialogs instantly (no exit phase)', () => {
+      const { rerender } = render(
+        <Modal isOpen={true} onClose={() => {}}>
+          <button>OK</button>
+        </Modal>
+      );
+      rerender(
+        <Modal isOpen={false} onClose={() => {}}>
+          <button>OK</button>
+        </Modal>
+      );
+      expect(screen.queryByRole('dialog', { hidden: true })).toBeNull();
     });
   });
 
@@ -139,6 +208,27 @@ describe('Modal', () => {
     expect(
       screen.getByRole('button', { name: 'Close dialog' })
     ).toBeInTheDocument();
+  });
+
+  it('hides the close button with showCloseButton={false} (no title)', () => {
+    renderModal({ showCloseButton: false, 'aria-label': 'Sheet' });
+    expect(
+      screen.queryByRole('button', { name: 'Close dialog' })
+    ).not.toBeInTheDocument();
+  });
+
+  it('hides the close button with showCloseButton={false} (with title)', () => {
+    renderModal({ showCloseButton: false, title: 'Sheet' });
+    expect(screen.getByText('Sheet')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Close dialog' })
+    ).not.toBeInTheDocument();
+  });
+
+  it('merges bodyClassName onto the scrollable body', () => {
+    renderModal({ bodyClassName: 'px-6 py-5' });
+    const body = screen.getByText('OK').parentElement;
+    expect(body).toHaveClass('px-6', 'py-5', 'overflow-y-auto');
   });
 
   describe('body scroll cleanup', () => {
@@ -191,6 +281,19 @@ describe('Modal', () => {
       renderModal();
       const dialog = screen.getByRole('dialog');
       expect(dialog).toHaveAttribute('aria-label', 'Dialog');
+    });
+
+    it('uses the aria-label prop over the "Dialog" fallback when no title', () => {
+      renderModal({ 'aria-label': 'Table of contents' });
+      expect(
+        screen.getByRole('dialog', { name: 'Table of contents' })
+      ).toBeInTheDocument();
+    });
+
+    it('title wins over the aria-label prop', () => {
+      renderModal({ title: 'My Dialog', 'aria-label': 'Ignored' });
+      const dialog = screen.getByRole('dialog', { name: 'My Dialog' });
+      expect(dialog).not.toHaveAttribute('aria-label');
     });
 
     it('close button has accessible name "Close dialog"', () => {

--- a/libs/shared/ui/src/lib/Modal.stories.tsx
+++ b/libs/shared/ui/src/lib/Modal.stories.tsx
@@ -51,6 +51,23 @@ const meta = {
         defaultValue: { summary: 'center' },
       },
     },
+    showCloseButton: {
+      description:
+        'Hide the built-in dismiss X when the content supplies its own close affordance',
+      control: 'boolean',
+      table: {
+        defaultValue: { summary: 'true' },
+      },
+    },
+    bodyClassName: {
+      description:
+        'Merged onto the scrollable body — override padding, add safe-area insets, etc.',
+      control: 'text',
+    },
+    'aria-label': {
+      description: 'Accessible name for the dialog when there is no title',
+      control: 'text',
+    },
     onClose: {
       description:
         'Callback fired when modal is closed (via backdrop click, Escape key, or close button)',
@@ -185,8 +202,9 @@ export const ExtraLarge: Story = {
 
 /**
  * `placement='sheet'` anchors the dialog to the bottom edge — a mobile
- * bottom-sheet with `rounded-t` corners and a slide-up entrance, while keeping
- * Modal's focus trap, scroll lock, and backdrop behavior.
+ * bottom-sheet with `rounded-t` corners that slides up from the bottom on
+ * open and slides back out on close, while keeping Modal's focus trap,
+ * scroll lock, and backdrop behavior.
  */
 export const BottomSheet: Story = {
   args: {
@@ -197,6 +215,62 @@ export const BottomSheet: Story = {
       'A bottom sheet keeps thumb-reach actions at the bottom of the screen on mobile.',
     footer: <Button name='apply-filters'>Apply filters</Button>,
     onClose: fn(),
+  },
+};
+
+/**
+ * Closing a sheet plays a slide-out exit before it unmounts (centered
+ * dialogs close instantly). While exiting, the sheet is inert and the
+ * backdrop is already gone.
+ */
+export const SheetExitAnimation: Story = {
+  args: {
+    isOpen: false,
+    onClose: fn(),
+    children: null,
+  },
+  render: function SheetExitDemo() {
+    const [isOpen, setIsOpen] = useState(false);
+    return (
+      <>
+        <Button onClick={() => setIsOpen(true)}>Open sheet</Button>
+        <Modal
+          isOpen={isOpen}
+          onClose={() => setIsOpen(false)}
+          placement='sheet'
+          title='Slides out on close'
+        >
+          Close this sheet (X, Escape, or backdrop) and it slides back down
+          before unmounting.
+        </Modal>
+      </>
+    );
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step('Open the sheet', async () => {
+      await userEvent.click(canvas.getByRole('button', { name: 'Open sheet' }));
+      await waitFor(() =>
+        expect(canvas.getByRole('dialog')).toBeInTheDocument()
+      );
+    });
+
+    await step(
+      'Close: exit phase keeps it mounted, then it unmounts',
+      async () => {
+        await userEvent.click(
+          canvas.getByRole('button', { name: 'Close dialog' })
+        );
+        // Still present mid-exit (inert), gone once the slide-out finishes
+        await expect(
+          canvas.getByRole('dialog', { hidden: true })
+        ).toBeInTheDocument();
+        await waitFor(() =>
+          expect(canvas.queryByRole('dialog', { hidden: true })).toBeNull()
+        );
+      }
+    );
   },
 };
 

--- a/libs/shared/ui/src/lib/Modal.tsx
+++ b/libs/shared/ui/src/lib/Modal.tsx
@@ -6,6 +6,7 @@ import {
   useEffect,
   useId,
   useRef,
+  useState,
   type ReactNode,
   type Ref,
 } from 'react';
@@ -30,6 +31,12 @@ export interface ModalProps {
   /** `sheet` anchors the dialog to the bottom edge as a mobile bottom sheet. */
   placement?: ModalPlacement;
   className?: string | undefined;
+  /** Merged onto the scrollable body — override its padding, add safe-area insets, etc. */
+  bodyClassName?: string | undefined;
+  /** Accessible name for the dialog when there is no `title`. */
+  'aria-label'?: string | undefined;
+  /** Hide the built-in dismiss X when the content supplies its own close affordance. */
+  showCloseButton?: boolean;
   closeOnBackdropClick?: boolean;
 }
 
@@ -51,9 +58,11 @@ const placementWrapperStyles: Record<ModalPlacement, string> = {
 
 const placementPanelStyles: Record<ModalPlacement, string> = {
   center: 'max-h-[calc(100dvh-2rem)] rounded-lg',
-  sheet:
-    'max-h-[85dvh] rounded-t-lg animate-slide-up motion-reduce:animate-none',
+  sheet: 'max-h-[85dvh] rounded-t-lg',
 };
+
+/** Matches the `sheet-out` animation duration in the consuming theme. */
+const SHEET_EXIT_MS = 250;
 
 export function Modal({
   isOpen,
@@ -65,11 +74,33 @@ export function Modal({
   variant = 'default',
   placement = 'center',
   className,
+  bodyClassName,
+  'aria-label': ariaLabel,
+  showCloseButton = true,
   closeOnBackdropClick = true,
   ref,
 }: ModalProps) {
   const triggerRef = useRef<Element | null>(null);
   const dialogRef = useRef<HTMLDivElement>(null);
+
+  // Sheets slide out before unmounting (same dismissing pattern as Toast);
+  // centered dialogs have no entrance animation, so they close instantly.
+  const [exiting, setExiting] = useState(false);
+  const prevOpenRef = useRef(isOpen);
+  useEffect(() => {
+    const wasOpen = prevOpenRef.current;
+    prevOpenRef.current = isOpen;
+    if (isOpen) {
+      setExiting(false);
+      return undefined;
+    }
+    if (wasOpen && placement === 'sheet') {
+      setExiting(true);
+      const timer = setTimeout(() => setExiting(false), SHEET_EXIT_MS);
+      return () => clearTimeout(timer);
+    }
+    return undefined;
+  }, [isOpen, placement]);
 
   useEffect(() => {
     if (typeof document === 'undefined') return;
@@ -137,20 +168,26 @@ export function Modal({
 
   const titleId = useId();
 
-  if (!isOpen) return null;
+  const isExiting = !isOpen && exiting;
+  if (!isOpen && !exiting) return null;
 
   return (
     <div
       className={cn(
         'fixed inset-0 z-50 flex justify-center',
-        placementWrapperStyles[placement]
+        placementWrapperStyles[placement],
+        isExiting && 'pointer-events-none'
       )}
     >
-      <div
-        className='absolute inset-0 bg-surface/80 backdrop-blur-sm'
-        onClick={closeOnBackdropClick ? handleClose : undefined}
-        aria-hidden='true'
-      />
+      {/* The backdrop pops away at close-start while the sheet slides out —
+          keeping dismissal feedback immediate. */}
+      {isOpen && (
+        <div
+          className='absolute inset-0 bg-surface/80 backdrop-blur-sm'
+          onClick={closeOnBackdropClick ? handleClose : undefined}
+          aria-hidden='true'
+        />
+      )}
       <div
         ref={node => {
           (dialogRef as React.MutableRefObject<HTMLDivElement | null>).current =
@@ -162,11 +199,17 @@ export function Modal({
         }}
         role='dialog'
         aria-modal='true'
+        inert={isExiting || undefined}
         aria-labelledby={title ? titleId : undefined}
-        aria-label={title ? undefined : 'Dialog'}
+        aria-label={title ? undefined : (ariaLabel ?? 'Dialog')}
         className={cn(
           'relative flex w-full flex-col overflow-hidden shadow-2xl',
           placementPanelStyles[placement],
+          placement === 'sheet' &&
+            cn(
+              'motion-reduce:animate-none',
+              isExiting ? 'animate-sheet-out' : 'animate-sheet-in'
+            ),
           sizeStyles[size],
           variantStyles[variant],
           className
@@ -177,18 +220,20 @@ export function Modal({
             <Heading variant='component' id={titleId}>
               {title}
             </Heading>
-            <Button
-              variant='bare'
-              size='sm'
-              onClick={handleClose}
-              aria-label='Close dialog'
-              className={DISMISS_BUTTON}
-            >
-              <X className='size-5' aria-hidden='true' />
-            </Button>
+            {showCloseButton && (
+              <Button
+                variant='bare'
+                size='sm'
+                onClick={handleClose}
+                aria-label='Close dialog'
+                className={DISMISS_BUTTON}
+              >
+                <X className='size-5' aria-hidden='true' />
+              </Button>
+            )}
           </div>
         )}
-        {!title && (
+        {!title && showCloseButton && (
           <Button
             variant='bare'
             size='sm'
@@ -199,10 +244,17 @@ export function Modal({
             <X className='size-5' aria-hidden='true' />
           </Button>
         )}
-        {/* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex -- focusable scroll region so keyboard users can scroll overflowing content (axe scrollable-region-focusable / WCAG 2.1.1) */}
-        <div className='min-h-0 flex-1 overflow-y-auto p-4 sm:p-6' tabIndex={0}>
+        {/* eslint-disable jsx-a11y/no-noninteractive-tabindex -- focusable scroll region so keyboard users can scroll overflowing content (axe scrollable-region-focusable / WCAG 2.1.1) */}
+        <div
+          className={cn(
+            'min-h-0 flex-1 overflow-y-auto p-4 sm:p-6',
+            bodyClassName
+          )}
+          tabIndex={0}
+        >
           {children}
         </div>
+        {/* eslint-enable jsx-a11y/no-noninteractive-tabindex */}
         {footer && (
           <div className='flex shrink-0 items-center justify-end gap-3 p-4 sm:p-6 border-t border-border'>
             {footer}

--- a/libs/shared/ui/src/styles/indigo-theme.css
+++ b/libs/shared/ui/src/styles/indigo-theme.css
@@ -26,6 +26,8 @@
   --animate-slide-up: slide-up 0.2s ease-out;
   --animate-slide-down: slide-down 0.15s ease-out;
   --animate-slide-out-down: slide-out-down 0.15s ease-in forwards;
+  --animate-sheet-in: sheet-in 0.3s ease-out;
+  --animate-sheet-out: sheet-out 0.25s ease-in forwards;
   --animate-scale-in: scale-in 0.15s ease-out;
 
   /* Colors - Brand (blue-indigo, oklch hue 250) */
@@ -175,6 +177,26 @@
   to {
     opacity: 0;
     transform: translateY(8px);
+  }
+}
+
+/* Full-height bottom-sheet travel (Modal placement='sheet') — unlike the
+   subtle 8px slide-up/down pop used by anchored popups. */
+@keyframes sheet-in {
+  from {
+    transform: translateY(100%);
+  }
+  to {
+    transform: translateY(0);
+  }
+}
+
+@keyframes sheet-out {
+  from {
+    transform: translateY(0);
+  }
+  to {
+    transform: translateY(100%);
   }
 }
 


### PR DESCRIPTION
Closes #1112. **Stacked on #1111** (needs its Jest mapper fix so app specs resolve shared-ui source) — merge #1111 first; this PR's diff then reduces to the Modal work.

## shared-ui: Modal learns to be a real sheet

- **Exit animation**: closing a `placement='sheet'` Modal now plays a full-height `sheet-out` slide before unmounting — Toast's `dismissing` pattern (250ms timeout, no animationend fragility). During the exit the panel is `inert` and the backdrop is already gone (matching how the hand-rolled sheets behaved); reopening mid-exit is safe; **centered dialogs still close instantly** (guarded by spec). Entrance upgraded too: `sheet-in` travels the full height, replacing the subtle 8px `slide-up` pop.
- **Three generic props** the migrations needed, all standard dialog-lib affordances: `aria-label` (dialog name when title-less, replacing hardcoded `'Dialog'`), `showCloseButton` (default true), `bodyClassName` (body padding / safe-area insets).
- Keyframes + `--animate-sheet-in/out` tokens in `indigo-theme.css` and the app theme; changeset **minor**.

## app: both sheets migrate, machinery deleted

- **`TableOfContents`** (mobile FAB sheet) and **`MobileNav`** (More sheet) now render `Modal placement='sheet'`, deleting the per-component backdrop, body-scroll lock, `useFocusTrap` wiring, document Escape listeners, and manual focus-return (~90 lines of duplicated a11y machinery). `useFocusTrap` itself stays — the app's headlessui-based `components/Modal.tsx` still consumes it (future consolidation candidate, out of scope).
- MobileNav keeps its own header (label + DarkModeToggle + X) via `showCloseButton={false}` and its safe-area padding via `bodyClassName`; an `md:hidden` wrapper scopes the non-portaled Modal so the backdrop can't linger if the viewport grows while open.
- E2E: the backdrop-close test's old z-order `dispatchEvent` workaround is obsolete (Modal's backdrop covers the bottom bar) — now a real click, asserting unmount via `toHaveCount(0)`.

## Validated

- shared-ui 880/880 · root 606/606 (both cache-cold) · Storybook interaction tests 339/339 including a new `SheetExitAnimation` play that exercises the exit in real Chromium · typecheck, lint, knip clean
- **Driven in the production build** (mobile viewport, Playwright): both sheets open full-bleed with correct chrome; mid-exit probes show `animationName: "sheet-out"` running with `inert` set and backdrop gone; after ~250ms the dialog unmounts, **focus returns to the trigger** (More button), and body scroll unlocks. TOC select-to-scroll closes the sheet and lands the heading at its scroll offset.
- Negative cases: centered-close-is-instant spec; reopen-during-exit spec; `showCloseButton=false` in both title modes.

## Residual risk

- New `SheetExitAnimation` + changed `BottomSheet` visuals → expect the usual visual-baseline regeneration on the develop push (and remember the `[skip ci]` head-commit cap before the next release PR).
- Sheet entrance for any existing `placement='sheet'` consumers changes from the 8px pop to a full slide — intended, noted in the changeset; no known external sheet consumers yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)