### PR TITLE
docs(changeset): note the Dropdown portal's SSR and outside-click semantics

### DIFF
--- a/.changeset/dropdown-portal-escape.md
+++ b/.changeset/dropdown-portal-escape.md
@@ -11,3 +11,11 @@ panel as "inside" via a new `panelRef` returned from `useAnchoredPanel`
 (inline panels like Popover are unaffected). Found as wyrdfold ux-sweep
 2026-08-12 B2: a target-picker Dropdown inside a modal was cut off at the
 modal edge until scrolled.
+
+Two notes for consumers. The menu mounts after hydration rather than during
+render, because `react-dom/server` supports neither portals nor `document` —
+uncontrolled dropdowns start closed and never notice, but a Dropdown given
+`open` from the first paint now renders its menu on mount instead of crashing
+the server render. And a modal that dismisses on outside-click via DOM
+containment must now count the portaled menu as inside, since it is no longer
+a descendant of the trigger.


### PR DESCRIPTION
Changelog accuracy for the 0.12.0 shared-ui release (no code change).

The `dropdown-portal-escape` changeset described the portal but not the two behaviours a consumer has to account for on the bump:

- the menu mounts **after hydration** rather than during render (`react-dom/server` has neither portals nor `document`), so a Dropdown given `open` from the first paint renders its menu on mount instead of crashing the server render;
- a modal doing its own DOM-containment outside-click check must now treat the portaled menu as inside, since it is no longer a descendant of the trigger.

Both are already flagged in #1123's review comment; this puts them in the published CHANGELOG where wyrdfold will actually read them.

— Claude (Claude Code)