### PR TITLE
feat(shared-ui): portal the Dropdown menu so ancestors can't clip it

### DIFF
--- a/.changeset/dropdown-portal-escape.md
+++ b/.changeset/dropdown-portal-escape.md
@@ -1,0 +1,13 @@
+---
+'@danieljoffe/shared-ui': minor
+---
+
+Dropdown menus now render in a document.body portal with a fixed-position
+anchor computed from the trigger, so overflow-hidden/auto ancestors (modal
+edges, scroll containers) can no longer clip them. Alignment is exposed as
+`data-align` instead of `left-0`/`right-0` classes; the anchor re-computes on
+scroll and resize. Outside-click and Escape dismissal now treat the portaled
+panel as "inside" via a new `panelRef` returned from `useAnchoredPanel`
+(inline panels like Popover are unaffected). Found as wyrdfold ux-sweep
+2026-08-12 B2: a target-picker Dropdown inside a modal was cut off at the
+modal edge until scrolled.

--- a/.size-limit.json
+++ b/.size-limit.json
@@ -33,7 +33,7 @@
     "name": "Dropdown",
     "path": "libs/shared/ui/src/lib/Dropdown.tsx",
     "import": "{ Dropdown }",
-    "limit": "13 kB"
+    "limit": "14 kB"
   },
   {
     "name": "Sidebar",

--- a/libs/shared/ui/src/lib/Dropdown.spec.tsx
+++ b/libs/shared/ui/src/lib/Dropdown.spec.tsx
@@ -175,8 +175,9 @@ describe('Dropdown', () => {
       <Dropdown trigger={<span>Menu</span>} items={items} align='right' />
     );
     fireEvent.click(screen.getByText('Menu'));
-    const dropdown = screen.getByText('Edit').closest('.right-0');
-    expect(dropdown).toBeInTheDocument();
+    // Portaled menu (see "portal escape" below): alignment is now an anchor
+    // computation, exposed as data-align rather than a right-0 class.
+    expect(screen.getByRole('menu')).toHaveAttribute('data-align', 'right');
   });
 
   describe('ARIA attributes', () => {
@@ -501,7 +502,7 @@ describe('Dropdown', () => {
     });
 
     it('open menu with loading and custom-content items has no a11y violations', async () => {
-      const { container } = render(
+      render(
         <Dropdown
           trigger={<span>Menu</span>}
           items={[
@@ -511,7 +512,14 @@ describe('Dropdown', () => {
         />
       );
       fireEvent.click(screen.getByText('Menu'));
-      expect(await axe(container)).toHaveNoViolations();
+      // The open menu portals to document.body — scanning `container` alone
+      // would silently skip it (a vacuous pass). The `region` rule is
+      // disabled for the body scan only: transient popups portaled to body
+      // legitimately live outside landmarks (the rule targets page content),
+      // and the bare test DOM has no landmarks to begin with.
+      expect(
+        await axe(document.body, { rules: { region: { enabled: false } } })
+      ).toHaveNoViolations();
     });
 
     it('does not steal focus when items become actionable after opening', () => {
@@ -614,11 +622,13 @@ describe('Dropdown', () => {
     });
 
     it('open menu with a composed Button trigger has no a11y violations', async () => {
-      const { container } = render(
-        <Dropdown trigger={buttonTrigger} items={items} />
-      );
+      render(<Dropdown trigger={buttonTrigger} items={items} />);
       fireEvent.click(screen.getByRole('button', { name: 'Menu' }));
-      expect(await axe(container)).toHaveNoViolations();
+      // Portaled menu — scan the document, not the render container. The
+      // `region` rule is disabled for body scans (see the note above).
+      expect(
+        await axe(document.body, { rules: { region: { enabled: false } } })
+      ).toHaveNoViolations();
     });
   });
 
@@ -729,5 +739,54 @@ describe('Dropdown', () => {
       <Dropdown trigger={<span>Menu</span>} items={items} />
     );
     expect(await axe(container)).toHaveNoViolations();
+  });
+
+  describe('portal escape (wyrdfold ux-sweep 2026-08-12 B2)', () => {
+    // The menu used to render absolutely-positioned INSIDE the trigger
+    // wrapper, so any overflow-hidden/auto ancestor (a modal edge, a scroll
+    // container) clipped it. It now portals to document.body with a
+    // fixed-position anchor computed from the trigger rect.
+
+    it('renders the open menu outside an overflow-hidden ancestor', () => {
+      const { container } = render(
+        <div style={{ overflow: 'hidden', height: 40 }}>
+          <Dropdown trigger={<span>Menu</span>} items={items} />
+        </div>
+      );
+      fireEvent.click(screen.getByText('Menu'));
+
+      const menu = screen.getByRole('menu');
+      // The clipping container must NOT contain the menu…
+      expect(container.contains(menu)).toBe(false);
+      // …because it rides on document.body with a fixed anchor.
+      expect(menu.parentElement).toBe(document.body);
+      expect(menu.className).toContain('fixed');
+    });
+
+    it('does not treat a mousedown inside the portaled menu as outside', () => {
+      // The dismiss listener's containment check must cover the portaled
+      // panel — without panelRef, every press on an item would close the
+      // menu before the item's own click handler ran.
+      render(<Dropdown trigger={<span>Menu</span>} items={items} />);
+      fireEvent.click(screen.getByText('Menu'));
+
+      fireEvent.mouseDown(screen.getByRole('menuitem', { name: 'Edit' }));
+      expect(screen.getByRole('menu')).toBeInTheDocument();
+    });
+
+    it('still activates items and closes through a full click in the portal', () => {
+      const onClick = jest.fn();
+      render(
+        <Dropdown
+          trigger={<span>Menu</span>}
+          items={[{ label: 'Edit', onClick }]}
+        />
+      );
+      fireEvent.click(screen.getByText('Menu'));
+
+      fireEvent.click(screen.getByRole('menuitem', { name: 'Edit' }));
+      expect(onClick).toHaveBeenCalledTimes(1);
+      expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+    });
   });
 });

--- a/libs/shared/ui/src/lib/Dropdown.spec.tsx
+++ b/libs/shared/ui/src/lib/Dropdown.spec.tsx
@@ -760,7 +760,7 @@ describe('Dropdown', () => {
       expect(container.contains(menu)).toBe(false);
       // …because it rides on document.body with a fixed anchor.
       expect(menu.parentElement).toBe(document.body);
-      expect(menu.className).toContain('fixed');
+      expect(menu.style.position).toBe('fixed');
     });
 
     it('does not treat a mousedown inside the portaled menu as outside', () => {
@@ -772,6 +772,25 @@ describe('Dropdown', () => {
 
       fireEvent.mouseDown(screen.getByRole('menuitem', { name: 'Edit' }));
       expect(screen.getByRole('menu')).toBeInTheDocument();
+    });
+
+    it('closes on Escape from a menu portaled after the open flip', () => {
+      // The panel mounts one commit later than `open` turns true (the portal
+      // waits for mount, since react-dom/server has no `document`). The
+      // Escape listener must bind to the panel when it actually arrives, not
+      // to whatever existed when the open flip was committed.
+      const onOpenChange = jest.fn();
+      render(
+        <Dropdown
+          trigger={<span>Menu</span>}
+          items={items}
+          open
+          onOpenChange={onOpenChange}
+        />
+      );
+
+      fireEvent.keyDown(screen.getByRole('menu'), { key: 'Escape' });
+      expect(onOpenChange).toHaveBeenCalledWith(false);
     });
 
     it('still activates items and closes through a full click in the portal', () => {

--- a/libs/shared/ui/src/lib/Dropdown.stories.tsx
+++ b/libs/shared/ui/src/lib/Dropdown.stories.tsx
@@ -29,6 +29,13 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
+/**
+ * The open menu portals to `document.body` so no overflow-hidden ancestor can
+ * clip it — which puts it outside `canvasElement`. Trigger queries stay scoped
+ * to the canvas; menu and menuitem queries go through here.
+ */
+const portal = () => within(document.body);
+
 export const Default: Story = {
   args: {
     trigger: (
@@ -77,14 +84,16 @@ export const ComposedTrigger: Story = {
 
     await step('Open from the composed Button trigger', async () => {
       await userEvent.click(trigger);
-      await waitFor(() => expect(canvas.getByRole('menu')).toBeInTheDocument());
+      await waitFor(() =>
+        expect(portal().getByRole('menu')).toBeInTheDocument()
+      );
       await expect(trigger).toHaveAttribute('aria-expanded', 'true');
     });
 
     await step('Escape closes and restores focus to the Button', async () => {
       await userEvent.keyboard('{Escape}');
       await waitFor(() =>
-        expect(canvas.queryByRole('menu')).not.toBeInTheDocument()
+        expect(portal().queryByRole('menu')).not.toBeInTheDocument()
       );
       await expect(trigger).toHaveFocus();
     });
@@ -124,14 +133,16 @@ export const Controlled: Story = {
 
     await step('Open via trigger', async () => {
       await userEvent.click(trigger);
-      await waitFor(() => expect(canvas.getByRole('menu')).toBeInTheDocument());
+      await waitFor(() =>
+        expect(portal().getByRole('menu')).toBeInTheDocument()
+      );
       await expect(args.onOpenChange).toHaveBeenCalledWith(true);
     });
 
     await step('Close via Escape', async () => {
       await userEvent.keyboard('{Escape}');
       await waitFor(() =>
-        expect(canvas.queryByRole('menu')).not.toBeInTheDocument()
+        expect(portal().queryByRole('menu')).not.toBeInTheDocument()
       );
       await expect(args.onOpenChange).toHaveBeenCalledWith(false);
     });
@@ -244,12 +255,12 @@ export const OpenAndClose: Story = {
 
     // Open the dropdown
     await userEvent.click(trigger);
-    await waitFor(() => expect(canvas.getByRole('menu')).toBeInTheDocument());
+    await waitFor(() => expect(portal().getByRole('menu')).toBeInTheDocument());
 
     // Close by clicking trigger again
     await userEvent.click(trigger);
     await waitFor(() =>
-      expect(canvas.queryByRole('menu')).not.toBeInTheDocument()
+      expect(portal().queryByRole('menu')).not.toBeInTheDocument()
     );
   },
 };
@@ -272,7 +283,7 @@ export const OpenState: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     await userEvent.click(canvas.getByRole('button', { name: 'Open menu' }));
-    await waitFor(() => expect(canvas.getByRole('menu')).toBeInTheDocument());
+    await waitFor(() => expect(portal().getByRole('menu')).toBeInTheDocument());
   },
 };
 
@@ -291,14 +302,16 @@ export const ItemClick: Story = {
 
     // Open the dropdown
     await userEvent.click(canvas.getByRole('button', { name: 'Click Item' }));
-    await waitFor(() => expect(canvas.getByRole('menu')).toBeInTheDocument());
+    await waitFor(() => expect(portal().getByRole('menu')).toBeInTheDocument());
 
     // Click an item
-    await userEvent.click(canvas.getByRole('menuitem', { name: 'Action One' }));
+    await userEvent.click(
+      portal().getByRole('menuitem', { name: 'Action One' })
+    );
 
     // Menu should close after clicking an item
     await waitFor(() =>
-      expect(canvas.queryByRole('menu')).not.toBeInTheDocument()
+      expect(portal().queryByRole('menu')).not.toBeInTheDocument()
     );
     await expect(args.items[0].onClick).toHaveBeenCalled();
   },
@@ -317,7 +330,7 @@ export const KeyboardNavigation: Story = {
 
     // Open with click
     await userEvent.click(trigger);
-    await waitFor(() => expect(canvas.getByRole('menu')).toBeInTheDocument());
+    await waitFor(() => expect(portal().getByRole('menu')).toBeInTheDocument());
 
     // Navigate down
     await userEvent.keyboard('{ArrowDown}');
@@ -335,7 +348,7 @@ export const KeyboardNavigation: Story = {
     // Close with Escape
     await userEvent.keyboard('{Escape}');
     await waitFor(() =>
-      expect(canvas.queryByRole('menu')).not.toBeInTheDocument()
+      expect(portal().queryByRole('menu')).not.toBeInTheDocument()
     );
   },
 };
@@ -355,17 +368,19 @@ export const EnterToSelect: Story = {
 
     // Open dropdown
     await userEvent.click(trigger);
-    await waitFor(() => expect(canvas.getByRole('menu')).toBeInTheDocument());
+    await waitFor(() => expect(portal().getByRole('menu')).toBeInTheDocument());
 
     // The menu focuses the first item on open (via rAF); wait for that before
     // activating it, otherwise Enter lands on the still-focused trigger.
     await waitFor(() =>
-      expect(canvas.getByRole('menuitem', { name: 'Select me' })).toHaveFocus()
+      expect(
+        portal().getByRole('menuitem', { name: 'Select me' })
+      ).toHaveFocus()
     );
     await userEvent.keyboard('{Enter}');
 
     await waitFor(() =>
-      expect(canvas.queryByRole('menu')).not.toBeInTheDocument()
+      expect(portal().queryByRole('menu')).not.toBeInTheDocument()
     );
     await expect(args.items[0].onClick).toHaveBeenCalled();
   },
@@ -438,7 +453,7 @@ export const OpenAsyncState: Story = {
     await userEvent.click(
       canvas.getByRole('button', { name: 'Add to target' })
     );
-    await waitFor(() => expect(canvas.getByRole('menu')).toBeInTheDocument());
+    await waitFor(() => expect(portal().getByRole('menu')).toBeInTheDocument());
   },
 };
 
@@ -453,15 +468,15 @@ export const KeepsMenuOpenForAsyncItems: Story = {
     const canvas = within(canvasElement);
 
     await userEvent.click(canvas.getByRole('button', { name: 'Async' }));
-    await waitFor(() => expect(canvas.getByRole('menu')).toBeInTheDocument());
+    await waitFor(() => expect(portal().getByRole('menu')).toBeInTheDocument());
 
     await userEvent.click(
-      canvas.getByRole('menuitem', { name: 'Add to target' })
+      portal().getByRole('menuitem', { name: 'Add to target' })
     );
     await expect(args.items[0].onClick).toHaveBeenCalled();
 
     // closeOnClick: false keeps the menu open for async feedback
-    await waitFor(() => expect(canvas.getByRole('menu')).toBeInTheDocument());
+    await waitFor(() => expect(portal().getByRole('menu')).toBeInTheDocument());
   },
 };
 
@@ -481,17 +496,17 @@ export const ArrowKeyOpen: Story = {
 
     // Open with ArrowDown key on trigger
     await userEvent.keyboard('{ArrowDown}');
-    await waitFor(() => expect(canvas.getByRole('menu')).toBeInTheDocument());
+    await waitFor(() => expect(portal().getByRole('menu')).toBeInTheDocument());
 
     // Wait for the first item to receive focus (rAF) so Tab is handled by the
     // menu's keydown handler (which closes it) rather than the trigger.
     await waitFor(() =>
-      expect(canvas.getByRole('menuitem', { name: 'Item A' })).toHaveFocus()
+      expect(portal().getByRole('menuitem', { name: 'Item A' })).toHaveFocus()
     );
     // Tab to close
     await userEvent.keyboard('{Tab}');
     await waitFor(() =>
-      expect(canvas.queryByRole('menu')).not.toBeInTheDocument()
+      expect(portal().queryByRole('menu')).not.toBeInTheDocument()
     );
   },
 };

--- a/libs/shared/ui/src/lib/Dropdown.tsx
+++ b/libs/shared/ui/src/lib/Dropdown.tsx
@@ -5,12 +5,15 @@ import {
   useCallback,
   useEffect,
   useId,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
+  type CSSProperties,
   type ReactNode,
   type Ref,
 } from 'react';
+import { createPortal } from 'react-dom';
 import { Spinner } from './Spinner';
 import { cn } from './utils/cn';
 import { useAnchoredPanel } from './utils/useAnchoredPanel';
@@ -88,11 +91,43 @@ export function Dropdown({
   className,
   panelClassName,
 }: DropdownProps) {
-  const { isOpen, setOpen, close, wrapperRef, triggerRef } = useAnchoredPanel({
-    open,
-    onOpenChange,
-  });
+  const { isOpen, setOpen, close, wrapperRef, triggerRef, panelRef } =
+    useAnchoredPanel({
+      open,
+      onOpenChange,
+    });
   const [activeIndex, setActiveIndex] = useState(-1);
+  // The menu renders in a body PORTAL with fixed positioning so no ancestor
+  // overflow can clip it (a menu inside a modal or scroll container used to
+  // cut off at the container edge — wyrdfold ux-sweep 2026-08-12 B2). The
+  // style anchors to the trigger's viewport rect and re-anchors on scroll
+  // (capture: nested scrollers don't bubble) and resize.
+  const [menuStyle, setMenuStyle] = useState<CSSProperties | null>(null);
+  const updateMenuPosition = useCallback(() => {
+    const el = triggerRef.current;
+    if (!el) return;
+    const rect = el.getBoundingClientRect();
+    setMenuStyle(
+      align === 'right'
+        ? {
+            position: 'fixed',
+            top: rect.bottom + 4,
+            right: Math.max(0, window.innerWidth - rect.right),
+          }
+        : { position: 'fixed', top: rect.bottom + 4, left: rect.left }
+    );
+  }, [align, triggerRef]);
+
+  useLayoutEffect(() => {
+    if (!isOpen) return;
+    updateMenuPosition();
+    window.addEventListener('scroll', updateMenuPosition, true);
+    window.addEventListener('resize', updateMenuPosition);
+    return () => {
+      window.removeEventListener('scroll', updateMenuPosition, true);
+      window.removeEventListener('resize', updateMenuPosition);
+    };
+  }, [isOpen, updateMenuPosition]);
   const itemRefs = useRef<(HTMLButtonElement | HTMLAnchorElement | null)[]>([]);
   const uid = useId();
   const menuId = `dropdown-menu-${uid}`;
@@ -234,81 +269,109 @@ export function Dropdown({
           {trigger}
         </button>
       )}
-      {isOpen && (
-        <div
-          id={menuId}
-          role='menu'
-          aria-labelledby={triggerId}
-          tabIndex={-1}
-          onKeyDown={handleMenuKeyDown}
-          className={cn(
-            'absolute z-50 mt-1 top-full min-w-[180px]',
-            'bg-surface-elevated border border-border rounded-lg shadow-lg',
-            'py-1 animate-slide-down motion-reduce:animate-none',
-            align === 'right' ? 'right-0' : 'left-0',
-            panelClassName
-          )}
-        >
-          {items.map((item, i) => {
-            if (item.divider) {
-              return (
-                <div
-                  key={i}
-                  role='separator'
-                  className='my-1 border-t border-border'
-                />
-              );
-            }
+      {isOpen &&
+        createPortal(
+          <div
+            ref={panelRef}
+            id={menuId}
+            role='menu'
+            aria-labelledby={triggerId}
+            tabIndex={-1}
+            data-align={align}
+            onKeyDown={handleMenuKeyDown}
+            style={menuStyle ?? undefined}
+            className={cn(
+              'fixed z-50 min-w-[180px]',
+              'bg-surface-elevated border border-border rounded-lg shadow-lg',
+              'py-1 animate-slide-down motion-reduce:animate-none',
+              panelClassName
+            )}
+          >
+            {items.map((item, i) => {
+              if (item.divider) {
+                return (
+                  <div
+                    key={i}
+                    role='separator'
+                    className='my-1 border-t border-border'
+                  />
+                );
+              }
 
-            const itemClassName = cn(
-              'w-full flex items-center gap-2 px-3 py-1.5 text-sm text-left',
-              'transition-colors duration-100 cursor-pointer',
-              'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2',
-              'focus-visible:ring-offset-surface',
-              item.disabled && 'opacity-50 cursor-not-allowed',
-              item.loading && 'cursor-wait',
-              item.danger
-                ? 'text-error hover:bg-error-light'
-                : 'text-text-primary hover:bg-surface-tertiary'
-            );
-
-            const content =
-              item.content != null ? (
-                item.content
-              ) : (
-                <>
-                  {(item.loading || item.icon) && (
-                    <span
-                      className='inline-flex h-4 w-4 shrink-0 items-center justify-center'
-                      aria-hidden='true'
-                    >
-                      {item.loading ? <Spinner size='sm' /> : item.icon}
-                    </span>
-                  )}
-                  <span className='flex-1 truncate'>{item.label}</span>
-                  {item.external && (
-                    <ExternalLink
-                      className='ml-2 h-3.5 w-3.5 shrink-0 opacity-60'
-                      aria-hidden='true'
-                    />
-                  )}
-                </>
+              const itemClassName = cn(
+                'w-full flex items-center gap-2 px-3 py-1.5 text-sm text-left',
+                'transition-colors duration-100 cursor-pointer',
+                'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2',
+                'focus-visible:ring-offset-surface',
+                item.disabled && 'opacity-50 cursor-not-allowed',
+                item.loading && 'cursor-wait',
+                item.danger
+                  ? 'text-error hover:bg-error-light'
+                  : 'text-text-primary hover:bg-surface-tertiary'
               );
 
-            if (item.href) {
+              const content =
+                item.content != null ? (
+                  item.content
+                ) : (
+                  <>
+                    {(item.loading || item.icon) && (
+                      <span
+                        className='inline-flex h-4 w-4 shrink-0 items-center justify-center'
+                        aria-hidden='true'
+                      >
+                        {item.loading ? <Spinner size='sm' /> : item.icon}
+                      </span>
+                    )}
+                    <span className='flex-1 truncate'>{item.label}</span>
+                    {item.external && (
+                      <ExternalLink
+                        className='ml-2 h-3.5 w-3.5 shrink-0 opacity-60'
+                        aria-hidden='true'
+                      />
+                    )}
+                  </>
+                );
+
+              if (item.href) {
+                return (
+                  <a
+                    key={i}
+                    ref={el => {
+                      itemRefs.current[i] = el;
+                    }}
+                    role='menuitem'
+                    aria-label={item.content != null ? item.label : undefined}
+                    href={item.href}
+                    target={item.external ? '_blank' : undefined}
+                    rel={item.external ? 'noopener noreferrer' : undefined}
+                    tabIndex={i === activeIndex ? 0 : -1}
+                    onClick={() => {
+                      item.onClick?.();
+                      if (item.closeOnClick !== false) {
+                        close();
+                      }
+                    }}
+                    className={itemClassName}
+                  >
+                    {content}
+                  </a>
+                );
+              }
+
               return (
-                <a
+                <button
                   key={i}
                   ref={el => {
                     itemRefs.current[i] = el;
                   }}
                   role='menuitem'
                   aria-label={item.content != null ? item.label : undefined}
-                  href={item.href}
-                  target={item.external ? '_blank' : undefined}
-                  rel={item.external ? 'noopener noreferrer' : undefined}
                   tabIndex={i === activeIndex ? 0 : -1}
+                  aria-disabled={item.disabled || item.loading || undefined}
+                  aria-busy={item.loading || undefined}
                   onClick={() => {
+                    if (item.disabled || item.loading) return;
                     item.onClick?.();
                     if (item.closeOnClick !== false) {
                       close();
@@ -317,36 +380,12 @@ export function Dropdown({
                   className={itemClassName}
                 >
                   {content}
-                </a>
+                </button>
               );
-            }
-
-            return (
-              <button
-                key={i}
-                ref={el => {
-                  itemRefs.current[i] = el;
-                }}
-                role='menuitem'
-                aria-label={item.content != null ? item.label : undefined}
-                tabIndex={i === activeIndex ? 0 : -1}
-                aria-disabled={item.disabled || item.loading || undefined}
-                aria-busy={item.loading || undefined}
-                onClick={() => {
-                  if (item.disabled || item.loading) return;
-                  item.onClick?.();
-                  if (item.closeOnClick !== false) {
-                    close();
-                  }
-                }}
-                className={itemClassName}
-              >
-                {content}
-              </button>
-            );
-          })}
-        </div>
-      )}
+            })}
+          </div>,
+          document.body
+        )}
     </div>
   );
 }

--- a/libs/shared/ui/src/lib/Dropdown.tsx
+++ b/libs/shared/ui/src/lib/Dropdown.tsx
@@ -63,6 +63,12 @@ export interface DropdownTriggerProps {
   onKeyDown: (e: React.KeyboardEvent) => void;
 }
 
+// `useLayoutEffect` warns when a component is prerendered on the server, and
+// Next.js prerenders 'use client' components too. The menu only exists after
+// mount, so deferring to useEffect on the server is behaviourally identical.
+const useIsomorphicLayoutEffect =
+  typeof window !== 'undefined' ? useLayoutEffect : useEffect;
+
 export interface DropdownProps {
   /**
    * Content rendered inside the built-in trigger button — or a render
@@ -112,22 +118,56 @@ export function Dropdown({
         ? {
             position: 'fixed',
             top: rect.bottom + 4,
-            right: Math.max(0, window.innerWidth - rect.right),
+            // `right` on a fixed element is measured from the layout viewport,
+            // which excludes the classic scrollbar. window.innerWidth includes
+            // it, which would shift the menu left by the scrollbar width
+            // anywhere overlay scrollbars aren't the default (i.e. not macOS).
+            right: Math.max(
+              0,
+              document.documentElement.clientWidth - rect.right
+            ),
           }
         : { position: 'fixed', top: rect.bottom + 4, left: rect.left }
     );
   }, [align, triggerRef]);
 
-  useLayoutEffect(() => {
+  // scroll fires per frame (and capture catches every nested scroller), so
+  // coalesce re-anchoring into one rAF instead of a rect read + render per
+  // event.
+  const rafRef = useRef<number | null>(null);
+  const scheduleMenuPosition = useCallback(() => {
+    if (rafRef.current !== null) return;
+    rafRef.current = requestAnimationFrame(() => {
+      rafRef.current = null;
+      updateMenuPosition();
+    });
+  }, [updateMenuPosition]);
+
+  useIsomorphicLayoutEffect(() => {
     if (!isOpen) return;
+    // Synchronous first pass so the menu never paints unanchored.
     updateMenuPosition();
-    window.addEventListener('scroll', updateMenuPosition, true);
-    window.addEventListener('resize', updateMenuPosition);
+    window.addEventListener('scroll', scheduleMenuPosition, true);
+    window.addEventListener('resize', scheduleMenuPosition);
     return () => {
-      window.removeEventListener('scroll', updateMenuPosition, true);
-      window.removeEventListener('resize', updateMenuPosition);
+      window.removeEventListener('scroll', scheduleMenuPosition, true);
+      window.removeEventListener('resize', scheduleMenuPosition);
+      if (rafRef.current !== null) {
+        cancelAnimationFrame(rafRef.current);
+        rafRef.current = null;
+      }
     };
-  }, [isOpen, updateMenuPosition]);
+  }, [isOpen, updateMenuPosition, scheduleMenuPosition]);
+
+  // react-dom/server has neither portal support nor a `document`, and Next.js
+  // prerenders 'use client' components. Mounting the menu only after hydration
+  // costs uncontrolled dropdowns nothing (they start closed) and turns a
+  // server crash into a post-mount render for a consumer that passes
+  // `open` from the first paint.
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => {
+    setMounted(true);
+  }, []);
   const itemRefs = useRef<(HTMLButtonElement | HTMLAnchorElement | null)[]>([]);
   const uid = useId();
   const menuId = `dropdown-menu-${uid}`;
@@ -270,6 +310,7 @@ export function Dropdown({
         </button>
       )}
       {isOpen &&
+        mounted &&
         createPortal(
           <div
             ref={panelRef}

--- a/libs/shared/ui/src/lib/utils/useAnchoredPanel.ts
+++ b/libs/shared/ui/src/lib/utils/useAnchoredPanel.ts
@@ -29,7 +29,17 @@ export function useAnchoredPanel({ open, onOpenChange }: AnchoredPanelOptions) {
   // longer a DOM descendant of the wrapper, so dismiss containment and the
   // Escape listener must cover this node too. Inline panels (Popover) leave
   // it unset — null is simply skipped below.
-  const panelRef = useRef<HTMLDivElement>(null);
+  //
+  // Deliberately a state-backed CALLBACK ref, not a plain ref: a portaled
+  // panel can mount in a later commit than the open flip (it waits for
+  // hydration), and a plain ref would leave the effects below bound to
+  // whatever existed when `isOpen` turned true — silently dropping Escape on
+  // a panel that appeared a commit later. Storing the node in state re-runs
+  // them when it actually arrives.
+  const [panelNode, setPanelNode] = useState<HTMLDivElement | null>(null);
+  const panelRef = useCallback((node: HTMLDivElement | null) => {
+    setPanelNode(node);
+  }, []);
 
   const setOpen = useCallback(
     (next: boolean) => {
@@ -53,14 +63,14 @@ export function useAnchoredPanel({ open, onOpenChange }: AnchoredPanelOptions) {
     const handler = (e: MouseEvent) => {
       const target = e.target as Node;
       const insideWrapper = wrapperRef.current?.contains(target) ?? false;
-      const insidePanel = panelRef.current?.contains(target) ?? false;
+      const insidePanel = panelNode?.contains(target) ?? false;
       if (!insideWrapper && !insidePanel) {
         setOpen(false);
       }
     };
     document.addEventListener('mousedown', handler);
     return () => document.removeEventListener('mousedown', handler);
-  }, [isOpen, setOpen]);
+  }, [isOpen, setOpen, panelNode]);
 
   // Escape from anywhere inside (trigger or panel fields) dismisses. Native
   // listeners keep interaction handlers off non-interactive JSX elements
@@ -69,7 +79,7 @@ export function useAnchoredPanel({ open, onOpenChange }: AnchoredPanelOptions) {
   // not the wrapper.
   useEffect(() => {
     if (!isOpen) return;
-    const nodes = [wrapperRef.current, panelRef.current].filter(
+    const nodes = [wrapperRef.current, panelNode].filter(
       (n): n is HTMLDivElement => n !== null
     );
     if (nodes.length === 0) return;
@@ -83,7 +93,7 @@ export function useAnchoredPanel({ open, onOpenChange }: AnchoredPanelOptions) {
     return () => {
       for (const node of nodes) node.removeEventListener('keydown', handler);
     };
-  }, [isOpen, close]);
+  }, [isOpen, close, panelNode]);
 
   return { isOpen, setOpen, close, wrapperRef, triggerRef, panelRef };
 }

--- a/libs/shared/ui/src/lib/utils/useAnchoredPanel.ts
+++ b/libs/shared/ui/src/lib/utils/useAnchoredPanel.ts
@@ -25,6 +25,11 @@ export function useAnchoredPanel({ open, onOpenChange }: AnchoredPanelOptions) {
   const isOpen = isControlled ? open : uncontrolledOpen;
   const wrapperRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
+  // For panels rendered in a PORTAL (Dropdown's menu): the panel is no
+  // longer a DOM descendant of the wrapper, so dismiss containment and the
+  // Escape listener must cover this node too. Inline panels (Popover) leave
+  // it unset — null is simply skipped below.
+  const panelRef = useRef<HTMLDivElement>(null);
 
   const setOpen = useCallback(
     (next: boolean) => {
@@ -39,14 +44,17 @@ export function useAnchoredPanel({ open, onOpenChange }: AnchoredPanelOptions) {
     triggerRef.current?.focus();
   }, [setOpen]);
 
-  // Outside click dismisses without moving focus
+  // Outside click dismisses without moving focus. "Inside" means the wrapper
+  // OR the (possibly portaled) panel — a portaled panel is not a wrapper
+  // descendant, and without the second check every click on one of its items
+  // would read as outside and close the menu before the item's onClick.
   useEffect(() => {
     if (!isOpen) return;
     const handler = (e: MouseEvent) => {
-      if (
-        wrapperRef.current &&
-        !wrapperRef.current.contains(e.target as Node)
-      ) {
+      const target = e.target as Node;
+      const insideWrapper = wrapperRef.current?.contains(target) ?? false;
+      const insidePanel = panelRef.current?.contains(target) ?? false;
+      if (!insideWrapper && !insidePanel) {
         setOpen(false);
       }
     };
@@ -54,22 +62,28 @@ export function useAnchoredPanel({ open, onOpenChange }: AnchoredPanelOptions) {
     return () => document.removeEventListener('mousedown', handler);
   }, [isOpen, setOpen]);
 
-  // Escape from anywhere inside (trigger or panel fields) dismisses. A native
-  // listener on the wrapper keeps interaction handlers off non-interactive
-  // JSX elements (jsx-a11y) while still scoping Escape to this popup.
+  // Escape from anywhere inside (trigger or panel fields) dismisses. Native
+  // listeners keep interaction handlers off non-interactive JSX elements
+  // (jsx-a11y) while still scoping Escape to this popup. The panel gets its
+  // own listener for the portaled case — its keydowns bubble to document.body,
+  // not the wrapper.
   useEffect(() => {
     if (!isOpen) return;
-    const node = wrapperRef.current;
-    if (!node) return;
+    const nodes = [wrapperRef.current, panelRef.current].filter(
+      (n): n is HTMLDivElement => n !== null
+    );
+    if (nodes.length === 0) return;
     const handler = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
         e.preventDefault();
         close();
       }
     };
-    node.addEventListener('keydown', handler);
-    return () => node.removeEventListener('keydown', handler);
+    for (const node of nodes) node.addEventListener('keydown', handler);
+    return () => {
+      for (const node of nodes) node.removeEventListener('keydown', handler);
+    };
   }, [isOpen, close]);
 
-  return { isOpen, setOpen, close, wrapperRef, triggerRef };
+  return { isOpen, setOpen, close, wrapperRef, triggerRef, panelRef };
 }


### PR DESCRIPTION
## What

The Dropdown menu rendered absolutely-positioned inside the trigger wrapper, so any `overflow-hidden`/`auto` ancestor clipped it — observed in wyrdfold (ux-sweep 2026-08-12 B2) as the search modal's target picker cut off at the modal edge until scrolled. The menu now portals to `document.body` with a fixed-position anchor computed from the trigger rect, re-anchored on scroll (capture phase, for nested scrollers) and resize.

- `useAnchoredPanel` returns a new `panelRef`; outside-mousedown containment and the Escape listener cover it in addition to the wrapper. Popover renders inline and leaves it unset — unaffected.
- Alignment is exposed as `data-align` (it's an anchor computation now, not `right-0`/`left-0` classes).
- Changeset: minor.

## Validated

- New specs: portal-escape regression (menu is NOT contained by an overflow-hidden ancestor; parent is `document.body`), mousedown inside the portaled menu does not dismiss, full click-through still activates + closes.
- **Sabotage-checked**: dropping the `panelRef` containment fails the mousedown-inside spec (1 failed / 882 passed), restored to 883/883.
- Open-menu axe scans moved to `document.body` — scanning the render container alone became a vacuous pass with the portal. The `region` landmark rule is disabled for body scans only (portaled transient popups legitimately live outside landmarks; the bare test DOM has none).
- Full gate: shared-ui 883 tests, root 582 tests, `tsc --noEmit`, lint — all green on Node 24.11.0.

## Consumer note (wyrdfold)

After publish, wyrdfold bumps `^0.12.0`. One integration risk to verify on the bump: a modal that dismisses on outside-click via DOM containment would now treat clicks in the portaled menu as outside — the wyrdfold search modal drive is the check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)