### PR TITLE
fix(shared-ui): publish what the package promises, promise what it publishes

### DIFF
--- a/.changeset/shared-ui-package-surface.md
+++ b/.changeset/shared-ui-package-surface.md
@@ -1,0 +1,22 @@
+---
+'@danieljoffe/shared-ui': patch
+---
+
+Packaging fixes for what the published tarball actually contains.
+
+`CHANGELOG.md` is now published, so release notes are readable from the
+registry rather than only on GitHub. The two theme stylesheets are published
+explicitly instead of via the whole `src/styles` directory, which was also
+shipping three Storybook-only files (`preview.scss`,
+`pyre-storybook-preview.css`, `storybook-docs.css`) that no `exports` path
+could reach.
+
+`sideEffects` no longer claims the entire package is effect-free: it now lists
+`**/*.css` and `**/*.scss`, so a bundler cannot tree-shake away a consumer's
+`@import '@danieljoffe/shared-ui/styles/indigo-theme.css'`.
+
+The README's theme-setup instructions pointed at
+`@danieljoffe/shared-ui/styles/theme.css`, which has not existed since that
+file was split into `indigo-theme.css` and `pyre-theme.css` — the documented
+quick start could not resolve. It now names the real paths and documents both
+themes.

--- a/.github/workflows/shared-ui-package-check.yml
+++ b/.github/workflows/shared-ui-package-check.yml
@@ -50,11 +50,19 @@ jobs:
       - name: Assert required files are present
         run: |
           set -euo pipefail
+          # Every consumer-facing entry point the package promises. The theme
+          # CSS is listed explicitly because `exports` maps those two paths
+          # straight at src/styles — nothing else in the repo imports them, so
+          # dropping them from `files` would only surface as a broken import
+          # in a downstream app.
           REQUIRED=(
             "dist/index.js"
             "dist/index.d.ts"
+            "src/styles/indigo-theme.css"
+            "src/styles/pyre-theme.css"
             "LICENSE.md"
             "README.md"
+            "CHANGELOG.md"
             "package.json"
           )
           MISSING=()

