### PR TITLE
fix(ux): smoketest findings — palette Résumé entry, main focus ring, wasted preloads

### DIFF
--- a/.changeset/pagelayout-focus-outline.md
+++ b/.changeset/pagelayout-focus-outline.md
@@ -1,0 +1,5 @@
+---
+'@danieljoffe/shared-ui': patch
+---
+
+PageLayout: suppress the focus outline on the `main` landmark. The App Router focuses it after every client-side navigation, which drew a visible ring around the entire page for all users; a non-interactive skip-link/navigation focus target needs no visible ring.

--- a/apps/root/src/app/(public)/page.tsx
+++ b/apps/root/src/app/(public)/page.tsx
@@ -234,8 +234,11 @@ export default function Index() {
           label='Featured Projects'
         />
         <div className='grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 reveal-stagger'>
-          {featuredProjects.map((project, i) => (
-            <PostCard key={project.slug} post={project} priority={i < 3} />
+          {featuredProjects.map(project => (
+            // No `priority`: these cards sit below the fold on every
+            // viewport, so preloading their covers wastes bandwidth and
+            // logs unused-preload warnings on every navigation.
+            <PostCard key={project.slug} post={project} />
           ))}
         </div>
         <div className='flex justify-center pt-4'>

--- a/apps/root/src/components/kit/TableOfContents.tsx
+++ b/apps/root/src/components/kit/TableOfContents.tsx
@@ -47,24 +47,48 @@ function useHeadings(contentSelector: string) {
 
     if (items.length === 0) return;
 
-    const observer = new IntersectionObserver(
-      entries => {
-        const visible = entries.find(e => e.isIntersecting);
-        if (visible?.target.id) {
-          setActiveId(visible.target.id);
+    // Scroll-position-derived spy instead of an IntersectionObserver: the
+    // active section is the last heading above the reading line, falling
+    // back to the first heading when the viewport is above all sections.
+    // The observer version only updated when a heading crossed its band, so
+    // it highlighted nothing on load and stayed stuck on the last section
+    // after scrolling back to the top.
+    //
+    // Must clear the scroll-margin headings land at after a TOC click
+    // (scroll-mt puts them ~166px down), or the clicked section would
+    // never register as active.
+    const READING_LINE_PX = 180;
+
+    let ticking = false;
+    const update = () => {
+      ticking = false;
+      let current = items[0]?.id ?? '';
+      for (const { id } of items) {
+        const el = document.getElementById(id);
+        if (el && el.getBoundingClientRect().top <= READING_LINE_PX) {
+          current = id;
         }
-      },
-      { rootMargin: '-80px 0px -60% 0px' }
-    );
+      }
+      setActiveId(current);
+    };
+    const onScroll = () => {
+      if (!ticking) {
+        ticking = true;
+        requestAnimationFrame(update);
+      }
+    };
 
-    items.forEach(({ id }) => {
-      const el = document.getElementById(id);
-      if (el) observer.observe(el);
+    queueMicrotask(() => {
+      setHeadings(items);
+      update();
     });
+    window.addEventListener('scroll', onScroll, { passive: true });
+    window.addEventListener('resize', onScroll, { passive: true });
 
-    queueMicrotask(() => setHeadings(items));
-
-    return () => observer.disconnect();
+    return () => {
+      window.removeEventListener('scroll', onScroll);
+      window.removeEventListener('resize', onScroll);
+    };
   }, [contentSelector]);
 
   return { headings, activeId };

--- a/apps/root/src/components/kit/__tests__/TableOfContents.spec.tsx
+++ b/apps/root/src/components/kit/__tests__/TableOfContents.spec.tsx
@@ -4,30 +4,12 @@ import {
   fireEvent,
   act,
   waitFor,
+  within,
 } from '@testing-library/react';
 import { axe, toHaveNoViolations } from 'jest-axe';
 import { TableOfContents } from '../TableOfContents';
 
 expect.extend(toHaveNoViolations);
-
-// Mock IntersectionObserver
-const mockObserve = jest.fn();
-const mockDisconnect = jest.fn();
-
-class MockIntersectionObserver {
-  callback: IntersectionObserverCallback;
-  constructor(callback: IntersectionObserverCallback) {
-    this.callback = callback;
-  }
-  observe = mockObserve;
-  unobserve = jest.fn();
-  disconnect = mockDisconnect;
-}
-
-Object.defineProperty(window, 'IntersectionObserver', {
-  writable: true,
-  value: MockIntersectionObserver,
-});
 
 // Mock matchMedia for reduced motion
 Object.defineProperty(window, 'matchMedia', {
@@ -95,6 +77,20 @@ describe('TableOfContents', () => {
     );
     expect(screen.getAllByText('Details').length).toBeGreaterThanOrEqual(2);
     expect(screen.getAllByText('Conclusion').length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('marks a section active on initial load (scroll-position spy)', async () => {
+    render(<TableOfContents desktop />);
+    await act(() => Promise.resolve());
+
+    // jsdom reports zero rects for every heading, so the spy resolves the
+    // last one — what matters here is that the spy runs at load at all
+    // (the old observer version highlighted nothing until a scroll).
+    const nav = screen.getByRole('navigation', { name: /table of contents/i });
+    const active = within(nav)
+      .getAllByRole('button')
+      .filter(b => b.getAttribute('aria-current') === 'location');
+    expect(active).toHaveLength(1);
   });
 
   it('scrolls to heading when TOC link is clicked', async () => {

--- a/apps/root/src/lib/__tests__/search.spec.ts
+++ b/apps/root/src/lib/__tests__/search.spec.ts
@@ -100,6 +100,66 @@ describe('MiniSearch Engine', () => {
     expect(results[0]?.id).toBe('blog:react-post');
   });
 
+  it('does not fuzzy-match short queries into stopwords like "to"', () => {
+    // fuzzy on a ≤3-char term accepts an edit that turns "toc" into "to",
+    // matching every document. The engine must gate fuzzy off at that
+    // length so short queries only exact/prefix match.
+    const shortEntries: SearchEntry[] = [
+      {
+        ...entries[0],
+        id: 'blog:toc-post',
+        title: 'TOC scroll spy',
+        excerpt: 'Table of contents',
+        tags: [],
+        body: 'Building a toc component.',
+      },
+      {
+        ...entries[0],
+        id: 'blog:unrelated',
+        title: 'Unrelated post',
+        excerpt: 'Nothing relevant',
+        tags: [],
+        body: 'How to build things and how to ship them.',
+      },
+    ];
+    const engine = createSearchEngine(shortEntries);
+    const results = engine.search('toc');
+    expect(results.map(r => r.id)).toEqual(['blog:toc-post']);
+  });
+
+  it('drops the barely-relevant OR tail below the relative score floor', () => {
+    const floorEntries: SearchEntry[] = [
+      {
+        ...entries[0],
+        id: 'blog:strong',
+        title: 'Service worker deep dive',
+        excerpt: 'service worker internals',
+        tags: ['service-worker'],
+        body: 'service worker service worker service worker',
+      },
+      {
+        ...entries[0],
+        id: 'blog:weak',
+        title: 'Unrelated ramble',
+        excerpt: 'nothing here',
+        tags: [],
+        body: [
+          'a very long body where the word service appears exactly once',
+          ...Array(120).fill('filler words diluting term frequency badly'),
+        ].join(' '),
+      },
+    ];
+    const engine = createSearchEngine(floorEntries);
+    const raw = engine.search('service worker');
+    const filtered = searchWithHighlights(
+      engine,
+      'service worker',
+      floorEntries
+    );
+    expect(raw.map(r => r.id)).toContain('blog:weak');
+    expect(filtered.map(r => r.id)).toEqual(['blog:strong']);
+  });
+
   it('finds the Résumé page by the unaccented spelling everyone types', () => {
     // The tokenizer does no diacritic folding and fuzzy matching cannot
     // bridge résumé→resume, so the static entry must carry the plain

--- a/apps/root/src/lib/__tests__/search.spec.ts
+++ b/apps/root/src/lib/__tests__/search.spec.ts
@@ -1,6 +1,6 @@
 import MiniSearch from 'minisearch';
 import { createSearchEngine, searchWithHighlights } from '../search';
-import type { SearchEntry } from '../searchIndex';
+import { buildSearchIndex, type SearchEntry } from '../searchIndex';
 
 describe('MiniSearch Engine', () => {
   let entries: SearchEntry[];
@@ -98,5 +98,14 @@ describe('MiniSearch Engine', () => {
     expect(results.length).toBeGreaterThan(0);
     expect(results[0]).toHaveProperty('matches');
     expect(results[0]?.id).toBe('blog:react-post');
+  });
+
+  it('finds the Résumé page by the unaccented spelling everyone types', () => {
+    // The tokenizer does no diacritic folding and fuzzy matching cannot
+    // bridge résumé→resume, so the static entry must carry the plain
+    // spelling in a searchable field. Guards the palette "resume" query.
+    const engine = createSearchEngine(buildSearchIndex());
+    const results = engine.search('resume');
+    expect(results.some(r => r.id === 'page:resume')).toBe(true);
   });
 });

--- a/apps/root/src/lib/__tests__/searchIndex.spec.ts
+++ b/apps/root/src/lib/__tests__/searchIndex.spec.ts
@@ -37,8 +37,8 @@ describe('buildSearchIndex', () => {
 
   it('includes generated entries and static page entries', () => {
     const index = buildSearchIndex();
-    // 2 generated + 1 static page
-    expect(index).toHaveLength(3);
+    // 2 generated + 2 static pages (About, Résumé)
+    expect(index).toHaveLength(4);
   });
 
   it('each entry has required fields', () => {
@@ -56,12 +56,12 @@ describe('buildSearchIndex', () => {
     }
   });
 
-  it('includes static page entry for about', () => {
+  it('includes static page entries for about and resume', () => {
     const index = buildSearchIndex();
     const pages = index.filter(e => e.type === 'page');
-    expect(pages).toHaveLength(1);
+    expect(pages).toHaveLength(2);
 
-    expect(pages[0].slug).toBe('about');
+    expect(pages.map(p => p.slug).sort()).toEqual(['about', 'resume']);
   });
 
   it('has body text for generated content entries', () => {

--- a/apps/root/src/lib/search.ts
+++ b/apps/root/src/lib/search.ts
@@ -19,8 +19,11 @@ export function createSearchEngine(
     ] as Array<keyof SearchEntry>,
     searchOptions: {
       boost: { title: 5, tags: 3.5, excerpt: 2, category: 1.5, body: 1 },
-      fuzzy: 0.2,
-      prefix: true,
+      // No fuzzing for terms of ≤3 chars: at that length one accepted edit
+      // turns "toc" into "to"/"doc"/"hoc", which matches every document in
+      // the corpus and inflates result counts to "everything, ranked".
+      fuzzy: term => (term.length > 3 ? 0.2 : false),
+      prefix: term => term.length >= 2,
       combineWith: 'OR',
     },
     extractField: (doc: SearchEntry, fieldName: string): string => {
@@ -35,6 +38,15 @@ export function createSearchEngine(
   return ms;
 }
 
+/**
+ * OR-combined multi-term queries match any document containing any term, so
+ * the result list grows a long tail of barely-relevant hits (score ~0.01
+ * against a top of ~13). Results below this fraction of the top score are
+ * noise, not answers — drop them so counts reflect what a reader would call
+ * a match.
+ */
+const RELATIVE_SCORE_FLOOR = 0.05;
+
 export function searchWithHighlights(
   engine: MiniSearch<SearchEntry>,
   query: string,
@@ -42,7 +54,11 @@ export function searchWithHighlights(
 ): Array<SearchEntry & { matches: Record<string, string[]> }> {
   if (!query.trim()) return [];
 
-  const results = engine.search(query);
+  const ranked = engine.search(query);
+  const topScore = ranked[0]?.score ?? 0;
+  const results = ranked.filter(
+    r => r.score >= topScore * RELATIVE_SCORE_FLOOR
+  );
 
   return results
     .map(result => {

--- a/apps/root/src/lib/searchIndex.ts
+++ b/apps/root/src/lib/searchIndex.ts
@@ -30,6 +30,23 @@ const staticEntries: SearchEntry[] = [
     date: null,
     author: 'Daniel Joffe',
   },
+  {
+    id: 'page:resume',
+    slug: 'resume',
+    type: 'page',
+    title: 'Résumé',
+    // "resume" (unaccented) must appear in a searchable field: the
+    // tokenizer does no diacritic folding, and fuzzy matching cannot
+    // bridge résumé→resume — without this the page is unfindable by
+    // the spelling everyone actually types.
+    excerpt: 'View and download my resume (CV)',
+    tags: ['resume', 'cv'],
+    category: 'page',
+    body: '',
+    url: '/resume',
+    date: null,
+    author: 'Daniel Joffe',
+  },
 ];
 
 export function buildSearchIndex(): SearchEntry[] {

--- a/libs/shared/ui/src/lib/PageLayout.spec.tsx
+++ b/libs/shared/ui/src/lib/PageLayout.spec.tsx
@@ -27,6 +27,11 @@ describe('PageLayout', () => {
     );
   });
 
+  it('suppresses the focus ring on the programmatic focus target', () => {
+    render(<PageLayout>Content</PageLayout>);
+    expect(screen.getByRole('main')).toHaveClass('outline-none');
+  });
+
   it('merges custom className with defaults', () => {
     render(<PageLayout className='custom-class'>Content</PageLayout>);
     expect(screen.getByRole('main')).toHaveClass('w-full', 'custom-class');

--- a/libs/shared/ui/src/lib/PageLayout.tsx
+++ b/libs/shared/ui/src/lib/PageLayout.tsx
@@ -24,8 +24,12 @@ export function PageLayout({ children, className, ...rest }: PageLayoutProps) {
       // The App Router focuses this landmark after navigation; `.focus()`
       // scrolls it into view, which would otherwise scroll the (static) nav
       // off-screen. `scroll-mt` ≥ the nav height keeps the scroll at the top.
+      // `outline-none`: that same programmatic focus otherwise draws a
+      // focus ring around the entire page for every user on every
+      // navigation — a non-interactive focus target needs no visible ring
+      // (skip-link users get their context from the content itself).
       className={cn(
-        'flex w-full flex-col gap-y-16 scroll-mt-16 lg:gap-y-20',
+        'flex w-full flex-col gap-y-16 scroll-mt-16 outline-none lg:gap-y-20',
         className
       )}
       {...rest}


### PR DESCRIPTION
Five fixes from the hands-on smoketest (clicking through real journeys on the prod build at desktop + mobile), independent of the dependency-remediation PR #1121. The last two were added after review feedback.

## Fixes

1. **⌘K palette couldn't find the Résumé page.** Typing "resume" returned WyrdFold/blog fuzz but never `/resume` — the page was simply absent from the static search index (only About was there), and MiniSearch does no diacritic folding so "Résumé"-accented content couldn't bridge the query either. Added the `page:resume` entry with the unaccented spelling in searchable fields. Verified live: "resume" → top result **Pages · Résumé**. Spec guard added.
2. **Full-page focus ring after every navigation** (shared-ui `PageLayout`, patch changeset). The App Router focuses `main#main-content` on client-side nav — correct a11y — but it drew a visible 1px ring around the entire content area for every user, mouse clicks included. `outline-none` on the non-interactive focus target; focus behavior itself unchanged (verified: main still receives focus, ring gone).
3. **Three wasted cover preloads on every page.** Home's featured-project cards set `priority` but all three sit below the fold on every viewport — browsers preloaded them, warned, and the preload links persist across client transitions so the warnings repeated on every page. Dropped `priority`; verified live: 0 preload warnings.
4. **TOC scroll-spy stuck states** (from review). The IntersectionObserver only updated when a heading crossed its detection band: nothing was highlighted at initial load, and the last section stayed active after scrolling back to the top. Replaced with a scroll-position-derived spy (active = last heading above the reading line, first as fallback; rAF-throttled passive listeners; the reading line clears the scroll-margin clicked headings land at). Verified live: load → first section active, click-to-last follows, back-to-top reverts.
5. **Search counts inflated for short queries** (from review). `fuzzy: 0.2` on a ≤3-char term accepts an edit, so "toc" matched "to" — i.e. **all 49 posts** ("49 results for 'toc'"), ranked above a tail of 0.01-score matches. Fuzzy now gates off at ≤3 chars, and `searchWithHighlights` drops results under 5% of the top score, so counts reflect real matches. Applies to blog search *and* the palette (shared engine). Verified live: "toc" → **2 results**; palette "resume" still top-ranked. Spec guards: short-query stopword test (fails on old config) + score-floor tail test.

## Validated

Root 586/586 · shared-ui 881/881 · storybook 339/339 · tsc/lint/knip clean · all five fixes verified in the running prod build (localhost review server current).

🤖 Generated with [Claude Code](https://claude.com/claude-code)