--- a/libs/shared/ui/README.md
+++ b/libs/shared/ui/README.md
@@ -52,10 +52,18 @@ Import the theme CSS to get design tokens (colors, spacing, typography, shadows,
 
 ```css
 /* In your global CSS or Tailwind entry point */
-@import '@danieljoffe/shared-ui/styles/theme.css';
+@import '@danieljoffe/shared-ui/styles/indigo-theme.css';
 ```
 
-The theme file is **self-contained** with no external imports. It uses Tailwind CSS 4's `@theme` directive so every token is available as both a CSS custom property and a Tailwind utility class (e.g., `bg-brand-500`, `text-text-secondary`, `shadow-md`).
+Two themes ship, and they define the same token _names_ — swap the import to
+re-brand without touching a component:
+
+| Theme                | Import path                                      |
+| -------------------- | ------------------------------------------------ |
+| **Indigo** (default) | `@danieljoffe/shared-ui/styles/indigo-theme.css` |
+| **Pyre**             | `@danieljoffe/shared-ui/styles/pyre-theme.css`   |
+
+Each theme file is **self-contained** with no external imports. It uses Tailwind CSS 4's `@theme` directive so every token is available as both a CSS custom property and a Tailwind utility class (e.g., `bg-brand-500`, `text-text-secondary`, `shadow-md`).
 
 > **oklch color space** -- Brand colors use `oklch()` for perceptually uniform lightness across the scale. Semantic surface/text/status colors use hex or `rgba` for maximum browser compatibility.
 
@@ -64,22 +72,22 @@ The theme file is **self-contained** with no external imports. It uses Tailwind 
 ```css
 /* app/globals.css */
 @import 'tailwindcss';
-@import '@danieljoffe/shared-ui/styles/theme.css';
+@import '@danieljoffe/shared-ui/styles/indigo-theme.css';
 ```
 
 That single import gives you every token below. No `tailwind.config` changes are needed in Tailwind CSS 4 -- the `@theme` directive registers tokens automatically.
 
 ### Integration paths
 
-| Approach               | When to use                        | How                                                                                                                                            |
-| ---------------------- | ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Full adoption**      | New apps built on shared-ui        | Import `theme.css` as shown above. All tokens, base styles, dark mode, and keyframes are active.                                               |
-| **Selective adoption** | Existing apps with their own theme | Copy individual `@theme` token groups into your own CSS. Or import `theme.css` and override specific variables in a subsequent `@theme` block. |
+| Approach               | When to use                        | How                                                                                                                                             |
+| ---------------------- | ---------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Full adoption**      | New apps built on shared-ui        | Import a theme file as shown above. All tokens, base styles, dark mode, and keyframes are active.                                               |
+| **Selective adoption** | Existing apps with their own theme | Copy individual `@theme` token groups into your own CSS. Or import a theme file and override specific variables in a subsequent `@theme` block. |
 
 To override tokens selectively:
 
 ```css
-@import '@danieljoffe/shared-ui/styles/theme.css';
+@import '@danieljoffe/shared-ui/styles/indigo-theme.css';
 
 @theme {
   --color-brand-500: oklch(0.6 0.2 280); /* shift brand toward purple */

--- a/libs/shared/ui/package.json
+++ b/libs/shared/ui/package.json
@@ -3,7 +3,10 @@
   "version": "0.12.0",
   "description": "React component library and design system — Tailwind CSS 4, React 19, server-component-friendly.",
   "type": "module",
-  "sideEffects": false,
+  "sideEffects": [
+    "**/*.css",
+    "**/*.scss"
+  ],
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -38,9 +41,11 @@
   },
   "files": [
     "dist",
-    "src/styles",
+    "src/styles/indigo-theme.css",
+    "src/styles/pyre-theme.css",
     "README.md",
-    "LICENSE.md"
+    "LICENSE.md",
+    "CHANGELOG.md"
   ],
   "keywords": [
     "react",

--- a/libs/shared/ui/src/lib/package.surface.spec.ts
+++ b/libs/shared/ui/src/lib/package.surface.spec.ts
@@ -1,0 +1,172 @@
+// Packaging contract for the published @danieljoffe/shared-ui package.
+//
+// Two classes of drift have shipped to npm unnoticed, because nothing reads
+// package.json and README.md against each other:
+//
+//   1. The README told consumers to `@import
+//      '@danieljoffe/shared-ui/styles/theme.css'` — the headline theme-setup
+//      step — for every release after theme.css was renamed to
+//      indigo-theme.css (76a6275). No export matched, so the documented
+//      quick start failed to resolve.
+//   2. `files` and `exports` drifted apart in both directions: CHANGELOG.md
+//      was exported to nobody because `files` omitted it, and three
+//      Storybook-only stylesheets shipped that no export path could reach.
+//
+// These are pure static checks on the manifest and the README, so they run in
+// the fast lane with the rest of the unit suite — no build, no pack.
+//
+// Boundary: without a build these can prove a documented subpath resolves into
+// a *published directory*, not that the specific file inside it exists. So a
+// README naming a component that no longer exists still passes here — that one
+// is caught loudly elsewhere, since apps/root and Storybook import every
+// component directly. Stylesheets had no such second reader, which is exactly
+// why `styles/theme.css` rotted unnoticed, and why they are held to the
+// stricter explicit-key rule below.
+//
+// The CI packaging job (.github/workflows/shared-ui-package-check.yml) covers
+// what needs a real build: that `npm pack` actually emits the required files
+// and that no source leaks in.
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const PKG_ROOT = join(__dirname, '..', '..');
+
+const pkg = JSON.parse(
+  readFileSync(join(PKG_ROOT, 'package.json'), 'utf8')
+) as {
+  name: string;
+  files: string[];
+  exports: Record<string, unknown>;
+};
+const readme = readFileSync(join(PKG_ROOT, 'README.md'), 'utf8');
+
+/**
+ * Resolution condition Nx/Vite use to point at TypeScript source inside this
+ * monorepo. It is never matched by an installed consumer, so its targets are
+ * deliberately absent from the tarball and excluded from the check below.
+ */
+const WORKSPACE_SOURCE_CONDITION = '@danieljoffe.com/source';
+
+/**
+ * Every concrete (wildcard-free) target a *consumer* can resolve through the
+ * `exports` map.
+ */
+function concreteExportTargets(): string[] {
+  const targets: string[] = [];
+  const walk = (node: unknown) => {
+    if (typeof node === 'string') {
+      if (!node.includes('*')) targets.push(node);
+      return;
+    }
+    if (node && typeof node === 'object') {
+      for (const [condition, value] of Object.entries(node)) {
+        if (condition === WORKSPACE_SOURCE_CONDITION) continue;
+        walk(value);
+      }
+    }
+  };
+  walk(pkg.exports);
+  return [...new Set(targets)];
+}
+
+/**
+ * npm's `files` semantics, narrowed to what this manifest uses: an entry is
+ * either the exact path or a directory prefix of it. package.json is always
+ * published regardless of `files`.
+ */
+function isPublished(path: string): boolean {
+  const rel = path.replace(/^\.\//, '');
+  if (rel === 'package.json') return true;
+  return pkg.files.some(
+    entry => rel === entry || rel.startsWith(`${entry.replace(/\/$/, '')}/`)
+  );
+}
+
+/** Subpaths the README tells consumers to import, e.g. `./styles/foo.css`. */
+function readmeSubpaths(): string[] {
+  const re = new RegExp(`${pkg.name}(/[^'"\`\\s)]+)?`, 'g');
+  const found = [...readme.matchAll(re)].map(m => (m[1] ? `.${m[1]}` : '.'));
+  return [...new Set(found)];
+}
+
+/**
+ * Whether a consumer's `import '@danieljoffe/shared-ui<subpath>'` resolves to
+ * a file this package actually ships.
+ *
+ * A stylesheet must match an *explicit* exports key. Matching the `./styles/*`
+ * wildcard is not enough and is precisely how the README's dead
+ * `styles/theme.css` went unnoticed: that wildcard targets
+ * `./dist/lib/styles/<name>.js`, so a `.css` subpath "matched" the pattern
+ * while resolving to `dist/lib/styles/theme.css.js`, which has never existed.
+ */
+function resolvesToShippedFile(subpath: string): boolean {
+  const entries = Object.entries(pkg.exports);
+  const isStylesheet = /\.(css|scss)$/.test(subpath);
+
+  const exact = entries.find(([key]) => key === subpath);
+  if (exact) return concreteTargetsOf(exact[1]).every(isPublished);
+  if (isStylesheet) return false;
+
+  return entries.some(([key, value]) => {
+    if (!key.includes('*')) return false;
+    const [prefix = '', suffix = ''] = key.split('*');
+    if (
+      !subpath.startsWith(prefix) ||
+      !subpath.endsWith(suffix) ||
+      subpath.length < prefix.length + suffix.length
+    ) {
+      return false;
+    }
+    const star = subpath.slice(prefix.length, subpath.length - suffix.length);
+    return concreteTargetsOf(value, star).every(isPublished);
+  });
+}
+
+/** Consumer-facing targets of an exports value, with `*` substituted. */
+function concreteTargetsOf(value: unknown, star = ''): string[] {
+  const targets: string[] = [];
+  const walk = (node: unknown) => {
+    if (typeof node === 'string') {
+      targets.push(node.replace('*', star));
+      return;
+    }
+    if (node && typeof node === 'object') {
+      for (const [condition, child] of Object.entries(node)) {
+        if (condition === WORKSPACE_SOURCE_CONDITION) continue;
+        walk(child);
+      }
+    }
+  };
+  walk(value);
+  return targets;
+}
+
+describe('published package surface', () => {
+  it('publishes every file the exports map points at', () => {
+    const unpublished = concreteExportTargets().filter(t => !isPublished(t));
+    expect(unpublished).toEqual([]);
+  });
+
+  it('publishes the changelog, licence and readme', () => {
+    for (const file of ['CHANGELOG.md', 'LICENSE.md', 'README.md']) {
+      expect(pkg.files).toContain(file);
+    }
+  });
+
+  it('resolves every package subpath the README tells consumers to import', () => {
+    const broken = readmeSubpaths().filter(s => !resolvesToShippedFile(s));
+    expect(broken).toEqual([]);
+  });
+
+  it('keeps CSS out of the sideEffects-free claim so bundlers cannot drop it', () => {
+    // `sideEffects: false` lets webpack tree-shake a consumer's
+    // `import '@danieljoffe/shared-ui/styles/indigo-theme.css'` away entirely,
+    // because the package would be claiming no module in it has an effect.
+    const sideEffects = (pkg as unknown as { sideEffects: unknown })
+      .sideEffects;
+    expect(Array.isArray(sideEffects)).toBe(true);
+    expect(sideEffects).toEqual(
+      expect.arrayContaining([expect.stringContaining('.css')])
+    );
+  });
+});


### PR DESCRIPTION
Started from the `CHANGELOG.md` omission spotted while verifying the 0.12.0 publish, then swept the rest of the published surface. None of this was visible from inside the repo: `apps/root` consumes shared-ui through the workspace, never through the registry, so only a downstream installer would ever hit these.

## The one you asked about

`CHANGELOG.md` was never in `files`, so `npm view`/registry readers got no release notes — only GitHub Releases had them. Added.

## What else the sweep turned up

**The README's documented quick start could not resolve.** Theme setup — repeated four times, including the first thing a new consumer does — said:

```css
@import '@danieljoffe/shared-ui/styles/theme.css';
```

`theme.css` has not existed since 76a6275 split it into `indigo-theme.css` and `pyre-theme.css`. It isn't a missing export either: the path *matches* the `./styles/*` wildcard, which targets `./dist/lib/styles/*.js`, so it resolves to `dist/lib/styles/theme.css.js` — never built, never shipped. Confirmed against the published 0.12.0 tarball: no `theme.css` anywhere, and `dist/lib/styles/` contains only `formStyles` and `semanticVariants`. Fixed to the real paths, with both themes documented.

**`sideEffects: false` was unsafe for the CSS the package exports.** It asserts no module in the package has an effect, which permits a bundler to drop a consumer's `@import '@danieljoffe/shared-ui/styles/indigo-theme.css'` as unused. Now `["**/*.css", "**/*.scss"]`.

**Three Storybook-only stylesheets were shipping to npm.** `files` listed the whole `src/styles` directory, so `preview.scss`, `pyre-storybook-preview.css` and `storybook-docs.css` went out even though no `exports` path can reach them. `files` now names the two theme files `exports` actually maps. This also retires the hazard `contrast.tokens.spec.ts` documents in its header — that `src/styles` ships raw, so a spec placed there would leak into the tarball.

## Guards, so it can't rot again

`package.surface.spec.ts` (4 tests, fast lane, no build needed) asserts:

1. every consumer-facing `exports` target is covered by `files`;
2. changelog, licence and readme are published;
3. CSS is excluded from the `sideEffects` claim;
4. every `@danieljoffe/shared-ui/…` subpath in the README resolves to a shipped file — and **stylesheets must match an explicit `exports` key**, since matching the wildcard is precisely what hid this bug.

The CI packaging job's `REQUIRED` list — the thing that should have caught the changelog — now includes `CHANGELOG.md` and both theme stylesheets.

**Sabotage-checked**, each reverted independently: dead README path → fail; `CHANGELOG.md` out of `files` → fail; `sideEffects: false` → fail; unpublish an exported theme file → fail. All four green when restored.

Known boundary, documented in the spec header rather than papered over: without a build these prove a documented subpath resolves into a *published directory*, not that the exact file exists. A README naming a deleted component still passes — but that is caught loudly, since `apps/root` and Storybook import every component directly. Stylesheets had no such second reader, which is why they get the stricter rule.

## Validated

- shared-ui **889 tests / 52 suites**, `tsc --noEmit`, lint, knip — all clean
- real `npm pack --dry-run` against a fresh build: 182 files, 64 kB; non-dist entries are exactly `CHANGELOG.md`, `LICENSE.md`, `README.md`, `package.json`, `src/styles/indigo-theme.css`, `src/styles/pyre-theme.css`; no source/test/story leaks

Patch changeset included — this changes what gets published, so it should ride a release rather than sit on `develop`.

— Claude (Claude Code)